### PR TITLE
provider/openai: add first-class prompt cache controls

### DIFF
--- a/provider/openai/message.go
+++ b/provider/openai/message.go
@@ -11,17 +11,19 @@ import (
 // --- API request types ---
 
 type apiRequest struct {
-	Model            string             `json:"model"`
-	Messages         []apiMessage       `json:"messages"`
-	Tools            []apiToolDef       `json:"tools,omitempty"`
-	ToolChoice       any                `json:"tool_choice,omitempty"`
-	Stream           bool               `json:"stream,omitempty"`
-	StreamOptions    *apiStreamOptions  `json:"stream_options,omitempty"`
-	MaxTokens        int                `json:"max_completion_tokens,omitempty"`
-	Temperature      *float64           `json:"temperature,omitempty"`
-	TopP             *float64           `json:"top_p,omitempty"`
-	ResponseFormat   *apiResponseFormat `json:"response_format,omitempty"`
-	ReasoningEffort  *string            `json:"reasoning_effort,omitempty"`
+	Model                string             `json:"model"`
+	Messages             []apiMessage       `json:"messages"`
+	Tools                []apiToolDef       `json:"tools,omitempty"`
+	ToolChoice           any                `json:"tool_choice,omitempty"`
+	Stream               bool               `json:"stream,omitempty"`
+	StreamOptions        *apiStreamOptions  `json:"stream_options,omitempty"`
+	MaxTokens            int                `json:"max_completion_tokens,omitempty"`
+	Temperature          *float64           `json:"temperature,omitempty"`
+	TopP                 *float64           `json:"top_p,omitempty"`
+	ResponseFormat       *apiResponseFormat `json:"response_format,omitempty"`
+	ReasoningEffort      *string            `json:"reasoning_effort,omitempty"`
+	PromptCacheKey       string             `json:"prompt_cache_key,omitempty"`
+	PromptCacheRetention string             `json:"prompt_cache_retention,omitempty"`
 }
 
 type apiStreamOptions struct {

--- a/provider/openai/openai.go
+++ b/provider/openai/openai.go
@@ -38,12 +38,14 @@ const (
 
 // Provider implements core.Model for OpenAI's Chat Completions API.
 type Provider struct {
-	apiKey       string
-	model        string
-	baseURL      string
-	httpClient   *http.Client
-	maxTokens    int
-	useResponses bool
+	apiKey              string
+	model               string
+	baseURL             string
+	httpClient          *http.Client
+	maxTokens           int
+	useResponses        bool
+	promptCacheKey      string
+	promptCacheRetention string
 }
 
 // Option configures the OpenAI provider.
@@ -84,6 +86,20 @@ func WithMaxTokens(n int) Option {
 	}
 }
 
+// WithPromptCacheKey sets the prompt cache key for request-level caching.
+func WithPromptCacheKey(key string) Option {
+	return func(p *Provider) {
+		p.promptCacheKey = key
+	}
+}
+
+// WithPromptCacheRetention sets the prompt cache retention policy (e.g. "auto").
+func WithPromptCacheRetention(retention string) Option {
+	return func(p *Provider) {
+		p.promptCacheRetention = retention
+	}
+}
+
 // New creates a new OpenAI provider with the given options.
 // Supports OPENAI_API_KEY and OPENAI_BASE_URL environment variables
 // for compatibility with OpenAI-compatible APIs (xAI, Together, etc.).
@@ -105,6 +121,13 @@ func New(opts ...Option) *Provider {
 		if envURL := os.Getenv("OPENAI_BASE_URL"); envURL != "" {
 			p.baseURL = envURL
 		}
+	}
+	// Support OPENAI_PROMPT_CACHE_KEY and OPENAI_PROMPT_CACHE_RETENTION env vars.
+	if p.promptCacheKey == "" {
+		p.promptCacheKey = os.Getenv("OPENAI_PROMPT_CACHE_KEY")
+	}
+	if p.promptCacheRetention == "" {
+		p.promptCacheRetention = os.Getenv("OPENAI_PROMPT_CACHE_RETENTION")
 	}
 	// Strip trailing /v1 or /v1/ from the base URL. Our endpoint path
 	// already includes /v1, so a base URL with /v1 (which is the convention
@@ -151,6 +174,7 @@ func (p *Provider) Request(ctx context.Context, messages []core.ModelMessage, se
 	if err != nil {
 		return nil, fmt.Errorf("openai: failed to build request: %w", err)
 	}
+	p.applyCacheSettings(req)
 
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -186,6 +210,7 @@ func (p *Provider) RequestStream(ctx context.Context, messages []core.ModelMessa
 	if err != nil {
 		return nil, fmt.Errorf("openai: failed to build request: %w", err)
 	}
+	p.applyCacheSettings(req)
 
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -249,6 +274,27 @@ func (p *Provider) doRequest(ctx context.Context, endpoint string, body []byte) 
 func (p *Provider) setHeaders(req *http.Request) {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+p.apiKey)
+}
+
+// applyCacheSettings attaches prompt cache control fields to the request
+// if configured on the provider.
+func (p *Provider) applyCacheSettings(req *apiRequest) {
+	if p.promptCacheKey != "" {
+		req.PromptCacheKey = p.promptCacheKey
+	}
+	if p.promptCacheRetention != "" {
+		req.PromptCacheRetention = p.promptCacheRetention
+	}
+}
+
+// applyCacheSettingsResponses attaches prompt cache control fields to a responses request.
+func (p *Provider) applyCacheSettingsResponses(req *responsesRequest) {
+	if p.promptCacheKey != "" {
+		req.PromptCacheKey = p.promptCacheKey
+	}
+	if p.promptCacheRetention != "" {
+		req.PromptCacheRetention = p.promptCacheRetention
+	}
 }
 
 func (p *Provider) shouldUseResponsesAPI() bool {

--- a/provider/openai/openai_test.go
+++ b/provider/openai/openai_test.go
@@ -2124,3 +2124,177 @@ data: [DONE]
 		t.Errorf("expected empty args to be '{}', got %q", tc.ArgsJSON)
 	}
 }
+
+// --- Prompt cache control tests ---
+
+func TestPromptCacheKeyOption(t *testing.T) {
+	p := New(WithAPIKey("test"), WithPromptCacheKey("my-cache-key"))
+	if p.promptCacheKey != "my-cache-key" {
+		t.Errorf("promptCacheKey = %q, want 'my-cache-key'", p.promptCacheKey)
+	}
+}
+
+func TestPromptCacheRetentionOption(t *testing.T) {
+	p := New(WithAPIKey("test"), WithPromptCacheRetention("auto"))
+	if p.promptCacheRetention != "auto" {
+		t.Errorf("promptCacheRetention = %q, want 'auto'", p.promptCacheRetention)
+	}
+}
+
+func TestPromptCacheEnvVars(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test")
+	t.Setenv("OPENAI_PROMPT_CACHE_KEY", "env-cache-key")
+	t.Setenv("OPENAI_PROMPT_CACHE_RETENTION", "auto")
+	p := New()
+	if p.promptCacheKey != "env-cache-key" {
+		t.Errorf("promptCacheKey = %q, want 'env-cache-key'", p.promptCacheKey)
+	}
+	if p.promptCacheRetention != "auto" {
+		t.Errorf("promptCacheRetention = %q, want 'auto'", p.promptCacheRetention)
+	}
+}
+
+func TestPromptCacheOptionOverridesEnv(t *testing.T) {
+	t.Setenv("OPENAI_PROMPT_CACHE_KEY", "env-key")
+	p := New(WithAPIKey("test"), WithPromptCacheKey("opt-key"))
+	if p.promptCacheKey != "opt-key" {
+		t.Errorf("promptCacheKey = %q, want 'opt-key' (option should override env)", p.promptCacheKey)
+	}
+}
+
+func TestApplyCacheSettingsChatCompletions(t *testing.T) {
+	p := New(WithAPIKey("test"), WithPromptCacheKey("ck"), WithPromptCacheRetention("auto"))
+	req := &apiRequest{Model: "gpt-4o"}
+	p.applyCacheSettings(req)
+	if req.PromptCacheKey != "ck" {
+		t.Errorf("PromptCacheKey = %q, want 'ck'", req.PromptCacheKey)
+	}
+	if req.PromptCacheRetention != "auto" {
+		t.Errorf("PromptCacheRetention = %q, want 'auto'", req.PromptCacheRetention)
+	}
+}
+
+func TestApplyCacheSettingsOmittedWhenUnset(t *testing.T) {
+	p := New(WithAPIKey("test"))
+	req := &apiRequest{Model: "gpt-4o"}
+	p.applyCacheSettings(req)
+	if req.PromptCacheKey != "" {
+		t.Errorf("PromptCacheKey should be empty, got %q", req.PromptCacheKey)
+	}
+	if req.PromptCacheRetention != "" {
+		t.Errorf("PromptCacheRetention should be empty, got %q", req.PromptCacheRetention)
+	}
+}
+
+func TestPromptCacheFieldsInChatCompletionsPayload(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]any
+		json.Unmarshal(body, &req)
+		if req["prompt_cache_key"] != "test-key-123" {
+			t.Errorf("prompt_cache_key = %v, want 'test-key-123'", req["prompt_cache_key"])
+		}
+		if req["prompt_cache_retention"] != "auto" {
+			t.Errorf("prompt_cache_retention = %v, want 'auto'", req["prompt_cache_retention"])
+		}
+		resp := apiResponse{
+			Choices: []apiChoice{{Message: apiChatMsg{Role: "assistant", Content: "ok"}, FinishReason: "stop"}},
+			Usage:   apiUsage{PromptTokens: 5, CompletionTokens: 1},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	p := New(WithAPIKey("k"), WithBaseURL(server.URL), WithPromptCacheKey("test-key-123"), WithPromptCacheRetention("auto"))
+	_, err := p.Request(context.Background(), []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "hi"}}},
+	}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPromptCacheFieldsOmittedFromPayloadWhenUnset(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		bodyStr := string(body)
+		if strings.Contains(bodyStr, "prompt_cache_key") {
+			t.Error("prompt_cache_key should not appear in payload when unset")
+		}
+		if strings.Contains(bodyStr, "prompt_cache_retention") {
+			t.Error("prompt_cache_retention should not appear in payload when unset")
+		}
+		resp := apiResponse{
+			Choices: []apiChoice{{Message: apiChatMsg{Role: "assistant", Content: "ok"}, FinishReason: "stop"}},
+			Usage:   apiUsage{PromptTokens: 5, CompletionTokens: 1},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	p := New(WithAPIKey("k"), WithBaseURL(server.URL))
+	_, err := p.Request(context.Background(), []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "hi"}}},
+	}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPromptCacheFieldsInResponsesPayload(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]any
+		json.Unmarshal(body, &req)
+		if req["prompt_cache_key"] != "resp-key" {
+			t.Errorf("prompt_cache_key = %v, want 'resp-key'", req["prompt_cache_key"])
+		}
+		resp := responsesAPIResponse{
+			ID: "resp_1", Model: "gpt-5.2-codex",
+			Output: []responsesOutputItem{{Type: "message", Role: "assistant", Content: []responsesContentItem{{Type: "output_text", Text: "ok"}}}},
+			Usage:  responsesUsage{InputTokens: 5, OutputTokens: 1},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	p := New(WithAPIKey("k"), WithBaseURL(server.URL), WithModel("gpt-5.2-codex"), WithPromptCacheKey("resp-key"))
+	_, err := p.Request(context.Background(), []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "hi"}}},
+	}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPromptCacheFieldsInStreamingPayload(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]any
+		json.Unmarshal(body, &req)
+		if req["prompt_cache_key"] != "stream-key" {
+			t.Errorf("prompt_cache_key = %v, want 'stream-key'", req["prompt_cache_key"])
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprintf(w, "data: {\"id\":\"c1\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"x\"},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n")
+	}))
+	defer server.Close()
+
+	p := New(WithAPIKey("k"), WithBaseURL(server.URL), WithPromptCacheKey("stream-key"))
+	stream, err := p.RequestStream(context.Background(), []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "hi"}}},
+	}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stream.Close()
+	for {
+		_, err := stream.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/provider/openai/responses.go
+++ b/provider/openai/responses.go
@@ -11,15 +11,17 @@ import (
 )
 
 type responsesRequest struct {
-	Model           string              `json:"model"`
-	Input           []map[string]any    `json:"input"`
-	Tools           []responsesToolDef  `json:"tools,omitempty"`
-	ToolChoice      any                 `json:"tool_choice,omitempty"`
-	MaxOutputTokens int                 `json:"max_output_tokens,omitempty"`
-	Temperature     *float64            `json:"temperature,omitempty"`
-	TopP            *float64            `json:"top_p,omitempty"`
-	Reasoning       *responsesReasoning `json:"reasoning,omitempty"`
-	Text            *responsesText      `json:"text,omitempty"`
+	Model                string              `json:"model"`
+	Input                []map[string]any    `json:"input"`
+	Tools                []responsesToolDef  `json:"tools,omitempty"`
+	ToolChoice           any                 `json:"tool_choice,omitempty"`
+	MaxOutputTokens      int                 `json:"max_output_tokens,omitempty"`
+	Temperature          *float64            `json:"temperature,omitempty"`
+	TopP                 *float64            `json:"top_p,omitempty"`
+	Reasoning            *responsesReasoning `json:"reasoning,omitempty"`
+	Text                 *responsesText      `json:"text,omitempty"`
+	PromptCacheKey       string              `json:"prompt_cache_key,omitempty"`
+	PromptCacheRetention string              `json:"prompt_cache_retention,omitempty"`
 }
 
 type responsesReasoning struct {
@@ -93,6 +95,7 @@ func (p *Provider) requestViaResponses(ctx context.Context, messages []core.Mode
 	if err != nil {
 		return nil, fmt.Errorf("openai: failed to build responses request: %w", err)
 	}
+	p.applyCacheSettingsResponses(req)
 
 	body, err := json.Marshal(req)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Adds `WithPromptCacheKey(string)` and `WithPromptCacheRetention(string)` provider options
- Reads `OPENAI_PROMPT_CACHE_KEY` and `OPENAI_PROMPT_CACHE_RETENTION` env vars as defaults
- Propagates cache fields to chat completions, responses API, and streaming request paths
- Fields are omitted (`omitempty`) when unset — no behavior change for existing users

## Test plan
- [x] Unit tests for option construction and env var reading
- [x] Integration tests verifying cache fields appear in chat completions payload
- [x] Integration tests verifying cache fields appear in responses API payload
- [x] Integration tests verifying cache fields appear in streaming payload
- [x] Regression test ensuring fields are omitted when not configured
- [x] All existing tests pass

Closes #12