### PR TITLE
Harden ext/team messaging and shutdown semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,13 @@ Gollem ships **50+ composable primitives** in a single framework. Here's what yo
 - **Batch execution** — `RunBatch` for concurrent multi-prompt runs with ordered results
 
 ### Multi-Agent Team Swarms
-- **Team orchestration** — Spawn concurrent teammate agents as goroutines with shared task boards, mailbox-based messaging, and automatic lifecycle management (`ext/team`)
+- **Team orchestration** — Spawn concurrent teammate agents as goroutines with shared task boards, best-effort mailbox messaging, out-of-band shutdown control, and automatic lifecycle management (`ext/team`)
 - **Dynamic personality generation** — LLM generates task-specific system prompts for each subagent and teammate before they start, dramatically improving agent effectiveness (`modelutil`)
 - **Cached personality generation** — SHA256-keyed cache prevents redundant LLM calls when identical tasks are delegated multiple times
-- **Mailbox messaging** — Buffered channel-based message queues with automatic draining via agent middleware; teammates see messages between model turns
+- **Mailbox messaging** — Best-effort buffered note delivery with automatic draining via agent middleware; `send_message` returns an error if the recipient mailbox is full
 - **Shared task board** — Concurrency-safe task tracking with status, ownership, blocking dependencies, and metadata
 - **Teammate lifecycle** — Starting, running, idle, shutting down, stopped states with automatic error recovery and leader notification
-- **Team-aware agent middleware** — Injects pending messages as `UserPromptPart` between model calls so agents stay coordinated without polling
+- **Team-aware agent middleware** — Injects pending teammate notes as `UserPromptPart` between model calls while team control signals remain out-of-band
 
 ### Composition & Multi-Agent
 - **Agent cloning** — `Clone()` creates independent copies with additional options
@@ -109,7 +109,7 @@ Gollem ships **50+ composable primitives** in a single framework. Here's what yo
 - **Unified `StreamText`** — Single function with `StreamTextOptions` for all modes
 
 ### Extensions
-- **Multi-agent team swarms** — Concurrent teammate agents with mailbox messaging, shared task boards, dynamic personality generation, and automatic lifecycle management (`ext/team`)
+- **Multi-agent team swarms** — Concurrent teammate agents with best-effort mailbox messaging, shared task boards, dynamic personality generation, and automatic lifecycle management (`ext/team`)
 - **Dynamic personality generation** — LLM-generated task-specific system prompts for subagents and teammates with SHA256-keyed caching (`modelutil`)
 - **Code mode (monty)** — LLM writes a single Python script that calls N tools as functions; executes in a WASM sandbox via [monty-go](https://github.com/fugue-labs/monty-go) — N tool calls in 1 model round-trip
 - **Graph workflow engine** — Typed state machines with conditional branching, fan-out/map-reduce, cycle detection, and Mermaid export
@@ -309,7 +309,7 @@ Use `AdoptWithWait(...)` instead when your code already wraps `cmd.Wait()` behin
 
 ### Multi-Agent Team Swarm
 
-Spawn concurrent teammates that coordinate through mailboxes and a shared task board. Each teammate gets a dynamically generated personality tailored to its specific task — the LLM itself writes the system prompt.
+Spawn concurrent teammates that coordinate through best-effort mailbox notes and a shared task board. Each teammate gets a dynamically generated personality tailored to its specific task — the LLM itself writes the system prompt.
 
 ```go
 import (
@@ -328,7 +328,7 @@ t := team.NewTeam(team.TeamConfig{
     ),
 })
 
-// Register the leader — returns middleware that auto-injects teammate messages.
+// Register the leader — returns middleware that auto-injects teammate notes.
 middleware := t.RegisterLeader("lead")
 leader := gollem.NewAgent[string](model,
     gollem.WithAgentMiddleware[string](middleware),
@@ -341,14 +341,16 @@ t.SpawnTeammate(ctx, "reviewer", "Review auth module for security vulnerabilitie
 t.SpawnTeammate(ctx, "tester", "Write comprehensive tests for the payment flow")
 t.SpawnTeammate(ctx, "docs", "Update API documentation for the new endpoints")
 
-// The leader coordinates — messages from teammates arrive automatically
-// between model turns via the team-awareness middleware.
+// The leader coordinates — teammate notes arrive automatically between
+// model turns via the team-awareness middleware.
 result, _ := leader.Run(ctx, "Coordinate the code review across all teammates")
 
 t.Shutdown(ctx)
 ```
 
 If your teammate toolset contains per-worker state, use `team.TeamConfig.ToolsetFactory` instead of sharing a single `Toolset`. This is the right pattern for stateful helpers such as background-process managers. `codetool.AgentOptions(...)` handles that automatically in team mode.
+
+Mailbox delivery is best-effort: `send_message` fails if the recipient mailbox is full. Shutdown is handled separately from mailbox note delivery so an in-flight worker cannot lose the request when its mailbox is drained for prompt injection.
 
 ### Multi-Agent with Event Coordination
 
@@ -793,7 +795,7 @@ summary, _ := orchestration.ChainRun(ctx, researcher, writer, "Topic: AI safety"
 
 ### Multi-Agent Team Swarms
 
-Spawn teams of concurrent agents that coordinate through mailbox messaging and a shared task board. Each teammate runs as a goroutine with its own context window and tools.
+Spawn teams of concurrent agents that coordinate through best-effort mailbox messaging and a shared task board. Each teammate runs as a goroutine with its own context window and tools.
 
 ```go
 import "github.com/fugue-labs/gollem/ext/team"
@@ -806,22 +808,22 @@ t := team.NewTeam(team.TeamConfig{
     Toolset: codingTools,
 })
 
-// Leader's middleware auto-injects messages from teammates between turns.
+// Leader's middleware auto-injects teammate notes between turns.
 middleware := t.RegisterLeader("lead")
 
 // Spawn teammates — each runs concurrently in its own goroutine.
 t.SpawnTeammate(ctx, "analyzer", "Analyze the codebase for dead code and unused imports")
 t.SpawnTeammate(ctx, "migrator", "Migrate database queries from raw SQL to the ORM")
 
-// Teammates can send messages, create/update tasks, and coordinate.
-// The leader sees all messages via the team-awareness middleware.
+// Teammates can send notes, create/update tasks, and coordinate.
+// The leader sees pending notes via the team-awareness middleware.
 leader := gollem.NewAgent[string](model,
     gollem.WithAgentMiddleware[string](middleware),
     gollem.WithTools[string](team.LeaderTools(t)...),
 )
 result, _ := leader.Run(ctx, "Coordinate the refactoring effort")
 
-// Graceful shutdown — sends shutdown messages, waits for completion.
+// Graceful shutdown — requests out-of-band shutdown, then waits for completion.
 t.Shutdown(ctx)
 ```
 

--- a/ext/team/e2e_test.go
+++ b/ext/team/e2e_test.go
@@ -324,6 +324,76 @@ func TestE2E_ShutdownViaMessage(t *testing.T) {
 	}
 }
 
+// TestE2E_InFlightShutdownMessageSurvivesMiddlewareDrain verifies that a
+// shutdown message delivered during a running turn still stops the teammate
+// after the current run, even when the middleware drains the mailbox entry
+// before the run finishes.
+func TestE2E_InFlightShutdownMessageSurvivesMiddlewareDrain(t *testing.T) {
+	toolStarted := make(chan struct{})
+	releaseTool := make(chan struct{})
+	waitTool := core.FuncTool[struct{}](
+		"wait",
+		"Wait until released",
+		func(ctx context.Context, _ struct{}) (string, error) {
+			select {
+			case <-toolStarted:
+			default:
+				close(toolStarted)
+			}
+			select {
+			case <-releaseTool:
+				return "released", nil
+			case <-ctx.Done():
+				return "", ctx.Err()
+			}
+		},
+	)
+
+	model := core.NewTestModel(
+		core.ToolCallResponseWithID("wait", `{}`, "call_wait"),
+		core.TextResponse("final"),
+	)
+	tm := NewTeam(TeamConfig{
+		Name:             "inflight-shutdown-team",
+		Leader:           "leader",
+		Model:            model,
+		WorkerExtraTools: []core.Tool{waitTool},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	w, err := tm.SpawnTeammate(ctx, "worker", "task")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-toolStarted:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for blocking tool to start")
+	}
+
+	w.mailbox.Send(Message{
+		From:    "leader",
+		To:      "worker",
+		Type:    MessageShutdownRequest,
+		Content: "all done",
+	})
+	w.Wake()
+
+	close(releaseTool)
+
+	deadline := time.After(3 * time.Second)
+	for w.State() != TeammateStopped {
+		select {
+		case <-deadline:
+			t.Fatalf("worker did not stop after in-flight shutdown message, state: %v", w.State())
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}
+
 // TestE2E_MultipleWakeCycles tests that a teammate can be woken multiple times.
 func TestE2E_MultipleWakeCycles(t *testing.T) {
 	model := core.NewTestModel(core.TextResponse("done"))

--- a/ext/team/events.go
+++ b/ext/team/events.go
@@ -36,8 +36,11 @@ type TaskCompletedEvent struct {
 
 // MessageSentEvent is published when a message is sent between teammates.
 type MessageSentEvent struct {
-	TeamName string
-	From     string
-	To       string
-	Summary  string
+	TeamName      string
+	MessageID     string
+	CorrelationID string
+	From          string
+	To            string
+	Type          MessageType
+	Summary       string
 }

--- a/ext/team/mailbox.go
+++ b/ext/team/mailbox.go
@@ -1,9 +1,12 @@
 package team
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 // MessageType classifies a team message.
@@ -18,13 +21,18 @@ const (
 
 // Message is a communication unit between teammates.
 type Message struct {
-	From      string      `json:"from"`
-	To        string      `json:"to"`
-	Type      MessageType `json:"type"`
-	Content   string      `json:"content"`
-	Summary   string      `json:"summary,omitempty"`
-	Timestamp time.Time   `json:"timestamp"`
+	ID            string      `json:"id,omitempty"`
+	CorrelationID string      `json:"correlation_id,omitempty"`
+	From          string      `json:"from"`
+	To            string      `json:"to"`
+	Type          MessageType `json:"type"`
+	Content       string      `json:"content"`
+	Summary       string      `json:"summary,omitempty"`
+	Timestamp     time.Time   `json:"timestamp"`
 }
+
+// ErrMailboxFull is returned when a non-blocking mailbox send cannot enqueue.
+var ErrMailboxFull = errors.New("mailbox full")
 
 // Mailbox is a buffered channel-based message queue for a teammate.
 type Mailbox struct {
@@ -36,15 +44,55 @@ func NewMailbox(bufferSize int) *Mailbox {
 	return &Mailbox{ch: make(chan Message, bufferSize)}
 }
 
-// Send enqueues a message without blocking. If the buffer is full,
-// the message is dropped (shouldn't happen with reasonable buffer sizes).
-func (m *Mailbox) Send(msg Message) {
+// newMessage constructs a team message with stable identity fields populated.
+func newMessage(from, to string, msgType MessageType, content, summary, correlationID string) Message {
+	id := uuid.NewString()
+	if correlationID == "" {
+		correlationID = id
+	}
+	return Message{
+		ID:            id,
+		CorrelationID: correlationID,
+		From:          from,
+		To:            to,
+		Type:          msgType,
+		Content:       content,
+		Summary:       summary,
+		Timestamp:     time.Now(),
+	}
+}
+
+func ensureMessageIdentity(msg Message) Message {
+	if msg.ID == "" {
+		msg.ID = uuid.NewString()
+	}
+	if msg.CorrelationID == "" {
+		msg.CorrelationID = msg.ID
+	}
+	if msg.Timestamp.IsZero() {
+		msg.Timestamp = time.Now()
+	}
+	return msg
+}
+
+// TrySend enqueues a message without blocking.
+// If the buffer is full, the message is not enqueued and ErrMailboxFull is returned.
+func (m *Mailbox) TrySend(msg Message) error {
+	msg = ensureMessageIdentity(msg)
 	select {
 	case m.ch <- msg:
+		return nil
 	default:
 		fmt.Fprintf(os.Stderr, "[gollem] WARNING: mailbox full, dropping message from %s to %s (type: %s)\n",
 			msg.From, msg.To, msg.Type)
+		return ErrMailboxFull
 	}
+}
+
+// Send preserves the historical fire-and-forget API for compatibility.
+// New code that needs delivery feedback should use TrySend.
+func (m *Mailbox) Send(msg Message) {
+	_ = m.TrySend(msg)
 }
 
 // DrainAll reads all pending messages without blocking.

--- a/ext/team/mailbox_test.go
+++ b/ext/team/mailbox_test.go
@@ -1,6 +1,7 @@
 package team
 
 import (
+	"errors"
 	"testing"
 	"time"
 )
@@ -17,6 +18,12 @@ func TestMailbox_SendAndDrain(t *testing.T) {
 	}
 	if msgs[0].From != "alice" {
 		t.Errorf("expected first message from alice, got %q", msgs[0].From)
+	}
+	if msgs[0].ID == "" {
+		t.Error("expected first message to have a generated ID")
+	}
+	if msgs[0].CorrelationID == "" {
+		t.Error("expected first message to have a generated correlation ID")
 	}
 	if msgs[1].From != "bob" {
 		t.Errorf("expected second message from bob, got %q", msgs[1].From)
@@ -40,9 +47,15 @@ func TestMailbox_DrainEmpty(t *testing.T) {
 func TestMailbox_BufferFull(t *testing.T) {
 	mb := NewMailbox(2)
 
-	mb.Send(Message{Content: "1"})
-	mb.Send(Message{Content: "2"})
-	mb.Send(Message{Content: "3"}) // Should be dropped silently.
+	if err := mb.TrySend(Message{Content: "1"}); err != nil {
+		t.Fatalf("first send failed: %v", err)
+	}
+	if err := mb.TrySend(Message{Content: "2"}); err != nil {
+		t.Fatalf("second send failed: %v", err)
+	}
+	if err := mb.TrySend(Message{Content: "3"}); !errors.Is(err, ErrMailboxFull) {
+		t.Fatalf("expected ErrMailboxFull, got %v", err)
+	}
 
 	msgs := mb.DrainAll()
 	if len(msgs) != 2 {

--- a/ext/team/middleware.go
+++ b/ext/team/middleware.go
@@ -21,8 +21,9 @@ func TeamAwarenessMiddleware(tm *Teammate) core.AgentMiddleware {
 		next func(context.Context, []core.ModelMessage, *core.ModelSettings, *core.ModelRequestParameters) (*core.ModelResponse, error),
 	) (*core.ModelResponse, error) {
 		// Drain any pending messages.
-		pending := tm.mailbox.DrainAll()
-		if len(pending) == 0 {
+		pending := tm.filterControlMessages(tm.mailbox.DrainAll())
+		shutdownMsg, hasShutdown := tm.shutdownRequest()
+		if len(pending) == 0 && !hasShutdown {
 			return next(ctx, messages, settings, params)
 		}
 
@@ -46,14 +47,22 @@ func TeamAwarenessMiddleware(tm *Teammate) core.AgentMiddleware {
 
 		// Format messages and inject as UserPromptPart.
 		var parts []string
-		hasShutdown := false
 		for _, msg := range pending {
-			if msg.Type == MessageShutdownRequest {
-				hasShutdown = true
-				parts = append(parts, fmt.Sprintf("[SHUTDOWN REQUEST from %s]: %s — Wrap up your current work and finish.", msg.From, msg.Content))
-			} else {
-				parts = append(parts, fmt.Sprintf("[Message from %s]: %s", msg.From, msg.Content))
+			parts = append(parts, fmt.Sprintf("[Message from %s]: %s", msg.From, msg.Content))
+		}
+		if hasShutdown {
+			from := shutdownMsg.From
+			if from == "" {
+				from = "team"
 			}
+			reason := shutdownMsg.Content
+			if reason == "" {
+				reason = "No reason provided"
+			}
+			// TODO: Phase 1+ should stop expressing shutdown via prompt text.
+			// The control path is now out-of-band; this injection remains only so
+			// the worker can wrap up gracefully within the current run.
+			parts = append(parts, fmt.Sprintf("[SHUTDOWN REQUEST from %s]: %s — Wrap up your current work and finish.", from, reason))
 		}
 
 		injection := strings.Join(parts, "\n\n")

--- a/ext/team/team.go
+++ b/ext/team/team.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/fugue-labs/gollem/core"
 	"github.com/fugue-labs/gollem/modelutil"
+	"github.com/google/uuid"
 )
 
 // TeamConfig configures a new team.
@@ -156,6 +157,7 @@ func WithTeammateAgentOptions(opts ...core.AgentOption[string]) TeammateOption {
 // messages from teammates are not lost.
 func (t *Team) RegisterLeader(name string) core.AgentMiddleware {
 	t.mu.Lock()
+	t.leader = name
 	existing := t.members[name]
 	t.mu.Unlock()
 
@@ -285,23 +287,47 @@ func (t *Team) SpawnTeammate(ctx context.Context, name, task string, opts ...Tea
 	return tm, nil
 }
 
+func (t *Team) leaderName() string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.leader
+}
+
+func (t *Team) leaderSenderName() string {
+	if leader := t.leaderName(); leader != "" {
+		return leader
+	}
+	return "leader"
+}
+
+func (t *Team) requestShutdown(name, from, reason, correlationID string) (Message, error) {
+	tm := t.GetTeammate(name)
+	if tm == nil {
+		return Message{}, fmt.Errorf("teammate %q not found", name)
+	}
+	if reason == "" {
+		reason = "work complete"
+	}
+	// First shutdown wins; Teammate.requestShutdown is intentionally idempotent.
+	msg := newMessage(from, name, MessageShutdownRequest, reason, "shutdown requested", correlationID)
+	msg = tm.requestShutdown(msg)
+	tm.Wake()
+	return msg, nil
+}
+
 // Shutdown gracefully shuts down all teammates.
 func (t *Team) Shutdown(ctx context.Context) error {
 	fmt.Fprintf(os.Stderr, "[gollem] team:%s shutting down\n", t.name)
 
 	// Signal all teammates to stop (skip the leader — it's the caller).
+	correlationID := uuid.NewString()
 	t.mu.RLock()
 	for _, tm := range t.members {
 		if tm.name == t.leader {
 			continue
 		}
-		tm.mailbox.Send(Message{
-			From:      "team",
-			To:        tm.name,
-			Type:      MessageShutdownRequest,
-			Content:   "Team is shutting down",
-			Timestamp: time.Now(),
-		})
+		msg := newMessage("team", tm.name, MessageShutdownRequest, "Team is shutting down", "team shutdown", correlationID)
+		tm.requestShutdown(msg)
 		tm.Wake()
 	}
 	t.mu.RUnlock()

--- a/ext/team/teammate.go
+++ b/ext/team/teammate.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/fugue-labs/gollem/core"
 )
@@ -47,14 +46,16 @@ type TeammateInfo struct {
 
 // Teammate represents a worker agent running as a goroutine.
 type Teammate struct {
-	mu      sync.Mutex
-	name    string
-	state   TeammateState
-	mailbox *Mailbox
-	agent   *core.Agent[string]
-	cancel  context.CancelFunc
-	team    *Team
-	wakeCh  chan struct{}
+	mu                sync.Mutex
+	name              string
+	state             TeammateState
+	mailbox           *Mailbox
+	agent             *core.Agent[string]
+	cancel            context.CancelFunc
+	team              *Team
+	wakeCh            chan struct{}
+	shutdownRequested bool
+	shutdownMessage   Message
 }
 
 // Name returns the teammate's name.
@@ -75,6 +76,50 @@ func (tm *Teammate) setState(s TeammateState) {
 	tm.state = s
 }
 
+func (tm *Teammate) requestShutdown(msg Message) Message {
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+
+	msg = ensureMessageIdentity(msg)
+	if msg.Type == "" {
+		msg.Type = MessageShutdownRequest
+	}
+	if !tm.shutdownRequested {
+		tm.shutdownRequested = true
+		tm.shutdownMessage = msg
+		if tm.state == TeammateIdle {
+			tm.state = TeammateShuttingDown
+		}
+	}
+	return tm.shutdownMessage
+}
+
+func (tm *Teammate) shutdownRequest() (Message, bool) {
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+	if !tm.shutdownRequested {
+		return Message{}, false
+	}
+	return tm.shutdownMessage, true
+}
+
+func (tm *Teammate) filterControlMessages(msgs []Message) []Message {
+	if len(msgs) == 0 {
+		return nil
+	}
+
+	filtered := make([]Message, 0, len(msgs))
+	for _, msg := range msgs {
+		msg = ensureMessageIdentity(msg)
+		if msg.Type == MessageShutdownRequest {
+			tm.requestShutdown(msg)
+			continue
+		}
+		filtered = append(filtered, msg)
+	}
+	return filtered
+}
+
 // Wake signals the teammate to process new messages.
 func (tm *Teammate) Wake() {
 	select {
@@ -88,11 +133,17 @@ func (tm *Teammate) Wake() {
 func (tm *Teammate) run(ctx context.Context, initialTask string) {
 	defer func() {
 		tm.setState(TeammateStopped)
+		reason := "stopped"
+		if _, ok := tm.shutdownRequest(); ok {
+			reason = "shutdown_requested"
+		} else if ctx.Err() != nil {
+			reason = "context_cancelled"
+		}
 		if tm.team.eventBus != nil {
 			core.PublishAsync(tm.team.eventBus, TeammateTerminatedEvent{
 				TeamName:     tm.team.name,
 				TeammateName: tm.name,
-				Reason:       "stopped",
+				Reason:       reason,
 			})
 		}
 		tm.team.wg.Done()
@@ -108,6 +159,13 @@ func (tm *Teammate) run(ctx context.Context, initialTask string) {
 	firstRun := true
 
 	for {
+		if msg, ok := tm.shutdownRequest(); ok {
+			tm.setState(TeammateShuttingDown)
+			fmt.Fprintf(os.Stderr, "[gollem] team:%s teammate:%s stopping after shutdown request from %s: %s\n",
+				tm.team.name, tm.name, msg.From, previewForLog(msg.Content, 240))
+			return
+		}
+
 		tm.setState(TeammateRunning)
 		fmt.Fprintf(os.Stderr, "[gollem] team:%s teammate:%s running\n", tm.team.name, tm.name)
 
@@ -118,6 +176,12 @@ func (tm *Teammate) run(ctx context.Context, initialTask string) {
 		firstRun = false
 
 		result, err := tm.agent.Run(runCtx, prompt)
+		if msg, ok := tm.shutdownRequest(); ok {
+			tm.setState(TeammateShuttingDown)
+			fmt.Fprintf(os.Stderr, "[gollem] team:%s teammate:%s stopping after current run due to shutdown request from %s: %s\n",
+				tm.team.name, tm.name, msg.From, previewForLog(msg.Content, 240))
+			return
+		}
 		if err != nil {
 			if ctx.Err() != nil {
 				// Context cancelled — shut down.
@@ -128,16 +192,20 @@ func (tm *Teammate) run(ctx context.Context, initialTask string) {
 				tm.team.name, tm.name, consecutiveErrors, err)
 
 			// Notify leader of error.
-			if tm.team.leader != "" {
-				if leaderMB := tm.team.getMailbox(tm.team.leader); leaderMB != nil {
-					leaderMB.Send(Message{
-						From:      tm.name,
-						To:        tm.team.leader,
-						Type:      MessageStatusUpdate,
-						Content:   fmt.Sprintf("Error on attempt %d: %v", consecutiveErrors, err),
-						Summary:   tm.name + " encountered an error",
-						Timestamp: time.Now(),
-					})
+			if leaderName := tm.team.leaderName(); leaderName != "" {
+				if leaderMB := tm.team.getMailbox(leaderName); leaderMB != nil {
+					statusMsg := newMessage(
+						tm.name,
+						leaderName,
+						MessageStatusUpdate,
+						fmt.Sprintf("Error on attempt %d: %v", consecutiveErrors, err),
+						tm.name+" encountered an error",
+						"",
+					)
+					if sendErr := leaderMB.TrySend(statusMsg); sendErr != nil {
+						fmt.Fprintf(os.Stderr, "[gollem] WARNING: failed to deliver error update from %s to leader %s: %v\n",
+							tm.name, leaderName, sendErr)
+					}
 				}
 			}
 
@@ -155,17 +223,21 @@ func (tm *Teammate) run(ctx context.Context, initialTask string) {
 				summary = tm.name + ": " + outputPreview
 			}
 			// Notify leader of completion via their mailbox.
-			if tm.team.leader != "" {
-				leaderMB := tm.team.getMailbox(tm.team.leader)
+			if leaderName := tm.team.leaderName(); leaderName != "" {
+				leaderMB := tm.team.getMailbox(leaderName)
 				if leaderMB != nil {
-					leaderMB.Send(Message{
-						From:      tm.name,
-						To:        tm.team.leader,
-						Type:      MessageStatusUpdate,
-						Content:   result.Output,
-						Summary:   summary,
-						Timestamp: time.Now(),
-					})
+					statusMsg := newMessage(
+						tm.name,
+						leaderName,
+						MessageStatusUpdate,
+						result.Output,
+						summary,
+						"",
+					)
+					if sendErr := leaderMB.TrySend(statusMsg); sendErr != nil {
+						fmt.Fprintf(os.Stderr, "[gollem] WARNING: failed to deliver completion update from %s to leader %s: %v\n",
+							tm.name, leaderName, sendErr)
+					}
 				}
 			}
 
@@ -177,6 +249,12 @@ func (tm *Teammate) run(ctx context.Context, initialTask string) {
 
 		// Go idle and wait for new work or shutdown.
 		tm.setState(TeammateIdle)
+		if msg, ok := tm.shutdownRequest(); ok {
+			tm.setState(TeammateShuttingDown)
+			fmt.Fprintf(os.Stderr, "[gollem] team:%s teammate:%s stopping while idle due to shutdown request from %s: %s\n",
+				tm.team.name, tm.name, msg.From, previewForLog(msg.Content, 240))
+			return
+		}
 		if tm.team.eventBus != nil {
 			core.PublishAsync(tm.team.eventBus, TeammateIdleEvent{
 				TeamName:     tm.team.name,
@@ -197,18 +275,15 @@ func (tm *Teammate) run(ctx context.Context, initialTask string) {
 			case <-tm.team.done:
 				return
 			case <-tm.wakeCh:
-				msgs := tm.mailbox.DrainAll()
+				msgs := tm.filterControlMessages(tm.mailbox.DrainAll())
+				if msg, ok := tm.shutdownRequest(); ok {
+					tm.setState(TeammateShuttingDown)
+					fmt.Fprintf(os.Stderr, "[gollem] team:%s teammate:%s received shutdown request from %s: %s\n",
+						tm.team.name, tm.name, msg.From, previewForLog(msg.Content, 240))
+					return
+				}
 				if len(msgs) == 0 {
 					continue // spurious wake — go back to select
-				}
-
-				// Check for shutdown request.
-				for _, msg := range msgs {
-					if msg.Type == MessageShutdownRequest {
-						fmt.Fprintf(os.Stderr, "[gollem] team:%s teammate:%s received shutdown request\n",
-							tm.team.name, tm.name)
-						return
-					}
 				}
 
 				// Build prompt from messages.

--- a/ext/team/tools.go
+++ b/ext/team/tools.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/fugue-labs/gollem/core"
 )
@@ -33,14 +32,14 @@ type taskCreateParams struct {
 }
 
 type taskUpdateParams struct {
-	ID          string            `json:"id" jsonschema:"description=Task ID to update"`
-	Status      string            `json:"status,omitempty" jsonschema:"description=New status: pending, in_progress, completed, or blocked"`
-	Owner       string            `json:"owner,omitempty" jsonschema:"description=Assign to a teammate by name"`
-	Subject     string            `json:"subject,omitempty" jsonschema:"description=New subject"`
-	Description string            `json:"description,omitempty" jsonschema:"description=New description"`
-	AddBlocks   []string          `json:"add_blocks,omitempty" jsonschema:"description=Task IDs that this task blocks"`
-	AddBlockedBy []string         `json:"add_blocked_by,omitempty" jsonschema:"description=Task IDs that block this task"`
-	Metadata    map[string]any    `json:"metadata,omitempty" jsonschema:"description=Key-value metadata to merge"`
+	ID           string         `json:"id" jsonschema:"description=Task ID to update"`
+	Status       string         `json:"status,omitempty" jsonschema:"description=New status: pending, in_progress, completed, or blocked"`
+	Owner        string         `json:"owner,omitempty" jsonschema:"description=Assign to a teammate by name"`
+	Subject      string         `json:"subject,omitempty" jsonschema:"description=New subject"`
+	Description  string         `json:"description,omitempty" jsonschema:"description=New description"`
+	AddBlocks    []string       `json:"add_blocks,omitempty" jsonschema:"description=Task IDs that this task blocks"`
+	AddBlockedBy []string       `json:"add_blocked_by,omitempty" jsonschema:"description=Task IDs that block this task"`
+	Metadata     map[string]any `json:"metadata,omitempty" jsonschema:"description=Key-value metadata to merge"`
 }
 
 type taskGetParams struct {
@@ -49,7 +48,7 @@ type taskGetParams struct {
 
 // LeaderTools returns tools available only to the team leader.
 func LeaderTools(t *Team) []core.Tool {
-	shared := SharedTools(t, "leader")
+	shared := SharedTools(t, t.leaderSenderName())
 	leader := []core.Tool{
 		spawnTool(t),
 		shutdownTool(t),
@@ -114,33 +113,23 @@ func shutdownTool(t *Team) core.Tool {
 				return nil, &core.ModelRetryError{Message: "name must not be empty"}
 			}
 
-			mb := t.getMailbox(params.Name)
-			if mb == nil {
-				return nil, fmt.Errorf("teammate %q not found", params.Name)
-			}
-
 			reason := params.Reason
 			if reason == "" {
 				reason = "work complete"
 			}
 
-			mb.Send(Message{
-				From:      "leader",
-				To:        params.Name,
-				Type:      MessageShutdownRequest,
-				Content:   reason,
-				Timestamp: time.Now(),
-			})
-
-			// Wake the teammate if idle.
-			if tm := t.GetTeammate(params.Name); tm != nil {
-				tm.Wake()
+			msg, err := t.requestShutdown(params.Name, t.leaderSenderName(), reason, "")
+			if err != nil {
+				return nil, err
 			}
 
 			return map[string]any{
-				"status":  "shutdown_requested",
-				"name":    params.Name,
-				"message": fmt.Sprintf("Shutdown request sent to %q", params.Name),
+				"status":         "shutdown_requested",
+				"name":           params.Name,
+				"requested_by":   msg.From,
+				"shutdown_id":    msg.ID,
+				"correlation_id": msg.CorrelationID,
+				"message":        fmt.Sprintf("Shutdown request sent to %q", params.Name),
 			}, nil
 		},
 	)
@@ -172,14 +161,10 @@ func sendMessageTool(t *Team, selfName string) core.Tool {
 				summary = params.Content
 			}
 
-			mb.Send(Message{
-				From:      selfName,
-				To:        params.To,
-				Content:   params.Content,
-				Type:      MessageText,
-				Summary:   summary,
-				Timestamp: time.Now(),
-			})
+			msg := newMessage(selfName, params.To, MessageText, params.Content, summary, "")
+			if err := mb.TrySend(msg); err != nil {
+				return nil, fmt.Errorf("failed to deliver message to %q: %w", params.To, err)
+			}
 
 			// Wake the recipient if idle.
 			if tm := t.GetTeammate(params.To); tm != nil {
@@ -188,17 +173,22 @@ func sendMessageTool(t *Team, selfName string) core.Tool {
 
 			if t.eventBus != nil {
 				core.PublishAsync(t.eventBus, MessageSentEvent{
-					TeamName: t.name,
-					From:     selfName,
-					To:       params.To,
-					Summary:  summary,
+					TeamName:      t.name,
+					MessageID:     msg.ID,
+					CorrelationID: msg.CorrelationID,
+					From:          selfName,
+					To:            params.To,
+					Type:          msg.Type,
+					Summary:       summary,
 				})
 			}
 
 			return map[string]any{
-				"status":  "sent",
-				"to":      params.To,
-				"message": fmt.Sprintf("Message sent to %q", params.To),
+				"status":         "sent",
+				"to":             params.To,
+				"message_id":     msg.ID,
+				"correlation_id": msg.CorrelationID,
+				"message":        fmt.Sprintf("Message sent to %q", params.To),
 			}, nil
 		},
 	)

--- a/ext/team/tools_test.go
+++ b/ext/team/tools_test.go
@@ -104,6 +104,15 @@ func TestShutdownTool(t *testing.T) {
 	if resultMap["status"] != "shutdown_requested" {
 		t.Errorf("expected status 'shutdown_requested', got %v", resultMap["status"])
 	}
+	if resultMap["requested_by"] != "leader" {
+		t.Errorf("expected requested_by 'leader', got %v", resultMap["requested_by"])
+	}
+	if resultMap["shutdown_id"] == "" {
+		t.Error("expected non-empty shutdown_id")
+	}
+	if resultMap["correlation_id"] == "" {
+		t.Error("expected non-empty correlation_id")
+	}
 
 	// Worker should stop.
 	deadline := time.After(3 * time.Second)
@@ -124,6 +133,35 @@ func TestShutdownTool_NotFound(t *testing.T) {
 	_, err := tool.Handler(context.Background(), nil, `{"name":"nobody"}`)
 	if err == nil {
 		t.Error("expected error for missing teammate")
+	}
+}
+
+func TestShutdownTool_UsesConfiguredLeaderName(t *testing.T) {
+	model := core.NewTestModel(core.TextResponse("done"))
+	tm := NewTeam(TeamConfig{
+		Name:   "test",
+		Leader: "lead",
+		Model:  model,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := tm.SpawnTeammate(ctx, "worker", "task")
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := tm.GetTeammate("worker")
+	waitForState(t, w, TeammateIdle, 3*time.Second)
+
+	tool := shutdownTool(tm)
+	result, err := tool.Handler(ctx, nil, `{"name":"worker","reason":"all done"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resultMap := result.(map[string]any)
+	if resultMap["requested_by"] != "lead" {
+		t.Errorf("expected requested_by 'lead', got %v", resultMap["requested_by"])
 	}
 }
 
@@ -165,6 +203,12 @@ func TestSendMessageTool(t *testing.T) {
 	if resultMap["status"] != "sent" {
 		t.Errorf("expected status 'sent', got %v", resultMap["status"])
 	}
+	if resultMap["message_id"] == "" {
+		t.Error("expected non-empty message_id")
+	}
+	if resultMap["correlation_id"] == "" {
+		t.Error("expected non-empty correlation_id")
+	}
 
 	// The send_message tool also wakes bob, which causes the teammate loop
 	// to drain the mailbox and run. So instead of checking the mailbox directly
@@ -188,6 +232,15 @@ func TestSendMessageTool(t *testing.T) {
 	if sentEvents[0].Summary != "review request" {
 		t.Errorf("expected summary 'review request', got %q", sentEvents[0].Summary)
 	}
+	if sentEvents[0].MessageID == "" {
+		t.Error("expected sent event to include message ID")
+	}
+	if sentEvents[0].CorrelationID == "" {
+		t.Error("expected sent event to include correlation ID")
+	}
+	if sentEvents[0].Type != MessageText {
+		t.Errorf("expected message type %q, got %q", MessageText, sentEvents[0].Type)
+	}
 
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer shutdownCancel()
@@ -200,6 +253,28 @@ func TestSendMessageTool_NotFound(t *testing.T) {
 	_, err := tool.Handler(context.Background(), nil, `{"to":"nobody","content":"hello"}`)
 	if err == nil {
 		t.Error("expected error for missing recipient")
+	}
+}
+
+func TestSendMessageTool_MailboxFullReturnsError(t *testing.T) {
+	tm := NewTeam(TeamConfig{
+		Name:        "test",
+		Leader:      "lead",
+		Model:       core.NewTestModel(core.TextResponse("done")),
+		MailboxSize: 1,
+	})
+	_ = tm.RegisterLeader("lead")
+
+	leaderMB := tm.getMailbox("lead")
+	if leaderMB == nil {
+		t.Fatal("expected leader mailbox")
+	}
+	leaderMB.Send(Message{From: "existing", To: "lead", Type: MessageText, Content: "already full"})
+
+	tool := sendMessageTool(tm, "alice")
+	_, err := tool.Handler(context.Background(), nil, `{"to":"lead","content":"overflow"}`)
+	if err == nil {
+		t.Fatal("expected mailbox full error")
 	}
 }
 


### PR DESCRIPTION
## Summary
- move `ext/team` shutdown handling out of mailbox-only state so in-flight workers cannot lose shutdown requests when middleware drains the mailbox
- make mailbox delivery honest by surfacing full-mailbox errors, threading message IDs/correlation IDs, and fixing leader identity handling
- update `ext/team` tests and README language to reflect best-effort mailbox notes plus out-of-band shutdown control

## Testing
- `go test ./ext/team/...`
- pre-push: `golangci-lint run`
- pre-push: `go test -race ./...`
- pre-push: `go vet ./...`
- pre-push: tidy verification