### PR TITLE
AGUI

### DIFF
--- a/core/agent.go
+++ b/core/agent.go
@@ -529,6 +529,27 @@ func (a *Agent[T]) Run(ctx context.Context, prompt string, opts ...RunOption) (*
 	// fire, inject this run's RunID so child work propagates the correct lineage.
 	ctx = a.beginRun(ctx, state, deps, prompt)
 
+	// Emit deferred resolution events AFTER RunStarted so subscribers
+	// see them in the correct order: RunStarted → RunResumed → DeferredResolved.
+	if a.eventBus != nil && len(cfg.deferredResults) > 0 {
+		Publish(a.eventBus, RunResumedEvent{
+			RunID:       state.runID,
+			ParentRunID: state.parentRunID,
+			ResumedAt:   time.Now(),
+		})
+		for _, dr := range cfg.deferredResults {
+			Publish(a.eventBus, DeferredResolvedEvent{
+				RunID:       state.runID,
+				ParentRunID: state.parentRunID,
+				ToolCallID:  dr.ToolCallID,
+				ToolName:    dr.ToolName,
+				Content:     dr.Content,
+				IsError:     dr.IsError,
+				ResolvedAt:  time.Now(),
+			})
+		}
+	}
+
 	result, runErr := a.runLoop(ctx, state, prompt, settings, limits, deps)
 	a.endRun(ctx, state, deps, prompt, runErr)
 
@@ -594,6 +615,26 @@ func (a *Agent[T]) RunStream(ctx context.Context, prompt string, opts ...RunOpti
 	}
 
 	ctx = a.beginRun(ctx, state, deps, prompt)
+
+	// Emit deferred resolution events AFTER RunStarted (same as Run).
+	if a.eventBus != nil && len(cfg.deferredResults) > 0 {
+		Publish(a.eventBus, RunResumedEvent{
+			RunID:       state.runID,
+			ParentRunID: state.parentRunID,
+			ResumedAt:   time.Now(),
+		})
+		for _, dr := range cfg.deferredResults {
+			Publish(a.eventBus, DeferredResolvedEvent{
+				RunID:       state.runID,
+				ParentRunID: state.parentRunID,
+				ToolCallID:  dr.ToolCallID,
+				ToolName:    dr.ToolName,
+				Content:     dr.Content,
+				IsError:     dr.IsError,
+				ResolvedAt:  time.Now(),
+			})
+		}
+	}
 
 	// Gather all tools and build lookup maps.
 	allTools := a.allTools()
@@ -1040,6 +1081,18 @@ func (a *Agent[T]) executeFunctionTools(
 					case sem <- struct{}{}:
 						defer func() { <-sem }()
 					case <-ctx.Done():
+						if a.eventBus != nil {
+							Publish(a.eventBus, ToolCalledEvent{
+								RunID: state.runID, ParentRunID: state.parentRunID,
+								ToolCallID: ic.call.ToolCallID, ToolName: ic.call.ToolName,
+								ArgsJSON: ic.call.ArgsJSON, CalledAt: time.Now(),
+							})
+							Publish(a.eventBus, ToolFailedEvent{
+								RunID: state.runID, ParentRunID: state.parentRunID,
+								ToolCallID: ic.call.ToolCallID, ToolName: ic.call.ToolName,
+								Error: "context cancelled waiting for semaphore", FailedAt: time.Now(),
+							})
+						}
 						mu.Lock()
 						results[ic.idx] = ToolReturnPart{
 							ToolName:   ic.call.ToolName,
@@ -1063,6 +1116,24 @@ func (a *Agent[T]) executeFunctionTools(
 	// Execute sequential tools.
 	for _, ic := range sequentialCalls {
 		if err := ctx.Err(); err != nil {
+			// Emit events for remaining sequential tools that won't execute.
+			if a.eventBus != nil {
+				for _, remaining := range sequentialCalls {
+					if results[remaining.idx] != nil {
+						continue // already executed
+					}
+					Publish(a.eventBus, NewToolCalledEvent(
+						state.runID, state.parentRunID,
+						remaining.call.ToolCallID, remaining.call.ToolName,
+						remaining.call.ArgsJSON, time.Now(),
+					))
+					Publish(a.eventBus, ToolFailedEvent{
+						RunID: state.runID, ParentRunID: state.parentRunID,
+						ToolCallID: remaining.call.ToolCallID, ToolName: remaining.call.ToolName,
+						Error: "context cancelled", FailedAt: time.Now(),
+					})
+				}
+			}
 			return nil, err
 		}
 		part := a.executeSingleTool(ctx, state, ic.call, ic.tool, deps, prompt)
@@ -1110,9 +1181,40 @@ func (a *Agent[T]) executeSingleTool(
 		))
 	}
 
+	// Enrich context with tool call ID early so approval funcs can access it.
+	approvalCtx := ContextWithToolCallID(ctx, call.ToolCallID)
+
 	// Check tool approval if required.
 	if tool.RequiresApproval {
+		if a.eventBus != nil {
+			Publish(a.eventBus, ApprovalRequestedEvent{
+				RunID:       state.runID,
+				ParentRunID: state.parentRunID,
+				ToolCallID:  call.ToolCallID,
+				ToolName:    call.ToolName,
+				ArgsJSON:    call.ArgsJSON,
+				RequestedAt: time.Now(),
+			})
+		}
 		if a.toolApprovalFunc == nil {
+			if a.eventBus != nil {
+				Publish(a.eventBus, ApprovalResolvedEvent{
+					RunID:       state.runID,
+					ParentRunID: state.parentRunID,
+					ToolCallID:  call.ToolCallID,
+					ToolName:    call.ToolName,
+					Approved:    false,
+					ResolvedAt:  time.Now(),
+				})
+				Publish(a.eventBus, ToolFailedEvent{
+					RunID:       state.runID,
+					ParentRunID: state.parentRunID,
+					ToolCallID:  call.ToolCallID,
+					ToolName:    call.ToolName,
+					Error:       "no approval function configured",
+					FailedAt:    time.Now(),
+				})
+			}
 			return RetryPromptPart{
 				Content:    fmt.Sprintf("tool %q requires approval but no approval function is configured", call.ToolName),
 				ToolName:   call.ToolName,
@@ -1120,8 +1222,45 @@ func (a *Agent[T]) executeSingleTool(
 				Timestamp:  time.Now(),
 			}
 		}
-		approved, approvalErr := a.toolApprovalFunc(ctx, call.ToolName, call.ArgsJSON)
+		firstApprovalWait := state.beginApprovalWait()
+		if a.eventBus != nil && firstApprovalWait {
+			Publish(a.eventBus, RunWaitingEvent{
+				RunID:       state.runID,
+				ParentRunID: state.parentRunID,
+				Reason:      "approval",
+				WaitingAt:   time.Now(),
+			})
+		}
+		approved, approvalErr := a.toolApprovalFunc(approvalCtx, call.ToolName, call.ArgsJSON)
+		lastApprovalResolved := state.endApprovalWait()
+		if a.eventBus != nil && lastApprovalResolved {
+			Publish(a.eventBus, RunResumedEvent{
+				RunID:       state.runID,
+				ParentRunID: state.parentRunID,
+				ResumedAt:   time.Now(),
+			})
+		}
+		if a.eventBus != nil {
+			Publish(a.eventBus, ApprovalResolvedEvent{
+				RunID:       state.runID,
+				ParentRunID: state.parentRunID,
+				ToolCallID:  call.ToolCallID,
+				ToolName:    call.ToolName,
+				Approved:    approvalErr == nil && approved,
+				ResolvedAt:  time.Now(),
+			})
+		}
 		if approvalErr != nil {
+			if a.eventBus != nil {
+				Publish(a.eventBus, ToolFailedEvent{
+					RunID:       state.runID,
+					ParentRunID: state.parentRunID,
+					ToolCallID:  call.ToolCallID,
+					ToolName:    call.ToolName,
+					Error:       "approval error: " + approvalErr.Error(),
+					FailedAt:    time.Now(),
+				})
+			}
 			return ToolReturnPart{
 				ToolName:   call.ToolName,
 				Content:    "error checking tool approval: " + approvalErr.Error(),
@@ -1130,6 +1269,16 @@ func (a *Agent[T]) executeSingleTool(
 			}
 		}
 		if !approved {
+			if a.eventBus != nil {
+				Publish(a.eventBus, ToolFailedEvent{
+					RunID:       state.runID,
+					ParentRunID: state.parentRunID,
+					ToolCallID:  call.ToolCallID,
+					ToolName:    call.ToolName,
+					Error:       "denied by user",
+					FailedAt:    time.Now(),
+				})
+			}
 			return RetryPromptPart{
 				Content:    fmt.Sprintf("tool call %q was denied by the user", call.ToolName),
 				ToolName:   call.ToolName,
@@ -1159,7 +1308,7 @@ func (a *Agent[T]) executeSingleTool(
 	}
 
 	// Apply tool timeout.
-	toolCtx := ContextWithToolCallID(ctx, call.ToolCallID)
+	toolCtx := approvalCtx
 	timeout := tool.Timeout
 	if timeout == 0 && a.defaultToolTimeout > 0 {
 		timeout = a.defaultToolTimeout
@@ -1187,6 +1336,40 @@ func (a *Agent[T]) executeSingleTool(
 				h.OnToolEnd(ctx, rc, call.ToolCallID, call.ToolName, resultStr, err)
 			}
 		})
+
+		// Publish ToolCompleted or ToolFailed runtime event.
+		// CallDeferred is not a failure — it's expected control flow.
+		if a.eventBus != nil {
+			var isDeferred bool
+			if err != nil {
+				var deferredCheck *CallDeferred
+				isDeferred = errors.As(err, &deferredCheck)
+			}
+			if !isDeferred {
+				dur := time.Since(toolStart).Milliseconds()
+				if err != nil {
+					Publish(a.eventBus, ToolFailedEvent{
+						RunID:       state.runID,
+						ParentRunID: state.parentRunID,
+						ToolCallID:  call.ToolCallID,
+						ToolName:    call.ToolName,
+						Error:       err.Error(),
+						DurationMs:  dur,
+						FailedAt:    time.Now(),
+					})
+				} else {
+					Publish(a.eventBus, ToolCompletedEvent{
+						RunID:       state.runID,
+						ParentRunID: state.parentRunID,
+						ToolCallID:  call.ToolCallID,
+						ToolName:    call.ToolName,
+						Result:      resultStr,
+						DurationMs:  dur,
+						CompletedAt: time.Now(),
+					})
+				}
+			}
+		}
 
 		// Add trace step for tool result.
 		if a.tracingEnabled {

--- a/core/deferred.go
+++ b/core/deferred.go
@@ -96,6 +96,8 @@ func (e *ErrDeferred[T]) Error() string {
 	return fmt.Sprintf("agent run deferred: %d tool call(s) require external resolution", len(e.Result.DeferredRequests))
 }
 
+func (e *ErrDeferred[T]) deferredRunError() {}
+
 // WithDeferredResults injects deferred tool results into the run.
 // When provided, the results are sent as ToolReturnParts (or RetryPromptParts
 // for error results) before the first model call.

--- a/core/eventbus_test.go
+++ b/core/eventbus_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"errors"
+	"io"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -16,6 +17,38 @@ type testEvent struct {
 type otherEvent struct {
 	Count int
 }
+
+type noResponseStreamModel struct{}
+
+func (m *noResponseStreamModel) Request(context.Context, []ModelMessage, *ModelSettings, *ModelRequestParameters) (*ModelResponse, error) {
+	return TextResponse("unused"), nil
+}
+
+func (m *noResponseStreamModel) RequestStream(context.Context, []ModelMessage, *ModelSettings, *ModelRequestParameters) (StreamedResponse, error) {
+	return &noResponseStream{}, nil
+}
+
+func (m *noResponseStreamModel) ModelName() string {
+	return "no-response-stream-model"
+}
+
+type noResponseStream struct {
+	done bool
+}
+
+func (s *noResponseStream) Next() (ModelResponseStreamEvent, error) {
+	if s.done {
+		return nil, io.EOF
+	}
+	s.done = true
+	return nil, io.EOF
+}
+
+func (s *noResponseStream) Response() *ModelResponse { return nil }
+
+func (s *noResponseStream) Usage() Usage { return Usage{} }
+
+func (s *noResponseStream) Close() error { return nil }
 
 func TestEventBus_PublishSubscribe(t *testing.T) {
 	bus := NewEventBus()
@@ -339,6 +372,167 @@ func TestEventBus_AgentIntegration(t *testing.T) {
 	}
 	if busFromTool != bus {
 		t.Error("expected EventBus to be accessible via RunContext in tool")
+	}
+}
+
+func TestEventBus_ConcurrentApprovalsPublishSingleWaitResumePair(t *testing.T) {
+	bus := NewEventBus()
+
+	var (
+		waitingCount atomic.Int32
+		resumedCount atomic.Int32
+	)
+	Subscribe(bus, func(RunWaitingEvent) {
+		waitingCount.Add(1)
+	})
+	Subscribe(bus, func(RunResumedEvent) {
+		resumedCount.Add(1)
+	})
+
+	approvalStarted := make(chan string, 2)
+	releaseApproval := make(chan struct{})
+	approvalFn := func(ctx context.Context, _ string, _ string) (bool, error) {
+		approvalStarted <- ToolCallIDFromContext(ctx)
+		<-releaseApproval
+		return true, nil
+	}
+
+	toolOne := FuncTool[struct{}]("tool_one", "first tool", func(context.Context, struct{}) (string, error) {
+		return "one", nil
+	}, WithRequiresApproval())
+	toolTwo := FuncTool[struct{}]("tool_two", "second tool", func(context.Context, struct{}) (string, error) {
+		return "two", nil
+	}, WithRequiresApproval())
+
+	model := NewTestModel(
+		MultiToolCallResponse(
+			ToolCallPart{ToolName: "tool_one", ToolCallID: "call_1", ArgsJSON: `{}`},
+			ToolCallPart{ToolName: "tool_two", ToolCallID: "call_2", ArgsJSON: `{}`},
+		),
+		TextResponse("done"),
+	)
+	agent := NewAgent[string](
+		model,
+		WithTools[string](toolOne, toolTwo),
+		WithToolApproval[string](approvalFn),
+		WithEventBus[string](bus),
+		WithMaxConcurrency[string](2),
+	)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := agent.Run(context.Background(), "run both tools")
+		done <- err
+	}()
+
+	seen := map[string]bool{}
+	for len(seen) < 2 {
+		select {
+		case toolCallID := <-approvalStarted:
+			seen[toolCallID] = true
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for approvals, saw %v", seen)
+		}
+	}
+
+	if waitingCount.Load() != 1 {
+		t.Fatalf("expected 1 RunWaitingEvent while approvals are blocked, got %d", waitingCount.Load())
+	}
+	if resumedCount.Load() != 0 {
+		t.Fatalf("expected no RunResumedEvent before approvals resolve, got %d", resumedCount.Load())
+	}
+
+	close(releaseApproval)
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("agent.Run returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for run completion")
+	}
+
+	if resumedCount.Load() != 1 {
+		t.Fatalf("expected 1 RunResumedEvent after all approvals resolve, got %d", resumedCount.Load())
+	}
+}
+
+func TestEventBus_RunStreamPublishesSingleTurnCompletion(t *testing.T) {
+	bus := NewEventBus()
+
+	var (
+		startedCount   atomic.Int32
+		completedCount atomic.Int32
+		lastCompleted  TurnCompletedEvent
+	)
+	Subscribe(bus, func(TurnStartedEvent) {
+		startedCount.Add(1)
+	})
+	Subscribe(bus, func(e TurnCompletedEvent) {
+		completedCount.Add(1)
+		lastCompleted = e
+	})
+
+	agent := NewAgent[string](
+		NewTestModel(TextResponse("streamed")),
+		WithEventBus[string](bus),
+	)
+	stream, err := agent.RunStream(context.Background(), "stream")
+	if err != nil {
+		t.Fatalf("RunStream returned error: %v", err)
+	}
+	if _, err := stream.Result(); err != nil {
+		t.Fatalf("stream.Result returned error: %v", err)
+	}
+
+	if startedCount.Load() != 1 {
+		t.Fatalf("expected 1 TurnStartedEvent, got %d", startedCount.Load())
+	}
+	if completedCount.Load() != 1 {
+		t.Fatalf("expected 1 TurnCompletedEvent, got %d", completedCount.Load())
+	}
+	if lastCompleted.Error != "" {
+		t.Fatalf("expected successful turn completion, got error %q", lastCompleted.Error)
+	}
+}
+
+func TestEventBus_RunStreamNoResponsePublishesSingleTurnCompletion(t *testing.T) {
+	bus := NewEventBus()
+
+	var (
+		startedCount   atomic.Int32
+		completedCount atomic.Int32
+		lastCompleted  TurnCompletedEvent
+	)
+	Subscribe(bus, func(TurnStartedEvent) {
+		startedCount.Add(1)
+	})
+	Subscribe(bus, func(e TurnCompletedEvent) {
+		completedCount.Add(1)
+		lastCompleted = e
+	})
+
+	agent := NewAgent[string](
+		&noResponseStreamModel{},
+		WithEventBus[string](bus),
+	)
+	stream, err := agent.RunStream(context.Background(), "broken stream")
+	if err != nil {
+		t.Fatalf("RunStream returned error: %v", err)
+	}
+	if _, err := stream.Result(); err == nil {
+		t.Fatal("expected stream.Result to fail when no final response is produced")
+	}
+
+	if startedCount.Load() != 1 {
+		t.Fatalf("expected 1 TurnStartedEvent, got %d", startedCount.Load())
+	}
+	if completedCount.Load() != 1 {
+		t.Fatalf("expected 1 TurnCompletedEvent, got %d", completedCount.Load())
+	}
+	if lastCompleted.Error != "stream completed without a response" {
+		t.Fatalf("unexpected TurnCompletedEvent error: %q", lastCompleted.Error)
 	}
 }
 

--- a/core/run_engine.go
+++ b/core/run_engine.go
@@ -181,6 +181,29 @@ func (a *Agent[T]) newTurnEngine(ctx context.Context, state *RunState, prompt st
 	}
 }
 
+// emitTurnCompleted publishes a TurnCompletedEvent if an event bus is configured.
+// Pass nil for resp if the model response was not received. Pass nil for turnErr
+// if the turn completed successfully.
+func (e *turnEngine[T]) emitTurnCompleted(resp *ModelResponse, turnErr error) {
+	if e.agent.eventBus == nil {
+		return
+	}
+	ev := TurnCompletedEvent{
+		RunID:       e.state.runID,
+		ParentRunID: e.state.parentRunID,
+		TurnNumber:  e.state.runStep,
+		CompletedAt: time.Now(),
+	}
+	if resp != nil {
+		ev.HasToolCalls = len(resp.ToolCalls()) > 0
+		ev.HasText = resp.TextContent() != ""
+	}
+	if turnErr != nil {
+		ev.Error = turnErr.Error()
+	}
+	Publish(e.agent.eventBus, ev)
+}
+
 // Step executes one non-streaming turn: one model response and any resulting
 // tool execution, including retries and deferred tool handling.
 func (e *turnEngine[T]) Step() (*ModelResponse, *RunResult[T], error) {
@@ -208,6 +231,14 @@ func (e *turnEngine[T]) Step() (*ModelResponse, *RunResult[T], error) {
 				h.OnTurnStart(e.ctx, turnRC, e.state.runStep)
 			}
 		})
+		if e.agent.eventBus != nil {
+			Publish(e.agent.eventBus, TurnStartedEvent{
+				RunID:       e.state.runID,
+				ParentRunID: e.state.parentRunID,
+				TurnNumber:  e.state.runStep,
+				StartedAt:   time.Now(),
+			})
+		}
 
 		preparedTools := e.agent.prepareTools(e.ctx, e.state, e.allTools, e.deps, e.prompt)
 		params := buildModelRequestParams(preparedTools, e.agent.outputSchema)
@@ -249,7 +280,9 @@ func (e *turnEngine[T]) Step() (*ModelResponse, *RunResult[T], error) {
 			beforeTokens := estimateTokens(messages)
 			processed, procErr := proc(e.ctx, messages)
 			if procErr != nil {
-				return nil, nil, fmt.Errorf("history processor failed: %w", procErr)
+				hpErr := fmt.Errorf("history processor failed: %w", procErr)
+				e.emitTurnCompleted(nil, hpErr)
+				return nil, nil, hpErr
 			}
 			afterCount := len(processed)
 			afterTokens := estimateTokens(processed)
@@ -276,7 +309,9 @@ func (e *turnEngine[T]) Step() (*ModelResponse, *RunResult[T], error) {
 			var dropped bool
 			messages, dropped = runMessageInterceptors(e.ctx, e.agent.messageInterceptors, messages)
 			if dropped {
-				return nil, nil, errors.New("message interceptor dropped the request")
+				miErr := errors.New("message interceptor dropped the request")
+				e.emitTurnCompleted(nil, miErr)
+				return nil, nil, miErr
 			}
 		}
 
@@ -291,10 +326,12 @@ func (e *turnEngine[T]) Step() (*ModelResponse, *RunResult[T], error) {
 				}
 			})
 			if gErr != nil {
-				return nil, nil, &GuardrailError{
+				grErr := &GuardrailError{
 					GuardrailName: g.name,
 					Message:       gErr.Error(),
 				}
+				e.emitTurnCompleted(nil, grErr)
+				return nil, nil, grErr
 			}
 		}
 
@@ -307,6 +344,15 @@ func (e *turnEngine[T]) Step() (*ModelResponse, *RunResult[T], error) {
 		})
 
 		modelReqStart := time.Now()
+		if e.agent.eventBus != nil {
+			Publish(e.agent.eventBus, ModelRequestStartedEvent{
+				RunID:        e.state.runID,
+				ParentRunID:  e.state.parentRunID,
+				TurnNumber:   e.state.runStep,
+				MessageCount: len(messages),
+				StartedAt:    modelReqStart,
+			})
+		}
 		if e.agent.tracingEnabled {
 			e.state.traceSteps = append(e.state.traceSteps, TraceStep{
 				Kind:      TraceModelRequest,
@@ -333,7 +379,9 @@ func (e *turnEngine[T]) Step() (*ModelResponse, *RunResult[T], error) {
 			resp, err = e.agent.model.Request(e.ctx, messages, settings, params)
 		}
 		if err != nil {
-			return nil, nil, fmt.Errorf("model request failed: %w", err)
+			modelErr := fmt.Errorf("model request failed: %w", err)
+			e.emitTurnCompleted(nil, modelErr)
+			return nil, nil, modelErr
 		}
 
 		e.state.usage.IncrRequest(resp.Usage)
@@ -349,6 +397,7 @@ func (e *turnEngine[T]) Step() (*ModelResponse, *RunResult[T], error) {
 
 		if len(e.agent.responseInterceptors) > 0 {
 			if runResponseInterceptors(e.ctx, e.agent.responseInterceptors, resp) {
+				e.emitTurnCompleted(resp, nil)
 				continue
 			}
 		}
@@ -366,6 +415,20 @@ func (e *turnEngine[T]) Step() (*ModelResponse, *RunResult[T], error) {
 				h.OnModelResponse(e.ctx, modelRC, resp)
 			}
 		})
+		if e.agent.eventBus != nil {
+			Publish(e.agent.eventBus, ModelResponseCompletedEvent{
+				RunID:        e.state.runID,
+				ParentRunID:  e.state.parentRunID,
+				TurnNumber:   e.state.runStep,
+				FinishReason: string(resp.FinishReason),
+				InputTokens:  resp.Usage.InputTokens,
+				OutputTokens: resp.Usage.OutputTokens,
+				HasToolCalls: len(resp.ToolCalls()) > 0,
+				HasText:      resp.TextContent() != "",
+				DurationMs:   time.Since(modelReqStart).Milliseconds(),
+				CompletedAt:  time.Now(),
+			})
+		}
 
 		if e.agent.tracingEnabled {
 			e.state.traceSteps = append(e.state.traceSteps, TraceStep{
@@ -378,6 +441,7 @@ func (e *turnEngine[T]) Step() (*ModelResponse, *RunResult[T], error) {
 
 		if e.limits.HasTokenLimits() {
 			if err := e.limits.CheckTokens(e.state.usage); err != nil {
+				e.emitTurnCompleted(resp, err)
 				return resp, nil, err
 			}
 		}
@@ -401,10 +465,13 @@ func (e *turnEngine[T]) Step() (*ModelResponse, *RunResult[T], error) {
 							}
 						}
 						if parseErr == nil {
+							e.emitTurnCompleted(resp, nil)
 							return resp, e.agent.buildRunResult(e.state, output), nil
 						}
 					}
-					return resp, nil, &RunConditionError{Reason: reason}
+					condErr := &RunConditionError{Reason: reason}
+					e.emitTurnCompleted(resp, condErr)
+					return resp, nil, condErr
 				}
 			}
 		}
@@ -416,9 +483,29 @@ func (e *turnEngine[T]) Step() (*ModelResponse, *RunResult[T], error) {
 			}
 		})
 		if err != nil {
+			e.emitTurnCompleted(resp, err)
 			return resp, nil, err
 		}
 		if len(deferredReqs) > 0 {
+			e.emitTurnCompleted(resp, nil)
+			if e.agent.eventBus != nil {
+				for _, dr := range deferredReqs {
+					Publish(e.agent.eventBus, DeferredRequestedEvent{
+						RunID:       e.state.runID,
+						ParentRunID: e.state.parentRunID,
+						ToolCallID:  dr.ToolCallID,
+						ToolName:    dr.ToolName,
+						ArgsJSON:    dr.ArgsJSON,
+						RequestedAt: time.Now(),
+					})
+				}
+				Publish(e.agent.eventBus, RunWaitingEvent{
+					RunID:       e.state.runID,
+					ParentRunID: e.state.parentRunID,
+					Reason:      "deferred",
+					WaitingAt:   time.Now(),
+				})
+			}
 			if len(nextParts) > 0 {
 				e.state.messages = append(e.state.messages, ModelRequest{
 					Parts:     nextParts,
@@ -438,12 +525,17 @@ func (e *turnEngine[T]) Step() (*ModelResponse, *RunResult[T], error) {
 				responseText := resp.TextContent()
 				if responseText != "" {
 					if storeErr := e.agent.knowledgeBase.Store(e.ctx, responseText); storeErr != nil {
-						return resp, nil, fmt.Errorf("knowledge base store failed: %w", storeErr)
+						kbErr := fmt.Errorf("knowledge base store failed: %w", storeErr)
+						e.emitTurnCompleted(resp, kbErr)
+						return resp, nil, kbErr
 					}
 				}
 			}
+			e.emitTurnCompleted(resp, nil)
 			return resp, e.agent.buildRunResult(e.state, result.output), nil
 		}
+		// No result — tool calls processed, continue to next turn.
+		e.emitTurnCompleted(resp, nil)
 		if len(nextParts) > 0 {
 			e.state.messages = append(e.state.messages, ModelRequest{
 				Parts:     nextParts,

--- a/core/run_state.go
+++ b/core/run_state.go
@@ -12,6 +12,7 @@ type RunState struct {
 	lastInputTokens int // input tokens from the most recent model response (0 on first turn)
 	retries         int
 	toolRetries     map[string]int
+	activeApprovals int
 	runStep         int
 	runID           string
 	parentRunID     string
@@ -99,6 +100,23 @@ func (s *RunState) snapshot(prompt string, toolState map[string]any) *RunStateSn
 		ToolState:       cloneAnyMap(toolState),
 		Timestamp:       time.Now(),
 	}
+}
+
+func (s *RunState) beginApprovalWait() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.activeApprovals++
+	return s.activeApprovals == 1
+}
+
+func (s *RunState) endApprovalWait() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.activeApprovals == 0 {
+		return false
+	}
+	s.activeApprovals--
+	return s.activeApprovals == 0
 }
 
 func cloneMessages(messages []ModelMessage) []ModelMessage {

--- a/core/runtime_events.go
+++ b/core/runtime_events.go
@@ -1,6 +1,9 @@
 package core
 
-import "time"
+import (
+	"errors"
+	"time"
+)
 
 const (
 	// RuntimeEventTypeRunStarted marks a run-start lifecycle event.
@@ -9,6 +12,30 @@ const (
 	RuntimeEventTypeRunCompleted = "run_completed"
 	// RuntimeEventTypeToolCalled marks a tool-start lifecycle event.
 	RuntimeEventTypeToolCalled = "tool_called"
+	// RuntimeEventTypeToolCompleted marks a tool-end lifecycle event (success).
+	RuntimeEventTypeToolCompleted = "tool_completed"
+	// RuntimeEventTypeToolFailed marks a tool-end lifecycle event (error).
+	RuntimeEventTypeToolFailed = "tool_failed"
+	// RuntimeEventTypeTurnStarted marks the start of an agent turn.
+	RuntimeEventTypeTurnStarted = "turn_started"
+	// RuntimeEventTypeTurnCompleted marks the end of an agent turn.
+	RuntimeEventTypeTurnCompleted = "turn_completed"
+	// RuntimeEventTypeModelRequestStarted marks the start of a model request.
+	RuntimeEventTypeModelRequestStarted = "model_request_started"
+	// RuntimeEventTypeModelResponseCompleted marks the end of a model response.
+	RuntimeEventTypeModelResponseCompleted = "model_response_completed"
+	// RuntimeEventTypeApprovalRequested marks a tool approval request.
+	RuntimeEventTypeApprovalRequested = "approval_requested"
+	// RuntimeEventTypeApprovalResolved marks a tool approval resolution.
+	RuntimeEventTypeApprovalResolved = "approval_resolved"
+	// RuntimeEventTypeDeferredRequested marks a deferred tool request.
+	RuntimeEventTypeDeferredRequested = "deferred_requested"
+	// RuntimeEventTypeDeferredResolved marks a deferred tool resolution.
+	RuntimeEventTypeDeferredResolved = "deferred_resolved"
+	// RuntimeEventTypeRunWaiting marks a run entering a waiting state.
+	RuntimeEventTypeRunWaiting = "run_waiting"
+	// RuntimeEventTypeRunResumed marks a run resuming from a waiting state.
+	RuntimeEventTypeRunResumed = "run_resumed"
 )
 
 // RuntimeEvent is implemented by built-in runtime lifecycle events.
@@ -37,6 +64,7 @@ type RunCompletedEvent struct {
 	RunID       string
 	ParentRunID string
 	Success     bool
+	Deferred    bool
 	Error       string
 	StartedAt   time.Time
 	CompletedAt time.Time
@@ -78,6 +106,7 @@ func NewRunCompletedEvent(runID, parentRunID string, startedAt, completedAt time
 		RunID:       runID,
 		ParentRunID: parentRunID,
 		Success:     runErr == nil,
+		Deferred:    isDeferredRunError(runErr),
 		StartedAt:   startedAt,
 		CompletedAt: completedAt,
 	}
@@ -85,6 +114,19 @@ func NewRunCompletedEvent(runID, parentRunID string, startedAt, completedAt time
 		evt.Error = runErr.Error()
 	}
 	return evt
+}
+
+type deferredRunError interface {
+	error
+	deferredRunError()
+}
+
+func isDeferredRunError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var deferred deferredRunError
+	return errors.As(err, &deferred)
 }
 
 // NewToolCalledEvent constructs a standardized tool-start event.
@@ -98,3 +140,188 @@ func NewToolCalledEvent(runID, parentRunID, toolCallID, toolName, argsJSON strin
 		CalledAt:    calledAt,
 	}
 }
+
+// ToolCompletedEvent is published when a tool call completes successfully.
+type ToolCompletedEvent struct {
+	RunID       string
+	ParentRunID string
+	ToolCallID  string
+	ToolName    string
+	Result      string
+	DurationMs  int64
+	CompletedAt time.Time
+}
+
+func (e ToolCompletedEvent) RuntimeEventType() string     { return RuntimeEventTypeToolCompleted }
+func (e ToolCompletedEvent) RuntimeRunID() string         { return e.RunID }
+func (e ToolCompletedEvent) RuntimeParentRunID() string   { return e.ParentRunID }
+func (e ToolCompletedEvent) RuntimeOccurredAt() time.Time { return e.CompletedAt }
+
+// ToolFailedEvent is published when a tool call fails.
+type ToolFailedEvent struct {
+	RunID       string
+	ParentRunID string
+	ToolCallID  string
+	ToolName    string
+	Error       string
+	DurationMs  int64
+	FailedAt    time.Time
+}
+
+func (e ToolFailedEvent) RuntimeEventType() string     { return RuntimeEventTypeToolFailed }
+func (e ToolFailedEvent) RuntimeRunID() string         { return e.RunID }
+func (e ToolFailedEvent) RuntimeParentRunID() string   { return e.ParentRunID }
+func (e ToolFailedEvent) RuntimeOccurredAt() time.Time { return e.FailedAt }
+
+// TurnStartedEvent is published when an agent turn begins.
+type TurnStartedEvent struct {
+	RunID       string
+	ParentRunID string
+	TurnNumber  int
+	StartedAt   time.Time
+}
+
+func (e TurnStartedEvent) RuntimeEventType() string     { return RuntimeEventTypeTurnStarted }
+func (e TurnStartedEvent) RuntimeRunID() string         { return e.RunID }
+func (e TurnStartedEvent) RuntimeParentRunID() string   { return e.ParentRunID }
+func (e TurnStartedEvent) RuntimeOccurredAt() time.Time { return e.StartedAt }
+
+// TurnCompletedEvent is published when an agent turn ends.
+// If the turn ended due to an error, Error is non-empty.
+type TurnCompletedEvent struct {
+	RunID        string
+	ParentRunID  string
+	TurnNumber   int
+	HasToolCalls bool
+	HasText      bool
+	Error        string
+	CompletedAt  time.Time
+}
+
+func (e TurnCompletedEvent) RuntimeEventType() string     { return RuntimeEventTypeTurnCompleted }
+func (e TurnCompletedEvent) RuntimeRunID() string         { return e.RunID }
+func (e TurnCompletedEvent) RuntimeParentRunID() string   { return e.ParentRunID }
+func (e TurnCompletedEvent) RuntimeOccurredAt() time.Time { return e.CompletedAt }
+
+// ModelRequestStartedEvent is published before a model request is sent.
+type ModelRequestStartedEvent struct {
+	RunID        string
+	ParentRunID  string
+	TurnNumber   int
+	MessageCount int
+	StartedAt    time.Time
+}
+
+func (e ModelRequestStartedEvent) RuntimeEventType() string {
+	return RuntimeEventTypeModelRequestStarted
+}
+func (e ModelRequestStartedEvent) RuntimeRunID() string         { return e.RunID }
+func (e ModelRequestStartedEvent) RuntimeParentRunID() string   { return e.ParentRunID }
+func (e ModelRequestStartedEvent) RuntimeOccurredAt() time.Time { return e.StartedAt }
+
+// ModelResponseCompletedEvent is published after a model response is received.
+type ModelResponseCompletedEvent struct {
+	RunID        string
+	ParentRunID  string
+	TurnNumber   int
+	FinishReason string
+	InputTokens  int
+	OutputTokens int
+	HasToolCalls bool
+	HasText      bool
+	DurationMs   int64
+	CompletedAt  time.Time
+}
+
+func (e ModelResponseCompletedEvent) RuntimeEventType() string {
+	return RuntimeEventTypeModelResponseCompleted
+}
+func (e ModelResponseCompletedEvent) RuntimeRunID() string         { return e.RunID }
+func (e ModelResponseCompletedEvent) RuntimeParentRunID() string   { return e.ParentRunID }
+func (e ModelResponseCompletedEvent) RuntimeOccurredAt() time.Time { return e.CompletedAt }
+
+// ApprovalRequestedEvent is published when a tool requires approval.
+type ApprovalRequestedEvent struct {
+	RunID       string
+	ParentRunID string
+	ToolCallID  string
+	ToolName    string
+	ArgsJSON    string
+	RequestedAt time.Time
+}
+
+func (e ApprovalRequestedEvent) RuntimeEventType() string     { return RuntimeEventTypeApprovalRequested }
+func (e ApprovalRequestedEvent) RuntimeRunID() string         { return e.RunID }
+func (e ApprovalRequestedEvent) RuntimeParentRunID() string   { return e.ParentRunID }
+func (e ApprovalRequestedEvent) RuntimeOccurredAt() time.Time { return e.RequestedAt }
+
+// ApprovalResolvedEvent is published when a tool approval is resolved.
+type ApprovalResolvedEvent struct {
+	RunID       string
+	ParentRunID string
+	ToolCallID  string
+	ToolName    string
+	Approved    bool
+	ResolvedAt  time.Time
+}
+
+func (e ApprovalResolvedEvent) RuntimeEventType() string     { return RuntimeEventTypeApprovalResolved }
+func (e ApprovalResolvedEvent) RuntimeRunID() string         { return e.RunID }
+func (e ApprovalResolvedEvent) RuntimeParentRunID() string   { return e.ParentRunID }
+func (e ApprovalResolvedEvent) RuntimeOccurredAt() time.Time { return e.ResolvedAt }
+
+// DeferredRequestedEvent is published when a tool call is deferred.
+type DeferredRequestedEvent struct {
+	RunID       string
+	ParentRunID string
+	ToolCallID  string
+	ToolName    string
+	ArgsJSON    string
+	RequestedAt time.Time
+}
+
+func (e DeferredRequestedEvent) RuntimeEventType() string     { return RuntimeEventTypeDeferredRequested }
+func (e DeferredRequestedEvent) RuntimeRunID() string         { return e.RunID }
+func (e DeferredRequestedEvent) RuntimeParentRunID() string   { return e.ParentRunID }
+func (e DeferredRequestedEvent) RuntimeOccurredAt() time.Time { return e.RequestedAt }
+
+// DeferredResolvedEvent is published when a deferred tool result is provided.
+type DeferredResolvedEvent struct {
+	RunID       string
+	ParentRunID string
+	ToolCallID  string
+	ToolName    string
+	Content     string
+	IsError     bool
+	ResolvedAt  time.Time
+}
+
+func (e DeferredResolvedEvent) RuntimeEventType() string     { return RuntimeEventTypeDeferredResolved }
+func (e DeferredResolvedEvent) RuntimeRunID() string         { return e.RunID }
+func (e DeferredResolvedEvent) RuntimeParentRunID() string   { return e.ParentRunID }
+func (e DeferredResolvedEvent) RuntimeOccurredAt() time.Time { return e.ResolvedAt }
+
+// RunWaitingEvent is published when a run enters a waiting state.
+type RunWaitingEvent struct {
+	RunID       string
+	ParentRunID string
+	Reason      string // "approval", "deferred", "approval_and_deferred"
+	WaitingAt   time.Time
+}
+
+func (e RunWaitingEvent) RuntimeEventType() string     { return RuntimeEventTypeRunWaiting }
+func (e RunWaitingEvent) RuntimeRunID() string         { return e.RunID }
+func (e RunWaitingEvent) RuntimeParentRunID() string   { return e.ParentRunID }
+func (e RunWaitingEvent) RuntimeOccurredAt() time.Time { return e.WaitingAt }
+
+// RunResumedEvent is published when a run resumes from a waiting state.
+type RunResumedEvent struct {
+	RunID       string
+	ParentRunID string
+	ResumedAt   time.Time
+}
+
+func (e RunResumedEvent) RuntimeEventType() string     { return RuntimeEventTypeRunResumed }
+func (e RunResumedEvent) RuntimeRunID() string         { return e.RunID }
+func (e RunResumedEvent) RuntimeParentRunID() string   { return e.ParentRunID }
+func (e RunResumedEvent) RuntimeOccurredAt() time.Time { return e.ResumedAt }

--- a/core/stream.go
+++ b/core/stream.go
@@ -288,6 +288,33 @@ func (s *agentStream[T]) Result() (*RunResult[T], error) {
 	return s.result, nil
 }
 
+// emitStreamTurnCompleted publishes a TurnCompletedEvent for streaming runs.
+func (s *agentStream[T]) emitStreamTurnCompleted(resp *ModelResponse, turnErr error) {
+	if s.agent.eventBus == nil {
+		return
+	}
+	ev := TurnCompletedEvent{
+		RunID:       s.state.runID,
+		ParentRunID: s.state.parentRunID,
+		TurnNumber:  s.state.runStep,
+		CompletedAt: time.Now(),
+	}
+	if resp != nil {
+		ev.HasToolCalls = len(resp.ToolCalls()) > 0
+		ev.HasText = resp.TextContent() != ""
+	}
+	if turnErr != nil {
+		ev.Error = turnErr.Error()
+	}
+	Publish(s.agent.eventBus, ev)
+}
+
+func (s *agentStream[T]) completeActiveTurn(resp *ModelResponse, turnErr error) {
+	s.emitStreamTurnCompleted(resp, turnErr)
+	s.currentTurnRC = nil
+	s.currentModelRC = nil
+}
+
 func (s *agentStream[T]) startTurn() error {
 	if err := s.ctx.Err(); err != nil {
 		return err
@@ -320,6 +347,14 @@ func (s *agentStream[T]) startTurn() error {
 			h.OnTurnStart(s.ctx, turnRC, s.state.runStep)
 		}
 	})
+	if s.agent.eventBus != nil {
+		Publish(s.agent.eventBus, TurnStartedEvent{
+			RunID:       s.state.runID,
+			ParentRunID: s.state.parentRunID,
+			TurnNumber:  s.state.runStep,
+			StartedAt:   time.Now(),
+		})
+	}
 
 	preparedTools := s.agent.prepareTools(s.ctx, s.state, s.allTools, s.deps, s.prompt)
 	params := buildModelRequestParams(preparedTools, s.agent.outputSchema)
@@ -361,7 +396,9 @@ func (s *agentStream[T]) startTurn() error {
 		beforeTokens := estimateTokens(messages)
 		processed, procErr := proc(s.ctx, messages)
 		if procErr != nil {
-			return fmt.Errorf("history processor failed: %w", procErr)
+			hpErr := fmt.Errorf("history processor failed: %w", procErr)
+			s.emitStreamTurnCompleted(nil, hpErr)
+			return hpErr
 		}
 		afterCount := len(processed)
 		afterTokens := estimateTokens(processed)
@@ -388,7 +425,9 @@ func (s *agentStream[T]) startTurn() error {
 		var dropped bool
 		messages, dropped = runMessageInterceptors(s.ctx, s.agent.messageInterceptors, messages)
 		if dropped {
-			return errors.New("message interceptor dropped the request")
+			miErr := errors.New("message interceptor dropped the request")
+			s.emitStreamTurnCompleted(nil, miErr)
+			return miErr
 		}
 	}
 
@@ -403,10 +442,12 @@ func (s *agentStream[T]) startTurn() error {
 			}
 		})
 		if gErr != nil {
-			return &GuardrailError{
+			grErr := &GuardrailError{
 				GuardrailName: g.name,
 				Message:       gErr.Error(),
 			}
+			s.emitStreamTurnCompleted(nil, grErr)
+			return grErr
 		}
 	}
 
@@ -419,6 +460,15 @@ func (s *agentStream[T]) startTurn() error {
 	})
 
 	modelReqStart := time.Now()
+	if s.agent.eventBus != nil {
+		Publish(s.agent.eventBus, ModelRequestStartedEvent{
+			RunID:        s.state.runID,
+			ParentRunID:  s.state.parentRunID,
+			TurnNumber:   s.state.runStep,
+			MessageCount: len(messages),
+			StartedAt:    modelReqStart,
+		})
+	}
 	if s.agent.tracingEnabled {
 		s.state.traceSteps = append(s.state.traceSteps, TraceStep{
 			Kind:      TraceModelRequest,
@@ -445,7 +495,9 @@ func (s *agentStream[T]) startTurn() error {
 		stream, err = s.agent.model.RequestStream(s.ctx, messages, settings, params)
 	}
 	if err != nil {
-		return fmt.Errorf("model stream request failed: %w", err)
+		streamErr := fmt.Errorf("model stream request failed: %w", err)
+		s.emitStreamTurnCompleted(nil, streamErr)
+		return streamErr
 	}
 
 	s.settings = settings
@@ -487,6 +539,7 @@ func (s *agentStream[T]) completeTurn() error {
 
 	if len(s.agent.responseInterceptors) > 0 {
 		if runResponseInterceptors(s.ctx, s.agent.responseInterceptors, resp) {
+			s.completeActiveTurn(resp, nil)
 			return nil
 		}
 	}
@@ -504,6 +557,20 @@ func (s *agentStream[T]) completeTurn() error {
 		}
 	})
 
+	if s.agent.eventBus != nil {
+		Publish(s.agent.eventBus, ModelResponseCompletedEvent{
+			RunID:        s.state.runID,
+			ParentRunID:  s.state.parentRunID,
+			TurnNumber:   s.state.runStep,
+			FinishReason: string(resp.FinishReason),
+			InputTokens:  resp.Usage.InputTokens,
+			OutputTokens: resp.Usage.OutputTokens,
+			HasToolCalls: len(resp.ToolCalls()) > 0,
+			HasText:      resp.TextContent() != "",
+			DurationMs:   time.Since(s.currentReqStart).Milliseconds(),
+			CompletedAt:  time.Now(),
+		})
+	}
 	if s.agent.tracingEnabled {
 		s.state.traceSteps = append(s.state.traceSteps, TraceStep{
 			Kind:      TraceModelResponse,
@@ -515,6 +582,7 @@ func (s *agentStream[T]) completeTurn() error {
 
 	if s.limits.HasTokenLimits() {
 		if err := s.limits.CheckTokens(s.state.usage); err != nil {
+			s.completeActiveTurn(resp, err)
 			return err
 		}
 	}
@@ -538,6 +606,7 @@ func (s *agentStream[T]) completeTurn() error {
 						}
 					}
 					if parseErr == nil {
+						s.completeActiveTurn(resp, nil)
 						s.finish(&RunResult[T]{
 							Output:    output,
 							Messages:  s.state.messages,
@@ -548,7 +617,9 @@ func (s *agentStream[T]) completeTurn() error {
 						return nil
 					}
 				}
-				return &RunConditionError{Reason: reason}
+				condErr := &RunConditionError{Reason: reason}
+				s.completeActiveTurn(resp, condErr)
+				return condErr
 			}
 		}
 	}
@@ -562,9 +633,29 @@ func (s *agentStream[T]) completeTurn() error {
 	})
 
 	if err != nil {
+		s.completeActiveTurn(resp, err)
 		return err
 	}
 	if len(deferredReqs) > 0 {
+		s.completeActiveTurn(resp, nil)
+		if s.agent.eventBus != nil {
+			for _, dr := range deferredReqs {
+				Publish(s.agent.eventBus, DeferredRequestedEvent{
+					RunID:       s.state.runID,
+					ParentRunID: s.state.parentRunID,
+					ToolCallID:  dr.ToolCallID,
+					ToolName:    dr.ToolName,
+					ArgsJSON:    dr.ArgsJSON,
+					RequestedAt: time.Now(),
+				})
+			}
+			Publish(s.agent.eventBus, RunWaitingEvent{
+				RunID:       s.state.runID,
+				ParentRunID: s.state.parentRunID,
+				Reason:      "deferred",
+				WaitingAt:   time.Now(),
+			})
+		}
 		if len(nextParts) > 0 {
 			s.state.messages = append(s.state.messages, ModelRequest{
 				Parts:     nextParts,
@@ -584,10 +675,13 @@ func (s *agentStream[T]) completeTurn() error {
 			responseText := resp.TextContent()
 			if responseText != "" {
 				if storeErr := s.agent.knowledgeBase.Store(s.ctx, responseText); storeErr != nil {
-					return fmt.Errorf("knowledge base store failed: %w", storeErr)
+					kbErr := fmt.Errorf("knowledge base store failed: %w", storeErr)
+					s.completeActiveTurn(resp, kbErr)
+					return kbErr
 				}
 			}
 		}
+		s.completeActiveTurn(resp, nil)
 		s.finish(&RunResult[T]{
 			Output:    result.output,
 			Messages:  s.state.messages,
@@ -598,6 +692,9 @@ func (s *agentStream[T]) completeTurn() error {
 		return nil
 	}
 
+	// No result — tool calls processed, continue to next turn.
+	s.completeActiveTurn(resp, nil)
+
 	if len(nextParts) > 0 {
 		s.state.messages = append(s.state.messages, ModelRequest{
 			Parts:     nextParts,
@@ -605,8 +702,6 @@ func (s *agentStream[T]) completeTurn() error {
 		})
 	}
 
-	s.currentTurnRC = nil
-	s.currentModelRC = nil
 	return nil
 }
 
@@ -615,6 +710,16 @@ func (s *agentStream[T]) finish(result *RunResult[T], runErr error) {
 		_ = s.current.Close()
 		s.current = nil
 	}
+
+	// If a turn is active (startTurn was called but completeTurn hasn't
+	// cleared currentTurnRC), emit TurnCompleted so the turn lifecycle
+	// is always balanced. This handles mid-stream errors and early Close.
+	if s.currentTurnRC != nil {
+		s.emitStreamTurnCompleted(s.finalResponse, runErr)
+		s.currentTurnRC = nil
+		s.currentModelRC = nil
+	}
+
 	s.done = true
 	s.result = result
 	s.err = runErr

--- a/ext/agui/DESIGN.md
+++ b/ext/agui/DESIGN.md
@@ -1,0 +1,732 @@
+# AGUI Integration Design for gollem
+
+This document defines the implementation contract for an AGUI adapter on top of gollem.
+It maps AGUI-style session, event, approval, reconnect, and resume concepts onto the
+runtime surfaces that already exist in `core`, `ext/temporal`, `ext/graph`, `ext/team`,
+and the HTTP handler examples in `contrib`.
+
+The goal is not to invent a new agent runtime. The goal is to normalize what gollem
+already emits, identify where the mapping is lossy, and make the missing signals
+explicit before implementation starts.
+
+---
+
+## 1. Design goals
+
+An AGUI integration for gollem should provide:
+
+1. A **stable session model** for an agent interaction, regardless of whether the run is:
+   - in-process (`Run`, `RunStream`, `Iter`)
+   - durable (`ext/temporal`)
+   - embedded in a graph (`ext/graph`)
+   - part of a team/orchestrator workflow (`ext/team`)
+2. A **normalized event stream** that can drive a UI without forcing the UI to know
+   gollem internals.
+3. A **human approval/external input contract** for tools that block on humans or external
+   systems.
+4. A **reconnect/resume story** that works for both live transports and durable workflows.
+5. An explicit **gap list** so implementation work is scoped and sequenced.
+
+Non-goals for the first AGUI implementation:
+
+- Replacing gollem's existing hooks, traces, or Temporal APIs.
+- Inventing a brand-new durable state model when `Snapshot`, `WorkflowStatus`, and
+  orchestrator state already exist.
+- Perfect fidelity for every provider-specific streaming detail on day one.
+
+---
+
+## 2. Existing gollem surfaces relevant to AGUI
+
+### Core runtime and message surfaces
+
+- `core/message.go`
+  - Conversation model: `ModelRequest`, `ModelResponse`
+  - Request parts: `SystemPromptPart`, `UserPromptPart`, `ToolReturnPart`, `RetryPromptPart`, etc.
+  - Response parts: `TextPart`, `ToolCallPart`, `ThinkingPart`
+  - Streaming events: `PartStartEvent`, `PartDeltaEvent`, `PartEndEvent`
+- `core/stream.go`
+  - `StreamResult[T]` and `agentStream[T]`
+  - Live text/event iteration via `StreamText()` and `StreamEvents()`
+  - Turn orchestration for streaming runs
+- `core/hooks.go`
+  - Rich lifecycle hooks: run, turn, model request/response, tool start/end,
+    guardrails, output validation/repair, run conditions, context compaction
+- `core/runtime_events.go`
+  - Event-bus-facing runtime events today: `RunStartedEvent`, `RunCompletedEvent`, `ToolCalledEvent`
+- `core/iter.go`
+  - Stepwise execution via `Agent.Iter`, one model response per `Next()`
+- `core/agent_runtime.go`
+  - Exposes runtime config for alternate execution engines like Temporal
+- `core/snapshot.go`, `core/run_state.go`, `core/deferred.go`, `core/serialize.go`
+  - Resume/checkpoint and deferred-tool primitives
+
+### Temporal surfaces
+
+- `ext/temporal/workflow.go`
+  - Durable workflow loop, waiting states, continue-as-new, approval/deferred handling
+- `ext/temporal/state.go`
+  - `WorkflowStatus`, `ApprovalSignal`, `DeferredResultSignal`, `AbortSignal`
+- `ext/temporal/model.go`
+  - Durable model request and stream activities
+- `ext/temporal/agent.go`
+  - `WithEventHandler(...)` exists, but the built-in workflow does not currently use it
+- `ext/temporal/README.md`
+  - Documents query/signal surface and durable resume model
+
+### Graph surfaces
+
+- `ext/graph/graph.go`
+  - Typed node graph with linear execution, conditional routing, fan-out, and reducer
+
+### Team/orchestrator surfaces
+
+- `ext/team/team.go`, `ext/team/teammate.go`, `ext/team/events.go`
+  - Team lifecycle, teammate lifecycle, task execution
+- `ext/team/store_adapter.go`, `ext/team/tasks.go`
+  - Team task visibility and task views
+- `ext/orchestrator/events.go`
+  - Durable task/lease/command/artifact events
+
+### Transport examples
+
+- `contrib/chi/handler.go`, `contrib/ginhandler/handler.go`, `contrib/echohandler/handler.go`, `contrib/fiberhandler/handler.go`
+  - Current SSE shape only streams text deltas plus a final `done` event
+
+---
+
+## 3. Proposed AGUI session contract
+
+AGUI should treat every gollem interaction as a **session** with one canonical identity.
+
+### 3.1 Session identity
+
+Each AGUI session should carry:
+
+| Field | Meaning | Current source |
+| --- | --- | --- |
+| `session_id` | Stable UI-facing identifier for reconnect/replay | New AGUI-owned ID |
+| `run_id` | Current gollem run ID | `RunContext.RunID`, `RunResult.RunID`, `WorkflowStatus.RunID` |
+| `parent_run_id` | Parent lineage | `RunContext.ParentRunID`, `WorkflowStatus.ParentRunID` |
+| `mode` | `core-run`, `core-stream`, `core-iter`, `temporal`, `graph`, `team` | Adapter-derived |
+| `created_at` | Session creation time | Adapter timestamp |
+| `status` | `starting`, `running`, `waiting`, `completed`, `failed`, `cancelled`, `aborted` | Derived |
+
+**Important distinction:**
+
+- `run_id` is a gollem/runtime concept.
+- `session_id` is the AGUI transport/replay concept.
+
+A single AGUI session may survive reconnects and, in Temporal, may survive continue-as-new.
+That is why AGUI needs its own session ID even though gollem already has run IDs.
+
+### 3.2 Session lifecycle
+
+The normalized lifecycle is:
+
+1. `session.opened`
+2. `session.input.accepted`
+3. `run.started`
+4. Zero or more cycles of:
+   - `turn.started`
+   - `model.request.started`
+   - `model.output.*`
+   - `model.response.completed`
+   - `tool.*` and/or `approval.*` and/or `external_input.*`
+   - `turn.completed`
+5. Optional waiting state:
+   - `session.waiting` with reason `approval` / `deferred` / `approval_and_deferred`
+6. Optional resumption:
+   - `session.resumed`
+7. Terminal event:
+   - `session.completed`
+   - `session.failed`
+   - `session.cancelled`
+   - `session.aborted`
+
+### 3.3 Session actions
+
+The AGUI control plane should support these actions:
+
+| AGUI action | Core mapping | Temporal mapping |
+| --- | --- | --- |
+| `approve_tool_call` | New async approval API required | `ApprovalSignal` |
+| `deny_tool_call` | New async approval API required | `ApprovalSignal{Approved:false}` |
+| `submit_deferred_result` | Resume with `WithDeferredResults(...)` | `DeferredResultSignal` |
+| `abort_session` | Context cancel / new adapter endpoint | `AbortSignal` |
+| `resume_session` | `WithSnapshot(...)` + optional `WithDeferredResults(...)` | Re-query stable workflow ID and continue signaling/querying |
+| `reconnect_stream` | New replay cursor needed | Query + replay/event sink needed |
+
+---
+
+## 4. AGUI event taxonomy and current gollem mapping
+
+The adapter should emit one normalized stream. Internally, the data comes from different
+places today: stream events, hooks, event bus events, trace steps, Temporal queries/signals,
+and team/orchestrator state.
+
+## 4.1 Session and lifecycle events
+
+| AGUI event | gollem source today | Notes |
+| --- | --- | --- |
+| `session.opened` | adapter-created | Not present in core |
+| `run.started` | `Hook.OnRunStart`; `RunStartedEvent` in `core/runtime_events.go` | Good fit |
+| `turn.started` | `Hook.OnTurnStart` | Hook-only today; not on event bus |
+| `turn.completed` | `Hook.OnTurnEnd` | Hook-only today |
+| `session.completed` | `Hook.OnRunEnd`; `RunCompletedEvent{Success:true}` | Good fit |
+| `session.failed` | `Hook.OnRunEnd`; `RunCompletedEvent{Success:false}` | Good fit |
+| `session.cancelled` | derived from context error | Not first-class |
+| `session.aborted` | `ext/temporal` abort path | Temporal-only today |
+| `session.waiting` | Temporal `WorkflowStatus.Waiting` | Missing in core |
+| `session.resumed` | adapter-derived from snapshot/workflow reconnect | Missing as first-class signal |
+
+## 4.2 Model request/response events
+
+| AGUI event | gollem source today | Notes |
+| --- | --- | --- |
+| `model.request.started` | `Hook.OnModelRequest` | No matching runtime event today |
+| `model.output.text.delta` | `PartDeltaEvent` + `TextPartDelta` | Available in `RunStream` |
+| `model.output.text.part_started` | `PartStartEvent` + `TextPart` | Available in `RunStream` |
+| `model.output.text.part_completed` | `PartEndEvent` | Available in `RunStream` |
+| `model.output.thinking.delta` | `PartDeltaEvent` + `ThinkingPartDelta` | Available in `RunStream` |
+| `model.output.tool_call.delta` | `PartDeltaEvent` + `ToolCallPartDelta` | Available in `RunStream` |
+| `model.response.completed` | `Hook.OnModelResponse`; `StreamedResponse.Response()` | No event-bus runtime event today |
+| `model.response.dropped` | response interceptors can drop; adapter can infer | No explicit signal today |
+
+## 4.3 Tool events
+
+| AGUI event | gollem source today | Notes |
+| --- | --- | --- |
+| `tool.call.requested` | `ToolCallPart` in model response | Can be derived |
+| `tool.execution.started` | `Hook.OnToolStart`; `ToolCalledEvent` | Good fit, but runtime event is start-only |
+| `tool.execution.completed` | `Hook.OnToolEnd` | Hook-only today |
+| `tool.execution.failed` | `Hook.OnToolEnd` with error | Hook-only today |
+| `tool.result.returned` | `ToolReturnPart` | Derivable from appended request message |
+| `tool.retry_requested` | `RetryPromptPart` | Derivable but not explicit as event |
+| `tool.deferred` | `CallDeferred` -> `DeferredToolRequest` | Core + Temporal concept exists |
+
+## 4.4 Approval and external-input events
+
+| AGUI event | gollem source today | Notes |
+| --- | --- | --- |
+| `approval.requested` | Temporal `PendingApprovals`; core `RequiresApproval` is synchronous only | Temporal has parity; core does not |
+| `approval.approved` | Temporal `ApprovalSignal{Approved:true}` | Core lacks eventable async path |
+| `approval.denied` | Temporal `ApprovalSignal{Approved:false}` | Core callback only |
+| `external_input.requested` | `DeferredToolRequest` | Good fit |
+| `external_input.provided` | `WithDeferredResults(...)`; `DeferredResultSignal` | Core resume is batch-based, not event-based |
+
+## 4.5 Topology events for graph/team variants
+
+| AGUI event | gollem source today | Notes |
+| --- | --- | --- |
+| `graph.node.started` | None | Missing |
+| `graph.node.completed` | None | Missing |
+| `graph.fanout.started` | None | Missing |
+| `graph.fanout.joined` | None | Missing |
+| `team.teammate.spawned` | `TeammateSpawnedEvent` | Good fit |
+| `team.teammate.idle` | `TeammateIdleEvent` | Good fit |
+| `team.teammate.terminated` | `TeammateTerminatedEvent` | Good fit |
+| `team.task.claimed/completed/failed/cancelled` | `ext/orchestrator/events.go` | Available at orchestrator layer |
+| `team.teammate.output.delta` | None | Missing |
+
+## 4.6 Snapshot/replay events
+
+| AGUI event | gollem source today | Notes |
+| --- | --- | --- |
+| `session.snapshot` | `core.Snapshot(...)`, `SerializedRunSnapshot`, Temporal `WorkflowStatus.Snapshot` | Good base |
+| `session.trace.updated` | `RunTrace` / `TraceStep` / Temporal status trace | Post-hoc or snapshot-like, not live stream |
+| `session.replay_checkpoint` | None | Missing |
+
+---
+
+## 5. Backend-specific mapping
+
+## 5.1 In-process `RunStream`
+
+`RunStream` is the best current source for a live AGUI stream.
+
+### What maps cleanly
+
+- `run.started` / `session.completed` via hooks and runtime events
+- `model.output.text.delta`, `model.output.thinking.delta`, `model.output.tool_call.delta`
+  via `StreamEvents()` and `PartDeltaEvent`
+- `model.response.completed` via `completeTurn()` in `core/stream.go`
+- `tool.execution.started` / `tool.execution.completed` via hooks
+- `session.snapshot` via `Snapshot(rc)` from hook callbacks
+
+### What is lossy today
+
+- Stream events do **not** carry `run_id`, `turn_number`, timestamps, or sequence IDs.
+- `RunStream` exposes raw part deltas but not a single normalized envelope.
+- Waiting states are only represented for deferred tools as terminal `ErrDeferred`; there is
+  no live `waiting` event in the in-process path.
+- Core approvals are synchronous callbacks, so there is no transport-neutral
+  `approval.requested -> approve/deny -> resume` flow.
+
+## 5.2 In-process `Run`
+
+`Run` can emit coarse AGUI lifecycle events, but not token-level deltas.
+
+Use it for:
+
+- request/response logging
+- tool lifecycle
+- final transcript assembly
+- synchronous UI surfaces that do not need streaming
+
+It is not enough by itself for an AGUI implementation whose main UX is live token streaming.
+
+## 5.3 `Agent.Iter`
+
+`Iter` gives a stable turn boundary, which is useful for AGUI step UIs.
+
+### Good fit
+
+- Each `Next()` corresponds to one model response / one visible step.
+- Useful for debugger-like UIs, execution timelines, and step buttons.
+
+### Limitations
+
+- `Iter` is step-granular, not token-granular.
+- No first-class pause/resume signals beyond `Close()` and external snapshot handling.
+
+## 5.4 `ext/temporal`
+
+Temporal is the strongest existing base for AGUI durability.
+
+### What maps cleanly
+
+- Stable durable run identity: `WorkflowStatus.RunID`
+- Current operational state: `WorkflowStatus`
+- Waiting states: `Waiting`, `WaitingReason`, `PendingApprovals`, `DeferredRequests`
+- Human actions:
+  - `ApprovalSignal`
+  - `DeferredResultSignal`
+  - `AbortSignal`
+- Continue-as-new durability with stable workflow ID targeting
+- Resume state via `WorkflowStatus.Snapshot` and `WorkflowOutput.Snapshot`
+
+### What is missing
+
+- The built-in workflow does **not** stream token deltas.
+- `TemporalAgent.WithEventHandler(...)` stores a handler, but the built-in workflow never
+  invokes it.
+- `WorkflowStatus` is a **snapshot** query, not an event replay log.
+- There is no reconnectable AGUI event cursor across live durable updates.
+
+### Temporal AGUI model
+
+For the first implementation, Temporal should be treated as:
+
+- **authoritative state store** for reconnect/resume
+- **control plane** for approvals and deferred results
+- **coarse event source** for waiting/completed/aborted transitions
+
+Not as a token-delta stream unless additional work is done.
+
+## 5.5 `ext/graph`
+
+A graph run should map to a parent AGUI session with nested graph execution events.
+
+### Proposed mapping
+
+- One AGUI session for the graph invocation
+- One AGUI span/step per node execution
+- Fan-out branches become child spans with branch metadata
+- Reducer/join emits a join event before continuing
+
+### Current reality
+
+`ext/graph/graph.go` has no observer/event API. Node execution is internal to `Run(...)`.
+So a general AGUI adapter cannot observe:
+
+- node start
+- node end
+- branch start
+- branch completion
+- reducer/join
+
+Any AGUI graph UI would therefore require wrappers around node functions or native graph events.
+
+## 5.6 `ext/team` and orchestrator
+
+A team run should map to a parent AGUI session representing the leader/coordinator, with
+child sessions or child scopes for each teammate/task.
+
+### What maps cleanly
+
+- teammate lifecycle:
+  - `TeammateSpawnedEvent`
+  - `TeammateIdleEvent`
+  - `TeammateTerminatedEvent`
+- orchestrator task lifecycle from `ext/orchestrator/events.go`:
+  - task created/claimed/completed/failed/cancelled
+  - lease renewed/released
+  - commands created/handled
+- task result view via `teamTaskView` / `orchestrator.TaskResult`
+
+### What is missing
+
+- No built-in forwarding of each teammate agent's model/tool deltas into a team event stream
+- No team-scoped event that says "teammate X is now running task Y" beyond store/task inspection
+- No normalized child-session IDs for teammate runs
+- No replayable per-teammate transcript stream
+
+## 5.7 `contrib/*handler`
+
+The contrib handlers are a useful proof that SSE works, but they are not AGUI transports.
+They currently emit:
+
+- unnamed `data:` events for text delta
+- `event: error`
+- `event: done` with final usage
+
+They do **not** emit:
+
+- session IDs
+- run IDs
+- sequence numbers
+- lifecycle events
+- approval requests
+- reconnect cursors
+- replay support
+
+AGUI should therefore be implemented as a new transport/adapter layer, not as a thin rename of
+existing contrib SSE handlers.
+
+---
+
+## 6. Approval flow contract
+
+## 6.1 Target AGUI approval flow
+
+The normalized approval flow should be:
+
+1. Model emits `tool.call.requested`
+2. Runtime decides approval is required
+3. AGUI emits `approval.requested` with:
+   - `session_id`
+   - `run_id`
+   - `tool_call_id`
+   - `tool_name`
+   - `args_json`
+   - optional human-readable summary
+4. Session enters `waiting`
+5. Client sends `approve_tool_call` or `deny_tool_call`
+6. AGUI emits `approval.approved` or `approval.denied`
+7. Tool either executes or a retry/denial message is returned to the model
+8. Session leaves `waiting`
+
+## 6.2 Current core behavior
+
+In core, approval is checked inside `executeSingleTool(...)` in `core/agent.go`:
+
+- if `tool.RequiresApproval` and `toolApprovalFunc` is configured, gollem synchronously calls
+  `ToolApprovalFunc(ctx, toolName, argsJSON)`
+- if approved, execution continues
+- if denied, a `RetryPromptPart` is returned to the model
+
+This is adequate for embedding gollem into an application-specific callback, but **not** for
+AGUI parity, because the waiting state is not first-class.
+
+### Consequence
+
+A general AGUI adapter cannot reliably surface a portable `approval.requested` event for
+non-Temporal runs unless core grows an async approval API.
+
+## 6.3 Current Temporal behavior
+
+Temporal already has the async shape needed by AGUI:
+
+- if the tool requires approval and no callback approval function is configured,
+  the workflow appends `ToolApprovalRequest` to `PendingApprovals`
+- `WorkflowStatus.Waiting` becomes true with `WaitingReason == "approval"`
+- client resolves it via `ApprovalSignal`
+
+This is the target behavior for AGUI parity across all runtimes.
+
+---
+
+## 7. Reconnect and resume contract
+
+Reconnect and resume are related, but not the same.
+
+- **Reconnect**: the client lost the transport but the run is still alive.
+- **Resume**: the run or process ended/paused and execution must continue from saved state.
+
+## 7.1 Reconnect contract
+
+AGUI reconnect should work like this:
+
+1. Client reconnects with `session_id` and last seen event sequence (`last_seq` / `Last-Event-ID`)
+2. Server replays buffered/durable events after that sequence
+3. Server resumes live streaming
+4. If replay is unavailable, server sends a fresh `session.snapshot` followed by current state
+
+### Current gollem support
+
+- In-process core: no native replay cursor or event log
+- Temporal: current state is queryable via `WorkflowStatus`, but there is no event replay log
+- Team/orchestrator: task state is durable, but message/token replay is not
+
+### Design implication
+
+AGUI needs its own replay buffer or durable event sink.
+
+## 7.2 Resume contract
+
+### Core resume
+
+Core already supports most of the semantic resume payload:
+
+- `core.Snapshot(...)`
+- `core.WithSnapshot(...)`
+- `core.WithDeferredResults(...)`
+- serializable messages and snapshots in `core/serialize.go` and `core/snapshot.go`
+
+This is enough to resume a conversation state, but not enough to resume a **live stream** from
+an exact output offset.
+
+### Temporal resume
+
+Temporal resume is stronger:
+
+- state is durable in workflow history
+- `WorkflowStatus` exposes snapshot, trace, pending approvals, and deferred requests
+- stable workflow ID survives continue-as-new when callers signal/query the workflow ID
+
+The main missing piece is **event replay**, not state replay.
+
+### Graph/team resume
+
+- Graph has no native checkpointing
+- Team/orchestrator has durable tasks/results, but not a unified replayable teammate event stream
+
+---
+
+## 8. Proposed AGUI adapter shape
+
+The implementation should be split into two layers.
+
+## 8.1 Normalization layer (`ext/agui`)
+
+A new `ext/agui` package should own:
+
+- `Session`
+- `Event`
+- event envelope and sequence assignment
+- translators from:
+  - core stream events
+  - hooks/runtime events
+  - Temporal status/signals
+  - team/orchestrator events
+  - graph observer events (once added)
+- replay buffer / event store abstraction
+
+## 8.2 Transport layer
+
+The transport layer should expose AGUI over SSE first.
+
+Responsibilities:
+
+- create/open session
+- reconnect using `session_id` + sequence
+- stream normalized events
+- accept actions (approval, deferred result, abort)
+
+This should be a new transport surface, not a retrofit of the current `contrib/*handler`
+text-only SSE examples.
+
+---
+
+## 9. Gap analysis: missing gollem signals for AGUI parity
+
+This is the actionable list.
+
+## P0: required for a credible AGUI implementation
+
+| Gap | Why it matters | Files/packages that must change |
+| --- | --- | --- |
+| No unified AGUI event envelope with sequence/correlation metadata | UI/reconnect logic needs one stable event shape | new `ext/agui`; likely reads from `core/message.go`, `core/stream.go`, `core/runtime_events.go` |
+| Runtime event coverage is too small (`run_started`, `run_completed`, `tool_called` only) | AGUI needs turn/model/tool-end/wait/resume events without depending only on hooks | `core/runtime_events.go`, `core/agent.go`, `core/stream.go`, `core/iter.go` |
+| Stream events lack `run_id`, `turn_number`, timestamps, and sequence IDs | Raw part deltas cannot be replayed or correlated cleanly | `core/message.go` and/or `core/stream.go` |
+| Core approval path is synchronous only | AGUI parity requires async `approval.requested -> approve/deny -> continue` | `core/agent.go`, `core/agent_runtime.go`, `core/hooks.go`, `core/runtime_events.go`, likely new `core/approval.go` |
+| Deferred-tool flow has no live wait/resume events in core | AGUI needs explicit waiting + external-input lifecycle | `core/deferred.go`, `core/agent.go`, `core/hooks.go`, `core/runtime_events.go` |
+| No replay checkpoint/event cursor in snapshots | Reconnect/resume cannot restart a structured event stream | `core/run_state.go`, `core/snapshot.go`, new `ext/agui` replay store |
+| Temporal built-in workflow does not emit live stream events | Durable AGUI needs more than snapshot polling | `ext/temporal/agent.go`, `ext/temporal/workflow.go`, `ext/temporal/model.go`, `ext/temporal/state.go` |
+| `TemporalAgent.WithEventHandler(...)` is unused by built-in workflow | There is already an obvious extension point, but it is inert | `ext/temporal/agent.go`, `ext/temporal/workflow.go` |
+| Existing HTTP SSE handlers only emit text deltas | They are insufficient as AGUI transports | `contrib/chi/handler.go`, `contrib/ginhandler/handler.go`, `contrib/echohandler/handler.go`, `contrib/fiberhandler/handler.go`, or preferably new `ext/agui` transport package |
+
+## P1: needed for full graph/team parity
+
+| Gap | Why it matters | Files/packages that must change |
+| --- | --- | --- |
+| `ext/graph` has no observer/event API | AGUI cannot render node timelines, fan-out branches, or reducer joins | `ext/graph/graph.go`, likely new `ext/graph/events.go` |
+| `ext/team` lacks per-task/per-teammate run progress events | AGUI can show team membership, but not rich teammate execution | `ext/team/events.go`, `ext/team/team.go`, `ext/team/teammate.go`, possibly `ext/team/tools.go` |
+| Team layer does not forward child agent deltas | Needed for nested teammate transcript panes | `ext/team/team.go`, `ext/team/teammate.go`, new `ext/agui` translator |
+| No normalized bridge from orchestrator task events to AGUI session/subsession model | Needed for durable team dashboards | `ext/orchestrator/events.go`, `ext/team/*`, new `ext/agui` |
+
+## P2: quality-of-life and simplification
+
+| Gap | Why it matters | Files/packages that must change |
+| --- | --- | --- |
+| Event bus has no obvious wildcard/runtime subscription API | AGUI adapters would prefer one subscription point instead of N concrete event types | `core/eventbus.go`, `core/runtime_events.go` |
+| Trace is mainly post-hoc, not live | Good for history, not enough for real-time UI | `core/trace.go`, `core/agent.go`, `core/stream.go` |
+| `Run`/`Iter`/`RunStream` do not expose a common event producer abstraction | AGUI adapter logic is harder than necessary | `core/stream.go`, `core/iter.go`, new adapter interface in `core` or `ext/agui` |
+
+---
+
+## 10. Concrete package-by-package change list
+
+## 10.1 `core`
+
+### `core/runtime_events.go`
+Add first-class runtime events for at least:
+
+- `turn_started`
+- `turn_completed`
+- `model_request_started`
+- `model_response_completed`
+- `tool_completed`
+- `approval_requested`
+- `approval_resolved`
+- `deferred_requested`
+- `deferred_resolved`
+- `run_waiting`
+- `run_resumed`
+- `snapshot_created` or `checkpoint_created`
+
+### `core/agent.go`
+Emit the new runtime events and support async approval/deferred waiting in the in-process path.
+This is the main file where parity is currently lost.
+
+### `core/stream.go`
+Either:
+
+- extend stream events with correlation metadata, or
+- wrap them into an AGUI envelope before leaving the core stream path.
+
+Also expose turn/run correlation in a reusable way so transports do not need to reconstruct it.
+
+### `core/hooks.go`
+If hooks remain the richest lifecycle source, add hook coverage for:
+
+- waiting entered/exited
+- approval requested/resolved
+- deferred requested/resolved
+- snapshot/checkpoint emitted
+
+### `core/deferred.go`
+Keep the existing deferred result model, but add first-class runtime semantics around it.
+
+### `core/run_state.go` and `core/snapshot.go`
+Add replay/checkpoint metadata needed by AGUI, such as event sequence or replay watermark.
+
+## 10.2 `ext/temporal`
+
+### `ext/temporal/workflow.go`
+This is the durable AGUI pivot point.
+
+Needed changes:
+
+- invoke `EventHandler` or replace it with an explicit workflow event sink
+- emit structured live workflow events when waiting/approving/resuming/completing
+- optionally persist replayable event envelopes for reconnect
+
+### `ext/temporal/state.go`
+`WorkflowStatus` is already strong. It likely only needs:
+
+- session/replay metadata
+- optional last event sequence
+- optional child session metadata if team/graph are layered on top
+
+### `ext/temporal/model.go`
+If token-delta AGUI parity is desired for durable runs, this file needs a way to forward
+stream chunks rather than collapsing `ModelRequestStreamActivity` into a final response.
+
+### `ext/temporal/agent.go`
+`WithEventHandler(...)` should become active or be replaced by a better-defined AGUI event hook.
+
+## 10.3 `ext/graph`
+
+### `ext/graph/graph.go`
+Add graph observer callbacks or event publication for:
+
+- node start/end
+- fan-out start/end
+- reducer/join
+- graph completed/failed
+
+Without this, AGUI graph rendering depends on app-specific wrappers.
+
+## 10.4 `ext/team`
+
+### `ext/team/events.go`
+Add richer events such as:
+
+- teammate running task
+- teammate completed task
+- teammate failed task
+- teammate output available
+- teammate waiting for approval/external input
+
+### `ext/team/team.go` and `ext/team/teammate.go`
+Forward child agent lifecycle into team-scoped events so AGUI can correlate teammate runs to
+child sessions without scraping logs or task store state.
+
+## 10.5 `contrib`
+
+The contrib handlers should either:
+
+- remain simple examples, while AGUI ships as a new package, or
+- gain a separate AGUI mode that emits structured events and supports reconnect.
+
+Either way, the current text-only SSE shape is not sufficient.
+
+---
+
+## 11. Recommended implementation order
+
+1. **Define `ext/agui` event/session types**
+   - normalized envelope
+   - sequence IDs
+   - replay abstraction
+2. **Upgrade core lifecycle signaling**
+   - add missing runtime events
+   - add async approval/deferred semantics for non-Temporal runs
+3. **Build core `RunStream` adapter**
+   - easiest path to an end-to-end AGUI demo
+4. **Add Temporal state + event bridge**
+   - query/signal integration for durable waiting/resume
+   - event sink or replay layer
+5. **Add graph/team observers**
+   - nested session visualization
+6. **Add transport package**
+   - SSE first, websocket optional later
+
+---
+
+## 12. Bottom line
+
+gollem already has most of the raw ingredients AGUI needs:
+
+- typed messages and streamed deltas
+- rich lifecycle hooks
+- event bus support
+- snapshots and resume inputs
+- durable Temporal queries/signals
+- team/orchestrator lifecycle events
+
+What it does **not** yet have is a single replayable event contract with first-class waiting,
+approval, resume, graph, and team semantics.
+
+The biggest parity gaps are:
+
+1. **core async approval/wait semantics**
+2. **broader runtime event coverage**
+3. **replay/cursor metadata for reconnect**
+4. **Temporal live event emission**
+5. **graph/team observer events**
+
+Those are the packages/files that must change before AGUI can be implemented as more than a
+text-delta demo.

--- a/ext/agui/action.go
+++ b/ext/agui/action.go
@@ -1,0 +1,41 @@
+package agui
+
+// Action types represent commands sent from the UI back to the AGUI session.
+const (
+	ActionApproveToolCall      = "approve_tool_call"
+	ActionDenyToolCall         = "deny_tool_call"
+	ActionSubmitDeferredResult = "submit_deferred_result"
+	ActionAbortSession         = "abort_session"
+	ActionResumeSession        = "resume_session"
+	ActionReconnectStream      = "reconnect_stream"
+)
+
+// Action is a command sent from the client to the AGUI session.
+type Action struct {
+	// Type is one of the Action* constants.
+	Type string `json:"type"`
+
+	// SessionID identifies the target session.
+	SessionID string `json:"session_id"`
+
+	// ToolCallID identifies the tool call for approval/deferred actions.
+	ToolCallID string `json:"tool_call_id,omitempty"`
+
+	// ToolName is the tool name for approval/deferred actions.
+	ToolName string `json:"tool_name,omitempty"`
+
+	// Approved is set for approve/deny actions.
+	Approved *bool `json:"approved,omitempty"`
+
+	// Content is the result content for deferred result submissions.
+	Content string `json:"content,omitempty"`
+
+	// IsError indicates the deferred result is an error.
+	IsError bool `json:"is_error,omitempty"`
+
+	// Message is an optional human-readable message (e.g., denial reason).
+	Message string `json:"message,omitempty"`
+
+	// LastSeq is the last seen event sequence for reconnect actions.
+	LastSeq uint64 `json:"last_seq,omitempty"`
+}

--- a/ext/agui/adapter.go
+++ b/ext/agui/adapter.go
@@ -1,0 +1,612 @@
+package agui
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/fugue-labs/gollem/core"
+)
+
+// AG-UI protocol event type constants per the official specification.
+// See https://docs.ag-ui.com/concepts/events
+// See https://github.com/ag-ui-protocol/ag-ui/tree/main/sdks/community/go
+const (
+	AGUIRunStarted  = "RUN_STARTED"
+	AGUIRunFinished = "RUN_FINISHED"
+	AGUIRunError    = "RUN_ERROR"
+
+	AGUIStepStarted  = "STEP_STARTED"
+	AGUIStepFinished = "STEP_FINISHED"
+
+	AGUITextMessageStart   = "TEXT_MESSAGE_START"
+	AGUITextMessageContent = "TEXT_MESSAGE_CONTENT"
+	AGUITextMessageEnd     = "TEXT_MESSAGE_END"
+
+	AGUIToolCallStart  = "TOOL_CALL_START"
+	AGUIToolCallArgs   = "TOOL_CALL_ARGS"
+	AGUIToolCallEnd    = "TOOL_CALL_END"
+	AGUIToolCallResult = "TOOL_CALL_RESULT"
+
+	AGUIReasoningStart          = "REASONING_START"
+	AGUIReasoningMessageStart   = "REASONING_MESSAGE_START"
+	AGUIReasoningMessageContent = "REASONING_MESSAGE_CONTENT"
+	AGUIReasoningMessageEnd     = "REASONING_MESSAGE_END"
+	AGUIReasoningEnd            = "REASONING_END"
+
+	AGUICustom = "CUSTOM"
+)
+
+// Adapter translates gollem runtime events into AG-UI protocol events.
+// It subscribes to gollem's EventBus and emits spec-conformant AG-UI events
+// as json.RawMessage, ready for SSE transport.
+//
+// Each event type is marshaled using a dedicated struct matching the official
+// AG-UI Go SDK types. This avoids JSON field collisions and ensures required
+// fields are always present.
+//
+// Events are delivered to listeners in strict order via a serializing channel.
+// A single goroutine drains the channel, guaranteeing that concurrent tool
+// goroutines cannot reorder events, and that listener panics are isolated.
+//
+// All public methods and event handlers are safe for concurrent use.
+type Adapter struct {
+	mu        sync.Mutex // protects all mutable state
+	threadID  string     // immutable after construction
+	listeners []func(json.RawMessage)
+	unsubs    []func()
+
+	activeMessageID   string
+	activeReasoningID string
+	msgCounter        int64 // only accessed under mu
+
+	outCh     chan []json.RawMessage // serializing delivery channel
+	done      chan struct{}          // closed when delivery goroutine exits
+	closeOnce sync.Once              // ensures Close is idempotent
+}
+
+// NewAdapter creates an AG-UI adapter for a gollem session.
+// threadID maps to AG-UI's threadId concept (immutable after construction).
+func NewAdapter(threadID string) *Adapter {
+	a := &Adapter{
+		threadID: threadID,
+		outCh:    make(chan []json.RawMessage, 256),
+		done:     make(chan struct{}),
+	}
+	go a.deliverLoop()
+	return a
+}
+
+// deliverLoop is the single goroutine that delivers events to listeners
+// in strict order. Panics in listeners are recovered per-event.
+func (a *Adapter) deliverLoop() {
+	defer close(a.done)
+	for batch := range a.outCh {
+		a.mu.Lock()
+		listeners := make([]func(json.RawMessage), len(a.listeners))
+		copy(listeners, a.listeners)
+		a.mu.Unlock()
+
+		for _, data := range batch {
+			for _, fn := range listeners {
+				if fn != nil {
+					func() {
+						defer func() { recover() }()
+						fn(data)
+					}()
+				}
+			}
+		}
+	}
+}
+
+// OnEvent registers a listener that receives raw AG-UI JSON events.
+// Each event is a complete JSON object ready for SSE `data:` framing.
+func (a *Adapter) OnEvent(fn func(json.RawMessage)) func() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.listeners = append(a.listeners, fn)
+	idx := len(a.listeners) - 1
+	return func() {
+		a.mu.Lock()
+		defer a.mu.Unlock()
+		if idx < len(a.listeners) {
+			a.listeners[idx] = nil
+		}
+	}
+}
+
+// pendingEvents accumulates marshaled events during a handler's execution.
+// Events are sent to the delivery channel after all state mutations are
+// complete, ensuring multi-event sequences are emitted atomically and
+// cross-handler ordering is preserved via the serializing channel.
+type pendingEvents struct {
+	data []json.RawMessage
+	ch   chan<- []json.RawMessage
+}
+
+// enqueue marshals an event and adds it to the pending batch.
+func (p *pendingEvents) enqueue(v any) {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return
+	}
+	p.data = append(p.data, data)
+}
+
+// send submits the batch to the delivery channel. Non-blocking if the
+// channel has capacity; blocks if the delivery goroutine is backed up.
+// Must be called AFTER releasing the adapter mutex.
+// Safe to call after Close() — recovers from send-on-closed-channel.
+func (p *pendingEvents) send() {
+	if len(p.data) == 0 {
+		return
+	}
+	defer func() { recover() }() // catch send on closed channel during shutdown
+	p.ch <- p.data
+}
+
+// beginEmit returns a pendingEvents batch targeting the delivery channel.
+// MUST be called with a.mu held.
+func (a *Adapter) beginEmit() *pendingEvents {
+	return &pendingEvents{ch: a.outCh}
+}
+
+func nowMillis() int64 {
+	return time.Now().UnixMilli()
+}
+
+// nextMessageID generates a unique message ID. MUST be called with a.mu held.
+func (a *Adapter) nextMessageID() string {
+	a.msgCounter++
+	return fmt.Sprintf("msg_%s_%d", a.threadID, a.msgCounter)
+}
+
+// SubscribeTo connects the adapter to a gollem EventBus.
+// Must only be called once; panics if called after subscriptions exist.
+func (a *Adapter) SubscribeTo(bus *core.EventBus) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if len(a.unsubs) > 0 {
+		panic("agui: SubscribeTo called on an adapter that is already subscribed")
+	}
+	a.unsubs = append(a.unsubs, core.Subscribe(bus, a.onRunStarted))
+	a.unsubs = append(a.unsubs, core.Subscribe(bus, a.onRunCompleted))
+	a.unsubs = append(a.unsubs, core.Subscribe(bus, a.onTurnStarted))
+	a.unsubs = append(a.unsubs, core.Subscribe(bus, a.onTurnCompleted))
+	a.unsubs = append(a.unsubs, core.Subscribe(bus, a.onToolCalled))
+	a.unsubs = append(a.unsubs, core.Subscribe(bus, a.onToolCompleted))
+	a.unsubs = append(a.unsubs, core.Subscribe(bus, a.onToolFailed))
+	a.unsubs = append(a.unsubs, core.Subscribe(bus, a.onApprovalRequested))
+	a.unsubs = append(a.unsubs, core.Subscribe(bus, a.onApprovalResolved))
+	a.unsubs = append(a.unsubs, core.Subscribe(bus, a.onDeferredRequested))
+	a.unsubs = append(a.unsubs, core.Subscribe(bus, a.onRunWaiting))
+	a.unsubs = append(a.unsubs, core.Subscribe(bus, a.onDeferredResolved))
+	a.unsubs = append(a.unsubs, core.Subscribe(bus, a.onRunResumed))
+}
+
+// Close unsubscribes from all event bus subscriptions and shuts down
+// the delivery goroutine. Blocks until all queued events are delivered.
+// Safe to call multiple times (idempotent).
+func (a *Adapter) Close() {
+	a.mu.Lock()
+	unsubs := a.unsubs
+	a.unsubs = nil
+	a.mu.Unlock()
+
+	for _, unsub := range unsubs {
+		unsub()
+	}
+	a.closeOnce.Do(func() {
+		close(a.outCh)
+		<-a.done
+	})
+}
+
+// ── Per-event-type structs (match official AG-UI Go SDK field names) ──
+
+type aguiRunStarted struct {
+	Type      string `json:"type"`
+	Timestamp int64  `json:"timestamp"`
+	ThreadID  string `json:"threadId"`
+	RunID     string `json:"runId"`
+}
+
+type aguiRunFinished struct {
+	Type      string `json:"type"`
+	Timestamp int64  `json:"timestamp"`
+	ThreadID  string `json:"threadId"`
+	RunID     string `json:"runId"`
+}
+
+type aguiRunError struct {
+	Type      string  `json:"type"`
+	Timestamp int64   `json:"timestamp"`
+	Message   string  `json:"message"`
+	Code      *string `json:"code,omitempty"`
+	RunID     string  `json:"runId,omitempty"`
+}
+
+type aguiStepStarted struct {
+	Type      string `json:"type"`
+	Timestamp int64  `json:"timestamp"`
+	StepName  string `json:"stepName"`
+}
+
+type aguiStepFinished struct {
+	Type      string `json:"type"`
+	Timestamp int64  `json:"timestamp"`
+	StepName  string `json:"stepName"`
+}
+
+type aguiTextMessageStart struct {
+	Type      string  `json:"type"`
+	Timestamp int64   `json:"timestamp"`
+	MessageID string  `json:"messageId"`
+	Role      *string `json:"role,omitempty"`
+}
+
+type aguiTextMessageContent struct {
+	Type      string `json:"type"`
+	Timestamp int64  `json:"timestamp"`
+	MessageID string `json:"messageId"`
+	Delta     string `json:"delta"`
+}
+
+type aguiTextMessageEnd struct {
+	Type      string `json:"type"`
+	Timestamp int64  `json:"timestamp"`
+	MessageID string `json:"messageId"`
+}
+
+type aguiToolCallStart struct {
+	Type            string  `json:"type"`
+	Timestamp       int64   `json:"timestamp"`
+	ToolCallID      string  `json:"toolCallId"`
+	ToolCallName    string  `json:"toolCallName"`
+	ParentMessageID *string `json:"parentMessageId,omitempty"`
+}
+
+type aguiToolCallArgs struct {
+	Type       string `json:"type"`
+	Timestamp  int64  `json:"timestamp"`
+	ToolCallID string `json:"toolCallId"`
+	Delta      string `json:"delta"`
+}
+
+type aguiToolCallEnd struct {
+	Type       string `json:"type"`
+	Timestamp  int64  `json:"timestamp"`
+	ToolCallID string `json:"toolCallId"`
+}
+
+type aguiToolCallResult struct {
+	Type       string  `json:"type"`
+	Timestamp  int64   `json:"timestamp"`
+	MessageID  string  `json:"messageId"`
+	ToolCallID string  `json:"toolCallId"`
+	Content    string  `json:"content"`
+	Role       *string `json:"role,omitempty"`
+}
+
+type aguiReasoningStart struct {
+	Type      string `json:"type"`
+	Timestamp int64  `json:"timestamp"`
+	MessageID string `json:"messageId"`
+}
+
+type aguiReasoningMessageStart struct {
+	Type      string `json:"type"`
+	Timestamp int64  `json:"timestamp"`
+	MessageID string `json:"messageId"`
+	Role      string `json:"role"`
+}
+
+type aguiReasoningMessageContent struct {
+	Type      string `json:"type"`
+	Timestamp int64  `json:"timestamp"`
+	MessageID string `json:"messageId"`
+	Delta     string `json:"delta"`
+}
+
+type aguiReasoningMessageEnd struct {
+	Type      string `json:"type"`
+	Timestamp int64  `json:"timestamp"`
+	MessageID string `json:"messageId"`
+}
+
+type aguiReasoningEnd struct {
+	Type      string `json:"type"`
+	Timestamp int64  `json:"timestamp"`
+	MessageID string `json:"messageId"`
+}
+
+type aguiCustom struct {
+	Type      string          `json:"type"`
+	Timestamp int64           `json:"timestamp"`
+	Name      string          `json:"name"`
+	Value     json.RawMessage `json:"value,omitempty"`
+}
+
+// ── Lifecycle ───────────────────────────────────────────────────────
+
+func (a *Adapter) onRunStarted(ev core.RunStartedEvent) {
+	a.mu.Lock()
+	batch := a.beginEmit()
+	batch.enqueue(aguiRunStarted{
+		Type: AGUIRunStarted, Timestamp: nowMillis(),
+		ThreadID: a.threadID, RunID: ev.RunID,
+	})
+	a.mu.Unlock()
+	batch.send()
+}
+
+func (a *Adapter) onRunCompleted(ev core.RunCompletedEvent) {
+	a.mu.Lock()
+	batch := a.beginEmit()
+	a.enqueueCloseActiveMessage(batch)
+	if ev.Success || ev.Deferred {
+		batch.enqueue(aguiRunFinished{
+			Type: AGUIRunFinished, Timestamp: nowMillis(),
+			ThreadID: a.threadID, RunID: ev.RunID,
+		})
+	} else {
+		batch.enqueue(aguiRunError{
+			Type: AGUIRunError, Timestamp: nowMillis(),
+			Message: ev.Error, RunID: ev.RunID,
+		})
+	}
+	a.mu.Unlock()
+	batch.send()
+}
+
+// ── Steps (gollem turns → AG-UI steps) ──────────────────────────────
+
+func (a *Adapter) onTurnStarted(ev core.TurnStartedEvent) {
+	a.mu.Lock()
+	batch := a.beginEmit()
+	batch.enqueue(aguiStepStarted{
+		Type: AGUIStepStarted, Timestamp: nowMillis(),
+		StepName: fmt.Sprintf("turn_%d", ev.TurnNumber),
+	})
+	a.mu.Unlock()
+	batch.send()
+}
+
+func (a *Adapter) onTurnCompleted(ev core.TurnCompletedEvent) {
+	a.mu.Lock()
+	batch := a.beginEmit()
+	a.enqueueCloseActiveMessage(batch)
+	batch.enqueue(aguiStepFinished{
+		Type: AGUIStepFinished, Timestamp: nowMillis(),
+		StepName: fmt.Sprintf("turn_%d", ev.TurnNumber),
+	})
+	a.mu.Unlock()
+	batch.send()
+}
+
+// ── Text streaming ──────────────────────────────────────────────────
+
+// EmitTextDelta is called by the streaming adapter (Phase 4) when text
+// tokens arrive. It manages the TextMessageStart/Content/End lifecycle.
+// Safe for concurrent use.
+func (a *Adapter) EmitTextDelta(messageID, delta string) {
+	a.mu.Lock()
+	batch := a.beginEmit()
+
+	if a.activeMessageID != messageID {
+		a.activeMessageID = messageID
+		role := "assistant"
+		batch.enqueue(aguiTextMessageStart{
+			Type: AGUITextMessageStart, Timestamp: nowMillis(),
+			MessageID: messageID, Role: &role,
+		})
+	}
+	if delta != "" {
+		batch.enqueue(aguiTextMessageContent{
+			Type: AGUITextMessageContent, Timestamp: nowMillis(),
+			MessageID: messageID, Delta: delta,
+		})
+	}
+
+	a.mu.Unlock()
+	batch.send()
+}
+
+// EmitReasoningDelta is called when thinking/reasoning tokens arrive.
+// Safe for concurrent use.
+func (a *Adapter) EmitReasoningDelta(messageID, delta string) {
+	a.mu.Lock()
+	batch := a.beginEmit()
+
+	if a.activeReasoningID != messageID {
+		a.activeReasoningID = messageID
+		batch.enqueue(aguiReasoningStart{
+			Type: AGUIReasoningStart, Timestamp: nowMillis(), MessageID: messageID,
+		})
+		batch.enqueue(aguiReasoningMessageStart{
+			Type: AGUIReasoningMessageStart, Timestamp: nowMillis(),
+			MessageID: messageID, Role: "reasoning",
+		})
+	}
+	if delta != "" {
+		batch.enqueue(aguiReasoningMessageContent{
+			Type: AGUIReasoningMessageContent, Timestamp: nowMillis(),
+			MessageID: messageID, Delta: delta,
+		})
+	}
+
+	a.mu.Unlock()
+	batch.send()
+}
+
+// enqueueCloseActiveMessage enqueues End events for any active text/reasoning
+// message and clears the active IDs. MUST be called with a.mu held.
+func (a *Adapter) enqueueCloseActiveMessage(batch *pendingEvents) {
+	ts := nowMillis()
+	if a.activeMessageID != "" {
+		batch.enqueue(aguiTextMessageEnd{
+			Type: AGUITextMessageEnd, Timestamp: ts, MessageID: a.activeMessageID,
+		})
+		a.activeMessageID = ""
+	}
+	if a.activeReasoningID != "" {
+		batch.enqueue(aguiReasoningMessageEnd{
+			Type: AGUIReasoningMessageEnd, Timestamp: ts, MessageID: a.activeReasoningID,
+		})
+		batch.enqueue(aguiReasoningEnd{
+			Type: AGUIReasoningEnd, Timestamp: ts, MessageID: a.activeReasoningID,
+		})
+		a.activeReasoningID = ""
+	}
+}
+
+// ── Tool calls ──────────────────────────────────────────────────────
+
+func (a *Adapter) onToolCalled(ev core.ToolCalledEvent) {
+	a.mu.Lock()
+	batch := a.beginEmit()
+	a.enqueueCloseActiveMessage(batch)
+
+	ts := nowMillis()
+	batch.enqueue(aguiToolCallStart{
+		Type: AGUIToolCallStart, Timestamp: ts,
+		ToolCallID: ev.ToolCallID, ToolCallName: ev.ToolName,
+	})
+	if ev.ArgsJSON != "" {
+		batch.enqueue(aguiToolCallArgs{
+			Type: AGUIToolCallArgs, Timestamp: ts,
+			ToolCallID: ev.ToolCallID, Delta: ev.ArgsJSON,
+		})
+	}
+	batch.enqueue(aguiToolCallEnd{
+		Type: AGUIToolCallEnd, Timestamp: ts, ToolCallID: ev.ToolCallID,
+	})
+
+	a.mu.Unlock()
+	batch.send()
+}
+
+func (a *Adapter) onToolCompleted(ev core.ToolCompletedEvent) {
+	role := "tool"
+	a.mu.Lock()
+	batch := a.beginEmit()
+	batch.enqueue(aguiToolCallResult{
+		Type: AGUIToolCallResult, Timestamp: nowMillis(),
+		MessageID: a.nextMessageID(), ToolCallID: ev.ToolCallID,
+		Content: ev.Result, Role: &role,
+	})
+	a.mu.Unlock()
+	batch.send()
+}
+
+func (a *Adapter) onToolFailed(ev core.ToolFailedEvent) {
+	role := "tool"
+	a.mu.Lock()
+	batch := a.beginEmit()
+	batch.enqueue(aguiToolCallResult{
+		Type: AGUIToolCallResult, Timestamp: nowMillis(),
+		MessageID: a.nextMessageID(), ToolCallID: ev.ToolCallID,
+		Content: "error: " + ev.Error, Role: &role,
+	})
+	a.mu.Unlock()
+	batch.send()
+}
+
+// ── Gollem-specific → AG-UI CUSTOM ─────────────────────────────────
+
+func (a *Adapter) onApprovalRequested(ev core.ApprovalRequestedEvent) {
+	a.mu.Lock()
+	batch := a.beginEmit()
+	batch.enqueue(aguiCustom{
+		Type: AGUICustom, Timestamp: nowMillis(),
+		Name: "gollem.approval.requested",
+		Value: mustMarshal(map[string]any{
+			"toolCallId": ev.ToolCallID, "toolName": ev.ToolName, "argsJson": ev.ArgsJSON,
+		}),
+	})
+	a.mu.Unlock()
+	batch.send()
+}
+
+func (a *Adapter) onApprovalResolved(ev core.ApprovalResolvedEvent) {
+	a.mu.Lock()
+	batch := a.beginEmit()
+	batch.enqueue(aguiCustom{
+		Type: AGUICustom, Timestamp: nowMillis(),
+		Name: "gollem.approval.resolved",
+		Value: mustMarshal(map[string]any{
+			"toolCallId": ev.ToolCallID, "toolName": ev.ToolName, "approved": ev.Approved,
+		}),
+	})
+	a.mu.Unlock()
+	batch.send()
+}
+
+func (a *Adapter) onDeferredRequested(ev core.DeferredRequestedEvent) {
+	a.mu.Lock()
+	batch := a.beginEmit()
+	batch.enqueue(aguiCustom{
+		Type: AGUICustom, Timestamp: nowMillis(),
+		Name: "gollem.deferred.requested",
+		Value: mustMarshal(map[string]any{
+			"toolCallId": ev.ToolCallID, "toolName": ev.ToolName, "argsJson": ev.ArgsJSON,
+		}),
+	})
+	a.mu.Unlock()
+	batch.send()
+}
+
+func (a *Adapter) onRunWaiting(ev core.RunWaitingEvent) {
+	a.mu.Lock()
+	batch := a.beginEmit()
+	batch.enqueue(aguiCustom{
+		Type: AGUICustom, Timestamp: nowMillis(),
+		Name:  "gollem.run.waiting",
+		Value: mustMarshal(map[string]any{"reason": ev.Reason}),
+	})
+	a.mu.Unlock()
+	batch.send()
+}
+
+func (a *Adapter) onDeferredResolved(ev core.DeferredResolvedEvent) {
+	a.mu.Lock()
+	batch := a.beginEmit()
+	batch.enqueue(aguiCustom{
+		Type: AGUICustom, Timestamp: nowMillis(),
+		Name: "gollem.deferred.resolved",
+		Value: mustMarshal(map[string]any{
+			"toolCallId": ev.ToolCallID,
+			"toolName":   ev.ToolName,
+			"content":    ev.Content,
+			"isError":    ev.IsError,
+		}),
+	})
+	a.mu.Unlock()
+	batch.send()
+}
+
+func (a *Adapter) onRunResumed(ev core.RunResumedEvent) {
+	a.mu.Lock()
+	batch := a.beginEmit()
+	batch.enqueue(aguiCustom{
+		Type: AGUICustom, Timestamp: nowMillis(),
+		Name: "gollem.run.resumed",
+		Value: mustMarshal(map[string]any{
+			"runId": ev.RunID,
+		}),
+	})
+	a.mu.Unlock()
+	batch.send()
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+func mustMarshal(v any) json.RawMessage {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return json.RawMessage(`{}`)
+	}
+	return b
+}

--- a/ext/agui/adapter.go
+++ b/ext/agui/adapter.go
@@ -92,7 +92,7 @@ func (a *Adapter) deliverLoop() {
 			for _, fn := range listeners {
 				if fn != nil {
 					func() {
-						defer func() { recover() }()
+						defer func() { _ = recover() }()
 						fn(data)
 					}()
 				}
@@ -143,7 +143,7 @@ func (p *pendingEvents) send() {
 	if len(p.data) == 0 {
 		return
 	}
-	defer func() { recover() }() // catch send on closed channel during shutdown
+	defer func() { _ = recover() }() // catch send on closed channel during shutdown
 	p.ch <- p.data
 }
 

--- a/ext/agui/adapter.go
+++ b/ext/agui/adapter.go
@@ -64,6 +64,8 @@ type Adapter struct {
 	outCh     chan []json.RawMessage // serializing delivery channel
 	done      chan struct{}          // closed when delivery goroutine exits
 	closeOnce sync.Once              // ensures Close is idempotent
+	sendMu    sync.RWMutex           // synchronizes sends with Close
+	closed    bool
 }
 
 // NewAdapter creates an AG-UI adapter for a gollem session.
@@ -122,8 +124,8 @@ func (a *Adapter) OnEvent(fn func(json.RawMessage)) func() {
 // complete, ensuring multi-event sequences are emitted atomically and
 // cross-handler ordering is preserved via the serializing channel.
 type pendingEvents struct {
-	data []json.RawMessage
-	ch   chan<- []json.RawMessage
+	data    []json.RawMessage
+	adapter *Adapter
 }
 
 // enqueue marshals an event and adds it to the pending batch.
@@ -138,19 +140,23 @@ func (p *pendingEvents) enqueue(v any) {
 // send submits the batch to the delivery channel. Non-blocking if the
 // channel has capacity; blocks if the delivery goroutine is backed up.
 // Must be called AFTER releasing the adapter mutex.
-// Safe to call after Close() — recovers from send-on-closed-channel.
+// Safe to call after Close() — batches are dropped once the adapter closes.
 func (p *pendingEvents) send() {
 	if len(p.data) == 0 {
 		return
 	}
-	defer func() { _ = recover() }() // catch send on closed channel during shutdown
-	p.ch <- p.data
+	p.adapter.sendMu.RLock()
+	defer p.adapter.sendMu.RUnlock()
+	if p.adapter.closed {
+		return
+	}
+	p.adapter.outCh <- p.data
 }
 
 // beginEmit returns a pendingEvents batch targeting the delivery channel.
 // MUST be called with a.mu held.
 func (a *Adapter) beginEmit() *pendingEvents {
-	return &pendingEvents{ch: a.outCh}
+	return &pendingEvents{adapter: a}
 }
 
 func nowMillis() int64 {
@@ -199,7 +205,10 @@ func (a *Adapter) Close() {
 		unsub()
 	}
 	a.closeOnce.Do(func() {
+		a.sendMu.Lock()
+		a.closed = true
 		close(a.outCh)
+		a.sendMu.Unlock()
 		<-a.done
 	})
 }

--- a/ext/agui/adapter_invariant_test.go
+++ b/ext/agui/adapter_invariant_test.go
@@ -279,7 +279,7 @@ func TestInvariant_MultipleToolsConcurrent(t *testing.T) {
 
 	// Simulate concurrent tool calls
 	var wg sync.WaitGroup
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		wg.Add(1)
 		go func(n int) {
 			defer wg.Done()
@@ -493,7 +493,7 @@ func TestInvariant_MessageIDUniqueness(t *testing.T) {
 
 	// Fire 20 tool completions concurrently — each should get a unique messageId
 	var wg sync.WaitGroup
-	for i := 0; i < 20; i++ {
+	for i := range 20 {
 		wg.Add(1)
 		go func(n int) {
 			defer wg.Done()

--- a/ext/agui/adapter_invariant_test.go
+++ b/ext/agui/adapter_invariant_test.go
@@ -1,0 +1,565 @@
+package agui
+
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/fugue-labs/gollem/core"
+)
+
+// ── AG-UI protocol invariant tests ──────────────────────────────────
+//
+// These tests verify structural invariants of the AG-UI event stream
+// that any compliant client depends on:
+//
+// 1. Every RUN_STARTED has a matching RUN_FINISHED or RUN_ERROR
+// 2. Every STEP_STARTED has a matching STEP_FINISHED (same stepName)
+// 3. Every TEXT_MESSAGE_START has a matching TEXT_MESSAGE_END (same messageId)
+// 4. TEXT_MESSAGE_CONTENT only appears between START and END for its messageId
+// 5. Every TOOL_CALL_START has a matching TOOL_CALL_END (same toolCallId)
+// 6. TOOL_CALL_ARGS only appears between START and END for its toolCallId
+// 7. Every REASONING_START has a matching REASONING_END
+// 8. Event ordering: no CONTENT after END for the same ID
+
+type protocolChecker struct {
+	t      *testing.T
+	events []map[string]any
+
+	activeRuns      map[string]bool
+	activeSteps     map[string]bool
+	activeMessages  map[string]bool
+	activeToolCalls map[string]bool
+	activeReasoning map[string]bool
+	endedMessages   map[string]bool
+}
+
+func newProtocolChecker(t *testing.T) *protocolChecker {
+	return &protocolChecker{
+		t:               t,
+		activeRuns:      make(map[string]bool),
+		activeSteps:     make(map[string]bool),
+		activeMessages:  make(map[string]bool),
+		activeToolCalls: make(map[string]bool),
+		activeReasoning: make(map[string]bool),
+		endedMessages:   make(map[string]bool),
+	}
+}
+
+func (pc *protocolChecker) collect(data json.RawMessage) {
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		pc.t.Errorf("failed to unmarshal event: %v", err)
+		return
+	}
+	pc.events = append(pc.events, m)
+}
+
+func (pc *protocolChecker) validate() {
+	pc.t.Helper()
+
+	for i, ev := range pc.events {
+		typ, _ := ev["type"].(string)
+		switch typ {
+		case AGUIRunStarted:
+			runID, _ := ev["runId"].(string)
+			if pc.activeRuns[runID] {
+				pc.t.Errorf("event[%d]: duplicate RUN_STARTED for run %q", i, runID)
+			}
+			pc.activeRuns[runID] = true
+
+		case AGUIRunFinished:
+			runID, _ := ev["runId"].(string)
+			if !pc.activeRuns[runID] {
+				pc.t.Errorf("event[%d]: RUN_FINISHED without RUN_STARTED for run %q", i, runID)
+			}
+			delete(pc.activeRuns, runID)
+
+		case AGUIRunError:
+			// RunError may or may not have runId
+			if runID, ok := ev["runId"].(string); ok && runID != "" {
+				delete(pc.activeRuns, runID)
+			}
+
+		case AGUIStepStarted:
+			name, _ := ev["stepName"].(string)
+			if pc.activeSteps[name] {
+				pc.t.Errorf("event[%d]: duplicate STEP_STARTED for step %q", i, name)
+			}
+			pc.activeSteps[name] = true
+
+		case AGUIStepFinished:
+			name, _ := ev["stepName"].(string)
+			if !pc.activeSteps[name] {
+				pc.t.Errorf("event[%d]: STEP_FINISHED without STEP_STARTED for step %q", i, name)
+			}
+			delete(pc.activeSteps, name)
+
+		case AGUITextMessageStart:
+			msgID, _ := ev["messageId"].(string)
+			if pc.activeMessages[msgID] {
+				pc.t.Errorf("event[%d]: duplicate TEXT_MESSAGE_START for message %q", i, msgID)
+			}
+			pc.activeMessages[msgID] = true
+
+		case AGUITextMessageContent:
+			msgID, _ := ev["messageId"].(string)
+			if !pc.activeMessages[msgID] {
+				pc.t.Errorf("event[%d]: TEXT_MESSAGE_CONTENT without active TEXT_MESSAGE_START for message %q", i, msgID)
+			}
+			if pc.endedMessages[msgID] {
+				pc.t.Errorf("event[%d]: TEXT_MESSAGE_CONTENT after TEXT_MESSAGE_END for message %q", i, msgID)
+			}
+			delta, _ := ev["delta"].(string)
+			if delta == "" {
+				pc.t.Errorf("event[%d]: TEXT_MESSAGE_CONTENT has empty delta", i)
+			}
+
+		case AGUITextMessageEnd:
+			msgID, _ := ev["messageId"].(string)
+			if !pc.activeMessages[msgID] {
+				pc.t.Errorf("event[%d]: TEXT_MESSAGE_END without TEXT_MESSAGE_START for message %q", i, msgID)
+			}
+			delete(pc.activeMessages, msgID)
+			pc.endedMessages[msgID] = true
+
+		case AGUIToolCallStart:
+			tcID, _ := ev["toolCallId"].(string)
+			if pc.activeToolCalls[tcID] {
+				pc.t.Errorf("event[%d]: duplicate TOOL_CALL_START for %q", i, tcID)
+			}
+			pc.activeToolCalls[tcID] = true
+			// Required fields
+			if _, ok := ev["toolCallName"]; !ok {
+				pc.t.Errorf("event[%d]: TOOL_CALL_START missing toolCallName", i)
+			}
+
+		case AGUIToolCallArgs:
+			tcID, _ := ev["toolCallId"].(string)
+			if !pc.activeToolCalls[tcID] {
+				pc.t.Errorf("event[%d]: TOOL_CALL_ARGS without active TOOL_CALL_START for %q", i, tcID)
+			}
+			delta, _ := ev["delta"].(string)
+			if delta == "" {
+				pc.t.Errorf("event[%d]: TOOL_CALL_ARGS has empty delta", i)
+			}
+
+		case AGUIToolCallEnd:
+			tcID, _ := ev["toolCallId"].(string)
+			if !pc.activeToolCalls[tcID] {
+				pc.t.Errorf("event[%d]: TOOL_CALL_END without TOOL_CALL_START for %q", i, tcID)
+			}
+			delete(pc.activeToolCalls, tcID)
+
+		case AGUIToolCallResult:
+			// Verify required fields
+			if _, ok := ev["messageId"]; !ok {
+				pc.t.Errorf("event[%d]: TOOL_CALL_RESULT missing messageId", i)
+			}
+			if _, ok := ev["toolCallId"]; !ok {
+				pc.t.Errorf("event[%d]: TOOL_CALL_RESULT missing toolCallId", i)
+			}
+			if _, ok := ev["content"]; !ok {
+				pc.t.Errorf("event[%d]: TOOL_CALL_RESULT missing content", i)
+			}
+
+		case AGUIReasoningStart:
+			msgID, _ := ev["messageId"].(string)
+			pc.activeReasoning[msgID] = true
+
+		case AGUIReasoningEnd:
+			msgID, _ := ev["messageId"].(string)
+			if !pc.activeReasoning[msgID] {
+				pc.t.Errorf("event[%d]: REASONING_END without REASONING_START for %q", i, msgID)
+			}
+			delete(pc.activeReasoning, msgID)
+
+		case AGUICustom:
+			if _, ok := ev["name"]; !ok {
+				pc.t.Errorf("event[%d]: CUSTOM missing name", i)
+			}
+		}
+
+		// Every event must have a timestamp (Unix millis number)
+		if _, ok := ev["timestamp"]; !ok {
+			pc.t.Errorf("event[%d] (%s): missing timestamp", i, typ)
+		}
+	}
+
+	// Check for unclosed entities
+	for run := range pc.activeRuns {
+		pc.t.Errorf("unclosed RUN_STARTED for run %q", run)
+	}
+	for step := range pc.activeSteps {
+		pc.t.Errorf("unclosed STEP_STARTED for step %q", step)
+	}
+	for msg := range pc.activeMessages {
+		pc.t.Errorf("unclosed TEXT_MESSAGE_START for message %q", msg)
+	}
+	for tc := range pc.activeToolCalls {
+		pc.t.Errorf("unclosed TOOL_CALL_START for tool call %q", tc)
+	}
+	for r := range pc.activeReasoning {
+		pc.t.Errorf("unclosed REASONING_START for %q", r)
+	}
+}
+
+// ── Full lifecycle invariant tests ──────────────────────────────────
+
+func TestInvariant_FullRunLifecycle(t *testing.T) {
+	bus := core.NewEventBus()
+	adapter := NewAdapter("thread_1")
+	pc := newProtocolChecker(t)
+	adapter.OnEvent(pc.collect)
+	adapter.SubscribeTo(bus)
+
+	// Simulate: run start → turn 1 (text) → turn 2 (tool call + result) → run finish
+	core.Publish(bus, core.RunStartedEvent{RunID: "r1", StartedAt: time.Now()})
+
+	// Turn 1: text response
+	core.Publish(bus, core.TurnStartedEvent{RunID: "r1", TurnNumber: 1, StartedAt: time.Now()})
+	adapter.EmitTextDelta("msg_1", "Hello ")
+	adapter.EmitTextDelta("msg_1", "world!")
+	core.Publish(bus, core.TurnCompletedEvent{RunID: "r1", TurnNumber: 1, HasText: true, CompletedAt: time.Now()})
+
+	// Turn 2: tool call
+	core.Publish(bus, core.TurnStartedEvent{RunID: "r1", TurnNumber: 2, StartedAt: time.Now()})
+	core.Publish(bus, core.ToolCalledEvent{
+		RunID: "r1", ToolCallID: "tc1", ToolName: "search",
+		ArgsJSON: `{"q":"test"}`, CalledAt: time.Now(),
+	})
+	core.Publish(bus, core.ToolCompletedEvent{
+		RunID: "r1", ToolCallID: "tc1", ToolName: "search",
+		Result: "found it", CompletedAt: time.Now(),
+	})
+	core.Publish(bus, core.TurnCompletedEvent{RunID: "r1", TurnNumber: 2, HasToolCalls: true, CompletedAt: time.Now()})
+
+	// Turn 3: final text
+	core.Publish(bus, core.TurnStartedEvent{RunID: "r1", TurnNumber: 3, StartedAt: time.Now()})
+	adapter.EmitTextDelta("msg_2", "Done!")
+	core.Publish(bus, core.TurnCompletedEvent{RunID: "r1", TurnNumber: 3, HasText: true, CompletedAt: time.Now()})
+
+	core.Publish(bus, core.RunCompletedEvent{RunID: "r1", Success: true, CompletedAt: time.Now()})
+
+	adapter.Close()
+	pc.validate()
+}
+
+func TestInvariant_RunWithError(t *testing.T) {
+	bus := core.NewEventBus()
+	adapter := NewAdapter("thread_1")
+	pc := newProtocolChecker(t)
+	adapter.OnEvent(pc.collect)
+	adapter.SubscribeTo(bus)
+
+	core.Publish(bus, core.RunStartedEvent{RunID: "r1", StartedAt: time.Now()})
+	core.Publish(bus, core.TurnStartedEvent{RunID: "r1", TurnNumber: 1, StartedAt: time.Now()})
+	adapter.EmitTextDelta("msg_1", "partial output")
+	core.Publish(bus, core.TurnCompletedEvent{
+		RunID: "r1", TurnNumber: 1, Error: "model failed", CompletedAt: time.Now(),
+	})
+	core.Publish(bus, core.RunCompletedEvent{
+		RunID: "r1", Success: false, Error: "model failed", CompletedAt: time.Now(),
+	})
+
+	adapter.Close()
+	pc.validate()
+}
+
+func TestInvariant_MultipleToolsConcurrent(t *testing.T) {
+	bus := core.NewEventBus()
+	adapter := NewAdapter("thread_1")
+	pc := newProtocolChecker(t)
+	adapter.OnEvent(pc.collect)
+	adapter.SubscribeTo(bus)
+
+	core.Publish(bus, core.RunStartedEvent{RunID: "r1", StartedAt: time.Now()})
+	core.Publish(bus, core.TurnStartedEvent{RunID: "r1", TurnNumber: 1, StartedAt: time.Now()})
+
+	// Simulate concurrent tool calls
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			tcID := string(rune('A'+n)) + "_tc"
+			core.Publish(bus, core.ToolCalledEvent{
+				RunID: "r1", ToolCallID: tcID, ToolName: "tool_" + tcID,
+				ArgsJSON: `{"n":` + string(rune('0'+n)) + `}`, CalledAt: time.Now(),
+			})
+			core.Publish(bus, core.ToolCompletedEvent{
+				RunID: "r1", ToolCallID: tcID, ToolName: "tool_" + tcID,
+				Result: "ok", CompletedAt: time.Now(),
+			})
+		}(i)
+	}
+	wg.Wait()
+
+	core.Publish(bus, core.TurnCompletedEvent{RunID: "r1", TurnNumber: 1, HasToolCalls: true, CompletedAt: time.Now()})
+	core.Publish(bus, core.RunCompletedEvent{RunID: "r1", Success: true, CompletedAt: time.Now()})
+
+	adapter.Close()
+	pc.validate()
+}
+
+func TestInvariant_TextThenToolThenText(t *testing.T) {
+	bus := core.NewEventBus()
+	adapter := NewAdapter("thread_1")
+	pc := newProtocolChecker(t)
+	adapter.OnEvent(pc.collect)
+	adapter.SubscribeTo(bus)
+
+	core.Publish(bus, core.RunStartedEvent{RunID: "r1", StartedAt: time.Now()})
+
+	// Turn 1: text + tool in same turn
+	core.Publish(bus, core.TurnStartedEvent{RunID: "r1", TurnNumber: 1, StartedAt: time.Now()})
+	adapter.EmitTextDelta("msg_1", "I'll search for that...")
+
+	// Tool call should auto-close the text message
+	core.Publish(bus, core.ToolCalledEvent{
+		RunID: "r1", ToolCallID: "tc1", ToolName: "search",
+		ArgsJSON: `{"q":"test"}`, CalledAt: time.Now(),
+	})
+	core.Publish(bus, core.ToolCompletedEvent{
+		RunID: "r1", ToolCallID: "tc1", Result: "results", CompletedAt: time.Now(),
+	})
+	core.Publish(bus, core.TurnCompletedEvent{RunID: "r1", TurnNumber: 1, CompletedAt: time.Now()})
+
+	// Turn 2: text response with results
+	core.Publish(bus, core.TurnStartedEvent{RunID: "r1", TurnNumber: 2, StartedAt: time.Now()})
+	adapter.EmitTextDelta("msg_2", "Here are the results!")
+	core.Publish(bus, core.TurnCompletedEvent{RunID: "r1", TurnNumber: 2, HasText: true, CompletedAt: time.Now()})
+
+	core.Publish(bus, core.RunCompletedEvent{RunID: "r1", Success: true, CompletedAt: time.Now()})
+
+	adapter.Close()
+	pc.validate()
+}
+
+func TestInvariant_ReasoningThenText(t *testing.T) {
+	bus := core.NewEventBus()
+	adapter := NewAdapter("thread_1")
+	pc := newProtocolChecker(t)
+	adapter.OnEvent(pc.collect)
+	adapter.SubscribeTo(bus)
+
+	core.Publish(bus, core.RunStartedEvent{RunID: "r1", StartedAt: time.Now()})
+	core.Publish(bus, core.TurnStartedEvent{RunID: "r1", TurnNumber: 1, StartedAt: time.Now()})
+
+	// Reasoning followed by text
+	adapter.EmitReasoningDelta("reason_1", "thinking about this...")
+	adapter.EmitTextDelta("msg_1", "Here's my answer")
+
+	core.Publish(bus, core.TurnCompletedEvent{RunID: "r1", TurnNumber: 1, HasText: true, CompletedAt: time.Now()})
+	core.Publish(bus, core.RunCompletedEvent{RunID: "r1", Success: true, CompletedAt: time.Now()})
+
+	adapter.Close()
+	pc.validate()
+}
+
+func TestInvariant_ApprovalDuringRun(t *testing.T) {
+	bus := core.NewEventBus()
+	adapter := NewAdapter("thread_1")
+	pc := newProtocolChecker(t)
+	adapter.OnEvent(pc.collect)
+	adapter.SubscribeTo(bus)
+
+	core.Publish(bus, core.RunStartedEvent{RunID: "r1", StartedAt: time.Now()})
+	core.Publish(bus, core.TurnStartedEvent{RunID: "r1", TurnNumber: 1, StartedAt: time.Now()})
+
+	core.Publish(bus, core.ToolCalledEvent{
+		RunID: "r1", ToolCallID: "tc1", ToolName: "delete",
+		ArgsJSON: `{"path":"/important"}`, CalledAt: time.Now(),
+	})
+	core.Publish(bus, core.ApprovalRequestedEvent{
+		RunID: "r1", ToolCallID: "tc1", ToolName: "delete", RequestedAt: time.Now(),
+	})
+	core.Publish(bus, core.RunWaitingEvent{RunID: "r1", Reason: "approval", WaitingAt: time.Now()})
+	core.Publish(bus, core.RunResumedEvent{RunID: "r1", ResumedAt: time.Now()})
+	core.Publish(bus, core.ApprovalResolvedEvent{
+		RunID: "r1", ToolCallID: "tc1", Approved: true, ResolvedAt: time.Now(),
+	})
+	core.Publish(bus, core.ToolCompletedEvent{
+		RunID: "r1", ToolCallID: "tc1", Result: "deleted", CompletedAt: time.Now(),
+	})
+	core.Publish(bus, core.TurnCompletedEvent{RunID: "r1", TurnNumber: 1, CompletedAt: time.Now()})
+	core.Publish(bus, core.RunCompletedEvent{RunID: "r1", Success: true, CompletedAt: time.Now()})
+
+	adapter.Close()
+	pc.validate()
+}
+
+func TestInvariant_DeferredWaitThenResume(t *testing.T) {
+	bus := core.NewEventBus()
+	adapter := NewAdapter("thread_1")
+	pc := newProtocolChecker(t)
+	adapter.OnEvent(pc.collect)
+	adapter.SubscribeTo(bus)
+
+	core.Publish(bus, core.RunStartedEvent{RunID: "r1", StartedAt: time.Now()})
+	core.Publish(bus, core.TurnStartedEvent{RunID: "r1", TurnNumber: 1, StartedAt: time.Now()})
+	core.Publish(bus, core.ToolCalledEvent{
+		RunID: "r1", ToolCallID: "tc1", ToolName: "fetch",
+		ArgsJSON: `{"id":1}`, CalledAt: time.Now(),
+	})
+	core.Publish(bus, core.DeferredRequestedEvent{
+		RunID: "r1", ToolCallID: "tc1", ToolName: "fetch",
+		ArgsJSON: `{"id":1}`, RequestedAt: time.Now(),
+	})
+	core.Publish(bus, core.RunWaitingEvent{RunID: "r1", Reason: "deferred", WaitingAt: time.Now()})
+	core.Publish(bus, core.TurnCompletedEvent{RunID: "r1", TurnNumber: 1, HasToolCalls: true, CompletedAt: time.Now()})
+	core.Publish(bus, core.RunCompletedEvent{
+		RunID: "r1", Success: false, Deferred: true,
+		Error:       "agent run deferred: 1 tool call(s) require external resolution",
+		CompletedAt: time.Now(),
+	})
+
+	core.Publish(bus, core.RunStartedEvent{RunID: "r2", StartedAt: time.Now()})
+	core.Publish(bus, core.RunResumedEvent{RunID: "r2", ResumedAt: time.Now()})
+	core.Publish(bus, core.DeferredResolvedEvent{
+		RunID: "r2", ToolCallID: "tc1", ToolName: "fetch",
+		Content: "done", ResolvedAt: time.Now(),
+	})
+	core.Publish(bus, core.TurnStartedEvent{RunID: "r2", TurnNumber: 1, StartedAt: time.Now()})
+	adapter.EmitTextDelta("msg_2", "Resolved.")
+	core.Publish(bus, core.TurnCompletedEvent{RunID: "r2", TurnNumber: 1, HasText: true, CompletedAt: time.Now()})
+	core.Publish(bus, core.RunCompletedEvent{RunID: "r2", Success: true, CompletedAt: time.Now()})
+
+	adapter.Close()
+	pc.validate()
+
+	var (
+		sawRunError         bool
+		sawRunResumed       bool
+		sawDeferredResolved bool
+	)
+	for _, ev := range pc.events {
+		if ev["type"] == AGUIRunError {
+			sawRunError = true
+		}
+		if ev["type"] != AGUICustom {
+			continue
+		}
+		name, _ := ev["name"].(string)
+		if name == "gollem.run.resumed" {
+			sawRunResumed = true
+		}
+		if name == "gollem.deferred.resolved" {
+			sawDeferredResolved = true
+		}
+	}
+	if sawRunError {
+		t.Fatal("deferred wait should not be emitted as RUN_ERROR")
+	}
+	if !sawRunResumed {
+		t.Fatal("expected gollem.run.resumed custom event")
+	}
+	if !sawDeferredResolved {
+		t.Fatal("expected gollem.deferred.resolved custom event")
+	}
+}
+
+func TestInvariant_NoEventsAfterClose(t *testing.T) {
+	bus := core.NewEventBus()
+	adapter := NewAdapter("thread_1")
+	pc := newProtocolChecker(t)
+	adapter.OnEvent(pc.collect)
+	adapter.SubscribeTo(bus)
+
+	core.Publish(bus, core.RunStartedEvent{RunID: "r1", StartedAt: time.Now()})
+	core.Publish(bus, core.RunCompletedEvent{RunID: "r1", Success: true, CompletedAt: time.Now()})
+	adapter.Close()
+
+	countBefore := len(pc.events)
+
+	// Events after close should be silently dropped (send on closed channel recovered)
+	core.Publish(bus, core.RunStartedEvent{RunID: "r2", StartedAt: time.Now()})
+	time.Sleep(10 * time.Millisecond)
+
+	if len(pc.events) != countBefore {
+		t.Errorf("events received after Close: %d new events", len(pc.events)-countBefore)
+	}
+
+	pc.validate()
+}
+
+func TestInvariant_MessageIDUniqueness(t *testing.T) {
+	bus := core.NewEventBus()
+	adapter := NewAdapter("thread_1")
+	pc := newProtocolChecker(t)
+	adapter.OnEvent(pc.collect)
+	adapter.SubscribeTo(bus)
+
+	// Fire 20 tool completions concurrently — each should get a unique messageId
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			core.Publish(bus, core.ToolCompletedEvent{
+				RunID:       "r1",
+				ToolCallID:  string(rune('A' + n)),
+				ToolName:    "tool",
+				Result:      "ok",
+				CompletedAt: time.Now(),
+			})
+		}(i)
+	}
+	wg.Wait()
+	adapter.Close()
+
+	// Collect all messageIds from TOOL_CALL_RESULT events
+	seen := map[string]bool{}
+	for _, ev := range pc.events {
+		if ev["type"] == AGUIToolCallResult {
+			msgID, _ := ev["messageId"].(string)
+			if msgID == "" {
+				t.Error("TOOL_CALL_RESULT has empty messageId")
+			}
+			if seen[msgID] {
+				t.Errorf("duplicate messageId: %q", msgID)
+			}
+			seen[msgID] = true
+		}
+	}
+}
+
+func TestInvariant_EmptyArgsNotEmitted(t *testing.T) {
+	bus := core.NewEventBus()
+	adapter := NewAdapter("thread_1")
+	pc := newProtocolChecker(t)
+	adapter.OnEvent(pc.collect)
+	adapter.SubscribeTo(bus)
+
+	core.Publish(bus, core.ToolCalledEvent{
+		RunID: "r1", ToolCallID: "tc1", ToolName: "no_args",
+		ArgsJSON: "", CalledAt: time.Now(),
+	})
+	adapter.Close()
+
+	for _, ev := range pc.events {
+		if ev["type"] == AGUIToolCallArgs {
+			t.Error("should not emit TOOL_CALL_ARGS for empty argsJSON")
+		}
+	}
+	pc.validate()
+}
+
+func TestInvariant_RunErrorClosesActiveText(t *testing.T) {
+	bus := core.NewEventBus()
+	adapter := NewAdapter("thread_1")
+	pc := newProtocolChecker(t)
+	adapter.OnEvent(pc.collect)
+	adapter.SubscribeTo(bus)
+
+	core.Publish(bus, core.RunStartedEvent{RunID: "r1", StartedAt: time.Now()})
+	adapter.EmitTextDelta("msg_1", "partial...")
+	// Error without explicitly closing the message — adapter should auto-close
+	core.Publish(bus, core.RunCompletedEvent{
+		RunID: "r1", Success: false, Error: "crash", CompletedAt: time.Now(),
+	})
+	adapter.Close()
+
+	pc.validate() // should have no unclosed TEXT_MESSAGE_START
+}

--- a/ext/agui/adapter_test.go
+++ b/ext/agui/adapter_test.go
@@ -33,12 +33,6 @@ func (c *eventCollector) all() []json.RawMessage {
 	return cp
 }
 
-func (c *eventCollector) len() int {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return len(c.events)
-}
-
 func parseType(data json.RawMessage) string {
 	var m map[string]any
 	json.Unmarshal(data, &m)
@@ -465,7 +459,7 @@ func TestAdapter_ConcurrentToolEvents_OrderPreserved(t *testing.T) {
 
 	// Simulate concurrent tool completions from parallel goroutines.
 	var wg sync.WaitGroup
-	for i := 0; i < 20; i++ {
+	for i := range 20 {
 		wg.Add(1)
 		go func(n int) {
 			defer wg.Done()
@@ -551,7 +545,7 @@ func TestAdapter_CloseWhilePublishing_NoPanic(t *testing.T) {
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			core.Publish(bus, core.ToolCompletedEvent{
 				RunID: "r1", ToolCallID: "tc", ToolName: "t",
 				Result: "ok", CompletedAt: time.Now(),

--- a/ext/agui/adapter_test.go
+++ b/ext/agui/adapter_test.go
@@ -1,0 +1,627 @@
+package agui
+
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/fugue-labs/gollem/core"
+)
+
+// collectEvents subscribes to an adapter and collects all emitted JSON events.
+func collectEvents(a *Adapter) *eventCollector {
+	c := &eventCollector{}
+	a.OnEvent(func(data json.RawMessage) {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		c.events = append(c.events, data)
+	})
+	return c
+}
+
+type eventCollector struct {
+	mu     sync.Mutex
+	events []json.RawMessage
+}
+
+func (c *eventCollector) all() []json.RawMessage {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	cp := make([]json.RawMessage, len(c.events))
+	copy(cp, c.events)
+	return cp
+}
+
+func (c *eventCollector) len() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.events)
+}
+
+func parseType(data json.RawMessage) string {
+	var m map[string]any
+	json.Unmarshal(data, &m)
+	if t, ok := m["type"].(string); ok {
+		return t
+	}
+	return ""
+}
+
+func parseField(data json.RawMessage, field string) any {
+	var m map[string]any
+	json.Unmarshal(data, &m)
+	return m[field]
+}
+
+// ── Adapter lifecycle tests ─────────────────────────────────────────
+
+func TestAdapter_RunStartedFinished(t *testing.T) {
+	bus := core.NewEventBus()
+	adapter := NewAdapter("thread_1")
+	defer adapter.Close()
+	c := collectEvents(adapter)
+	adapter.SubscribeTo(bus)
+
+	core.Publish(bus, core.RunStartedEvent{
+		RunID: "run_1", ParentRunID: "", Prompt: "hello", StartedAt: time.Now(),
+	})
+	core.Publish(bus, core.RunCompletedEvent{
+		RunID: "run_1", Success: true, CompletedAt: time.Now(),
+	})
+
+	adapter.Close()
+
+	events := c.all()
+	if len(events) < 2 {
+		t.Fatalf("expected at least 2 events, got %d", len(events))
+	}
+
+	if got := parseType(events[0]); got != AGUIRunStarted {
+		t.Errorf("event[0] type = %q, want %q", got, AGUIRunStarted)
+	}
+	if got := parseField(events[0], "threadId"); got != "thread_1" {
+		t.Errorf("event[0] threadId = %v, want %q", got, "thread_1")
+	}
+	if got := parseField(events[0], "runId"); got != "run_1" {
+		t.Errorf("event[0] runId = %v, want %q", got, "run_1")
+	}
+
+	last := events[len(events)-1]
+	if got := parseType(last); got != AGUIRunFinished {
+		t.Errorf("last event type = %q, want %q", got, AGUIRunFinished)
+	}
+}
+
+func TestAdapter_RunError(t *testing.T) {
+	bus := core.NewEventBus()
+	adapter := NewAdapter("thread_1")
+	defer adapter.Close()
+	c := collectEvents(adapter)
+	adapter.SubscribeTo(bus)
+
+	core.Publish(bus, core.RunStartedEvent{RunID: "run_1", StartedAt: time.Now()})
+	core.Publish(bus, core.RunCompletedEvent{
+		RunID: "run_1", Success: false, Error: "boom", CompletedAt: time.Now(),
+	})
+	adapter.Close()
+
+	events := c.all()
+	last := events[len(events)-1]
+	if got := parseType(last); got != AGUIRunError {
+		t.Errorf("last event type = %q, want %q", got, AGUIRunError)
+	}
+	if got := parseField(last, "message"); got != "boom" {
+		t.Errorf("RunError message = %v, want %q", got, "boom")
+	}
+	if got := parseField(last, "runId"); got != "run_1" {
+		t.Errorf("RunError runId = %v, want %q", got, "run_1")
+	}
+}
+
+func TestAdapter_RunDeferredDoesNotEmitError(t *testing.T) {
+	bus := core.NewEventBus()
+	adapter := NewAdapter("thread_1")
+	defer adapter.Close()
+	c := collectEvents(adapter)
+	adapter.SubscribeTo(bus)
+
+	core.Publish(bus, core.RunStartedEvent{RunID: "run_1", StartedAt: time.Now()})
+	core.Publish(bus, core.RunWaitingEvent{RunID: "run_1", Reason: "deferred", WaitingAt: time.Now()})
+	core.Publish(bus, core.RunCompletedEvent{
+		RunID: "run_1", Success: false, Deferred: true,
+		Error:       "agent run deferred: 1 tool call(s) require external resolution",
+		CompletedAt: time.Now(),
+	})
+	adapter.Close()
+
+	events := c.all()
+	last := events[len(events)-1]
+	if got := parseType(last); got != AGUIRunFinished {
+		t.Errorf("last event type = %q, want %q", got, AGUIRunFinished)
+	}
+}
+
+func TestAdapter_RunResumedAndDeferredResolvedAsCustom(t *testing.T) {
+	bus := core.NewEventBus()
+	adapter := NewAdapter("thread_1")
+	defer adapter.Close()
+	c := collectEvents(adapter)
+	adapter.SubscribeTo(bus)
+
+	core.Publish(bus, core.RunResumedEvent{RunID: "run_1", ResumedAt: time.Now()})
+	core.Publish(bus, core.DeferredResolvedEvent{
+		RunID: "run_1", ToolCallID: "tc1", ToolName: "search",
+		Content: "done", IsError: false, ResolvedAt: time.Now(),
+	})
+	adapter.Close()
+
+	events := c.all()
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+	if got := parseType(events[0]); got != AGUICustom {
+		t.Fatalf("event[0] type = %q, want %q", got, AGUICustom)
+	}
+	if got := parseField(events[0], "name"); got != "gollem.run.resumed" {
+		t.Errorf("event[0] name = %v, want %q", got, "gollem.run.resumed")
+	}
+	if got := parseField(events[1], "name"); got != "gollem.deferred.resolved" {
+		t.Errorf("event[1] name = %v, want %q", got, "gollem.deferred.resolved")
+	}
+}
+
+// ── Step (turn) event tests ─────────────────────────────────────────
+
+func TestAdapter_TurnMapsToStep(t *testing.T) {
+	bus := core.NewEventBus()
+	adapter := NewAdapter("t1")
+	defer adapter.Close()
+	c := collectEvents(adapter)
+	adapter.SubscribeTo(bus)
+
+	core.Publish(bus, core.TurnStartedEvent{RunID: "r1", TurnNumber: 1, StartedAt: time.Now()})
+	core.Publish(bus, core.TurnCompletedEvent{RunID: "r1", TurnNumber: 1, CompletedAt: time.Now()})
+	adapter.Close()
+
+	events := c.all()
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+	if got := parseType(events[0]); got != AGUIStepStarted {
+		t.Errorf("event[0] type = %q, want %q", got, AGUIStepStarted)
+	}
+	if got := parseField(events[0], "stepName"); got != "turn_1" {
+		t.Errorf("stepName = %v, want %q", got, "turn_1")
+	}
+	if got := parseType(events[1]); got != AGUIStepFinished {
+		t.Errorf("event[1] type = %q, want %q", got, AGUIStepFinished)
+	}
+}
+
+// ── Tool call event tests ───────────────────────────────────────────
+
+func TestAdapter_ToolCallLifecycle(t *testing.T) {
+	bus := core.NewEventBus()
+	adapter := NewAdapter("t1")
+	defer adapter.Close()
+	c := collectEvents(adapter)
+	adapter.SubscribeTo(bus)
+
+	core.Publish(bus, core.ToolCalledEvent{
+		RunID: "r1", ToolCallID: "tc1", ToolName: "get_weather",
+		ArgsJSON: `{"city":"NYC"}`, CalledAt: time.Now(),
+	})
+	core.Publish(bus, core.ToolCompletedEvent{
+		RunID: "r1", ToolCallID: "tc1", ToolName: "get_weather",
+		Result: "sunny", CompletedAt: time.Now(),
+	})
+	adapter.Close()
+
+	events := c.all()
+	types := make([]string, len(events))
+	for i, ev := range events {
+		types[i] = parseType(ev)
+	}
+
+	// Expect: TOOL_CALL_START, TOOL_CALL_ARGS, TOOL_CALL_END, TOOL_CALL_RESULT
+	expected := []string{AGUIToolCallStart, AGUIToolCallArgs, AGUIToolCallEnd, AGUIToolCallResult}
+	if len(types) != len(expected) {
+		t.Fatalf("expected %d events %v, got %d: %v", len(expected), expected, len(types), types)
+	}
+	for i, want := range expected {
+		if types[i] != want {
+			t.Errorf("event[%d] type = %q, want %q", i, types[i], want)
+		}
+	}
+
+	// Check TOOL_CALL_START fields
+	if got := parseField(events[0], "toolCallId"); got != "tc1" {
+		t.Errorf("toolCallId = %v, want %q", got, "tc1")
+	}
+	if got := parseField(events[0], "toolCallName"); got != "get_weather" {
+		t.Errorf("toolCallName = %v, want %q", got, "get_weather")
+	}
+
+	// Check TOOL_CALL_RESULT fields
+	if got := parseField(events[3], "content"); got != "sunny" {
+		t.Errorf("result content = %v, want %q", got, "sunny")
+	}
+	if got := parseField(events[3], "role"); got != "tool" {
+		t.Errorf("result role = %v, want %q", got, "tool")
+	}
+	if got := parseField(events[3], "messageId"); got == nil || got == "" {
+		t.Error("result messageId should be non-empty")
+	}
+}
+
+func TestAdapter_ToolFailed(t *testing.T) {
+	bus := core.NewEventBus()
+	adapter := NewAdapter("t1")
+	defer adapter.Close()
+	c := collectEvents(adapter)
+	adapter.SubscribeTo(bus)
+
+	core.Publish(bus, core.ToolCalledEvent{
+		RunID: "r1", ToolCallID: "tc1", ToolName: "bad_tool",
+		ArgsJSON: `{}`, CalledAt: time.Now(),
+	})
+	core.Publish(bus, core.ToolFailedEvent{
+		RunID: "r1", ToolCallID: "tc1", ToolName: "bad_tool",
+		Error: "timeout", FailedAt: time.Now(),
+	})
+	adapter.Close()
+
+	events := c.all()
+	last := events[len(events)-1]
+	if got := parseType(last); got != AGUIToolCallResult {
+		t.Errorf("last event type = %q, want %q", got, AGUIToolCallResult)
+	}
+	if got := parseField(last, "content").(string); got != "error: timeout" {
+		t.Errorf("error content = %q, want %q", got, "error: timeout")
+	}
+}
+
+// ── Text streaming tests ────────────────────────────────────────────
+
+func TestAdapter_TextMessageLifecycle(t *testing.T) {
+	adapter := NewAdapter("t1")
+	defer adapter.Close()
+	c := collectEvents(adapter)
+
+	adapter.EmitTextDelta("msg_1", "hello")
+	adapter.EmitTextDelta("msg_1", " world")
+
+	// Close triggers TextMessageEnd
+	bus := core.NewEventBus()
+	adapter.SubscribeTo(bus)
+	core.Publish(bus, core.TurnCompletedEvent{RunID: "r1", TurnNumber: 1, CompletedAt: time.Now()})
+	adapter.Close()
+
+	events := c.all()
+	types := make([]string, len(events))
+	for i, ev := range events {
+		types[i] = parseType(ev)
+	}
+
+	// TEXT_MESSAGE_START, TEXT_MESSAGE_CONTENT, TEXT_MESSAGE_CONTENT, TEXT_MESSAGE_END, STEP_FINISHED
+	if types[0] != AGUITextMessageStart {
+		t.Errorf("event[0] = %q, want TEXT_MESSAGE_START", types[0])
+	}
+	if types[1] != AGUITextMessageContent {
+		t.Errorf("event[1] = %q, want TEXT_MESSAGE_CONTENT", types[1])
+	}
+	if types[2] != AGUITextMessageContent {
+		t.Errorf("event[2] = %q, want TEXT_MESSAGE_CONTENT", types[2])
+	}
+
+	// Verify role on start
+	if got := parseField(events[0], "role"); got != "assistant" {
+		t.Errorf("TextMessageStart role = %v, want %q", got, "assistant")
+	}
+	// Verify delta
+	if got := parseField(events[1], "delta"); got != "hello" {
+		t.Errorf("delta = %v, want %q", got, "hello")
+	}
+}
+
+func TestAdapter_TextMessageAutoClose_OnToolCall(t *testing.T) {
+	bus := core.NewEventBus()
+	adapter := NewAdapter("t1")
+	defer adapter.Close()
+	c := collectEvents(adapter)
+	adapter.SubscribeTo(bus)
+
+	adapter.EmitTextDelta("msg_1", "thinking...")
+	core.Publish(bus, core.ToolCalledEvent{
+		RunID: "r1", ToolCallID: "tc1", ToolName: "search",
+		ArgsJSON: `{}`, CalledAt: time.Now(),
+	})
+	adapter.Close()
+
+	events := c.all()
+	types := make([]string, len(events))
+	for i, ev := range events {
+		types[i] = parseType(ev)
+	}
+
+	// Should see: TEXT_MESSAGE_START, TEXT_MESSAGE_CONTENT, TEXT_MESSAGE_END, TOOL_CALL_START, ...
+	endIdx := -1
+	for i, t := range types {
+		if t == AGUITextMessageEnd {
+			endIdx = i
+			break
+		}
+	}
+	if endIdx == -1 {
+		t.Fatal("TEXT_MESSAGE_END not found")
+	}
+
+	toolStartIdx := -1
+	for i, t := range types {
+		if t == AGUIToolCallStart {
+			toolStartIdx = i
+			break
+		}
+	}
+	if toolStartIdx == -1 {
+		t.Fatal("TOOL_CALL_START not found")
+	}
+	if endIdx >= toolStartIdx {
+		t.Errorf("TEXT_MESSAGE_END (idx=%d) should come before TOOL_CALL_START (idx=%d)", endIdx, toolStartIdx)
+	}
+}
+
+func TestAdapter_EmptyDeltaNotEmitted(t *testing.T) {
+	adapter := NewAdapter("t1")
+	defer adapter.Close()
+	c := collectEvents(adapter)
+
+	adapter.EmitTextDelta("msg_1", "")
+	adapter.Close()
+
+	events := c.all()
+	for _, ev := range events {
+		if parseType(ev) == AGUITextMessageContent {
+			t.Error("should not emit TEXT_MESSAGE_CONTENT for empty delta")
+		}
+	}
+}
+
+// ── Reasoning tests ─────────────────────────────────────────────────
+
+func TestAdapter_ReasoningLifecycle(t *testing.T) {
+	adapter := NewAdapter("t1")
+	defer adapter.Close()
+	c := collectEvents(adapter)
+
+	adapter.EmitReasoningDelta("reason_1", "let me think")
+
+	bus := core.NewEventBus()
+	adapter.SubscribeTo(bus)
+	core.Publish(bus, core.TurnCompletedEvent{RunID: "r1", TurnNumber: 1, CompletedAt: time.Now()})
+	adapter.Close()
+
+	events := c.all()
+	types := make([]string, len(events))
+	for i, ev := range events {
+		types[i] = parseType(ev)
+	}
+
+	if types[0] != AGUIReasoningStart {
+		t.Errorf("event[0] = %q, want REASONING_START", types[0])
+	}
+	if types[1] != AGUIReasoningMessageStart {
+		t.Errorf("event[1] = %q, want REASONING_MESSAGE_START", types[1])
+	}
+	// Verify role is "reasoning" per AG-UI spec
+	if got := parseField(events[1], "role"); got != "reasoning" {
+		t.Errorf("ReasoningMessageStart role = %v, want %q", got, "reasoning")
+	}
+	if types[2] != AGUIReasoningMessageContent {
+		t.Errorf("event[2] = %q, want REASONING_MESSAGE_CONTENT", types[2])
+	}
+}
+
+// ── Custom events (gollem-specific) ─────────────────────────────────
+
+func TestAdapter_ApprovalEventsAsCustom(t *testing.T) {
+	bus := core.NewEventBus()
+	adapter := NewAdapter("t1")
+	defer adapter.Close()
+	c := collectEvents(adapter)
+	adapter.SubscribeTo(bus)
+
+	core.Publish(bus, core.ApprovalRequestedEvent{
+		RunID: "r1", ToolCallID: "tc1", ToolName: "delete_file",
+		ArgsJSON: `{"path":"/tmp"}`, RequestedAt: time.Now(),
+	})
+	core.Publish(bus, core.ApprovalResolvedEvent{
+		RunID: "r1", ToolCallID: "tc1", ToolName: "delete_file",
+		Approved: true, ResolvedAt: time.Now(),
+	})
+	adapter.Close()
+
+	events := c.all()
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+	if got := parseType(events[0]); got != AGUICustom {
+		t.Errorf("event[0] type = %q, want CUSTOM", got)
+	}
+	if got := parseField(events[0], "name"); got != "gollem.approval.requested" {
+		t.Errorf("custom name = %v, want %q", got, "gollem.approval.requested")
+	}
+}
+
+// ── Concurrency tests ───────────────────────────────────────────────
+
+func TestAdapter_ConcurrentToolEvents_OrderPreserved(t *testing.T) {
+	bus := core.NewEventBus()
+	adapter := NewAdapter("t1")
+	defer adapter.Close()
+	c := collectEvents(adapter)
+	adapter.SubscribeTo(bus)
+
+	// Simulate concurrent tool completions from parallel goroutines.
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			core.Publish(bus, core.ToolCompletedEvent{
+				RunID:       "r1",
+				ToolCallID:  "tc_" + string(rune('A'+n)),
+				ToolName:    "tool",
+				Result:      "ok",
+				CompletedAt: time.Now(),
+			})
+		}(i)
+	}
+	wg.Wait()
+	adapter.Close()
+
+	events := c.all()
+	if len(events) != 20 {
+		t.Fatalf("expected 20 TOOL_CALL_RESULT events, got %d", len(events))
+	}
+
+	// Every event should be TOOL_CALL_RESULT (no interleaving with other types).
+	for i, ev := range events {
+		if got := parseType(ev); got != AGUIToolCallResult {
+			t.Errorf("event[%d] type = %q, want TOOL_CALL_RESULT", i, got)
+		}
+	}
+}
+
+func TestAdapter_ConcurrentTextAndTools_NoInterleavedBatch(t *testing.T) {
+	bus := core.NewEventBus()
+	adapter := NewAdapter("t1")
+	defer adapter.Close()
+	c := collectEvents(adapter)
+	adapter.SubscribeTo(bus)
+
+	// Fire text delta and tool call concurrently.
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		adapter.EmitTextDelta("msg_1", "hello")
+	}()
+	go func() {
+		defer wg.Done()
+		core.Publish(bus, core.ToolCalledEvent{
+			RunID: "r1", ToolCallID: "tc1", ToolName: "search",
+			ArgsJSON: `{}`, CalledAt: time.Now(),
+		})
+	}()
+	wg.Wait()
+	adapter.Close()
+
+	events := c.all()
+	// Verify no TEXT_MESSAGE_CONTENT appears after TEXT_MESSAGE_END for the same messageId.
+	endSeen := map[string]bool{}
+	for _, ev := range events {
+		typ := parseType(ev)
+		msgID, _ := parseField(ev, "messageId").(string)
+		if typ == AGUITextMessageEnd {
+			endSeen[msgID] = true
+		}
+		if typ == AGUITextMessageContent && endSeen[msgID] {
+			t.Errorf("TEXT_MESSAGE_CONTENT after TEXT_MESSAGE_END for message %q", msgID)
+		}
+	}
+}
+
+// ── Close safety tests ──────────────────────────────────────────────
+
+func TestAdapter_DoubleClose_NoPanic(t *testing.T) {
+	adapter := NewAdapter("t1")
+	adapter.Close()
+	adapter.Close() // should not panic
+}
+
+func TestAdapter_CloseWhilePublishing_NoPanic(t *testing.T) {
+	bus := core.NewEventBus()
+	adapter := NewAdapter("t1")
+	adapter.SubscribeTo(bus)
+
+	// Fire events and close concurrently.
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			core.Publish(bus, core.ToolCompletedEvent{
+				RunID: "r1", ToolCallID: "tc", ToolName: "t",
+				Result: "ok", CompletedAt: time.Now(),
+			})
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		time.Sleep(time.Millisecond)
+		adapter.Close()
+	}()
+	wg.Wait()
+	// If we get here without panic, test passes.
+}
+
+func TestAdapter_ListenerPanic_DoesNotCrash(t *testing.T) {
+	bus := core.NewEventBus()
+	adapter := NewAdapter("t1")
+	defer adapter.Close()
+
+	adapter.OnEvent(func(data json.RawMessage) {
+		panic("boom")
+	})
+	adapter.SubscribeTo(bus)
+
+	core.Publish(bus, core.RunStartedEvent{RunID: "r1", StartedAt: time.Now()})
+	core.Publish(bus, core.RunCompletedEvent{RunID: "r1", Success: true, CompletedAt: time.Now()})
+	adapter.Close()
+	// If we get here without panic, the panic recovery works.
+}
+
+// ── SubscribeTo guard ───────────────────────────────────────────────
+
+func TestAdapter_SubscribeTo_PanicsOnDouble(t *testing.T) {
+	bus := core.NewEventBus()
+	adapter := NewAdapter("t1")
+	defer adapter.Close()
+	adapter.SubscribeTo(bus)
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic on double SubscribeTo")
+		}
+	}()
+	adapter.SubscribeTo(bus) // should panic
+}
+
+// ── Timestamp format ────────────────────────────────────────────────
+
+func TestAdapter_TimestampIsUnixMillis(t *testing.T) {
+	bus := core.NewEventBus()
+	adapter := NewAdapter("t1")
+	defer adapter.Close()
+	c := collectEvents(adapter)
+	adapter.SubscribeTo(bus)
+
+	core.Publish(bus, core.RunStartedEvent{RunID: "r1", StartedAt: time.Now()})
+	adapter.Close()
+
+	events := c.all()
+	if len(events) == 0 {
+		t.Fatal("no events")
+	}
+	ts := parseField(events[0], "timestamp")
+	tsFloat, ok := ts.(float64) // JSON numbers are float64
+	if !ok {
+		t.Fatalf("timestamp is %T, want float64 (JSON number)", ts)
+	}
+	// Should be a reasonable Unix millis value (after 2020).
+	if tsFloat < 1577836800000 {
+		t.Errorf("timestamp %v is too small for Unix millis", tsFloat)
+	}
+}

--- a/ext/agui/approval.go
+++ b/ext/agui/approval.go
@@ -1,0 +1,159 @@
+package agui
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/fugue-labs/gollem/core"
+)
+
+// ApprovalResult is the outcome of an approval request.
+type ApprovalResult struct {
+	Approved bool
+	Message  string
+}
+
+// ApprovalBridge provides an async-compatible implementation of
+// core.ToolApprovalFunc that blocks until Resolve() is called from
+// the AGUI transport layer. This bridges the synchronous core approval
+// interface with the event-driven AGUI model.
+//
+// Usage:
+//
+//	bridge := agui.NewApprovalBridge()
+//	agent := core.NewAgent[T](model,
+//	    core.WithToolApproval[T](bridge.ToolApprovalFunc()),
+//	)
+//
+// When a tool requires approval, the bridge blocks the agent goroutine.
+// The AGUI adapter surfaces the request as an event, and the UI calls
+// bridge.Resolve() to unblock the agent.
+//
+// The returned ToolApprovalFunc is safe to reuse across multiple calls.
+type ApprovalBridge struct {
+	mu      sync.Mutex
+	pending map[string]*pendingApproval
+
+	// OnRequest is called when an approval is requested, before blocking.
+	// It is called under the bridge lock, so Resolve() for the same tool
+	// call ID will block until OnRequest returns. This guarantees event
+	// ordering: the approval.requested event is emitted before any
+	// resolution can occur.
+	// If nil, the bridge still blocks — the adapter must use the event bus instead.
+	OnRequest func(req ApprovalRequest)
+}
+
+type pendingApproval struct {
+	ch   chan ApprovalResult
+	done chan struct{} // closed when the waiter has consumed or abandoned the result
+}
+
+// ApprovalRequest describes a pending approval.
+type ApprovalRequest struct {
+	ToolCallID string
+	ToolName   string
+	ArgsJSON   string
+}
+
+// NewApprovalBridge creates a new approval bridge.
+func NewApprovalBridge() *ApprovalBridge {
+	return &ApprovalBridge{
+		pending: make(map[string]*pendingApproval),
+	}
+}
+
+// ToolApprovalFunc returns a core.ToolApprovalFunc that blocks until
+// Resolve() is called for the corresponding tool call ID. The tool call
+// ID is extracted from the context via core.ToolCallIDFromContext().
+func (b *ApprovalBridge) ToolApprovalFunc() core.ToolApprovalFunc {
+	return func(ctx context.Context, toolName, argsJSON string) (bool, error) {
+		toolCallID := core.ToolCallIDFromContext(ctx)
+		if toolCallID == "" {
+			return false, fmt.Errorf("agui: no tool call ID in context for approval")
+		}
+
+		pa := &pendingApproval{
+			ch:   make(chan ApprovalResult, 1),
+			done: make(chan struct{}),
+		}
+
+		// Register cleanup BEFORE the OnRequest call so it runs even
+		// if OnRequest panics (the defer is already on the stack).
+		defer func() {
+			close(pa.done)
+			b.mu.Lock()
+			delete(b.pending, toolCallID)
+			b.mu.Unlock()
+		}()
+
+		b.mu.Lock()
+		b.pending[toolCallID] = pa
+		// Call OnRequest under lock to guarantee the event is emitted
+		// before any Resolve() call for this tool call ID can proceed.
+		func() {
+			defer b.mu.Unlock()
+			if b.OnRequest != nil {
+				b.OnRequest(ApprovalRequest{
+					ToolCallID: toolCallID,
+					ToolName:   toolName,
+					ArgsJSON:   argsJSON,
+				})
+			}
+		}()
+
+		select {
+		case result := <-pa.ch:
+			return result.Approved, nil
+		case <-ctx.Done():
+			return false, ctx.Err()
+		}
+	}
+}
+
+// Resolve unblocks a pending approval request. Returns true if the
+// tool call ID had a pending request and the result was delivered,
+// false if it was already resolved, context-cancelled, or never existed.
+func (b *ApprovalBridge) Resolve(toolCallID string, approved bool, message string) bool {
+	b.mu.Lock()
+	pa, ok := b.pending[toolCallID]
+	b.mu.Unlock()
+
+	if !ok {
+		return false
+	}
+
+	result := ApprovalResult{Approved: approved, Message: message}
+
+	// Use select to avoid blocking if the waiter already abandoned
+	// (context cancelled). The channel has capacity 1 so this won't
+	// block if the waiter hasn't read yet.
+	select {
+	case pa.ch <- result:
+		// Sent successfully. Wait for the waiter to acknowledge
+		// consumption so we can report success accurately.
+		<-pa.done
+		return true
+	case <-pa.done:
+		// Waiter already abandoned (context cancelled).
+		return false
+	}
+}
+
+// PendingCount returns the number of pending approval requests.
+func (b *ApprovalBridge) PendingCount() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.pending)
+}
+
+// PendingIDs returns the tool call IDs of all pending approval requests.
+func (b *ApprovalBridge) PendingIDs() []string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	ids := make([]string, 0, len(b.pending))
+	for id := range b.pending {
+		ids = append(ids, id)
+	}
+	return ids
+}

--- a/ext/agui/approval.go
+++ b/ext/agui/approval.go
@@ -2,7 +2,7 @@ package agui
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"sync"
 
 	"github.com/fugue-labs/gollem/core"
@@ -70,7 +70,7 @@ func (b *ApprovalBridge) ToolApprovalFunc() core.ToolApprovalFunc {
 	return func(ctx context.Context, toolName, argsJSON string) (bool, error) {
 		toolCallID := core.ToolCallIDFromContext(ctx)
 		if toolCallID == "" {
-			return false, fmt.Errorf("agui: no tool call ID in context for approval")
+			return false, errors.New("agui: no tool call ID in context for approval")
 		}
 
 		pa := &pendingApproval{

--- a/ext/agui/approval_test.go
+++ b/ext/agui/approval_test.go
@@ -1,0 +1,285 @@
+package agui
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/fugue-labs/gollem/core"
+)
+
+func TestApprovalBridge_BasicApprove(t *testing.T) {
+	bridge := NewApprovalBridge()
+	fn := bridge.ToolApprovalFunc()
+
+	ctx := core.ContextWithToolCallID(context.Background(), "tc_1")
+
+	var approved bool
+	var err error
+	done := make(chan struct{})
+	go func() {
+		approved, err = fn(ctx, "delete_file", `{"path":"/tmp"}`)
+		close(done)
+	}()
+
+	// Wait for the request to be pending.
+	time.Sleep(10 * time.Millisecond)
+	if bridge.PendingCount() != 1 {
+		t.Fatalf("expected 1 pending, got %d", bridge.PendingCount())
+	}
+
+	ok := bridge.Resolve("tc_1", true, "go ahead")
+	if !ok {
+		t.Error("Resolve returned false")
+	}
+
+	<-done
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !approved {
+		t.Error("expected approved=true")
+	}
+	if bridge.PendingCount() != 0 {
+		t.Errorf("expected 0 pending after resolve, got %d", bridge.PendingCount())
+	}
+}
+
+func TestApprovalBridge_BasicDeny(t *testing.T) {
+	bridge := NewApprovalBridge()
+	fn := bridge.ToolApprovalFunc()
+
+	ctx := core.ContextWithToolCallID(context.Background(), "tc_1")
+
+	var approved bool
+	var err error
+	done := make(chan struct{})
+	go func() {
+		approved, err = fn(ctx, "delete_file", `{}`)
+		close(done)
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	bridge.Resolve("tc_1", false, "nope")
+	<-done
+
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if approved {
+		t.Error("expected approved=false")
+	}
+}
+
+func TestApprovalBridge_ContextCancelled(t *testing.T) {
+	bridge := NewApprovalBridge()
+	fn := bridge.ToolApprovalFunc()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ctx = core.ContextWithToolCallID(ctx, "tc_1")
+
+	var err error
+	done := make(chan struct{})
+	go func() {
+		_, err = fn(ctx, "tool", `{}`)
+		close(done)
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+	<-done
+
+	if err == nil {
+		t.Error("expected context error")
+	}
+	if bridge.PendingCount() != 0 {
+		t.Errorf("expected 0 pending after cancel, got %d", bridge.PendingCount())
+	}
+}
+
+func TestApprovalBridge_ResolveAfterCancel_ReturnsFalse(t *testing.T) {
+	bridge := NewApprovalBridge()
+	fn := bridge.ToolApprovalFunc()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ctx = core.ContextWithToolCallID(ctx, "tc_1")
+
+	done := make(chan struct{})
+	go func() {
+		fn(ctx, "tool", `{}`)
+		close(done)
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+	<-done
+
+	// Resolve after cancel should return false.
+	ok := bridge.Resolve("tc_1", true, "")
+	if ok {
+		t.Error("Resolve after cancel should return false")
+	}
+}
+
+func TestApprovalBridge_ResolveUnknownID_ReturnsFalse(t *testing.T) {
+	bridge := NewApprovalBridge()
+	ok := bridge.Resolve("nonexistent", true, "")
+	if ok {
+		t.Error("Resolve for unknown ID should return false")
+	}
+}
+
+func TestApprovalBridge_MissingToolCallID_ReturnsError(t *testing.T) {
+	bridge := NewApprovalBridge()
+	fn := bridge.ToolApprovalFunc()
+
+	_, err := fn(context.Background(), "tool", `{}`)
+	if err == nil {
+		t.Error("expected error for missing tool call ID")
+	}
+}
+
+func TestApprovalBridge_OnRequestCalledBeforeBlocking(t *testing.T) {
+	bridge := NewApprovalBridge()
+	var received ApprovalRequest
+	bridge.OnRequest = func(req ApprovalRequest) {
+		received = req
+	}
+	fn := bridge.ToolApprovalFunc()
+
+	ctx := core.ContextWithToolCallID(context.Background(), "tc_1")
+	done := make(chan struct{})
+	go func() {
+		fn(ctx, "my_tool", `{"key":"val"}`)
+		close(done)
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	if received.ToolCallID != "tc_1" {
+		t.Errorf("OnRequest ToolCallID = %q, want %q", received.ToolCallID, "tc_1")
+	}
+	if received.ToolName != "my_tool" {
+		t.Errorf("OnRequest ToolName = %q, want %q", received.ToolName, "my_tool")
+	}
+
+	bridge.Resolve("tc_1", true, "")
+	<-done
+}
+
+func TestApprovalBridge_OnRequestPanic_DoesNotDeadlock(t *testing.T) {
+	bridge := NewApprovalBridge()
+
+	// Use a flag instead of panic to avoid test framework issues
+	// with panics in goroutines. The defer-ordering fix ensures
+	// cleanup runs even if OnRequest panics — we verify by checking
+	// that the bridge is usable after a context-cancelled approval
+	// where OnRequest sets an error flag.
+	var onRequestCalled bool
+	bridge.OnRequest = func(req ApprovalRequest) {
+		onRequestCalled = true
+	}
+	fn := bridge.ToolApprovalFunc()
+
+	// Verify OnRequest is called and bridge cleans up on cancel.
+	ctx, cancel := context.WithCancel(context.Background())
+	ctx = core.ContextWithToolCallID(ctx, "tc_1")
+
+	done := make(chan struct{})
+	go func() {
+		fn(ctx, "tool", `{}`)
+		close(done)
+	}()
+	time.Sleep(10 * time.Millisecond)
+	if !onRequestCalled {
+		t.Error("OnRequest should have been called")
+	}
+	cancel()
+	<-done
+
+	if bridge.PendingCount() != 0 {
+		t.Errorf("expected 0 pending after cancel, got %d", bridge.PendingCount())
+	}
+
+	// Bridge should be usable again.
+	ctx2 := core.ContextWithToolCallID(context.Background(), "tc_2")
+	done2 := make(chan struct{})
+	go func() {
+		fn(ctx2, "tool2", `{}`)
+		close(done2)
+	}()
+	time.Sleep(10 * time.Millisecond)
+	bridge.Resolve("tc_2", true, "")
+	<-done2
+}
+
+func TestApprovalBridge_ConcurrentApprovals(t *testing.T) {
+	bridge := NewApprovalBridge()
+	fn := bridge.ToolApprovalFunc()
+
+	const N = 10
+	results := make([]bool, N)
+	var wg sync.WaitGroup
+
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			tcID := "tc_" + string(rune('A'+n))
+			ctx := core.ContextWithToolCallID(context.Background(), tcID)
+			approved, err := fn(ctx, "tool", `{}`)
+			if err != nil {
+				t.Errorf("tool %s error: %v", tcID, err)
+				return
+			}
+			results[n] = approved
+		}(i)
+	}
+
+	// Wait for all to be pending.
+	time.Sleep(50 * time.Millisecond)
+	if bridge.PendingCount() != N {
+		t.Fatalf("expected %d pending, got %d", N, bridge.PendingCount())
+	}
+
+	// Resolve all — approve even, deny odd.
+	for i := 0; i < N; i++ {
+		tcID := "tc_" + string(rune('A'+i))
+		bridge.Resolve(tcID, i%2 == 0, "")
+	}
+
+	wg.Wait()
+
+	for i := 0; i < N; i++ {
+		want := i%2 == 0
+		if results[i] != want {
+			t.Errorf("tool %d: approved=%v, want %v", i, results[i], want)
+		}
+	}
+}
+
+func TestApprovalBridge_PendingIDs(t *testing.T) {
+	bridge := NewApprovalBridge()
+	fn := bridge.ToolApprovalFunc()
+
+	ctx1 := core.ContextWithToolCallID(context.Background(), "tc_a")
+	ctx2 := core.ContextWithToolCallID(context.Background(), "tc_b")
+
+	go fn(ctx1, "t1", `{}`)
+	go fn(ctx2, "t2", `{}`)
+
+	time.Sleep(20 * time.Millisecond)
+
+	ids := bridge.PendingIDs()
+	if len(ids) != 2 {
+		t.Fatalf("expected 2 pending IDs, got %d: %v", len(ids), ids)
+	}
+
+	bridge.Resolve("tc_a", true, "")
+	bridge.Resolve("tc_b", true, "")
+	time.Sleep(10 * time.Millisecond)
+
+	if bridge.PendingCount() != 0 {
+		t.Errorf("expected 0 pending, got %d", bridge.PendingCount())
+	}
+}

--- a/ext/agui/approval_test.go
+++ b/ext/agui/approval_test.go
@@ -221,7 +221,7 @@ func TestApprovalBridge_ConcurrentApprovals(t *testing.T) {
 	results := make([]bool, N)
 	var wg sync.WaitGroup
 
-	for i := 0; i < N; i++ {
+	for i := range N {
 		wg.Add(1)
 		go func(n int) {
 			defer wg.Done()
@@ -243,14 +243,14 @@ func TestApprovalBridge_ConcurrentApprovals(t *testing.T) {
 	}
 
 	// Resolve all — approve even, deny odd.
-	for i := 0; i < N; i++ {
+	for i := range N {
 		tcID := "tc_" + string(rune('A'+i))
 		bridge.Resolve(tcID, i%2 == 0, "")
 	}
 
 	wg.Wait()
 
-	for i := 0; i < N; i++ {
+	for i := range N {
 		want := i%2 == 0
 		if results[i] != want {
 			t.Errorf("tool %d: approved=%v, want %v", i, results[i], want)

--- a/ext/agui/approval_test.go
+++ b/ext/agui/approval_test.go
@@ -142,9 +142,9 @@ func TestApprovalBridge_MissingToolCallID_ReturnsError(t *testing.T) {
 
 func TestApprovalBridge_OnRequestCalledBeforeBlocking(t *testing.T) {
 	bridge := NewApprovalBridge()
-	var received ApprovalRequest
+	reqCh := make(chan ApprovalRequest, 1)
 	bridge.OnRequest = func(req ApprovalRequest) {
-		received = req
+		reqCh <- req
 	}
 	fn := bridge.ToolApprovalFunc()
 
@@ -155,7 +155,12 @@ func TestApprovalBridge_OnRequestCalledBeforeBlocking(t *testing.T) {
 		close(done)
 	}()
 
-	time.Sleep(10 * time.Millisecond)
+	var received ApprovalRequest
+	select {
+	case received = <-reqCh:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for OnRequest")
+	}
 	if received.ToolCallID != "tc_1" {
 		t.Errorf("OnRequest ToolCallID = %q, want %q", received.ToolCallID, "tc_1")
 	}
@@ -175,9 +180,9 @@ func TestApprovalBridge_OnRequestPanic_DoesNotDeadlock(t *testing.T) {
 	// cleanup runs even if OnRequest panics — we verify by checking
 	// that the bridge is usable after a context-cancelled approval
 	// where OnRequest sets an error flag.
-	var onRequestCalled bool
+	onRequestCalled := make(chan struct{}, 1)
 	bridge.OnRequest = func(req ApprovalRequest) {
-		onRequestCalled = true
+		onRequestCalled <- struct{}{}
 	}
 	fn := bridge.ToolApprovalFunc()
 
@@ -190,8 +195,12 @@ func TestApprovalBridge_OnRequestPanic_DoesNotDeadlock(t *testing.T) {
 		fn(ctx, "tool", `{}`)
 		close(done)
 	}()
-	time.Sleep(10 * time.Millisecond)
-	if !onRequestCalled {
+	select {
+	case <-onRequestCalled:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for OnRequest")
+	}
+	if bridge.PendingCount() == 0 {
 		t.Error("OnRequest should have been called")
 	}
 	cancel()

--- a/ext/agui/event.go
+++ b/ext/agui/event.go
@@ -1,0 +1,223 @@
+// Package agui provides a normalized event stream and session model for
+// building agent UIs on top of gollem. It translates gollem's internal
+// lifecycle signals (hooks, runtime events, stream events) into a single
+// replayable event contract with stable session identity.
+//
+// See DESIGN.md in this package for the full integration specification.
+package agui
+
+import (
+	"encoding/json"
+	"sync/atomic"
+	"time"
+)
+
+// Event type constants for the AGUI normalized event stream.
+const (
+	// Session lifecycle
+	EventSessionOpened        = "session.opened"
+	EventSessionInputAccepted = "session.input.accepted"
+	EventSessionCompleted     = "session.completed"
+	EventSessionFailed        = "session.failed"
+	EventSessionCancelled     = "session.cancelled"
+	EventSessionAborted       = "session.aborted"
+	EventSessionWaiting       = "session.waiting"
+	EventSessionResumed       = "session.resumed"
+	EventSessionSnapshot      = "session.snapshot"
+
+	// Run lifecycle
+	EventRunStarted   = "run.started"
+	EventRunCompleted = "run.completed"
+
+	// Turn lifecycle
+	EventTurnStarted   = "turn.started"
+	EventTurnCompleted = "turn.completed"
+
+	// Model request/response
+	EventModelRequestStarted    = "model.request.started"
+	EventModelResponseCompleted = "model.response.completed"
+
+	// Model output streaming
+	EventModelOutputTextDelta       = "model.output.text.delta"
+	EventModelOutputTextStarted     = "model.output.text.started"
+	EventModelOutputTextCompleted   = "model.output.text.completed"
+	EventModelOutputThinkingDelta   = "model.output.thinking.delta"
+	EventModelOutputToolCallDelta   = "model.output.tool_call.delta"
+	EventModelOutputToolCallStarted = "model.output.tool_call.started"
+
+	// Tool lifecycle
+	EventToolCallRequested      = "tool.call.requested"
+	EventToolExecutionStarted   = "tool.execution.started"
+	EventToolExecutionCompleted = "tool.execution.completed"
+	EventToolExecutionFailed    = "tool.execution.failed"
+	EventToolDeferred           = "tool.deferred"
+
+	// Approval
+	EventApprovalRequested = "approval.requested"
+	EventApprovalApproved  = "approval.approved"
+	EventApprovalDenied    = "approval.denied"
+
+	// External input (deferred tools)
+	EventExternalInputRequested = "external_input.requested"
+	EventExternalInputProvided  = "external_input.provided"
+
+	// Graph topology (P1)
+	EventGraphNodeStarted   = "graph.node.started"
+	EventGraphNodeCompleted = "graph.node.completed"
+	EventGraphFanoutStarted = "graph.fanout.started"
+	EventGraphFanoutJoined  = "graph.fanout.joined"
+
+	// Team topology (P1)
+	EventTeamTeammateSpawned     = "team.teammate.spawned"
+	EventTeamTeammateIdle        = "team.teammate.idle"
+	EventTeamTeammateTerminated  = "team.teammate.terminated"
+	EventTeamTeammateOutputDelta = "team.teammate.output.delta"
+)
+
+// Event is the normalized AGUI event envelope. Every event emitted through
+// the AGUI adapter uses this structure, regardless of the underlying gollem
+// backend (core Run, RunStream, Iter, Temporal, graph, or team).
+type Event struct {
+	// ID is a unique event identifier for deduplication.
+	ID string `json:"id"`
+
+	// Sequence is a monotonically increasing counter within a session.
+	// Used for reconnect replay: clients send last_seq to resume.
+	Sequence uint64 `json:"sequence"`
+
+	// Type is one of the Event* constants.
+	Type string `json:"type"`
+
+	// SessionID is the stable AGUI session identifier.
+	SessionID string `json:"session_id"`
+
+	// RunID is the current gollem run ID.
+	RunID string `json:"run_id,omitempty"`
+
+	// ParentRunID is the parent run ID for nested/child runs.
+	ParentRunID string `json:"parent_run_id,omitempty"`
+
+	// TurnNumber is the current turn within the run (1-based).
+	TurnNumber int `json:"turn_number,omitempty"`
+
+	// Timestamp is when the event occurred.
+	Timestamp time.Time `json:"timestamp"`
+
+	// Data contains event-type-specific payload.
+	Data json.RawMessage `json:"data,omitempty"`
+}
+
+// Sequencer assigns monotonically increasing sequence numbers to events.
+type Sequencer struct {
+	counter atomic.Uint64
+}
+
+// Next returns the next sequence number.
+func (s *Sequencer) Next() uint64 {
+	return s.counter.Add(1)
+}
+
+// ── Event data payloads ─────────────────────────────────────────────
+
+// SessionOpenedData is the payload for EventSessionOpened.
+type SessionOpenedData struct {
+	Mode string `json:"mode"` // "core-run", "core-stream", "core-iter", "temporal", "graph", "team"
+}
+
+// SessionWaitingData is the payload for EventSessionWaiting.
+type SessionWaitingData struct {
+	Reason string `json:"reason"` // "approval", "deferred", "approval_and_deferred"
+}
+
+// RunStartedData is the payload for EventRunStarted.
+type RunStartedData struct {
+	Prompt string `json:"prompt,omitempty"`
+}
+
+// RunCompletedData is the payload for EventRunCompleted.
+type RunCompletedData struct {
+	Success bool   `json:"success"`
+	Error   string `json:"error,omitempty"`
+}
+
+// TurnData is the payload for EventTurnStarted / EventTurnCompleted.
+type TurnData struct {
+	TurnNumber int `json:"turn_number"`
+}
+
+// ModelRequestData is the payload for EventModelRequestStarted.
+type ModelRequestData struct {
+	MessageCount int `json:"message_count"`
+}
+
+// ModelResponseData is the payload for EventModelResponseCompleted.
+type ModelResponseData struct {
+	FinishReason string `json:"finish_reason,omitempty"`
+	InputTokens  int    `json:"input_tokens,omitempty"`
+	OutputTokens int    `json:"output_tokens,omitempty"`
+	HasToolCalls bool   `json:"has_tool_calls,omitempty"`
+	HasText      bool   `json:"has_text,omitempty"`
+}
+
+// TextDeltaData is the payload for EventModelOutputTextDelta.
+type TextDeltaData struct {
+	Delta string `json:"delta"`
+}
+
+// ThinkingDeltaData is the payload for EventModelOutputThinkingDelta.
+type ThinkingDeltaData struct {
+	Delta string `json:"delta"`
+}
+
+// ToolCallDeltaData is the payload for EventModelOutputToolCallDelta.
+type ToolCallDeltaData struct {
+	ToolCallID string `json:"tool_call_id"`
+	ToolName   string `json:"tool_name,omitempty"`
+	ArgsDelta  string `json:"args_delta,omitempty"`
+}
+
+// ToolExecutionData is the payload for tool execution events.
+type ToolExecutionData struct {
+	ToolCallID string `json:"tool_call_id"`
+	ToolName   string `json:"tool_name"`
+	ArgsJSON   string `json:"args_json,omitempty"`
+	Result     string `json:"result,omitempty"`
+	Error      string `json:"error,omitempty"`
+	DurationMs int64  `json:"duration_ms,omitempty"`
+}
+
+// ApprovalData is the payload for approval events.
+type ApprovalData struct {
+	ToolCallID string `json:"tool_call_id"`
+	ToolName   string `json:"tool_name"`
+	ArgsJSON   string `json:"args_json,omitempty"`
+	Approved   *bool  `json:"approved,omitempty"` // nil for requested, set for resolved
+	Message    string `json:"message,omitempty"`
+}
+
+// ExternalInputData is the payload for external input (deferred tool) events.
+type ExternalInputData struct {
+	ToolCallID string `json:"tool_call_id"`
+	ToolName   string `json:"tool_name"`
+	ArgsJSON   string `json:"args_json,omitempty"`
+	Content    string `json:"content,omitempty"`
+	IsError    bool   `json:"is_error,omitempty"`
+}
+
+// ErrorData is a general error payload.
+type ErrorData struct {
+	Message string `json:"message"`
+	Code    string `json:"code,omitempty"`
+}
+
+// MarshalData serializes a payload into json.RawMessage for Event.Data.
+func MarshalData(v any) json.RawMessage {
+	if v == nil {
+		return nil
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return json.RawMessage(`{"error":"failed to marshal event data"}`)
+	}
+	return b
+}

--- a/ext/agui/event.go
+++ b/ext/agui/event.go
@@ -14,7 +14,7 @@ import (
 
 // Event type constants for the AGUI normalized event stream.
 const (
-	// Session lifecycle
+	// Session lifecycle.
 	EventSessionOpened        = "session.opened"
 	EventSessionInputAccepted = "session.input.accepted"
 	EventSessionCompleted     = "session.completed"
@@ -25,19 +25,19 @@ const (
 	EventSessionResumed       = "session.resumed"
 	EventSessionSnapshot      = "session.snapshot"
 
-	// Run lifecycle
+	// Run lifecycle.
 	EventRunStarted   = "run.started"
 	EventRunCompleted = "run.completed"
 
-	// Turn lifecycle
+	// Turn lifecycle.
 	EventTurnStarted   = "turn.started"
 	EventTurnCompleted = "turn.completed"
 
-	// Model request/response
+	// Model request/response.
 	EventModelRequestStarted    = "model.request.started"
 	EventModelResponseCompleted = "model.response.completed"
 
-	// Model output streaming
+	// Model output streaming.
 	EventModelOutputTextDelta       = "model.output.text.delta"
 	EventModelOutputTextStarted     = "model.output.text.started"
 	EventModelOutputTextCompleted   = "model.output.text.completed"
@@ -45,29 +45,29 @@ const (
 	EventModelOutputToolCallDelta   = "model.output.tool_call.delta"
 	EventModelOutputToolCallStarted = "model.output.tool_call.started"
 
-	// Tool lifecycle
+	// Tool lifecycle.
 	EventToolCallRequested      = "tool.call.requested"
 	EventToolExecutionStarted   = "tool.execution.started"
 	EventToolExecutionCompleted = "tool.execution.completed"
 	EventToolExecutionFailed    = "tool.execution.failed"
 	EventToolDeferred           = "tool.deferred"
 
-	// Approval
+	// Approval.
 	EventApprovalRequested = "approval.requested"
 	EventApprovalApproved  = "approval.approved"
 	EventApprovalDenied    = "approval.denied"
 
-	// External input (deferred tools)
+	// External input (deferred tools).
 	EventExternalInputRequested = "external_input.requested"
 	EventExternalInputProvided  = "external_input.provided"
 
-	// Graph topology (P1)
+	// Graph topology (P1).
 	EventGraphNodeStarted   = "graph.node.started"
 	EventGraphNodeCompleted = "graph.node.completed"
 	EventGraphFanoutStarted = "graph.fanout.started"
 	EventGraphFanoutJoined  = "graph.fanout.joined"
 
-	// Team topology (P1)
+	// Team topology (P1).
 	EventTeamTeammateSpawned     = "team.teammate.spawned"
 	EventTeamTeammateIdle        = "team.teammate.idle"
 	EventTeamTeammateTerminated  = "team.teammate.terminated"

--- a/ext/agui/replay.go
+++ b/ext/agui/replay.go
@@ -1,0 +1,128 @@
+package agui
+
+import "sync"
+
+// EventBuffer is an in-memory replay buffer that stores events for reconnect
+// replay. When a client reconnects with a last_seq, the buffer can replay
+// all events after that sequence number.
+//
+// For production use with durable sessions (Temporal), this should be backed
+// by a persistent store. This in-memory implementation is suitable for
+// in-process core runs.
+type EventBuffer struct {
+	mu     sync.RWMutex
+	events []Event
+	cap    int
+}
+
+// NewEventBuffer creates a replay buffer with the given capacity.
+// When capacity is exceeded, the oldest events are dropped.
+func NewEventBuffer(capacity int) *EventBuffer {
+	if capacity <= 0 {
+		capacity = 10000
+	}
+	return &EventBuffer{
+		events: make([]Event, 0, min(capacity, 256)),
+		cap:    capacity,
+	}
+}
+
+// Append adds an event to the buffer. If the buffer is at capacity,
+// the oldest event is dropped.
+func (b *EventBuffer) Append(ev Event) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if len(b.events) >= b.cap {
+		// Drop oldest 10% to avoid frequent shifts
+		drop := b.cap / 10
+		if drop < 1 {
+			drop = 1
+		}
+		copy(b.events, b.events[drop:])
+		newLen := len(b.events) - drop
+		// Zero out stale references so GC can collect evicted event payloads.
+		var zero Event
+		for i := newLen; i < len(b.events); i++ {
+			b.events[i] = zero
+		}
+		b.events = b.events[:newLen]
+	}
+
+	b.events = append(b.events, ev)
+}
+
+// Since returns all events with sequence > lastSeq, in order.
+// The boolean return indicates whether the replay is complete:
+//   - true: all events after lastSeq are returned (no gap).
+//   - false: some events were evicted from the buffer. The caller
+//     should send a session.snapshot instead of replaying.
+//
+// When lastSeq is 0 (fresh client), all buffered events are returned with
+// complete=true. This means the client accepts whatever history is available;
+// if events were evicted before the client connected, those are simply not
+// available and no gap is reported. Use LastSeq() == 0 && Len() > 0 to detect
+// whether the buffer has been active before a fresh client connects.
+//
+// Returns (nil, true) if no new events exist.
+func (b *EventBuffer) Since(lastSeq uint64) (events []Event, complete bool) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	if len(b.events) == 0 {
+		return nil, true
+	}
+
+	// If lastSeq is before the oldest buffered event, we have a gap.
+	oldestSeq := b.events[0].Sequence
+	if lastSeq > 0 && lastSeq < oldestSeq-1 {
+		// Gap detected: events between lastSeq and oldestSeq were evicted.
+		return nil, false
+	}
+
+	// Binary search for the first event after lastSeq.
+	lo, hi := 0, len(b.events)
+	for lo < hi {
+		mid := (lo + hi) / 2
+		if b.events[mid].Sequence <= lastSeq {
+			lo = mid + 1
+		} else {
+			hi = mid
+		}
+	}
+
+	if lo >= len(b.events) {
+		return nil, true
+	}
+
+	result := make([]Event, len(b.events)-lo)
+	copy(result, b.events[lo:])
+	return result, true
+}
+
+// All returns all buffered events in order.
+func (b *EventBuffer) All() []Event {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	result := make([]Event, len(b.events))
+	copy(result, b.events)
+	return result
+}
+
+// Len returns the number of buffered events.
+func (b *EventBuffer) Len() int {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return len(b.events)
+}
+
+// LastSeq returns the sequence number of the most recent event, or 0 if empty.
+func (b *EventBuffer) LastSeq() uint64 {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	if len(b.events) == 0 {
+		return 0
+	}
+	return b.events[len(b.events)-1].Sequence
+}

--- a/ext/agui/replay_test.go
+++ b/ext/agui/replay_test.go
@@ -1,0 +1,151 @@
+package agui
+
+import (
+	"testing"
+)
+
+func TestEventBuffer_AppendAndSince(t *testing.T) {
+	buf := NewEventBuffer(100)
+	s := &Session{ID: "ses_1", Mode: SessionModeCoreRun}
+
+	for i := 0; i < 10; i++ {
+		buf.Append(s.NewEvent(EventRunStarted, nil))
+	}
+
+	if buf.Len() != 10 {
+		t.Fatalf("expected 10 events, got %d", buf.Len())
+	}
+
+	// Since(0) returns all.
+	events, complete := buf.Since(0)
+	if !complete {
+		t.Error("expected complete=true for Since(0)")
+	}
+	if len(events) != 10 {
+		t.Errorf("expected 10 events, got %d", len(events))
+	}
+
+	// Since(5) returns events 6-10.
+	events, complete = buf.Since(5)
+	if !complete {
+		t.Error("expected complete=true")
+	}
+	if len(events) != 5 {
+		t.Errorf("expected 5 events after seq 5, got %d", len(events))
+	}
+	if events[0].Sequence != 6 {
+		t.Errorf("first event sequence = %d, want 6", events[0].Sequence)
+	}
+
+	// Since(last) returns nil.
+	events, complete = buf.Since(buf.LastSeq())
+	if !complete {
+		t.Error("expected complete=true")
+	}
+	if events != nil {
+		t.Errorf("expected nil events after last seq, got %d", len(events))
+	}
+}
+
+func TestEventBuffer_Eviction(t *testing.T) {
+	buf := NewEventBuffer(10)
+	s := &Session{ID: "ses_1", Mode: SessionModeCoreRun}
+
+	// Fill to capacity and beyond.
+	for i := 0; i < 15; i++ {
+		buf.Append(s.NewEvent(EventRunStarted, nil))
+	}
+
+	if buf.Len() > 10 {
+		t.Errorf("buffer should not exceed capacity, got %d", buf.Len())
+	}
+
+	// Since(0) returns all available (fresh client).
+	events, complete := buf.Since(0)
+	if !complete {
+		t.Error("expected complete=true for fresh client")
+	}
+	if len(events) != buf.Len() {
+		t.Errorf("expected %d events, got %d", buf.Len(), len(events))
+	}
+
+	// Since(1) should detect gap (sequence 1 was evicted).
+	events, complete = buf.Since(1)
+	if complete {
+		t.Error("expected complete=false for evicted sequence")
+	}
+	if events != nil {
+		t.Error("expected nil events on gap")
+	}
+}
+
+func TestEventBuffer_Empty(t *testing.T) {
+	buf := NewEventBuffer(10)
+
+	events, complete := buf.Since(0)
+	if !complete {
+		t.Error("expected complete=true for empty buffer")
+	}
+	if events != nil {
+		t.Error("expected nil events for empty buffer")
+	}
+	if buf.LastSeq() != 0 {
+		t.Errorf("expected LastSeq=0 for empty buffer, got %d", buf.LastSeq())
+	}
+}
+
+func TestEventBuffer_SingleElement(t *testing.T) {
+	buf := NewEventBuffer(10)
+	s := &Session{ID: "ses_1", Mode: SessionModeCoreRun}
+
+	buf.Append(s.NewEvent(EventRunStarted, nil))
+
+	events, complete := buf.Since(0)
+	if !complete {
+		t.Error("expected complete=true")
+	}
+	if len(events) != 1 {
+		t.Errorf("expected 1 event, got %d", len(events))
+	}
+
+	events, complete = buf.Since(1)
+	if !complete {
+		t.Error("expected complete=true")
+	}
+	if events != nil {
+		t.Error("expected nil events after only event")
+	}
+}
+
+func TestEventBuffer_All(t *testing.T) {
+	buf := NewEventBuffer(100)
+	s := &Session{ID: "ses_1", Mode: SessionModeCoreRun}
+
+	for i := 0; i < 5; i++ {
+		buf.Append(s.NewEvent(EventRunStarted, nil))
+	}
+
+	all := buf.All()
+	if len(all) != 5 {
+		t.Errorf("expected 5 events, got %d", len(all))
+	}
+
+	// Modifying the returned slice should not affect the buffer.
+	all[0] = Event{}
+	origAll := buf.All()
+	if origAll[0].Sequence == 0 {
+		t.Error("returned slice should be a copy")
+	}
+}
+
+func TestSequencer_Monotonic(t *testing.T) {
+	var s Sequencer
+	prev := uint64(0)
+	for i := 0; i < 100; i++ {
+		next := s.Next()
+		if next <= prev {
+			t.Errorf("sequence %d is not greater than %d", next, prev)
+		}
+		prev = next
+	}
+}

--- a/ext/agui/replay_test.go
+++ b/ext/agui/replay_test.go
@@ -8,7 +8,7 @@ func TestEventBuffer_AppendAndSince(t *testing.T) {
 	buf := NewEventBuffer(100)
 	s := &Session{ID: "ses_1", Mode: SessionModeCoreRun}
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		buf.Append(s.NewEvent(EventRunStarted, nil))
 	}
 
@@ -52,7 +52,7 @@ func TestEventBuffer_Eviction(t *testing.T) {
 	s := &Session{ID: "ses_1", Mode: SessionModeCoreRun}
 
 	// Fill to capacity and beyond.
-	for i := 0; i < 15; i++ {
+	for range 15 {
 		buf.Append(s.NewEvent(EventRunStarted, nil))
 	}
 
@@ -121,7 +121,7 @@ func TestEventBuffer_All(t *testing.T) {
 	buf := NewEventBuffer(100)
 	s := &Session{ID: "ses_1", Mode: SessionModeCoreRun}
 
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		buf.Append(s.NewEvent(EventRunStarted, nil))
 	}
 
@@ -141,7 +141,7 @@ func TestEventBuffer_All(t *testing.T) {
 func TestSequencer_Monotonic(t *testing.T) {
 	var s Sequencer
 	prev := uint64(0)
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		next := s.Next()
 		if next <= prev {
 			t.Errorf("sequence %d is not greater than %d", next, prev)

--- a/ext/agui/session.go
+++ b/ext/agui/session.go
@@ -1,0 +1,146 @@
+package agui
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"sync"
+	"time"
+)
+
+// SessionStatus represents the current state of an AGUI session.
+type SessionStatus string
+
+const (
+	SessionStatusStarting  SessionStatus = "starting"
+	SessionStatusRunning   SessionStatus = "running"
+	SessionStatusWaiting   SessionStatus = "waiting"
+	SessionStatusCompleted SessionStatus = "completed"
+	SessionStatusFailed    SessionStatus = "failed"
+	SessionStatusCancelled SessionStatus = "cancelled"
+	SessionStatusAborted   SessionStatus = "aborted"
+)
+
+// SessionMode identifies the gollem backend driving this session.
+type SessionMode string
+
+const (
+	SessionModeCoreRun    SessionMode = "core-run"
+	SessionModeCoreStream SessionMode = "core-stream"
+	SessionModeCoreIter   SessionMode = "core-iter"
+	SessionModeTemporal   SessionMode = "temporal"
+	SessionModeGraph      SessionMode = "graph"
+	SessionModeTeam       SessionMode = "team"
+)
+
+// Session tracks the state of an AGUI interaction. It owns a stable session ID
+// that survives reconnects and, in Temporal mode, continue-as-new cycles.
+type Session struct {
+	mu sync.RWMutex
+
+	// Identity
+	ID          string      `json:"session_id"`
+	RunID       string      `json:"run_id"`
+	ParentRunID string      `json:"parent_run_id,omitempty"`
+	Mode        SessionMode `json:"mode"`
+
+	// Lifecycle
+	Status    SessionStatus `json:"status"`
+	CreatedAt time.Time     `json:"created_at"`
+	UpdatedAt time.Time     `json:"updated_at"`
+
+	// Waiting state
+	WaitingReason string `json:"waiting_reason,omitempty"`
+
+	// Replay
+	seq Sequencer
+}
+
+// NewSession creates a new AGUI session.
+func NewSession(mode SessionMode) *Session {
+	now := time.Now()
+	return &Session{
+		ID:        newSessionID(),
+		Mode:      mode,
+		Status:    SessionStatusStarting,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+}
+
+// SetRunID updates the gollem run ID for this session.
+func (s *Session) SetRunID(runID, parentRunID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.RunID = runID
+	s.ParentRunID = parentRunID
+	s.UpdatedAt = time.Now()
+}
+
+// SetStatus transitions the session to a new status.
+func (s *Session) SetStatus(status SessionStatus) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.Status = status
+	s.UpdatedAt = time.Now()
+	if status != SessionStatusWaiting {
+		s.WaitingReason = ""
+	}
+}
+
+// SetWaiting transitions the session to waiting with a reason.
+func (s *Session) SetWaiting(reason string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.Status = SessionStatusWaiting
+	s.WaitingReason = reason
+	s.UpdatedAt = time.Now()
+}
+
+// GetStatus returns the current session status.
+func (s *Session) GetStatus() SessionStatus {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.Status
+}
+
+// NewEvent creates a new Event with automatic sequencing and session identity.
+func (s *Session) NewEvent(eventType string, data any) Event {
+	s.mu.RLock()
+	runID := s.RunID
+	parentRunID := s.ParentRunID
+	s.mu.RUnlock()
+
+	return Event{
+		ID:          newEventID(),
+		Sequence:    s.seq.Next(),
+		Type:        eventType,
+		SessionID:   s.ID,
+		RunID:       runID,
+		ParentRunID: parentRunID,
+		Timestamp:   time.Now(),
+		Data:        MarshalData(data),
+	}
+}
+
+// NewTurnEvent creates a new Event with turn number set.
+func (s *Session) NewTurnEvent(eventType string, turnNumber int, data any) Event {
+	ev := s.NewEvent(eventType, data)
+	ev.TurnNumber = turnNumber
+	return ev
+}
+
+func newSessionID() string {
+	return "ses_" + randomHex(12)
+}
+
+func newEventID() string {
+	return "evt_" + randomHex(8)
+}
+
+func randomHex(n int) string {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		panic("agui: crypto/rand failed: " + err.Error())
+	}
+	return hex.EncodeToString(b)
+}

--- a/ext/agui/session_test.go
+++ b/ext/agui/session_test.go
@@ -9,7 +9,7 @@ func TestSession_NewEvent_UniqueIDs(t *testing.T) {
 	s.SetRunID("run_1", "")
 
 	seen := map[string]bool{}
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		ev := s.NewEvent(EventRunStarted, nil)
 		if seen[ev.ID] {
 			t.Errorf("duplicate event ID: %s", ev.ID)
@@ -23,7 +23,7 @@ func TestSession_NewEvent_MonotonicSequence(t *testing.T) {
 	s.SetRunID("run_1", "parent_1")
 
 	prev := uint64(0)
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		ev := s.NewEvent(EventTurnStarted, nil)
 		if ev.Sequence <= prev {
 			t.Errorf("sequence %d not greater than %d", ev.Sequence, prev)

--- a/ext/agui/session_test.go
+++ b/ext/agui/session_test.go
@@ -1,0 +1,89 @@
+package agui
+
+import (
+	"testing"
+)
+
+func TestSession_NewEvent_UniqueIDs(t *testing.T) {
+	s := NewSession(SessionModeCoreRun)
+	s.SetRunID("run_1", "")
+
+	seen := map[string]bool{}
+	for i := 0; i < 100; i++ {
+		ev := s.NewEvent(EventRunStarted, nil)
+		if seen[ev.ID] {
+			t.Errorf("duplicate event ID: %s", ev.ID)
+		}
+		seen[ev.ID] = true
+	}
+}
+
+func TestSession_NewEvent_MonotonicSequence(t *testing.T) {
+	s := NewSession(SessionModeCoreStream)
+	s.SetRunID("run_1", "parent_1")
+
+	prev := uint64(0)
+	for i := 0; i < 100; i++ {
+		ev := s.NewEvent(EventTurnStarted, nil)
+		if ev.Sequence <= prev {
+			t.Errorf("sequence %d not greater than %d", ev.Sequence, prev)
+		}
+		prev = ev.Sequence
+	}
+}
+
+func TestSession_NewEvent_CarriesRunID(t *testing.T) {
+	s := NewSession(SessionModeCoreRun)
+	s.SetRunID("run_42", "parent_7")
+
+	ev := s.NewEvent(EventToolExecutionStarted, nil)
+	if ev.RunID != "run_42" {
+		t.Errorf("RunID = %q, want %q", ev.RunID, "run_42")
+	}
+	if ev.ParentRunID != "parent_7" {
+		t.Errorf("ParentRunID = %q, want %q", ev.ParentRunID, "parent_7")
+	}
+	if ev.SessionID != s.ID {
+		t.Errorf("SessionID = %q, want %q", ev.SessionID, s.ID)
+	}
+}
+
+func TestSession_NewTurnEvent_HasTurnNumber(t *testing.T) {
+	s := NewSession(SessionModeCoreRun)
+	ev := s.NewTurnEvent(EventTurnStarted, 5, nil)
+	if ev.TurnNumber != 5 {
+		t.Errorf("TurnNumber = %d, want 5", ev.TurnNumber)
+	}
+}
+
+func TestSession_StatusTransitions(t *testing.T) {
+	s := NewSession(SessionModeCoreRun)
+	if s.GetStatus() != SessionStatusStarting {
+		t.Errorf("initial status = %q, want %q", s.GetStatus(), SessionStatusStarting)
+	}
+
+	s.SetStatus(SessionStatusRunning)
+	if s.GetStatus() != SessionStatusRunning {
+		t.Errorf("status = %q, want %q", s.GetStatus(), SessionStatusRunning)
+	}
+
+	s.SetWaiting("approval")
+	if s.GetStatus() != SessionStatusWaiting {
+		t.Errorf("status = %q, want %q", s.GetStatus(), SessionStatusWaiting)
+	}
+
+	s.SetStatus(SessionStatusCompleted)
+	if s.GetStatus() != SessionStatusCompleted {
+		t.Errorf("status = %q, want %q", s.GetStatus(), SessionStatusCompleted)
+	}
+}
+
+func TestNewSession_HasValidID(t *testing.T) {
+	s := NewSession(SessionModeCoreRun)
+	if len(s.ID) < 10 {
+		t.Errorf("session ID too short: %q", s.ID)
+	}
+	if s.ID[:4] != "ses_" {
+		t.Errorf("session ID should start with ses_, got %q", s.ID)
+	}
+}


### PR DESCRIPTION
## Summary

This PR adds an initial AGUI integration layer on top of gollem's runtime and event surfaces.

It includes:
- a new `ext/agui` package for AGUI event translation, replay buffering, session state, and approval bridging
- expanded core runtime lifecycle events for turns, model request/response, tool completion/failure, approval, deferred work, and wait/resume transitions
- event emission from both `Run` and `RunStream` so non-streaming and streaming paths expose a consistent lifecycle model
- fixes for approval wait/resume accounting so concurrent approval-gated tools only emit one run-level wait/resume pair
- fixes for deferred runs so AGUI treats deferred waiting as resumable state instead of a terminal error
- follow-up lint and race fixes, including adapter shutdown/send synchronization

## Why

AGUI needs a stable event model that can represent:
- run and turn boundaries
- tool execution start/end
- approval requested/resolved
- deferred tool request/resolution
- session waiting and resumption
- reconnect/replay-oriented transport behavior

Before this change, gollem exposed only a subset of that lifecycle on the runtime event bus, and AGUI-specific transport logic did not exist.

## Testing

Validated with:
- `go test ./...`
- `golangci-lint run ./ext/agui/...`
- `go test -race ./ext/agui`
- repo pre-push checks: `golangci-lint`, `go test -race`, `go vet`, and go module tidy verification

## Notes

The branch includes three commits:
- `f683da7` Add AGUI adapter and runtime lifecycle events
- `4036943` Fix AGUI lint issues
- `443bf92` Fix AGUI race conditions
