### PR TITLE
fix(mcp): give the notification stream 5s to connect after HTTP 202

### DIFF
--- a/ext/mcp/http.go
+++ b/ext/mcp/http.go
@@ -147,7 +147,7 @@ func (c *HTTPClient) call(ctx context.Context, method string, params any) (json.
 		_, _ = io.Copy(io.Discard, resp.Body)
 		if resp.StatusCode == http.StatusAccepted {
 			c.ensureNotificationStream()
-			if !c.waitForStream(ctx, 250*time.Millisecond) {
+			if !c.waitForStream(ctx, streamConnectWait) {
 				c.removePending(id)
 				return nil, errors.New("mcp: HTTP request accepted but no event stream is connected")
 			}
@@ -363,6 +363,17 @@ func (c *HTTPClient) isStreamConnected() bool {
 	defer c.streamMu.Unlock()
 	return c.streamConnected
 }
+
+// streamConnectWait bounds how long a call whose response was
+// deferred to the notification stream (HTTP 202) waits for that
+// stream to connect. The wait returns the moment the stream is up,
+// so a generous bound only delays the failure path. The previous
+// 250ms bound lost the cold-start race deterministically: a client's
+// first tools/call could be accepted by the server before the
+// client's notification GET finished connecting, surfacing as
+// "request accepted but no event stream is connected" on otherwise
+// healthy local servers (and as a load-dependent flake in CI).
+const streamConnectWait = 5 * time.Second
 
 func (c *HTTPClient) waitForStream(ctx context.Context, timeout time.Duration) bool {
 	if c.isStreamConnected() {


### PR DESCRIPTION
When a tools/call response is deferred to the notification stream (HTTP 202 Accepted), the client waited only 250ms for that stream to connect before failing with 'request accepted but no event stream is connected'. A client's first tools/call routinely loses that race on cold start — the POST is accepted before the notification GET finishes connecting — which made sleepy's remote evolve fail deterministically on fresh connections and flaked CI under load.

waitForStream returns the moment the stream is up, so the generous 5s bound only delays the failure path, never the success path.