### PR TITLE
Cap WebSocket per-read deadline at 3 minutes to prevent hung API calls

### DIFF
--- a/provider/openai/responses_ws.go
+++ b/provider/openai/responses_ws.go
@@ -194,8 +194,9 @@ func (p *Provider) sendResponsesCreateLocked(ctx context.Context, conn *response
 	}
 
 	for {
-		if hasReqDeadline {
-			_ = conn.conn.SetReadDeadline(reqDeadline)
+		readDeadline, hasReadDeadline := p.requestIODeadline(ctx, time.Now())
+		if hasReadDeadline {
+			_ = conn.conn.SetReadDeadline(readDeadline)
 		} else {
 			_ = conn.conn.SetReadDeadline(time.Now().Add(fallbackWebSocketReadTimeout))
 		}
@@ -231,19 +232,19 @@ func (p *Provider) sendResponsesCreateLocked(ctx context.Context, conn *response
 // Unlike HTTP requests (where http.Client.Timeout bounds a single roundtrip),
 // websocket reads may legitimately block for extended periods while the model
 // reasons (especially with high/xhigh reasoning effort). However, we still
-// cap per-read deadlines at fallbackWebSocketReadTimeout (10m) to prevent a
+// cap per-read deadlines at fallbackWebSocketReadTimeout (3m) to prevent a
 // hung API call from consuming the entire task budget. A single model turn
-// (even with xhigh reasoning) should complete well within 10 minutes; if it
+// (even with xhigh reasoning) should complete well within 3 minutes; if it
 // doesn't, the connection is likely hung and the retry/fallback logic should
 // kick in.
 //
 // When the context deadline is closer than the cap, we use the context
 // deadline (existing behavior). When the context deadline is much further
-// out (e.g. a 30-minute task budget), we cap at 10 minutes per read so
+// out (e.g. a 30-minute task budget), we cap at 3 minutes per read so
 // hung connections fail fast and can be retried.
-func (p *Provider) requestIODeadline(ctx context.Context, _ time.Time) (time.Time, bool) {
+func (p *Provider) requestIODeadline(ctx context.Context, now time.Time) (time.Time, bool) {
 	if d, ok := ctx.Deadline(); ok {
-		if cap := time.Now().Add(fallbackWebSocketReadTimeout); cap.Before(d) {
+		if cap := now.Add(fallbackWebSocketReadTimeout); cap.Before(d) {
 			return cap, true
 		}
 		return d, true

--- a/provider/openai/responses_ws_test.go
+++ b/provider/openai/responses_ws_test.go
@@ -839,6 +839,97 @@ func TestSendResponsesCreateLockedUsesFallbackReadTimeoutWithoutContextDeadline(
 	}
 }
 
+func TestSendResponsesCreateLockedRecomputesReadDeadlinePerEvent(t *testing.T) {
+	oldRead := fallbackWebSocketReadTimeout
+	oldWrite := fallbackWebSocketWriteTimeout
+	fallbackWebSocketReadTimeout = 150 * time.Millisecond
+	fallbackWebSocketWriteTimeout = 2 * time.Second
+	defer func() {
+		fallbackWebSocketReadTimeout = oldRead
+		fallbackWebSocketWriteTimeout = oldWrite
+	}()
+
+	upgrader := websocket.Upgrader{
+		CheckOrigin: func(r *http.Request) bool { return true },
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/responses" {
+			http.NotFound(w, r)
+			return
+		}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("websocket upgrade failed: %v", err)
+			return
+		}
+		defer conn.Close()
+
+		_, _, err = conn.ReadMessage()
+		if err != nil {
+			return
+		}
+
+		time.Sleep(100 * time.Millisecond)
+		if err := conn.WriteJSON(responsesWSEvent{Type: "response.output_text.delta"}); err != nil {
+			t.Errorf("write websocket progress event: %v", err)
+			return
+		}
+
+		time.Sleep(100 * time.Millisecond)
+		if err := conn.WriteJSON(responsesWSEvent{
+			Type: "response.completed",
+			Response: &responsesAPIResponse{
+				ID:     "resp_done",
+				Model:  "gpt-5.3-codex",
+				Output: []responsesOutputItem{},
+				Usage:  responsesUsage{},
+			},
+		}); err != nil {
+			t.Errorf("write websocket completed event: %v", err)
+			return
+		}
+	}))
+	defer server.Close()
+
+	p := New(
+		WithAPIKey("test-key"),
+		WithModel("gpt-5.3-codex"),
+		WithBaseURL(server.URL),
+		WithTransport("websocket"),
+	)
+	conn, err := p.ensureResponsesWebSocketLocked(context.Background())
+	if err != nil {
+		t.Fatalf("ensure websocket failed: %v", err)
+	}
+	defer p.resetResponsesWebSocketLocked()
+
+	req := &responsesRequest{
+		Model: "gpt-5.3-codex",
+		Input: []map[string]any{
+			responsesMessage("user", "hello"),
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 750*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	resp, err := p.sendResponsesCreateLocked(ctx, conn, req)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("expected rolling read deadlines to allow progress, got: %v", err)
+	}
+	if resp == nil || resp.ID != "resp_done" {
+		t.Fatalf("unexpected response: %#v", resp)
+	}
+	if elapsed < 180*time.Millisecond {
+		t.Fatalf("expected both delayed events to be read, took too little time: %v", elapsed)
+	}
+	if elapsed > time.Second {
+		t.Fatalf("expected response to complete promptly, took too long: %v", elapsed)
+	}
+}
+
 func TestRequestViaResponsesWebSocketUsesContextDeadlineNotHTTPTimeout(t *testing.T) {
 	upgrader := websocket.Upgrader{
 		CheckOrigin: func(r *http.Request) bool { return true },


### PR DESCRIPTION
## Summary
- Caps WebSocket read deadlines at 3 minutes instead of using the full context deadline (30-60min task budget)
- Hung first API calls now trigger retry + HTTP fallback instead of consuming the entire trial
- Affected ~11% of eval trials (24/201) which showed 0 tool calls and 0 tokens

## Data
Longest successful model call across 1144 calls with xhigh reasoning: **43.9s** (p99: 25.2s, p99.5: 29.4s). 3 minutes provides ample headroom for API load variance.

## Timeout chain for hung connections
1. WS read hangs → 3min timeout → reconnect + retry
2. Retry also hangs → 3min timeout → error
3. HTTP fallback triggers with remaining task budget
4. Total worst case: ~6 minutes before HTTP fallback (was: entire 30-60min budget)

## Test plan
- [x] `go test ./provider/openai/...` passes
- [x] `go build ./cmd/gollem/` compiles
- [ ] Verify in next Terminal-Bench run that 0-tool timeout trials are eliminated