### PR TITLE
Add Temporal coverage tests

### DIFF
--- a/core/agent_runtime_test.go
+++ b/core/agent_runtime_test.go
@@ -1,0 +1,354 @@
+package core
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+)
+
+type runtimeConfigOutput struct {
+	Answer string `json:"answer"`
+}
+
+type runtimeConfigDeps struct {
+	Token string `json:"token"`
+}
+
+type runtimeConfigExporter struct{}
+
+func (runtimeConfigExporter) Export(context.Context, *RunTrace) error { return nil }
+
+func TestAgentRuntimeConfig_ClonesAndExports(t *testing.T) {
+	model := NewTestModel(TextResponse("ok"))
+
+	directTool := FuncTool[struct {
+		Value int `json:"value"`
+	}]("direct_tool", "Direct tool", func(_ context.Context, _ struct {
+		Value int `json:"value"`
+	}) (string, error) {
+		return "direct", nil
+	})
+	preparedTool := FuncTool[struct{}]("prepared_tool", "Prepared tool", func(_ context.Context, _ struct{}) (string, error) {
+		return "prepared", nil
+	})
+	preparedTool.PrepareFunc = func(_ context.Context, _ *RunContext, def ToolDefinition) *ToolDefinition {
+		def.Description = "prepared copy"
+		return &def
+	}
+	toolsetTool := FuncTool[struct{}]("toolset_tool", "Toolset tool", func(_ context.Context, _ struct{}) (string, error) {
+		return "toolset", nil
+	})
+
+	reqLimit := 4
+	toolCallLimit := 7
+	temperature := 0.7
+	maxTokens := 128
+	topP := 0.9
+	thinking := 256
+	effort := "high"
+	quota := &UsageQuota{
+		MaxRequests:    5,
+		MaxTotalTokens: 1000,
+	}
+	tracker := NewCostTracker(map[string]ModelPricing{
+		model.ModelName(): {
+			InputTokenCost:  0.001,
+			OutputTokenCost: 0.002,
+		},
+	})
+	tracker.currency = "EUR"
+	bus := NewEventBus()
+	kb := NewStaticKnowledgeBase("facts")
+	deps := runtimeConfigDeps{Token: "abc123"}
+
+	agent := NewAgent[runtimeConfigOutput](model)
+	agent.systemPrompts = []string{"system prompt"}
+	agent.dynamicSystemPrompts = []SystemPromptFunc{
+		func(_ context.Context, _ *RunContext) (string, error) { return "dynamic prompt", nil },
+	}
+	agent.historyProcessors = []HistoryProcessor{
+		func(_ context.Context, messages []ModelMessage) ([]ModelMessage, error) { return messages, nil },
+	}
+	agent.tools = []Tool{directTool, preparedTool}
+	agent.toolsets = []*Toolset{NewToolset("shared", toolsetTool)}
+	agent.hooks = []Hook{{
+		OnRunStart: func(_ context.Context, _ *RunContext, _ string) {},
+	}}
+	agent.inputGuardrails = []namedInputGuardrail{{
+		name: "input_guardrail",
+		fn: func(_ context.Context, prompt string) (string, error) {
+			return prompt, nil
+		},
+	}}
+	agent.turnGuardrails = []namedTurnGuardrail{{
+		name: "turn_guardrail",
+		fn:   func(_ context.Context, _ *RunContext, _ []ModelMessage) error { return nil },
+	}}
+	agent.toolsPrepareFunc = func(_ context.Context, _ *RunContext, tools []ToolDefinition) []ToolDefinition {
+		return tools
+	}
+	agent.outputSchema = buildOutputSchema[runtimeConfigOutput](
+		WithOutputMode(OutputModeNative),
+		WithOutputToolName("structured_output"),
+		WithOutputToolDescription("Structured output"),
+	)
+	agent.outputValidators = []OutputValidatorFunc[runtimeConfigOutput]{
+		func(_ context.Context, _ *RunContext, output runtimeConfigOutput) (runtimeConfigOutput, error) {
+			return output, nil
+		},
+	}
+	agent.repairFunc = RepairFunc[runtimeConfigOutput](func(_ context.Context, _ string, _ error) (runtimeConfigOutput, error) {
+		return runtimeConfigOutput{Answer: "fixed"}, nil
+	})
+	agent.modelSettings = &ModelSettings{
+		MaxTokens:       &maxTokens,
+		Temperature:     &temperature,
+		TopP:            &topP,
+		ToolChoice:      ToolChoiceForce("direct_tool"),
+		ThinkingBudget:  &thinking,
+		ReasoningEffort: &effort,
+	}
+	agent.usageLimits = UsageLimits{
+		RequestLimit:   &reqLimit,
+		ToolCallsLimit: &toolCallLimit,
+	}
+	agent.usageQuota = quota
+	agent.maxRetries = 6
+	agent.endStrategy = EndStrategyExhaustive
+	agent.maxConcurrency = 3
+	agent.defaultToolTimeout = 2 * time.Second
+	agent.toolChoice = ToolChoiceRequired()
+	agent.toolChoiceAutoReset = true
+	agent.toolApprovalFunc = func(_ context.Context, _ string, _ string) (bool, error) { return true, nil }
+	agent.globalToolResultValidators = []ToolResultValidatorFunc{
+		func(_ context.Context, _ *RunContext, _ string, _ string) error { return nil },
+	}
+	agent.middleware = []RequestMiddlewareFunc{
+		func(ctx context.Context, messages []ModelMessage, settings *ModelSettings, params *ModelRequestParameters, next func(context.Context, []ModelMessage, *ModelSettings, *ModelRequestParameters) (*ModelResponse, error)) (*ModelResponse, error) {
+			return next(ctx, messages, settings, params)
+		},
+	}
+	agent.streamMiddleware = []AgentStreamMiddleware{
+		func(_ context.Context, _ []ModelMessage, _ *ModelSettings, _ *ModelRequestParameters, _ AgentStreamFunc) (StreamedResponse, error) {
+			return nil, nil
+		},
+	}
+	agent.messageInterceptors = []MessageInterceptor{
+		func(_ context.Context, messages []ModelMessage) InterceptResult {
+			return InterceptResult{Action: MessageAllow, Messages: messages}
+		},
+	}
+	agent.responseInterceptors = []ResponseInterceptor{
+		func(_ context.Context, _ *ModelResponse) InterceptResult {
+			return InterceptResult{Action: MessageAllow}
+		},
+	}
+	agent.runConditions = []RunCondition{
+		func(_ context.Context, _ *RunContext, _ *ModelResponse) (bool, string) { return false, "" },
+	}
+	agent.tracingEnabled = true
+	agent.traceExporters = []TraceExporter{runtimeConfigExporter{}}
+	agent.eventBus = bus
+	agent.deps = deps
+	agent.autoContext = &AutoContextConfig{
+		MaxTokens:    200,
+		KeepLastN:    3,
+		SummaryModel: model,
+	}
+	agent.knowledgeBase = kb
+	agent.kbAutoStore = true
+	agent.costTracker = tracker
+
+	cfg := agent.RuntimeConfig()
+
+	if len(cfg.Tools) != 3 {
+		t.Fatalf("expected 3 tools including toolset tools, got %d", len(cfg.Tools))
+	}
+	if cfg.Tools[0].Definition.Name != "direct_tool" || cfg.Tools[2].Definition.Name != "toolset_tool" {
+		t.Fatalf("unexpected tool names: %+v", []string{
+			cfg.Tools[0].Definition.Name,
+			cfg.Tools[1].Definition.Name,
+			cfg.Tools[2].Definition.Name,
+		})
+	}
+	if len(cfg.SystemPrompts) != 1 || cfg.SystemPrompts[0] != "system prompt" {
+		t.Fatalf("unexpected system prompts: %+v", cfg.SystemPrompts)
+	}
+	if len(cfg.DynamicSystemPrompts) != 1 || cfg.DynamicSystemPrompts[0] == nil {
+		t.Fatalf("expected cloned dynamic system prompts, got %+v", cfg.DynamicSystemPrompts)
+	}
+	if len(cfg.HistoryProcessors) != 1 || cfg.HistoryProcessors[0] == nil {
+		t.Fatalf("expected cloned history processors, got %+v", cfg.HistoryProcessors)
+	}
+	if len(cfg.Hooks) != 1 || cfg.Hooks[0].OnRunStart == nil {
+		t.Fatalf("expected cloned hooks, got %+v", cfg.Hooks)
+	}
+	if len(cfg.InputGuardrails) != 1 || cfg.InputGuardrails[0].Name != "input_guardrail" {
+		t.Fatalf("unexpected input guardrails: %+v", cfg.InputGuardrails)
+	}
+	if len(cfg.TurnGuardrails) != 1 || cfg.TurnGuardrails[0].Name != "turn_guardrail" {
+		t.Fatalf("unexpected turn guardrails: %+v", cfg.TurnGuardrails)
+	}
+	if cfg.AgentToolsPrepare == nil {
+		t.Fatal("expected agent tools prepare func")
+	}
+	if cfg.OutputSchema == nil || cfg.OutputSchema.OutputObject == nil {
+		t.Fatalf("expected native output schema clone, got %+v", cfg.OutputSchema)
+	}
+	if cfg.OutputSchema.OutputTools[0].Name != "structured_output" {
+		t.Fatalf("unexpected output tool name %q", cfg.OutputSchema.OutputTools[0].Name)
+	}
+	if cfg.OutputRepair == nil {
+		t.Fatal("expected output repair func")
+	}
+	if len(cfg.OutputValidators) != 1 || cfg.OutputValidators[0] == nil {
+		t.Fatalf("expected output validators, got %+v", cfg.OutputValidators)
+	}
+	if cfg.ModelSettings == nil || cfg.ModelSettings.ToolChoice == nil {
+		t.Fatalf("expected model settings clone, got %+v", cfg.ModelSettings)
+	}
+	if cfg.ModelSettings == agent.modelSettings || cfg.ModelSettings.ToolChoice == agent.modelSettings.ToolChoice {
+		t.Fatal("expected model settings and tool choice to be deep-cloned")
+	}
+	if cfg.UsageQuota == nil || cfg.UsageQuota == agent.usageQuota {
+		t.Fatal("expected usage quota clone")
+	}
+	if cfg.MaxRetries != 6 || cfg.EndStrategy != EndStrategyExhaustive || cfg.MaxConcurrency != 3 {
+		t.Fatalf("unexpected runtime execution settings: %+v", cfg)
+	}
+	if cfg.DefaultToolTimeout != 2*time.Second {
+		t.Fatalf("unexpected default tool timeout %v", cfg.DefaultToolTimeout)
+	}
+	if cfg.ToolChoice == nil || cfg.ToolChoice == agent.toolChoice || cfg.ToolChoice.Mode != "required" {
+		t.Fatalf("unexpected tool choice clone: %+v", cfg.ToolChoice)
+	}
+	if !cfg.ToolChoiceAutoReset {
+		t.Fatal("expected tool choice auto reset to be preserved")
+	}
+	if cfg.ToolApprovalFunc == nil {
+		t.Fatal("expected tool approval func")
+	}
+	if len(cfg.GlobalToolResultValidators) != 1 || cfg.GlobalToolResultValidators[0] == nil {
+		t.Fatalf("expected global tool validators, got %+v", cfg.GlobalToolResultValidators)
+	}
+	if len(cfg.RequestMiddleware) != 1 || cfg.RequestMiddleware[0] == nil {
+		t.Fatalf("expected request middleware, got %+v", cfg.RequestMiddleware)
+	}
+	if len(cfg.StreamMiddleware) != 1 || cfg.StreamMiddleware[0] == nil {
+		t.Fatalf("expected stream middleware, got %+v", cfg.StreamMiddleware)
+	}
+	if len(cfg.MessageInterceptors) != 1 || cfg.MessageInterceptors[0] == nil {
+		t.Fatalf("expected message interceptors, got %+v", cfg.MessageInterceptors)
+	}
+	if len(cfg.ResponseInterceptors) != 1 || cfg.ResponseInterceptors[0] == nil {
+		t.Fatalf("expected response interceptors, got %+v", cfg.ResponseInterceptors)
+	}
+	if len(cfg.RunConditions) != 1 || cfg.RunConditions[0] == nil {
+		t.Fatalf("expected run conditions, got %+v", cfg.RunConditions)
+	}
+	if !cfg.TracingEnabled || len(cfg.TraceExporters) != 1 || cfg.TraceExporters[0] == nil {
+		t.Fatalf("expected tracing config, got %+v", cfg.TraceExporters)
+	}
+	if cfg.ModelName != model.ModelName() {
+		t.Fatalf("expected model name %q, got %q", model.ModelName(), cfg.ModelName)
+	}
+	if !cfg.HasCostTracker || cfg.CostCurrency != "EUR" {
+		t.Fatalf("unexpected cost tracker metadata: has=%v currency=%q", cfg.HasCostTracker, cfg.CostCurrency)
+	}
+	if cfg.EventBus != bus {
+		t.Fatal("expected event bus pointer to be preserved")
+	}
+	if !reflect.DeepEqual(cfg.AgentDeps, deps) {
+		t.Fatalf("unexpected agent deps: %+v", cfg.AgentDeps)
+	}
+	if cfg.AutoContext == nil || cfg.AutoContext == agent.autoContext || cfg.AutoContext.MaxTokens != 200 {
+		t.Fatalf("unexpected auto-context clone: %+v", cfg.AutoContext)
+	}
+	if cfg.KnowledgeBase != kb || !cfg.KnowledgeAutoStore {
+		t.Fatalf("unexpected knowledge base config: kb=%v auto=%v", cfg.KnowledgeBase, cfg.KnowledgeAutoStore)
+	}
+	if got := cfg.CostPricing[model.ModelName()].InputTokenCost; got != 0.001 {
+		t.Fatalf("unexpected cloned cost pricing: %+v", cfg.CostPricing)
+	}
+
+	agent.systemPrompts[0] = "changed"
+	agent.dynamicSystemPrompts[0] = nil
+	agent.historyProcessors[0] = nil
+	agent.tools[0].Definition.Name = "changed_tool"
+	agent.hooks[0] = Hook{}
+	agent.inputGuardrails[0].name = "changed_input"
+	agent.turnGuardrails[0].name = "changed_turn"
+	agent.outputSchema.OutputTools[0].Name = "changed_output"
+	agent.outputSchema.OutputObject.Name = "changed_object"
+	agent.modelSettings.ToolChoice.ToolName = "changed_choice"
+	agent.usageQuota.MaxRequests = 99
+	agent.autoContext.MaxTokens = 999
+	agent.costTracker.pricing[model.ModelName()] = ModelPricing{InputTokenCost: 9.9}
+
+	if cfg.SystemPrompts[0] != "system prompt" {
+		t.Fatalf("expected cloned system prompts to remain stable, got %+v", cfg.SystemPrompts)
+	}
+	if cfg.DynamicSystemPrompts[0] == nil || cfg.HistoryProcessors[0] == nil {
+		t.Fatal("expected cloned function slices to remain populated")
+	}
+	if cfg.Tools[0].Definition.Name != "direct_tool" {
+		t.Fatalf("expected cloned tools to remain stable, got %+v", cfg.Tools[0].Definition)
+	}
+	if cfg.Hooks[0].OnRunStart == nil {
+		t.Fatal("expected cloned hooks to remain populated")
+	}
+	if cfg.InputGuardrails[0].Name != "input_guardrail" || cfg.TurnGuardrails[0].Name != "turn_guardrail" {
+		t.Fatalf("expected cloned guardrail names to remain stable, got %+v / %+v", cfg.InputGuardrails, cfg.TurnGuardrails)
+	}
+	if cfg.OutputSchema.OutputTools[0].Name != "structured_output" || cfg.OutputSchema.OutputObject.Name != "structured_output" {
+		t.Fatalf("expected cloned output schema to remain stable, got %+v", cfg.OutputSchema)
+	}
+	if cfg.ModelSettings.ToolChoice.ToolName != "direct_tool" {
+		t.Fatalf("expected cloned model settings to remain stable, got %+v", cfg.ModelSettings)
+	}
+	if cfg.UsageQuota.MaxRequests != 5 {
+		t.Fatalf("expected cloned quota to remain stable, got %+v", cfg.UsageQuota)
+	}
+	if cfg.AutoContext.MaxTokens != 200 {
+		t.Fatalf("expected cloned auto-context to remain stable, got %+v", cfg.AutoContext)
+	}
+	if got := cfg.CostPricing[model.ModelName()].InputTokenCost; got != 0.001 {
+		t.Fatalf("expected cloned cost pricing to remain stable, got %+v", cfg.CostPricing)
+	}
+}
+
+func TestAgentRuntimeCloneHelpers_NilAndEmpty(t *testing.T) {
+	if cloneOutputSchema(nil) != nil {
+		t.Fatal("expected nil output schema clone")
+	}
+	if cloneModelSettings(nil) != nil {
+		t.Fatal("expected nil model settings clone")
+	}
+	if cloneToolChoice(nil) != nil {
+		t.Fatal("expected nil tool choice clone")
+	}
+	if cloneUsageQuota(nil) != nil {
+		t.Fatal("expected nil usage quota clone")
+	}
+	if cloneModelPricingMap(nil) != nil {
+		t.Fatal("expected nil pricing clone")
+	}
+	if cloneAutoContextConfig(nil) != nil {
+		t.Fatal("expected nil auto-context clone")
+	}
+	if cloneInputGuardrails(nil) != nil {
+		t.Fatal("expected nil input guardrails clone")
+	}
+	if cloneTurnGuardrails(nil) != nil {
+		t.Fatal("expected nil turn guardrails clone")
+	}
+
+	agent := NewAgent[string](NewTestModel(TextResponse("ok")))
+	if got := agent.costPricing(); got != nil {
+		t.Fatalf("expected nil pricing with no cost tracker, got %+v", got)
+	}
+	if got := agent.costCurrency(); got != "" {
+		t.Fatalf("expected empty currency with no cost tracker, got %q", got)
+	}
+}

--- a/ext/temporal/callbacks_test.go
+++ b/ext/temporal/callbacks_test.go
@@ -430,6 +430,80 @@ func TestTemporalAgent_RunWorkflow_ToolsetGuardrailsAndHooks(t *testing.T) {
 	})
 }
 
+func TestTemporalAgent_RunWorkflow_InputGuardrailRejects(t *testing.T) {
+	evaluated := 0
+	model := core.NewTestModel(core.TextResponse("should not run"))
+	agent := core.NewAgent[string](model,
+		core.WithInputGuardrail[string]("block", func(_ context.Context, _ string) (string, error) {
+			return "", errors.New("blocked")
+		}),
+		core.WithHooks[string](core.Hook{
+			OnGuardrailEvaluated: func(_ context.Context, _ *core.RunContext, name string, passed bool, err error) {
+				if name == "block" && !passed && err != nil {
+					evaluated++
+				}
+			},
+		}),
+	)
+	ta := NewTemporalAgent(agent, WithName("workflow-input-guardrail-reject"))
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	registerTemporalWorkflow(env, ta)
+
+	env.ExecuteWorkflow(ta.RunWorkflow, WorkflowInput{Prompt: "reject me"})
+	err := env.GetWorkflowError()
+	if err == nil {
+		t.Fatal("expected workflow error from input guardrail rejection")
+	}
+	if !strings.Contains(err.Error(), `guardrail "block": blocked`) {
+		t.Fatalf("unexpected input guardrail error: %v", err)
+	}
+	if evaluated != 1 {
+		t.Fatalf("expected one failed guardrail evaluation hook, got %d", evaluated)
+	}
+	if got := len(model.Calls()); got != 0 {
+		t.Fatalf("expected model not to run after input guardrail rejection, got %d calls", got)
+	}
+}
+
+func TestTemporalAgent_RunWorkflow_TurnGuardrailRejects(t *testing.T) {
+	evaluated := 0
+	model := core.NewTestModel(core.TextResponse("should not run"))
+	agent := core.NewAgent[string](model,
+		core.WithTurnGuardrail[string]("halt", func(_ context.Context, _ *core.RunContext, _ []core.ModelMessage) error {
+			return errors.New("turn blocked")
+		}),
+		core.WithHooks[string](core.Hook{
+			OnGuardrailEvaluated: func(_ context.Context, _ *core.RunContext, name string, passed bool, err error) {
+				if name == "halt" && !passed && err != nil {
+					evaluated++
+				}
+			},
+		}),
+	)
+	ta := NewTemporalAgent(agent, WithName("workflow-turn-guardrail-reject"))
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	registerTemporalWorkflow(env, ta)
+
+	env.ExecuteWorkflow(ta.RunWorkflow, WorkflowInput{Prompt: "reject turn"})
+	err := env.GetWorkflowError()
+	if err == nil {
+		t.Fatal("expected workflow error from turn guardrail rejection")
+	}
+	if !strings.Contains(err.Error(), `guardrail "halt": turn blocked`) {
+		t.Fatalf("unexpected turn guardrail error: %v", err)
+	}
+	if evaluated != 1 {
+		t.Fatalf("expected one failed turn guardrail evaluation hook, got %d", evaluated)
+	}
+	if got := len(model.Calls()); got != 0 {
+		t.Fatalf("expected model not to run after turn guardrail rejection, got %d calls", got)
+	}
+}
+
 func TestTemporalAgent_RunWorkflow_RunConditionTextOutput(t *testing.T) {
 	runConditionChecks := 0
 	model := core.NewTestModel(core.TextResponse("stop here"))

--- a/ext/temporal/driver_helpers_test.go
+++ b/ext/temporal/driver_helpers_test.go
@@ -1,0 +1,364 @@
+package temporal
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
+
+	"github.com/fugue-labs/gollem/core"
+)
+
+type helperOutput struct {
+	Answer string `json:"answer"`
+}
+
+func TestInitialRequestPartsHelpers(t *testing.T) {
+	now := time.Unix(1, 0).UTC()
+	parts := []core.ModelRequestPart{
+		core.SystemPromptPart{Content: "system", Timestamp: now},
+		core.UserPromptPart{Content: "hello", Timestamp: now},
+	}
+
+	data, err := MarshalInitialRequestParts(parts)
+	if err != nil {
+		t.Fatalf("marshal initial request parts: %v", err)
+	}
+
+	decoded, err := UnmarshalInitialRequestParts(data)
+	if err != nil {
+		t.Fatalf("unmarshal initial request parts: %v", err)
+	}
+	if len(decoded) != 2 {
+		t.Fatalf("expected 2 decoded parts, got %d", len(decoded))
+	}
+
+	encodedParts, err := core.EncodeRequestParts(parts)
+	if err != nil {
+		t.Fatalf("encode request parts: %v", err)
+	}
+	decodedFromStructured, err := unmarshalInitialRequestParts(encodedParts, nil)
+	if err != nil {
+		t.Fatalf("unmarshal structured initial request parts: %v", err)
+	}
+	if len(decodedFromStructured) != 2 {
+		t.Fatalf("expected 2 structured decoded parts, got %d", len(decodedFromStructured))
+	}
+
+	twoRequests, err := core.MarshalMessages([]core.ModelMessage{
+		core.ModelRequest{Parts: parts},
+		core.ModelRequest{Parts: parts},
+	})
+	if err != nil {
+		t.Fatalf("marshal two requests: %v", err)
+	}
+	if _, err := UnmarshalInitialRequestParts(twoRequests); err == nil {
+		t.Fatal("expected error for multiple wrapper messages")
+	}
+
+	responseWrapper, err := core.MarshalMessages([]core.ModelMessage{
+		core.ModelResponse{Parts: []core.ModelResponsePart{core.TextPart{Content: "nope"}}},
+	})
+	if err != nil {
+		t.Fatalf("marshal response wrapper: %v", err)
+	}
+	if _, err := UnmarshalInitialRequestParts(responseWrapper); err == nil {
+		t.Fatal("expected error for non-request wrapper")
+	}
+}
+
+func TestInjectDeferredResults(t *testing.T) {
+	now := time.Unix(5, 0).UTC()
+
+	mergedState := &workflowRunState{
+		Messages: []core.ModelMessage{
+			core.ModelRequest{
+				Parts: []core.ModelRequestPart{
+					core.UserPromptPart{Content: "start", Timestamp: now},
+				},
+				Timestamp: now,
+			},
+		},
+	}
+	injectDeferredResults(mergedState, []core.DeferredToolResult{
+		{ToolName: "search", ToolCallID: "call_1", Content: "done"},
+		{ToolName: "search", ToolCallID: "call_2", Content: "retry me", IsError: true},
+	}, now)
+
+	req, ok := mergedState.Messages[0].(core.ModelRequest)
+	if !ok {
+		t.Fatalf("expected merged request, got %T", mergedState.Messages[0])
+	}
+	if len(req.Parts) != 3 {
+		t.Fatalf("expected merged request to have 3 parts, got %d", len(req.Parts))
+	}
+	if _, ok := req.Parts[1].(core.ToolReturnPart); !ok {
+		t.Fatalf("expected tool return part, got %T", req.Parts[1])
+	}
+	if _, ok := req.Parts[2].(core.RetryPromptPart); !ok {
+		t.Fatalf("expected retry prompt part, got %T", req.Parts[2])
+	}
+
+	appendedState := &workflowRunState{
+		Messages: []core.ModelMessage{
+			core.ModelResponse{Parts: []core.ModelResponsePart{core.TextPart{Content: "assistant"}}},
+		},
+	}
+	injectDeferredResults(appendedState, []core.DeferredToolResult{
+		{ToolName: "search", ToolCallID: "call_3", Content: "later"},
+	}, now)
+
+	if len(appendedState.Messages) != 2 {
+		t.Fatalf("expected appended request message, got %d messages", len(appendedState.Messages))
+	}
+	if _, ok := appendedState.Messages[1].(core.ModelRequest); !ok {
+		t.Fatalf("expected appended request, got %T", appendedState.Messages[1])
+	}
+}
+
+func TestDriverDecodeAndRetryHelpers(t *testing.T) {
+	if _, err := decodeTemporalOutput[helperOutput](nil); err == nil {
+		t.Fatal("expected error for empty workflow output")
+	}
+	if _, err := decodeTemporalOutput[helperOutput]([]byte(`{`)); err == nil {
+		t.Fatal("expected error for invalid workflow output JSON")
+	}
+	decoded, err := decodeTemporalOutput[helperOutput]([]byte(`{"answer":"ok"}`))
+	if err != nil {
+		t.Fatalf("decode temporal output: %v", err)
+	}
+	if decoded.Answer != "ok" {
+		t.Fatalf("unexpected decoded output: %+v", decoded)
+	}
+
+	structured, err := decodeStructuredOutput[helperOutput](`{"result":{"answer":"wrapped"}}`, "result")
+	if err != nil {
+		t.Fatalf("decode structured output: %v", err)
+	}
+	if structured.Answer != "wrapped" {
+		t.Fatalf("unexpected structured output: %+v", structured)
+	}
+	if _, err := decodeStructuredOutput[helperOutput](`{"other":{"answer":"wrapped"}}`, "result"); err == nil {
+		t.Fatal("expected error for missing wrapper key")
+	}
+	if _, err := decodeStructuredOutput[helperOutput](`{`, "result"); err == nil {
+		t.Fatal("expected error for invalid structured output JSON")
+	}
+
+	start := time.Unix(10, 0).UTC()
+	if got := deterministicWorkflowDuration(start, start); got != time.Nanosecond {
+		t.Fatalf("expected 1ns duration for equal timestamps, got %v", got)
+	}
+	if got := deterministicWorkflowDuration(start, start.Add(-time.Second)); got != 0 {
+		t.Fatalf("expected zero duration for reversed timestamps, got %v", got)
+	}
+
+	if got := availableToolNames(core.AgentRuntimeConfig[string]{}); got != "(none)" {
+		t.Fatalf("expected no tool names, got %q", got)
+	}
+	names := availableToolNames(core.AgentRuntimeConfig[string]{
+		Tools: []core.Tool{
+			{Definition: core.ToolDefinition{Name: "lookup"}},
+		},
+		OutputSchema: &core.OutputSchema{
+			OutputTools: []core.ToolDefinition{{Name: "final_result"}},
+		},
+	})
+	if names != "lookup, final_result" {
+		t.Fatalf("unexpected tool names %q", names)
+	}
+
+	if last := lastWorkflowModelResponse(nil); last != nil {
+		t.Fatalf("expected nil last response, got %+v", last)
+	}
+	last := lastWorkflowModelResponse([]core.ModelMessage{
+		core.ModelRequest{},
+		core.ModelResponse{Parts: []core.ModelResponsePart{core.TextPart{Content: "first"}}},
+		core.ModelRequest{},
+		core.ModelResponse{Parts: []core.ModelResponsePart{core.TextPart{Content: "second"}}},
+	})
+	if last == nil || last.TextContent() != "second" {
+		t.Fatalf("unexpected last response: %+v", last)
+	}
+
+	state := &workflowRunState{}
+	if err := incrementWorkflowRetries(state, 2); err != nil {
+		t.Fatalf("unexpected retry increment error: %v", err)
+	}
+	if state.Retries != 1 {
+		t.Fatalf("expected retries to increment to 1, got %d", state.Retries)
+	}
+
+	state = &workflowRunState{}
+	err = incrementWorkflowRetries(state, 0)
+	var unexpected *core.UnexpectedModelBehavior
+	if !errors.As(err, &unexpected) {
+		t.Fatalf("expected unexpected model behavior, got %T: %v", err, err)
+	}
+
+	state = &workflowRunState{
+		Messages: []core.ModelMessage{
+			core.ModelResponse{
+				FinishReason: core.FinishReasonLength,
+				Parts: []core.ModelResponsePart{
+					core.ToolCallPart{ToolName: "lookup", ToolCallID: "call_1", ArgsJSON: `{"bad"`},
+				},
+			},
+		},
+	}
+	err = incrementWorkflowRetries(state, 0)
+	var incomplete *core.IncompleteToolCall
+	if !errors.As(err, &incomplete) {
+		t.Fatalf("expected incomplete tool call, got %T: %v", err, err)
+	}
+}
+
+func TestBuildActivityOptionsAndWorkflowHelpers(t *testing.T) {
+	opts := buildActivityOptions(ActivityConfig{
+		MaxRetries: maxTemporalActivityAttempts + 25,
+	})
+	if opts.RetryPolicy == nil {
+		t.Fatal("expected retry policy")
+	}
+	if opts.RetryPolicy.MaximumAttempts != int32(maxTemporalActivityAttempts) {
+		t.Fatalf("expected attempts to clamp at %d, got %d", maxTemporalActivityAttempts, opts.RetryPolicy.MaximumAttempts)
+	}
+	if opts.StartToCloseTimeout != DefaultActivityConfig().StartToCloseTimeout {
+		t.Fatalf("expected default timeout, got %v", opts.StartToCloseTimeout)
+	}
+	if opts.RetryPolicy.InitialInterval != DefaultActivityConfig().InitialInterval {
+		t.Fatalf("expected default retry interval, got %v", opts.RetryPolicy.InitialInterval)
+	}
+
+	now := time.Unix(15, 0).UTC()
+	req := buildInitialWorkflowRequest(
+		[]string{"system-1", "system-2"},
+		"hello",
+		[]core.ModelRequestPart{core.RetryPromptPart{Content: "retry", Timestamp: now}},
+		now,
+	)
+	if len(req.Parts) != 4 {
+		t.Fatalf("expected 4 initial request parts, got %d", len(req.Parts))
+	}
+	if got := req.Parts[2].(core.UserPromptPart).Content; got != "hello" {
+		t.Fatalf("unexpected user prompt content %q", got)
+	}
+
+	cost := buildWorkflowCostSnapshot(true, "test-model", map[string]core.ModelPricing{
+		"test-model": {
+			InputTokenCost:  0.001,
+			OutputTokenCost: 0.002,
+		},
+	}, "EUR", core.RunUsage{Usage: core.Usage{InputTokens: 2, OutputTokens: 3}})
+	if cost == nil || cost.Currency != "EUR" || cost.TotalCost <= 0 {
+		t.Fatalf("unexpected workflow cost snapshot: %+v", cost)
+	}
+	if got := buildWorkflowCostSnapshot(false, "test-model", nil, "", core.RunUsage{}); got != nil {
+		t.Fatalf("expected nil workflow cost without tracker, got %+v", got)
+	}
+}
+
+func TestBuildWorkflowRequestParamsFromDefinitions(t *testing.T) {
+	params := buildWorkflowRequestParamsFromDefinitions(core.AgentRuntimeConfig[string]{
+		OutputSchema: &core.OutputSchema{
+			Mode:       core.OutputModeTool,
+			AllowsText: true,
+			OutputTools: []core.ToolDefinition{
+				{Name: "final_result", Kind: core.ToolKindOutput},
+			},
+		},
+	}, []core.ToolDefinition{{Name: "lookup", Kind: core.ToolKindFunction}})
+
+	if params.OutputMode != core.OutputModeTool || !params.AllowTextOutput {
+		t.Fatalf("unexpected output params: %+v", params)
+	}
+	if len(params.FunctionTools) != 1 || params.FunctionTools[0].Name != "lookup" {
+		t.Fatalf("unexpected function tools: %+v", params.FunctionTools)
+	}
+	if len(params.OutputTools) != 1 || params.OutputTools[0].Name != "final_result" {
+		t.Fatalf("unexpected output tools: %+v", params.OutputTools)
+	}
+}
+
+func TestNewWorkflowRunStateDecodesSnapshotAndTraceSteps(t *testing.T) {
+	now := time.Unix(20, 0).UTC()
+	traceRaw, err := json.Marshal([]core.TraceStep{{Kind: core.TraceToolCall, Timestamp: now}})
+	if err != nil {
+		t.Fatalf("marshal trace steps: %v", err)
+	}
+	snapshot, err := core.EncodeRunSnapshot(&core.RunSnapshot{
+		Messages: []core.ModelMessage{
+			core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "prompt", Timestamp: now}}},
+		},
+		Usage:           core.RunUsage{Requests: 2},
+		LastInputTokens: 11,
+		Retries:         1,
+		ToolRetries:     map[string]int{"lookup": 2},
+		RunID:           "snap-run",
+		RunStep:         3,
+		RunStartTime:    now.Add(-time.Minute),
+		Prompt:          "prompt",
+		ToolState:       map[string]any{"lookup": map[string]any{"count": 1}},
+		Timestamp:       now,
+	})
+	if err != nil {
+		t.Fatalf("encode snapshot: %v", err)
+	}
+
+	input := WorkflowInput{
+		Snapshot:       snapshot,
+		TraceStepsJSON: traceRaw,
+		DepsJSON:       []byte(`{"tenant":"acme"}`),
+	}
+
+	type summary struct {
+		RunID       string
+		RunStep     int
+		TraceKinds  []string
+		ToolRetries map[string]int
+		DepsJSON    string
+	}
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	env.SetStartTime(now)
+	env.ExecuteWorkflow(func(ctx workflow.Context) (summary, error) {
+		state, err := newWorkflowRunState(ctx, input)
+		if err != nil {
+			return summary{}, err
+		}
+		result := summary{
+			RunID:       state.RunID,
+			RunStep:     state.RunStep,
+			ToolRetries: state.ToolRetries,
+			DepsJSON:    string(state.DepsJSON),
+		}
+		for _, step := range state.TraceSteps {
+			result.TraceKinds = append(result.TraceKinds, string(step.Kind))
+		}
+		return result, nil
+	})
+	if err := env.GetWorkflowError(); err != nil {
+		t.Fatalf("workflow error: %v", err)
+	}
+
+	var got summary
+	if err := env.GetWorkflowResult(&got); err != nil {
+		t.Fatalf("get workflow result: %v", err)
+	}
+	if got.RunID != "snap-run" || got.RunStep != 3 {
+		t.Fatalf("unexpected restored run state summary: %+v", got)
+	}
+	if len(got.TraceKinds) != 1 || got.TraceKinds[0] != string(core.TraceToolCall) {
+		t.Fatalf("unexpected restored trace kinds: %+v", got.TraceKinds)
+	}
+	if got.ToolRetries["lookup"] != 2 {
+		t.Fatalf("unexpected restored tool retries: %+v", got.ToolRetries)
+	}
+	if got.DepsJSON != `{"tenant":"acme"}` {
+		t.Fatalf("unexpected deps json %q", got.DepsJSON)
+	}
+}

--- a/ext/temporal/state_deps_test.go
+++ b/ext/temporal/state_deps_test.go
@@ -1,0 +1,186 @@
+package temporal
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/fugue-labs/gollem/core"
+)
+
+type depsFixture struct {
+	Name string `json:"name"`
+}
+
+func TestDeferredResultSignal_DeferredToolResult(t *testing.T) {
+	signal := DeferredResultSignal{
+		ToolName:   "lookup",
+		ToolCallID: "call_1",
+		Content:    "done",
+		IsError:    true,
+	}
+
+	result := signal.DeferredToolResult()
+	if result.ToolName != "lookup" || result.ToolCallID != "call_1" || result.Content != "done" || !result.IsError {
+		t.Fatalf("unexpected deferred tool result: %+v", result)
+	}
+}
+
+func TestDecodeWorkflowStatusMessages(t *testing.T) {
+	if _, err := DecodeWorkflowStatusMessages(nil); err == nil {
+		t.Fatal("expected error for nil workflow status")
+	}
+
+	now := time.Unix(30, 0).UTC()
+	messages := []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "hello", Timestamp: now}}},
+	}
+
+	structured, err := core.EncodeMessages(messages)
+	if err != nil {
+		t.Fatalf("encode messages: %v", err)
+	}
+	decoded, err := DecodeWorkflowStatusMessages(&WorkflowStatus{Messages: structured})
+	if err != nil {
+		t.Fatalf("decode structured messages: %v", err)
+	}
+	if len(decoded) != 1 {
+		t.Fatalf("expected 1 structured message, got %d", len(decoded))
+	}
+
+	raw, err := core.MarshalMessages(messages)
+	if err != nil {
+		t.Fatalf("marshal messages: %v", err)
+	}
+	decoded, err = DecodeWorkflowStatusMessages(&WorkflowStatus{MessagesJSON: raw})
+	if err != nil {
+		t.Fatalf("decode legacy messages_json: %v", err)
+	}
+	if len(decoded) != 1 {
+		t.Fatalf("expected 1 legacy message, got %d", len(decoded))
+	}
+}
+
+func TestDecodeWorkflowStatusTrace(t *testing.T) {
+	if _, err := DecodeWorkflowStatusTrace(nil); err == nil {
+		t.Fatal("expected error for nil workflow status")
+	}
+
+	trace := &core.RunTrace{RunID: "trace-1"}
+	decoded, err := DecodeWorkflowStatusTrace(&WorkflowStatus{Trace: trace})
+	if err != nil {
+		t.Fatalf("decode structured trace: %v", err)
+	}
+	if decoded != trace {
+		t.Fatal("expected structured trace pointer to be preserved")
+	}
+
+	raw, err := json.Marshal(core.RunTrace{RunID: "trace-2"})
+	if err != nil {
+		t.Fatalf("marshal legacy trace: %v", err)
+	}
+	decoded, err = DecodeWorkflowStatusTrace(&WorkflowStatus{TraceJSON: raw})
+	if err != nil {
+		t.Fatalf("decode legacy trace_json: %v", err)
+	}
+	if decoded == nil || decoded.RunID != "trace-2" {
+		t.Fatalf("unexpected decoded legacy trace: %+v", decoded)
+	}
+}
+
+func TestDecodeTemporalDeps(t *testing.T) {
+	defaultDeps := depsFixture{Name: "default"}
+	got, err := decodeTemporalDeps(nil, nil, defaultDeps, nil)
+	if err != nil {
+		t.Fatalf("decode default deps: %v", err)
+	}
+	if !reflect.DeepEqual(got, defaultDeps) {
+		t.Fatalf("expected default deps %+v, got %+v", defaultDeps, got)
+	}
+
+	data, err := json.Marshal(depsFixture{Name: "workflow"})
+	if err != nil {
+		t.Fatalf("marshal deps: %v", err)
+	}
+	if _, err := decodeTemporalDeps(nil, nil, nil, data); err == nil {
+		t.Fatal("expected error when deps type is unavailable")
+	}
+
+	got, err = decodeTemporalDeps(nil, reflect.TypeOf(&depsFixture{}), nil, data)
+	if err != nil {
+		t.Fatalf("decode pointer deps: %v", err)
+	}
+	ptr, ok := got.(*depsFixture)
+	if !ok || ptr.Name != "workflow" {
+		t.Fatalf("unexpected pointer deps: %#v", got)
+	}
+
+	got, err = decodeTemporalDeps(nil, reflect.TypeOf(depsFixture{}), nil, data)
+	if err != nil {
+		t.Fatalf("decode value deps: %v", err)
+	}
+	value, ok := got.(depsFixture)
+	if !ok || value.Name != "workflow" {
+		t.Fatalf("unexpected value deps: %#v", got)
+	}
+}
+
+func TestTemporalAgentMarshalDeps(t *testing.T) {
+	var nilAgent *TemporalAgent[string]
+	if _, err := nilAgent.MarshalDeps(depsFixture{}); err == nil {
+		t.Fatal("expected error when TemporalAgent is nil")
+	}
+
+	agent := core.NewAgent[string](core.NewTestModel(core.TextResponse("ok")))
+	ta := NewTemporalAgent(agent, WithName("deps-marshal"))
+
+	data, err := ta.MarshalDeps(depsFixture{Name: "tenant"})
+	if err != nil {
+		t.Fatalf("marshal deps: %v", err)
+	}
+	if string(data) != `{"name":"tenant"}` {
+		t.Fatalf("unexpected marshaled deps %q", string(data))
+	}
+	if data, err := ta.MarshalDeps(nil); err != nil || data != nil {
+		t.Fatalf("expected nil deps to marshal to nil,nil, got %q %v", string(data), err)
+	}
+}
+
+func TestReadablePayloadDecodeHelpers(t *testing.T) {
+	traceRaw, err := json.Marshal(core.RunTrace{RunID: "trace-raw"})
+	if err != nil {
+		t.Fatalf("marshal trace: %v", err)
+	}
+	trace, err := decodeTrace(nil, traceRaw)
+	if err != nil {
+		t.Fatalf("decode raw trace: %v", err)
+	}
+	if trace == nil || trace.RunID != "trace-raw" {
+		t.Fatalf("unexpected decoded raw trace: %+v", trace)
+	}
+
+	traceStepsRaw, err := json.Marshal([]core.TraceStep{{Kind: core.TraceModelResponse}})
+	if err != nil {
+		t.Fatalf("marshal trace steps: %v", err)
+	}
+	steps, err := decodeTraceSteps(nil, traceStepsRaw)
+	if err != nil {
+		t.Fatalf("decode raw trace steps: %v", err)
+	}
+	if len(steps) != 1 || steps[0].Kind != core.TraceModelResponse {
+		t.Fatalf("unexpected decoded trace steps: %+v", steps)
+	}
+
+	snapshot, err := core.EncodeRunSnapshot(&core.RunSnapshot{RunID: "run-1"})
+	if err != nil {
+		t.Fatalf("encode snapshot: %v", err)
+	}
+	decodedSnapshot, err := decodeSerializedSnapshot(snapshot, nil)
+	if err != nil {
+		t.Fatalf("decode structured snapshot: %v", err)
+	}
+	if decodedSnapshot == nil || decodedSnapshot.RunID != "run-1" {
+		t.Fatalf("unexpected decoded snapshot: %+v", decodedSnapshot)
+	}
+}

--- a/ext/temporal/workflow_test.go
+++ b/ext/temporal/workflow_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -446,5 +447,182 @@ func TestTemporalAgent_RunWorkflow_DeferredSignal(t *testing.T) {
 	}
 	if !foundDeferredResult {
 		t.Error("expected follow-up model call to include deferred tool result")
+	}
+}
+
+func TestTemporalAgent_RunWorkflow_ApprovalDeniedSignal(t *testing.T) {
+	type Params struct{}
+
+	executed := false
+	tool := core.FuncTool[Params]("dangerous_action", "Dangerous action", func(_ context.Context, _ Params) (string, error) {
+		executed = true
+		return "done", nil
+	}, core.WithRequiresApproval())
+
+	model := core.NewTestModel(
+		core.ToolCallResponseWithID("dangerous_action", `{}`, "call_denied"),
+		core.TextResponse("fallback after denial"),
+	)
+	agent := core.NewAgent[string](model, core.WithTools[string](tool))
+	ta := NewTemporalAgent(agent, WithName("workflow-approval-denied"))
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	registerTemporalWorkflow(env, ta)
+	env.RegisterDelayedCallback(func() {
+		env.SignalWorkflow(ta.ApprovalSignalName(), ApprovalSignal{
+			ToolName:   "dangerous_action",
+			ToolCallID: "call_denied",
+			Approved:   false,
+			Message:    "needs review",
+		})
+	}, time.Second)
+
+	env.ExecuteWorkflow(ta.RunWorkflow, WorkflowInput{Prompt: "do dangerous thing"})
+	if err := env.GetWorkflowError(); err != nil {
+		t.Fatalf("workflow error: %v", err)
+	}
+
+	var output WorkflowOutput
+	if err := env.GetWorkflowResult(&output); err != nil {
+		t.Fatalf("workflow result: %v", err)
+	}
+	result, err := ta.DecodeWorkflowOutput(&output)
+	if err != nil {
+		t.Fatalf("decode workflow output: %v", err)
+	}
+	if result.Output != "fallback after denial" {
+		t.Fatalf("expected fallback output after denial, got %q", result.Output)
+	}
+	if executed {
+		t.Fatal("expected tool execution to be skipped after denial")
+	}
+
+	calls := model.Calls()
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 model calls after denial, got %d", len(calls))
+	}
+	foundRetry := false
+	for _, msg := range calls[1].Messages {
+		req, ok := msg.(core.ModelRequest)
+		if !ok {
+			continue
+		}
+		for _, part := range req.Parts {
+			retry, ok := part.(core.RetryPromptPart)
+			if ok && retry.ToolCallID == "call_denied" &&
+				retry.Content == `tool call "dangerous_action" was denied by the user: needs review` {
+				foundRetry = true
+			}
+		}
+	}
+	if !foundRetry {
+		t.Fatal("expected denied approval to be sent back as a retry prompt")
+	}
+}
+
+func TestTemporalWorkflowHelpers(t *testing.T) {
+	if got := waitingReason(nil, nil); got != "" {
+		t.Fatalf("expected empty waiting reason, got %q", got)
+	}
+	if got := waitingReason([]ToolApprovalRequest{{ToolCallID: "a"}}, nil); got != "approval" {
+		t.Fatalf("expected approval waiting reason, got %q", got)
+	}
+	if got := waitingReason(nil, []core.DeferredToolRequest{{ToolCallID: "b"}}); got != "deferred" {
+		t.Fatalf("expected deferred waiting reason, got %q", got)
+	}
+	if got := waitingReason(
+		[]ToolApprovalRequest{{ToolCallID: "a"}},
+		[]core.DeferredToolRequest{{ToolCallID: "b"}},
+	); got != "approval_and_deferred" {
+		t.Fatalf("expected combined waiting reason, got %q", got)
+	}
+
+	if err := workflowAbortError("   "); err == nil || err.Error() != "workflow aborted" {
+		t.Fatalf("expected default abort error, got %v", err)
+	}
+	if err := workflowAbortError(" user stopped "); err == nil || err.Error() != "workflow aborted: user stopped" {
+		t.Fatalf("expected trimmed abort error, got %v", err)
+	}
+
+	if got := approvalDeniedMessage("dangerous_action", ""); got != `tool call "dangerous_action" was denied by the user` {
+		t.Fatalf("unexpected approval denied message %q", got)
+	}
+	if got := approvalDeniedMessage("dangerous_action", " not now "); got != `tool call "dangerous_action" was denied by the user: not now` {
+		t.Fatalf("unexpected approval denied message with detail %q", got)
+	}
+
+	limit := 2
+	if err := limitsToolCalls(core.UsageLimits{}, 2, 2); err != nil {
+		t.Fatalf("expected no error without tool call limit, got %v", err)
+	}
+	if err := limitsToolCalls(core.UsageLimits{ToolCallsLimit: &limit}, 1, 1); err != nil {
+		t.Fatalf("expected no error within tool call limit, got %v", err)
+	}
+	err := limitsToolCalls(core.UsageLimits{ToolCallsLimit: &limit}, 1, 2)
+	var usageErr *core.UsageLimitExceeded
+	if !errors.As(err, &usageErr) {
+		t.Fatalf("expected usage limit exceeded, got %T: %v", err, err)
+	}
+	if !strings.Contains(err.Error(), "tool call limit of 2 exceeded") {
+		t.Fatalf("unexpected tool call limit error %v", err)
+	}
+}
+
+func TestTemporalAgent_DecodeWorkflowOutput_LegacyAndPausedBranches(t *testing.T) {
+	ta := NewTemporalAgent(core.NewAgent[string](core.NewTestModel(core.TextResponse("ok"))), WithName("decode-legacy"))
+
+	if _, err := ta.DecodeWorkflowOutput(nil); err == nil {
+		t.Fatal("expected nil workflow output error")
+	}
+	if _, err := ta.DecodeWorkflowOutput(&WorkflowOutput{
+		Completed:        false,
+		DeferredRequests: []core.DeferredToolRequest{{ToolCallID: "call_1"}},
+	}); err == nil || !strings.Contains(err.Error(), "workflow paused with 1 deferred tool request") {
+		t.Fatalf("expected paused workflow error, got %v", err)
+	}
+
+	now := time.Unix(40, 0).UTC()
+	snapshotJSON, err := core.MarshalSnapshot(&core.RunSnapshot{
+		Messages: []core.ModelMessage{
+			core.ModelRequest{
+				Parts:     []core.ModelRequestPart{core.UserPromptPart{Content: "legacy", Timestamp: now}},
+				Timestamp: now,
+			},
+		},
+		Usage:     core.RunUsage{Requests: 1},
+		RunID:     "legacy-run",
+		ToolState: map[string]any{"tool": map[string]any{"count": 1}},
+		Timestamp: now,
+	})
+	if err != nil {
+		t.Fatalf("marshal legacy snapshot: %v", err)
+	}
+	traceJSON, err := json.Marshal(core.RunTrace{RunID: "legacy-run"})
+	if err != nil {
+		t.Fatalf("marshal legacy trace: %v", err)
+	}
+
+	result, err := ta.DecodeWorkflowOutput(&WorkflowOutput{
+		Completed:    true,
+		OutputJSON:   json.RawMessage(`"legacy-output"`),
+		SnapshotJSON: snapshotJSON,
+		TraceJSON:    traceJSON,
+		Cost:         &core.RunCost{TotalCost: 1.23},
+	})
+	if err != nil {
+		t.Fatalf("decode legacy workflow output: %v", err)
+	}
+	if result.Output != "legacy-output" {
+		t.Fatalf("expected legacy output, got %q", result.Output)
+	}
+	if result.RunID != "legacy-run" {
+		t.Fatalf("expected legacy run id, got %q", result.RunID)
+	}
+	if result.Trace == nil || result.Trace.RunID != "legacy-run" {
+		t.Fatalf("expected decoded legacy trace, got %+v", result.Trace)
+	}
+	if result.Cost == nil || result.Cost.TotalCost != 1.23 {
+		t.Fatalf("expected cost to be preserved, got %+v", result.Cost)
 	}
 }


### PR DESCRIPTION
## Summary
- add focused unit tests for `core.Agent.RuntimeConfig()` and its clone/export helpers
- add Temporal driver/status/deps helper coverage for serialization, resume state, and decode branches
- expand workflow callback and workflow-path tests for approval denial, guardrail rejection, legacy decode branches, and helper logic

## Verification
- `go test ./core/... ./ext/temporal/...`
- `go test ./...`
- `go test ./core/... ./ext/temporal/... -coverprofile=/tmp/gollem_temporal_cover.out`
- repo pre-push gate: `golangci-lint`, `go test -race ./...`, `go vet ./...`, tidy check