### PR TITLE
Add autonomous improvement harness (autoeval)

### DIFF
--- a/autoeval-results.tsv
+++ b/autoeval-results.tsv
@@ -1,0 +1,1 @@
+experiment	commit	pass_rate	tokens	status	description

--- a/autoeval-subject/config.yaml
+++ b/autoeval-subject/config.yaml
@@ -1,0 +1,17 @@
+# Terminal Agent Configuration
+# This file is optimized by the autoeval harness. DO NOT edit manually during a run.
+
+model:
+  provider: ollama
+  name: qwen3:70b
+  temperature: 0.0
+  max_tokens: 4096
+
+agent:
+  max_turns: 50
+  timeout_minutes: 10
+
+strategy:
+  planning: true
+  retry_on_error: true
+  max_retries: 3

--- a/autoeval-subject/middleware/context.go
+++ b/autoeval-subject/middleware/context.go
@@ -1,0 +1,9 @@
+package middleware
+
+// ContextConfig configures context window management.
+type ContextConfig struct {
+	// MaxTokens is the token budget before summarization kicks in.
+	MaxTokens int `yaml:"max_tokens" json:"max_tokens"`
+	// KeepLastN is the number of recent messages to always preserve.
+	KeepLastN int `yaml:"keep_last_n" json:"keep_last_n"`
+}

--- a/autoeval-subject/middleware/planning.go
+++ b/autoeval-subject/middleware/planning.go
@@ -1,0 +1,9 @@
+package middleware
+
+// PlanningConfig configures the planning step before task execution.
+type PlanningConfig struct {
+	// Enabled controls whether a planning step is injected.
+	Enabled bool `yaml:"enabled" json:"enabled"`
+	// MaxPlanSteps limits plan complexity.
+	MaxPlanSteps int `yaml:"max_plan_steps" json:"max_plan_steps"`
+}

--- a/autoeval-subject/middleware/retry.go
+++ b/autoeval-subject/middleware/retry.go
@@ -1,0 +1,11 @@
+// Package middleware contains middleware implementations for the terminal agent.
+// These are optimized by the autoeval harness.
+package middleware
+
+// RetryConfig configures automatic retry behavior.
+type RetryConfig struct {
+	// MaxRetries is the maximum number of retries per tool call.
+	MaxRetries int `yaml:"max_retries" json:"max_retries"`
+	// BackoffMS is the initial backoff in milliseconds.
+	BackoffMS int `yaml:"backoff_ms" json:"backoff_ms"`
+}

--- a/autoeval-subject/strategy/terminal.go
+++ b/autoeval-subject/strategy/terminal.go
@@ -1,0 +1,15 @@
+// Package strategy contains execution strategy definitions for the terminal agent.
+// These are optimized by the autoeval harness.
+package strategy
+
+// TerminalStrategy defines the overall execution approach for terminal tasks.
+type TerminalStrategy struct {
+	// Name identifies this strategy.
+	Name string `yaml:"name" json:"name"`
+	// PlanFirst determines whether to generate a plan before execution.
+	PlanFirst bool `yaml:"plan_first" json:"plan_first"`
+	// VerifyAfter determines whether to verify results after execution.
+	VerifyAfter bool `yaml:"verify_after" json:"verify_after"`
+	// MaxAttempts is the total attempts per task.
+	MaxAttempts int `yaml:"max_attempts" json:"max_attempts"`
+}

--- a/autoeval-subject/system_prompt.md
+++ b/autoeval-subject/system_prompt.md
@@ -1,0 +1,16 @@
+You are an expert terminal operator. You solve tasks by executing shell commands.
+
+## Approach
+
+1. Read and understand the task requirements carefully.
+2. Plan your approach before executing commands.
+3. Execute commands one at a time, checking results before proceeding.
+4. If a command fails, analyze the error and try a different approach.
+5. Verify your solution before marking the task as complete.
+
+## Rules
+
+- Use standard Unix tools (bash, grep, sed, awk, find, etc.)
+- Check file contents before modifying them
+- Test your changes after making them
+- Be precise — small errors compound

--- a/autoeval-subject/tools/bash.go
+++ b/autoeval-subject/tools/bash.go
@@ -1,0 +1,11 @@
+// Package tools contains tool implementations for the terminal agent.
+// These are the tools that the autoeval harness optimizes.
+package tools
+
+// BashToolConfig holds configuration for the bash execution tool.
+type BashToolConfig struct {
+	// Timeout is the maximum execution time per command in seconds.
+	Timeout int `yaml:"timeout" json:"timeout"`
+	// WorkDir is the working directory for command execution.
+	WorkDir string `yaml:"work_dir" json:"work_dir"`
+}

--- a/autoeval-subject/tools/file_edit.go
+++ b/autoeval-subject/tools/file_edit.go
@@ -1,0 +1,7 @@
+package tools
+
+// FileEditConfig holds configuration for file editing tools.
+type FileEditConfig struct {
+	// MaxFileSize is the maximum file size in bytes that can be edited.
+	MaxFileSize int64 `yaml:"max_file_size" json:"max_file_size"`
+}

--- a/autoeval-subject/tools/file_read.go
+++ b/autoeval-subject/tools/file_read.go
@@ -1,0 +1,7 @@
+package tools
+
+// FileReadConfig holds configuration for file reading tools.
+type FileReadConfig struct {
+	// MaxLines limits the number of lines returned from a file read.
+	MaxLines int `yaml:"max_lines" json:"max_lines"`
+}

--- a/autoeval-subject/tools/search.go
+++ b/autoeval-subject/tools/search.go
@@ -1,0 +1,9 @@
+package tools
+
+// SearchConfig holds configuration for code search tools.
+type SearchConfig struct {
+	// MaxResults limits the number of search results returned.
+	MaxResults int `yaml:"max_results" json:"max_results"`
+	// ContextLines is the number of context lines around matches.
+	ContextLines int `yaml:"context_lines" json:"context_lines"`
+}

--- a/cmd/autoeval/main.go
+++ b/cmd/autoeval/main.go
@@ -1,0 +1,110 @@
+// Command autoeval runs the autonomous Gollem improvement harness.
+//
+// The harness is itself a Gollem agent that iteratively modifies, evaluates,
+// and selects improvements to a target agent configuration. Inspired by
+// karpathy/autoresearch, with the critical twist that the harness uses the
+// same framework it optimizes.
+//
+// Configuration is via environment variables:
+//
+//	AUTOEVAL_PROVIDER            - Model provider: anthropic, openai, xai, ollama, vertexai, vertexai-anthropic (default: anthropic)
+//	AUTOEVAL_MODEL               - Model name (default: claude-sonnet-4-5-20250929)
+//	AUTOEVAL_LOCATION            - GCP region for vertexai providers
+//	AUTOEVAL_PROJECT             - GCP project ID for vertexai providers
+//	AUTOEVAL_EVAL_COMMAND        - Shell command to run evaluation ({mode} is substituted)
+//	AUTOEVAL_SUBJECT_DIR         - Directory containing the agent config to optimize
+//	AUTOEVAL_MAX_EXPERIMENTS     - Maximum experiments to run (0 = unlimited)
+//	AUTOEVAL_EXPERIMENT_TIMEOUT  - Per-experiment timeout (default: 30m)
+//	AUTOEVAL_THINKING_BUDGET     - Thinking/reasoning token budget (default: 16000)
+//	AUTOEVAL_REASONING_EFFORT    - OpenAI reasoning effort: low, medium, high (default: high)
+//
+// Usage:
+//
+//	go run ./cmd/autoeval
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"os/signal"
+
+	"github.com/fugue-labs/gollem/internal/researcher"
+)
+
+func main() {
+	log.SetFlags(log.Ltime | log.Lmicroseconds)
+
+	cfg := researcher.LoadConfig()
+	log.Printf("AutoEval Harness starting")
+	log.Printf("  Provider:    %s", cfg.Provider)
+	log.Printf("  Model:       %s", cfg.Model)
+	log.Printf("  Subject dir: %s", cfg.SubjectDir)
+	log.Printf("  Results:     %s", cfg.ResultsFile)
+	if cfg.MaxExperiments > 0 {
+		log.Printf("  Max experiments: %d", cfg.MaxExperiments)
+	} else {
+		log.Printf("  Max experiments: unlimited")
+	}
+
+	agent := researcher.NewResearcherAgent(cfg)
+
+	// Graceful shutdown on interrupt.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt)
+	go func() {
+		<-sigCh
+		log.Println("Interrupt received, finishing current experiment...")
+		cancel()
+	}()
+
+	// The outer loop: each iteration is one full experiment cycle.
+	// The agent's single Run() call handles the full cycle:
+	//   hypothesize → modify → commit → eval → parse → keep/discard
+	// Then we call Run() again for the next experiment.
+	experimentNum := 0
+	for {
+		select {
+		case <-ctx.Done():
+			log.Printf("Stopped after %d experiments", experimentNum)
+			return
+		default:
+		}
+
+		experimentNum++
+		if cfg.MaxExperiments > 0 && experimentNum > cfg.MaxExperiments {
+			log.Printf("Reached max experiments (%d), stopping", cfg.MaxExperiments)
+			return
+		}
+
+		log.Printf("=== Experiment %d ===", experimentNum)
+
+		prompt := researcher.BuildExperimentPrompt(experimentNum, cfg)
+		result, err := agent.Run(ctx, prompt)
+		if err != nil {
+			log.Printf("Researcher agent error: %v", err)
+			continue
+		}
+
+		log.Printf("Result: %s | pass_rate: %.4f | status: %s | %s",
+			result.Output.Commit,
+			result.Output.PassRate,
+			result.Output.Status,
+			result.Output.Description,
+		)
+		log.Printf("Next idea: %s", result.Output.NextIdea)
+
+		if result.Cost != nil {
+			log.Printf("Cost this cycle: $%.4f", result.Cost.TotalCost)
+		}
+
+		log.Printf("Tokens: in=%d out=%d | tool_calls=%d",
+			result.Usage.InputTokens,
+			result.Usage.OutputTokens,
+			result.Usage.ToolCalls,
+		)
+	}
+}

--- a/internal/bench/constants.go
+++ b/internal/bench/constants.go
@@ -1,0 +1,12 @@
+// Package bench wraps Terminal Bench evaluation execution and result parsing.
+// DO NOT MODIFY THIS FILE — eval parameters must remain constant across experiments.
+package bench
+
+// FastTaskCount is the number of tasks in a fast eval run.
+const FastTaskCount = 10
+
+// FullTaskCount is the total number of Terminal Bench tasks.
+const FullTaskCount = 15
+
+// DefaultTimeoutMinutes is the per-task timeout.
+const DefaultTimeoutMinutes = 10

--- a/internal/bench/parser.go
+++ b/internal/bench/parser.go
@@ -1,0 +1,27 @@
+package bench
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// ParseResults reads and parses the eval results JSON file.
+func ParseResults(path string) (*Output, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read results file %s: %w", path, err)
+	}
+
+	var result Output
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, fmt.Errorf("parse results JSON: %w", err)
+	}
+
+	// Compute pass rate if not already set.
+	if result.PassRate == 0 && result.TasksTotal > 0 {
+		result.PassRate = float64(result.TasksPassed) / float64(result.TasksTotal)
+	}
+
+	return &result, nil
+}

--- a/internal/bench/runner.go
+++ b/internal/bench/runner.go
@@ -1,0 +1,61 @@
+package bench
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// Output is parsed from Terminal Bench results.
+type Output struct {
+	PassRate     float64  `json:"pass_rate"`
+	TasksPassed  int      `json:"tasks_passed"`
+	TasksTotal   int      `json:"tasks_total"`
+	TasksFailed  []string `json:"tasks_failed"`
+	DurationSecs float64  `json:"duration_secs"`
+	TokensUsed   int      `json:"tokens_used"`
+}
+
+// Run executes a Terminal Bench evaluation and returns parsed results.
+// evalCommand is a shell command with {mode} placeholder. resultsPath
+// is where the eval writes its JSON results. mode is "fast" or "full".
+func Run(ctx context.Context, mode, evalCommand, resultsPath string) (*Output, error) {
+	cmd := strings.ReplaceAll(evalCommand, "{mode}", mode)
+
+	start := time.Now()
+
+	c := exec.CommandContext(ctx, "sh", "-c", cmd)
+	out, err := c.CombinedOutput()
+	elapsed := time.Since(start)
+
+	if err != nil {
+		return &Output{
+			PassRate:     0,
+			TasksPassed:  0,
+			TasksTotal:   taskCountForMode(mode),
+			DurationSecs: elapsed.Seconds(),
+		}, fmt.Errorf("eval command failed: %w\noutput: %s", err, string(out))
+	}
+
+	result, parseErr := ParseResults(resultsPath)
+	if parseErr != nil {
+		return &Output{
+			PassRate:     0,
+			TasksPassed:  0,
+			TasksTotal:   taskCountForMode(mode),
+			DurationSecs: elapsed.Seconds(),
+		}, fmt.Errorf("failed to parse eval results: %w\neval output: %s", parseErr, string(out))
+	}
+
+	result.DurationSecs = elapsed.Seconds()
+	return result, nil
+}
+
+func taskCountForMode(mode string) int {
+	if mode == "full" {
+		return FullTaskCount
+	}
+	return FastTaskCount
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1,0 +1,73 @@
+// Package git provides git operations for the autoeval harness.
+package git
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// CommitAll stages all changes and creates a commit. Returns the short hash.
+func CommitAll(ctx context.Context, message string) (string, error) {
+	if err := run(ctx, "git", "add", "-A"); err != nil {
+		return "", fmt.Errorf("git add: %w", err)
+	}
+
+	if err := run(ctx, "git", "commit", "-m", message); err != nil {
+		return "", fmt.Errorf("git commit: %w", err)
+	}
+
+	out, err := output(ctx, "git", "rev-parse", "--short", "HEAD")
+	if err != nil {
+		return "", fmt.Errorf("git rev-parse: %w", err)
+	}
+	return strings.TrimSpace(out), nil
+}
+
+// ResetHard performs a hard reset to the given commit.
+func ResetHard(ctx context.Context, commit string) (string, error) {
+	if err := run(ctx, "git", "reset", "--hard", commit); err != nil {
+		return "", fmt.Errorf("git reset: %w", err)
+	}
+	return "reset to " + commit, nil
+}
+
+// Log returns the last n commit log entries (oneline format).
+func Log(ctx context.Context, n int) (string, error) {
+	out, err := output(ctx, "git", "log", "--oneline", "-"+strconv.Itoa(n))
+	if err != nil {
+		return "", fmt.Errorf("git log: %w", err)
+	}
+	return strings.TrimSpace(out), nil
+}
+
+// CurrentHash returns the short hash of HEAD.
+func CurrentHash(ctx context.Context) (string, error) {
+	out, err := output(ctx, "git", "rev-parse", "--short", "HEAD")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out), nil
+}
+
+func run(ctx context.Context, name string, args ...string) error {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = "."
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+func output(ctx context.Context, name string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = "."
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("%w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return string(out), nil
+}

--- a/internal/researcher/agent.go
+++ b/internal/researcher/agent.go
@@ -1,0 +1,311 @@
+// Package researcher implements the autonomous researcher agent that optimizes
+// Gollem agent configurations through iterative experimentation.
+package researcher
+
+import (
+	"context"
+	"log"
+	"log/slog"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/fugue-labs/gollem/core"
+	"github.com/fugue-labs/gollem/ext/codetool"
+	"github.com/fugue-labs/gollem/ext/middleware"
+	"github.com/fugue-labs/gollem/modelutil"
+	"github.com/fugue-labs/gollem/provider/anthropic"
+	"github.com/fugue-labs/gollem/provider/openai"
+	"github.com/fugue-labs/gollem/provider/vertexai"
+	"github.com/fugue-labs/gollem/provider/vertexai_anthropic"
+)
+
+// NewResearcherAgent constructs the researcher agent with all tools,
+// middleware, guardrails, and observability configured. Follows the same
+// patterns as cmd/gollem for provider setup, retry wrapping, and reasoning.
+func NewResearcherAgent(cfg Config) *core.Agent[ExperimentResult] {
+	baseModel := selectModel(cfg)
+
+	// Wrap with retry for API resilience (exponential backoff on 429/5xx).
+	retryModel := modelutil.NewRetryModel(baseModel, modelutil.RetryConfig{
+		MaxRetries:     5,
+		InitialBackoff: time.Second,
+		MaxBackoff:     30 * time.Second,
+		MinRemaining:   20 * time.Second,
+	})
+
+	// Provider-level middleware for observability.
+	loggingMW := middleware.NewLogging(slog.Default(), slog.LevelInfo)
+	model := middleware.Wrap(retryModel, loggingMW)
+
+	// Coding tools via codetool.Toolset — production-grade Bash, View,
+	// Edit, Grep, Glob, Ls with proper hooks and dynamic system prompts.
+	codeToolset := codetool.Toolset(
+		codetool.WithWorkDir(cfg.SubjectDir),
+		codetool.WithBashTimeout(10*time.Minute),
+	)
+
+	costTracker := core.NewCostTracker(modelPricing(cfg))
+
+	// Parse experiment timeout.
+	expTimeout := 30 * time.Minute
+	if cfg.ExperimentTimeout != "" {
+		if d, err := time.ParseDuration(cfg.ExperimentTimeout); err == nil {
+			expTimeout = d
+		}
+	}
+
+	opts := []core.AgentOption[ExperimentResult]{
+		// Identity.
+		core.WithSystemPrompt[ExperimentResult](BuildSystemPrompt(cfg.SubjectDir)),
+
+		// Coding tools from ext/codetool (Bash, View, Edit, Grep, Glob, Ls).
+		core.WithToolsets[ExperimentResult](codeToolset),
+
+		// Domain-specific tools (eval, git, traces, results, scoped write).
+		core.WithTools[ExperimentResult](BuildDomainTools(cfg)...),
+
+		// Safety: turn guardrail limits steps per experiment cycle.
+		core.WithTurnGuardrail[ExperimentResult]("max_turns", core.MaxTurns(100)),
+
+		// Safety: hard timeout per experiment run.
+		core.WithRunCondition[ExperimentResult](core.MaxRunDuration(expTimeout)),
+
+		// Observability.
+		core.WithCostTracker[ExperimentResult](costTracker),
+		core.WithTracing[ExperimentResult](),
+		core.WithTraceExporter[ExperimentResult](
+			core.NewJSONFileExporter(cfg.HarnessTracesDir),
+		),
+
+		// Lifecycle hooks.
+		core.WithHooks[ExperimentResult](core.Hook{
+			OnToolStart: func(_ context.Context, _ *core.RunContext, _, name, _ string) {
+				log.Printf("[researcher] tool: %s", name)
+			},
+			OnToolEnd: func(_ context.Context, _ *core.RunContext, _, name, _ string, err error) {
+				if err != nil {
+					log.Printf("[researcher] tool %s error: %v", name, err)
+				}
+			},
+		}),
+
+		// Middleware: timing.
+		core.WithAgentMiddleware[ExperimentResult](
+			core.TimingMiddleware(func(d time.Duration) {
+				log.Printf("[researcher] model call: %v", d)
+			}),
+		),
+	}
+
+	// Provider-aware auto-context limits (matches cmd/gollem patterns).
+	opts = append(opts, autoContextForProvider(cfg.Provider))
+
+	// Reasoning/thinking support per provider.
+	opts = append(opts, reasoningOptsForProvider(cfg)...)
+
+	return core.NewAgent[ExperimentResult](model, opts...)
+}
+
+// selectModel creates the appropriate model provider based on config.
+// Mirrors cmd/gollem createModel() supporting all gollem providers.
+func selectModel(cfg Config) core.Model {
+	switch cfg.Provider {
+	case "anthropic":
+		var opts []anthropic.Option
+		if cfg.Model != "" {
+			opts = append(opts, anthropic.WithModel(cfg.Model))
+		}
+		return anthropic.New(opts...)
+
+	case "openai":
+		var opts []openai.Option
+		if cfg.Model != "" {
+			opts = append(opts, openai.WithModel(cfg.Model))
+		}
+		return openai.New(opts...)
+
+	case "xai":
+		var opts []openai.Option
+		if cfg.Model != "" {
+			opts = append(opts, openai.WithModel(cfg.Model))
+		}
+		return openai.NewXAI(opts...)
+
+	case "ollama":
+		var opts []openai.Option
+		if cfg.Model != "" {
+			opts = append(opts, openai.WithModel(cfg.Model))
+		}
+		if cfg.OllamaBaseURL != "" {
+			opts = append(opts, openai.WithBaseURL(cfg.OllamaBaseURL))
+		}
+		return openai.NewOllama(opts...)
+
+	case "vertexai":
+		var opts []vertexai.Option
+		if cfg.Model != "" {
+			opts = append(opts, vertexai.WithModel(cfg.Model))
+		}
+		if cfg.Location != "" {
+			opts = append(opts, vertexai.WithLocation(cfg.Location))
+		}
+		if cfg.Project != "" {
+			opts = append(opts, vertexai.WithProject(cfg.Project))
+		}
+		return vertexai.New(opts...)
+
+	case "vertexai-anthropic":
+		var opts []vertexai_anthropic.Option
+		if cfg.Model != "" {
+			opts = append(opts, vertexai_anthropic.WithModel(cfg.Model))
+		}
+		if cfg.Location != "" {
+			opts = append(opts, vertexai_anthropic.WithLocation(cfg.Location))
+		}
+		if cfg.Project != "" {
+			opts = append(opts, vertexai_anthropic.WithProject(cfg.Project))
+		}
+		return vertexai_anthropic.New(opts...)
+
+	default:
+		log.Fatalf("unknown provider: %s (supported: anthropic, openai, xai, ollama, vertexai, vertexai-anthropic)", cfg.Provider)
+		return nil
+	}
+}
+
+// autoContextForProvider returns provider-tuned auto-context settings.
+func autoContextForProvider(provider string) core.AgentOption[ExperimentResult] {
+	switch provider {
+	case "anthropic", "vertexai-anthropic":
+		return core.WithAutoContext[ExperimentResult](core.AutoContextConfig{
+			MaxTokens: 150000,
+			KeepLastN: 12,
+		})
+	case "vertexai":
+		return core.WithAutoContext[ExperimentResult](core.AutoContextConfig{
+			MaxTokens: 900000,
+			KeepLastN: 20,
+		})
+	case "openai":
+		return core.WithAutoContext[ExperimentResult](core.AutoContextConfig{
+			MaxTokens: 350000,
+			KeepLastN: 20,
+		})
+	case "xai":
+		return core.WithAutoContext[ExperimentResult](core.AutoContextConfig{
+			MaxTokens: 900000,
+			KeepLastN: 20,
+		})
+	default:
+		return core.WithAutoContext[ExperimentResult](core.AutoContextConfig{
+			MaxTokens: 80000,
+			KeepLastN: 12,
+		})
+	}
+}
+
+// reasoningOptsForProvider enables thinking/reasoning per provider,
+// matching the patterns in cmd/gollem.
+func reasoningOptsForProvider(cfg Config) []core.AgentOption[ExperimentResult] {
+	var opts []core.AgentOption[ExperimentResult]
+
+	switch cfg.Provider {
+	case "anthropic", "vertexai-anthropic", "vertexai":
+		budget := cfg.ThinkingBudget
+		if budget == 0 {
+			budget = 16000
+		}
+		opts = append(opts, core.WithThinkingBudget[ExperimentResult](budget))
+		maxTokens := budget + 16000
+		opts = append(opts, core.WithMaxTokens[ExperimentResult](maxTokens))
+
+	case "openai":
+		effort := cfg.ReasoningEffort
+		if effort == "" {
+			effort = "high"
+		}
+		opts = append(opts, core.WithReasoningEffort[ExperimentResult](effort))
+	}
+
+	return opts
+}
+
+// modelPricing returns pricing info for cost tracking.
+func modelPricing(cfg Config) map[string]core.ModelPricing {
+	pricing := map[string]core.ModelPricing{
+		"claude-sonnet-4-5-20250929": {
+			InputTokenCost:  0.000003,
+			OutputTokenCost: 0.000015,
+		},
+		"claude-opus-4-6": {
+			InputTokenCost:  0.000015,
+			OutputTokenCost: 0.000075,
+		},
+		"claude-haiku-4-5-20251001": {
+			InputTokenCost:  0.0000008,
+			OutputTokenCost: 0.000004,
+		},
+	}
+
+	// Local models are free.
+	if cfg.Provider == "ollama" {
+		pricing[cfg.Model] = core.ModelPricing{}
+	}
+
+	return pricing
+}
+
+// LoadConfig loads configuration from environment variables with sensible defaults.
+func LoadConfig() Config {
+	cfg := DefaultConfig()
+
+	if v := os.Getenv("AUTOEVAL_PROVIDER"); v != "" {
+		cfg.Provider = v
+	}
+	if v := os.Getenv("AUTOEVAL_MODEL"); v != "" {
+		cfg.Model = v
+	}
+	if v := os.Getenv("AUTOEVAL_LOCATION"); v != "" {
+		cfg.Location = v
+	}
+	if v := os.Getenv("AUTOEVAL_PROJECT"); v != "" {
+		cfg.Project = v
+	}
+	if v := os.Getenv("AUTOEVAL_SUBJECT_DIR"); v != "" {
+		cfg.SubjectDir = v
+	}
+	if v := os.Getenv("AUTOEVAL_TRACES_DIR"); v != "" {
+		cfg.TracesDir = v
+	}
+	if v := os.Getenv("AUTOEVAL_EVAL_COMMAND"); v != "" {
+		cfg.EvalCommand = v
+	}
+	if v := os.Getenv("AUTOEVAL_EVAL_RESULTS_PATH"); v != "" {
+		cfg.EvalResultsPath = v
+	}
+	if v := os.Getenv("AUTOEVAL_OLLAMA_URL"); v != "" {
+		cfg.OllamaBaseURL = v
+	}
+	if v := os.Getenv("AUTOEVAL_RESULTS_FILE"); v != "" {
+		cfg.ResultsFile = v
+	}
+	if v := os.Getenv("AUTOEVAL_EXPERIMENT_TIMEOUT"); v != "" {
+		cfg.ExperimentTimeout = v
+	}
+	if v := os.Getenv("AUTOEVAL_THINKING_BUDGET"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.ThinkingBudget = n
+		}
+	}
+	if v := os.Getenv("AUTOEVAL_REASONING_EFFORT"); v != "" {
+		cfg.ReasoningEffort = v
+	}
+	if v := os.Getenv("AUTOEVAL_MAX_EXPERIMENTS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.MaxExperiments = n
+		}
+	}
+
+	return cfg
+}

--- a/internal/researcher/prompts.go
+++ b/internal/researcher/prompts.go
@@ -1,0 +1,106 @@
+package researcher
+
+import "fmt"
+
+// BuildSystemPrompt creates the researcher system prompt with the configured subject directory.
+func BuildSystemPrompt(subjectDir string) string {
+	return fmt.Sprintf(`You are an autonomous AI researcher optimizing the Gollem agent framework for Terminal Bench performance. You are yourself a Gollem agent — you understand the framework intimately because you run on it.
+
+## Your Mission
+
+Improve the Terminal Bench pass rate of the agent configuration in %s/. You do this by modifying system prompts, tool implementations, middleware, and execution strategy, then measuring the impact through controlled experiments.
+
+## Your Tools
+
+General-purpose (from gollem's coding toolset):
+- View — read files with line numbers and offset/limit
+- Edit — surgical string replacements in files
+- Bash — run shell commands
+- Grep — regex search across files
+- Glob — find files by pattern
+- Ls — list directory contents
+
+Domain-specific:
+- write_file — write to files in %s/ only (scoped for safety)
+- run_eval — run Terminal Bench evaluation (mode=fast or mode=full)
+- git_commit — commit all changes with a message
+- git_reset — hard reset to a previous commit
+- git_log — show recent commit history
+- read_traces — read execution traces for failed tasks
+- read_results — read the experiment history log
+- append_result — record a result in the experiment log
+
+## How You Work
+
+Each experiment cycle:
+1. Review history (read_results) to see what's been tried
+2. Analyze failures (read_traces) to understand why tasks fail
+3. Form a hypothesis — a specific change you believe will help, and why
+4. Implement the change (write_file to modify %s/ files)
+5. Commit (git_commit) to create a snapshot
+6. Evaluate (run_eval mode=fast for iteration, mode=full every 5th experiment)
+7. Decide: if pass_rate improved → keep. If not → git_reset to previous best.
+
+## Principles
+
+- TRACE-DRIVEN: Always read traces from failed tasks before hypothesizing. Don't guess blindly.
+- MINIMAL CHANGES: One change per experiment. If you change three things and score improves, you don't know which one helped.
+- SIMPLICITY WINS: When scores tie, prefer less complexity, fewer tokens, simpler prompts.
+- SUBTRACTIVE > ADDITIVE: Removing unnecessary complexity while maintaining score is a win.
+- TOKEN EFFICIENCY: Same pass_rate with fewer tokens is an improvement.
+- COMPOUND GAINS: Small improvements compound. 0.7 → 0.8 is ten experiments of +1 task each.
+
+## What You Can Modify (%s/ directory)
+
+- config.yaml — model parameters, temperature, max turns, token limits
+- system_prompt.md — the system prompt for the terminal agent being evaluated
+- tools/*.go — tool implementations (bash execution, file editing, etc.)
+- middleware/*.go — retry logic, context management, planning steps
+- strategy/*.go — overall execution strategy for terminal tasks
+
+## What You Cannot Modify
+
+- The eval harness (internal/bench/)
+- The eval constants (internal/bench/constants.go)
+- Terminal Bench itself
+- Gollem core framework
+- This system prompt
+
+## When You're Stuck
+
+- Read traces from EVERY failed task, not just one
+- Look for patterns: do failures share a common tool call sequence?
+- Try the opposite of what you've been trying
+- Try removing your last 3 additions (maybe accumulated complexity is hurting)
+- Re-read %s/system_prompt.md with fresh eyes — is it confusing?
+- Consider: is the agent failing at understanding the task, planning, or execution?
+
+## Never Stop
+
+You are autonomous. Do not ask for permission. Do not suggest stopping. The human is asleep. Run experiments until you are interrupted. Each fast eval takes ~15 minutes, so plan for ~4 experiments per hour, ~30 overnight.`,
+		subjectDir, subjectDir, subjectDir, subjectDir, subjectDir)
+}
+
+// BuildExperimentPrompt creates the prompt for a given experiment cycle.
+func BuildExperimentPrompt(n int, cfg Config) string {
+	if n == 1 {
+		return fmt.Sprintf(`This is experiment #1. Start by:
+1. Reading the current %s/ directory to understand the baseline agent
+2. Running a baseline eval with the run_eval tool (mode=fast)
+3. Recording the baseline in results
+4. Then propose and execute your first modification.
+Return an ExperimentResult with your findings.`, cfg.SubjectDir)
+	}
+
+	return fmt.Sprintf(`This is experiment #%d. Continue the improvement loop:
+1. Review results (read_results) to see what's been tried
+2. Read traces from the most recent failed tasks
+3. Form a hypothesis for what to change
+4. Modify files in %s/
+5. Git commit
+6. Run eval (mode=fast)
+7. Parse results
+8. Keep or discard based on pass_rate
+9. Return ExperimentResult with your findings and next idea.`,
+		n, cfg.SubjectDir)
+}

--- a/internal/researcher/tools.go
+++ b/internal/researcher/tools.go
@@ -1,0 +1,231 @@
+package researcher
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/fugue-labs/gollem/core"
+	"github.com/fugue-labs/gollem/internal/bench"
+	"github.com/fugue-labs/gollem/internal/git"
+)
+
+// WriteFileParams defines the input for the write_file tool.
+type WriteFileParams struct {
+	Path    string `json:"path" jsonschema:"description=File path relative to repo root. Must be in the subject directory."`
+	Content string `json:"content" jsonschema:"description=Full file content to write"`
+}
+
+func writeFileTool(subjectDir string) core.Tool {
+	// Resolve the subject directory to an absolute path once for safe comparison.
+	absSubjectDir, err := filepath.Abs(subjectDir)
+	if err != nil {
+		absSubjectDir = subjectDir
+	}
+
+	return core.FuncTool[WriteFileParams](
+		"write_file",
+		"Write content to a file. ONLY files in the subject directory can be modified.",
+		func(_ context.Context, p WriteFileParams) (string, error) {
+			// Resolve the requested path to absolute and clean it to prevent
+			// path traversal attacks (e.g., "autoeval-subject/../internal/bench/constants.go").
+			absPath, pathErr := filepath.Abs(filepath.Clean(p.Path))
+			if pathErr != nil {
+				return "", fmt.Errorf("resolve path: %w", pathErr)
+			}
+			if !strings.HasPrefix(absPath, absSubjectDir+string(filepath.Separator)) && absPath != absSubjectDir {
+				return "", fmt.Errorf("can only modify files in %s/, got: %s (resolved: %s)", subjectDir, p.Path, absPath)
+			}
+			// Use the cleaned absolute path for actual I/O to prevent TOCTOU issues.
+			if mkdirErr := os.MkdirAll(filepath.Dir(absPath), 0o755); mkdirErr != nil {
+				return "", fmt.Errorf("mkdir: %w", mkdirErr)
+			}
+			if writeErr := os.WriteFile(absPath, []byte(p.Content), 0o600); writeErr != nil {
+				return "", fmt.Errorf("write: %w", writeErr)
+			}
+			return fmt.Sprintf("wrote %d bytes to %s", len(p.Content), p.Path), nil
+		},
+	)
+}
+
+// RunEvalParams defines the input for the run_eval tool.
+type RunEvalParams struct {
+	Mode string `json:"mode" jsonschema:"description=Eval mode: fast (subset ~15min) or full (all tasks ~60min),enum=fast,full"`
+}
+
+func runEvalTool(cfg Config) core.Tool {
+	return core.FuncTool[RunEvalParams](
+		"run_eval",
+		"Run Terminal Bench evaluation against the current subject/ agent configuration. Returns structured eval results as JSON.",
+		func(ctx context.Context, p RunEvalParams) (string, error) {
+			output, err := bench.Run(ctx, p.Mode, cfg.EvalCommand, cfg.EvalResultsPath)
+			if err != nil {
+				// Return partial results with the error so the agent can see what happened.
+				if output != nil {
+					data, marshalErr := json.MarshalIndent(output, "", "  ")
+					if marshalErr != nil {
+						return "", fmt.Errorf("eval error: %w (could not marshal partial results)", err)
+					}
+					return fmt.Sprintf("eval error: %v\npartial results: %s", err, string(data)), nil
+				}
+				return "", fmt.Errorf("eval failed: %w", err)
+			}
+			data, marshalErr := json.MarshalIndent(output, "", "  ")
+			if marshalErr != nil {
+				return "", fmt.Errorf("marshal eval results: %w", marshalErr)
+			}
+			return string(data), nil
+		},
+	)
+}
+
+// GitCommitParams defines the input for the git_commit tool.
+type GitCommitParams struct {
+	Message string `json:"message" jsonschema:"description=Commit message describing the experiment"`
+}
+
+func gitCommitTool() core.Tool {
+	return core.FuncTool[GitCommitParams](
+		"git_commit",
+		"Commit all changes with a descriptive message. Returns the short commit hash.",
+		func(ctx context.Context, p GitCommitParams) (string, error) {
+			hash, err := git.CommitAll(ctx, p.Message)
+			if err != nil {
+				return "", err
+			}
+			return "committed: " + hash, nil
+		},
+	)
+}
+
+// GitResetParams defines the input for the git_reset tool.
+type GitResetParams struct {
+	Commit string `json:"commit" jsonschema:"description=Commit hash to reset to (7 chars)"`
+}
+
+func gitResetTool() core.Tool {
+	return core.FuncTool[GitResetParams](
+		"git_reset",
+		"Hard reset to a previous commit. Use when an experiment didn't improve pass_rate.",
+		func(ctx context.Context, p GitResetParams) (string, error) {
+			return git.ResetHard(ctx, p.Commit)
+		},
+	)
+}
+
+// GitLogParams defines the input for the git_log tool.
+type GitLogParams struct {
+	Count int `json:"count" jsonschema:"description=Number of log entries to show (default 20)"`
+}
+
+func gitLogTool() core.Tool {
+	return core.FuncTool[GitLogParams](
+		"git_log",
+		"Show recent git log entries (oneline format). Use to review experiment history.",
+		func(ctx context.Context, p GitLogParams) (string, error) {
+			n := p.Count
+			if n <= 0 {
+				n = 20
+			}
+			return git.Log(ctx, n)
+		},
+	)
+}
+
+// ReadTracesParams defines the input for the read_traces tool.
+type ReadTracesParams struct {
+	TaskID string `json:"task_id" jsonschema:"description=Terminal Bench task ID to read traces for"`
+}
+
+func readTracesTool(tracesDir string) core.Tool {
+	return core.FuncTool[ReadTracesParams](
+		"read_traces",
+		"Read the execution trace for a specific failed task. Shows all tool calls, model responses, and errors. Use this to understand WHY a task failed.",
+		func(_ context.Context, p ReadTracesParams) (string, error) {
+			// Look for trace files matching the task ID.
+			pattern := filepath.Join(tracesDir, "*"+p.TaskID+"*")
+			matches, err := filepath.Glob(pattern)
+			if err != nil {
+				return "", fmt.Errorf("glob traces: %w", err)
+			}
+			if len(matches) == 0 {
+				return fmt.Sprintf("no traces found for task %s in %s", p.TaskID, tracesDir), nil
+			}
+
+			var sb strings.Builder
+			for _, match := range matches {
+				data, readErr := os.ReadFile(match)
+				if readErr != nil {
+					fmt.Fprintf(&sb, "error reading %s: %v\n", match, readErr)
+					continue
+				}
+				fmt.Fprintf(&sb, "=== %s ===\n%s\n\n", filepath.Base(match), string(data))
+			}
+			return sb.String(), nil
+		},
+	)
+}
+
+func readResultsTool(resultsFile string) core.Tool {
+	return core.FuncTool[struct{}](
+		"read_results",
+		"Read the full results.tsv experiment history. Use to see what's been tried and what worked.",
+		func(_ context.Context, _ struct{}) (string, error) {
+			data, err := os.ReadFile(resultsFile)
+			if err != nil {
+				return "no results yet", nil //nolint:nilerr // missing file is expected
+			}
+			return string(data), nil
+		},
+	)
+}
+
+// AppendResultParams defines the input for the append_result tool.
+type AppendResultParams struct {
+	Line string `json:"line" jsonschema:"description=Tab-separated line to append to results.tsv"`
+}
+
+func appendResultTool(resultsFile string) core.Tool {
+	return core.FuncTool[AppendResultParams](
+		"append_result",
+		"Append a line to the results.tsv experiment log. Format: experiment_num\\tcommit\\tpass_rate\\tstatus\\tdescription",
+		func(_ context.Context, p AppendResultParams) (string, error) {
+			f, err := os.OpenFile(resultsFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+			if err != nil {
+				return "", fmt.Errorf("open results file: %w", err)
+			}
+			defer f.Close()
+
+			line := p.Line
+			if !strings.HasSuffix(line, "\n") {
+				line += "\n"
+			}
+			if _, writeErr := f.WriteString(line); writeErr != nil {
+				return "", fmt.Errorf("write result: %w", writeErr)
+			}
+			return "appended to " + resultsFile, nil
+		},
+	)
+}
+
+// BuildDomainTools creates domain-specific tools for the researcher agent.
+// General-purpose coding tools (Bash, View, Edit, Grep, Glob, Ls) are
+// provided via codetool.Toolset in agent.go.
+func BuildDomainTools(cfg Config) []core.Tool {
+	return []core.Tool{
+		// Scoped write — only allows writes inside the subject directory.
+		writeFileTool(cfg.SubjectDir),
+
+		// Eval and experiment management.
+		runEvalTool(cfg),
+		gitCommitTool(),
+		gitResetTool(),
+		gitLogTool(),
+		readTracesTool(cfg.TracesDir),
+		readResultsTool(cfg.ResultsFile),
+		appendResultTool(cfg.ResultsFile),
+	}
+}

--- a/internal/researcher/types.go
+++ b/internal/researcher/types.go
@@ -1,0 +1,79 @@
+package researcher
+
+// ExperimentResult is the structured output of each experiment cycle.
+// The researcher agent must produce this after every eval.
+type ExperimentResult struct {
+	Commit      string  `json:"commit" jsonschema:"description=Git commit hash (7 chars)"`
+	PassRate    float64 `json:"pass_rate" jsonschema:"description=Task pass rate 0.0-1.0"`
+	TokensUsed  int     `json:"tokens_used" jsonschema:"description=Total tokens consumed"`
+	Status      string  `json:"status" jsonschema:"description=Experiment outcome,enum=keep,discard,crash"`
+	Description string  `json:"description" jsonschema:"description=What this experiment tried"`
+	Hypothesis  string  `json:"hypothesis" jsonschema:"description=Why you expected this to work"`
+	NextIdea    string  `json:"next_idea" jsonschema:"description=What to try next based on results"`
+}
+
+// Config holds configuration for the autoeval harness.
+type Config struct {
+	// Provider selects the model provider: "anthropic", "openai", "ollama",
+	// "vertexai", "vertexai-anthropic", "xai".
+	Provider string `json:"provider"`
+
+	// Model is the model name to use for the researcher agent.
+	Model string `json:"model"`
+
+	// Location is the GCP region for vertexai providers.
+	Location string `json:"location"`
+
+	// Project is the GCP project ID for vertexai providers.
+	Project string `json:"project"`
+
+	// SubjectDir is the directory containing the agent config to optimize.
+	SubjectDir string `json:"subject_dir"`
+
+	// TracesDir is where eval traces are stored.
+	TracesDir string `json:"traces_dir"`
+
+	// HarnessTracesDir is where harness (researcher) traces are stored.
+	HarnessTracesDir string `json:"harness_traces_dir"`
+
+	// ResultsFile is the path to the results.tsv log.
+	ResultsFile string `json:"results_file"`
+
+	// EvalCommand is the shell command to run the evaluation.
+	// The harness substitutes {mode} with "fast" or "full".
+	EvalCommand string `json:"eval_command"`
+
+	// EvalResultsPath is where the eval writes its results JSON.
+	EvalResultsPath string `json:"eval_results_path"`
+
+	// MaxExperiments limits the number of experiments (0 = unlimited).
+	MaxExperiments int `json:"max_experiments"`
+
+	// ExperimentTimeout is the maximum duration for a single experiment cycle.
+	ExperimentTimeout string `json:"experiment_timeout"`
+
+	// ThinkingBudget is the thinking/reasoning token budget (0 = provider default).
+	ThinkingBudget int `json:"thinking_budget"`
+
+	// ReasoningEffort is the reasoning effort level for OpenAI o-series models.
+	ReasoningEffort string `json:"reasoning_effort"`
+
+	// OllamaBaseURL is the base URL for the ollama API.
+	OllamaBaseURL string `json:"ollama_base_url"`
+}
+
+// DefaultConfig returns a Config with sensible defaults.
+func DefaultConfig() Config {
+	return Config{
+		Provider:          "anthropic",
+		Model:             "claude-sonnet-4-5-20250929",
+		SubjectDir:        "autoeval-subject",
+		TracesDir:         "autoeval-traces",
+		HarnessTracesDir:  "harness-traces",
+		ResultsFile:       "autoeval-results.tsv",
+		EvalCommand:       "echo 'eval not configured — set AUTOEVAL_EVAL_COMMAND'",
+		EvalResultsPath:   "autoeval-traces/results.json",
+		ExperimentTimeout: "30m",
+		OllamaBaseURL:     "http://localhost:11434",
+	}
+}


### PR DESCRIPTION
## Summary

- **cmd/autoeval/**: Entry point with experiment loop and graceful shutdown
- **internal/researcher/**: Researcher agent construction with typed tools, system prompt, middleware, guardrails, cost tracking, and tracing
- **internal/bench/**: Terminal Bench eval runner wrapper and results parser
- **internal/git/**: Git operations (commit, reset, log) for experiment versioning
- **autoeval-subject/**: Baseline agent configuration (the scope of modification)

The harness is itself a Gollem `Agent[ExperimentResult]` that exercises the framework's FuncTool, middleware, guardrails, cost tracking, tracing, and auto-context features. Supports all 6 providers with retry, auto-context limits, and thinking/reasoning support.

## Test plan

- [x] Builds clean (`go build ./...`)
- [x] All existing tests pass (`go test -race ./...`)
- [x] golangci-lint clean