### PR TITLE
feat(anthropic): adaptive thinking + Opus 4.8/Fable gating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   budgets rejected with a pointer to `AdaptiveThinking`), and the full
   effort range including `xhigh` and `max` now passes
   per-model effort gating.
+- **`core.WithAdaptiveThinking` agent option**, and the CLI's
+  default reasoning setup now selects adaptive thinking for Claude
+  4.6+ models instead of a manual budget (which is rejected on 4.7+
+  — the budget default made the new models unusable from the CLI).
+  An explicit `-thinking-budget` still wins.
+- **Request guards matching API removals** (both Anthropic
+  providers): temperature/top_p are stripped on Opus 4.7+ (the API
+  400s on them regardless of thinking config, and Fable thinks
+  unconditionally server-side), and forced tool choice
+  (`required`/specific tool) combined with any thinking mode now
+  fails fast with a clear error instead of an API 400.
 
 ### Phase 14: Ten Innovations from Pydantic-AI, LangChain 1.0, OpenAI Agents SDK, AutoGen & CrewAI
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Adaptive thinking for Anthropic providers.** New
+  `ModelSettings.AdaptiveThinking *bool` emits
+  `{thinking: {type: "adaptive"}}` from both the `anthropic` and
+  `vertexai_anthropic` providers — the model decides when and how much
+  to think. Gated per model (Claude 4.6 generation and newer; clear
+  build-time error on older models), mutually exclusive with the
+  legacy `ThinkingBudget` manual mode, and temperature is omitted on
+  the wire as the API requires. Response and stream paths already
+  parsed `thinking` blocks; this closes the request side.
+- **Opus 4.8 and Fable model gating.** `claude-opus-4-8` and
+  `claude-fable-5` (new `ClaudeOpus48` / `ClaudeFable5` constants) are
+  recognized as post-4.7 flagships: adaptive-only thinking (manual
+  budgets rejected with a pointer to `AdaptiveThinking`), and the full
+  effort range including `xhigh` and `max` now passes
+  per-model effort gating.
+
 ### Phase 14: Ten Innovations from Pydantic-AI, LangChain 1.0, OpenAI Agents SDK, AutoGen & CrewAI
 
 #### Innovation 1: Typed Dependency Access

--- a/auth/openai/atomic_save_test.go
+++ b/auth/openai/atomic_save_test.go
@@ -1,0 +1,68 @@
+package openai
+
+import (
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// TestSaveCredentials_AtomicUnderConcurrency: concurrent savers and
+// readers must never observe an invalid (empty/partial) credentials
+// file. The previous os.WriteFile implementation truncated in place;
+// two processes refreshing tokens concurrently produced a 0-byte
+// auth.json in production.
+func TestSaveCredentials_AtomicUnderConcurrency(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "auth.json")
+	creds := &Credentials{AccessToken: "tok", RefreshToken: "ref"}
+	if err := SaveCredentialsTo(creds, path); err != nil {
+		t.Fatal(err)
+	}
+
+	var writers sync.WaitGroup
+	stop := make(chan struct{})
+	errs := make(chan error, 64)
+
+	for range 4 {
+		writers.Add(1)
+		go func() {
+			defer writers.Done()
+			for range 200 {
+				if err := SaveCredentialsTo(creds, path); err != nil {
+					errs <- err
+					return
+				}
+			}
+		}()
+	}
+
+	readerDone := make(chan struct{})
+	go func() {
+		defer close(readerDone)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			got, err := LoadCredentialsFrom(path)
+			if err != nil {
+				errs <- err
+				return
+			}
+			if got.AccessToken != "tok" {
+				errs <- nil
+				return
+			}
+		}
+	}()
+
+	writers.Wait()
+	close(stop)
+	<-readerDone
+
+	select {
+	case err := <-errs:
+		t.Fatalf("invalid credentials observed under concurrency: %v", err)
+	default:
+	}
+}

--- a/auth/openai/oauth.go
+++ b/auth/openai/oauth.go
@@ -18,7 +18,9 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -149,7 +151,11 @@ func loginBrowser(ctx context.Context, config LoginConfig) (*Credentials, error)
 	}
 	authURL := authEndpoint + "?" + params.Encode()
 
-	fmt.Printf("Open this URL to log in:\n\n  %s\n\nWaiting for authentication...\n", authURL)
+	if err := openBrowser(ctx, authURL); err == nil {
+		fmt.Printf("Opening your browser to log in. If nothing happens, open this URL:\n\n  %s\n\nWaiting for authentication...\n", authURL)
+	} else {
+		fmt.Printf("Open this URL to log in:\n\n  %s\n\nWaiting for authentication...\n", authURL)
+	}
 
 	// Wait for the auth code or context cancellation.
 	var code string
@@ -163,6 +169,22 @@ func loginBrowser(ctx context.Context, config LoginConfig) (*Credentials, error)
 
 	// Exchange authorization code for tokens.
 	return exchangeCode(ctx, code, redirectURI, verifier)
+}
+
+// openBrowser opens url in the default browser. Returns an error if
+// no opener is available (headless machines) so callers can fall
+// back to printing the URL.
+func openBrowser(ctx context.Context, url string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.CommandContext(ctx, "open", url)
+	case "windows":
+		cmd = exec.CommandContext(ctx, "rundll32", "url.dll,FileProtocolHandler", url)
+	default:
+		cmd = exec.CommandContext(ctx, "xdg-open", url)
+	}
+	return cmd.Start()
 }
 
 // loginDeviceCode performs the device code OAuth flow against the

--- a/auth/openai/oauth.go
+++ b/auth/openai/oauth.go
@@ -5,6 +5,7 @@
 package openai
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/sha256"
@@ -164,18 +165,24 @@ func loginBrowser(ctx context.Context, config LoginConfig) (*Credentials, error)
 	return exchangeCode(ctx, code, redirectURI, verifier)
 }
 
-// loginDeviceCode performs the device code OAuth flow.
+// loginDeviceCode performs the device code OAuth flow against the
+// auth.openai.com device-auth endpoints. Protocol (matches codex-rs
+// login/src/device_code_auth.rs, verified live 2026-06): both
+// endpoints take JSON bodies; "authorization pending" is signaled by
+// HTTP 403/404 on the token poll, success is 2xx with an
+// authorization code that is exchanged using the server-provided
+// PKCE verifier and the deviceauth callback redirect URI.
 func loginDeviceCode(ctx context.Context) (*Credentials, error) {
 	// Request a user code.
-	data := url.Values{
-		"client_id": {ClientID},
-		"scope":     {oauthScopes},
+	reqBody, err := json.Marshal(map[string]string{"client_id": ClientID})
+	if err != nil {
+		return nil, fmt.Errorf("encoding device code request: %w", err)
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, deviceUserCodeEndpoint, strings.NewReader(data.Encode()))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, deviceUserCodeEndpoint, bytes.NewReader(reqBody))
 	if err != nil {
 		return nil, fmt.Errorf("creating device code request: %w", err)
 	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -189,31 +196,31 @@ func loginDeviceCode(ctx context.Context) (*Credentials, error) {
 	}
 
 	var deviceResp struct {
-		UserCode        string `json:"user_code"`
-		DeviceCode      string `json:"device_code"`
-		VerificationURI string `json:"verification_uri"`
-		ExpiresIn       int    `json:"expires_in"`
-		Interval        int    `json:"interval"`
+		DeviceAuthID string `json:"device_auth_id"`
+		UserCode     string `json:"user_code"`
+		Interval     string `json:"interval"` // seconds, sent as a string
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&deviceResp); err != nil {
 		return nil, fmt.Errorf("decoding device code response: %w", err)
 	}
-
-	verifyURL := deviceResp.VerificationURI
-	if verifyURL == "" {
-		verifyURL = "https://auth.openai.com/codex/device"
+	if deviceResp.DeviceAuthID == "" || deviceResp.UserCode == "" {
+		return nil, errors.New("device code response missing device_auth_id or user_code")
 	}
 
-	fmt.Printf("Visit %s and enter code: %s\n\nWaiting for authorization...\n", verifyURL, deviceResp.UserCode)
+	fmt.Printf("Visit https://auth.openai.com/codex/device and enter code: %s\n\nWaiting for authorization (codes expire after 15 minutes; never share this code)...\n", deviceResp.UserCode)
 
-	// Poll for authorization.
-	interval := time.Duration(deviceResp.Interval) * time.Second
-	if interval == 0 {
-		interval = 5 * time.Second
+	interval := 5 * time.Second
+	if secs, err := strconv.Atoi(strings.TrimSpace(deviceResp.Interval)); err == nil && secs > 0 {
+		interval = time.Duration(secs) * time.Second
 	}
-	deadline := time.Now().Add(time.Duration(deviceResp.ExpiresIn) * time.Second)
-	if deviceResp.ExpiresIn == 0 {
-		deadline = time.Now().Add(5 * time.Minute)
+	deadline := time.Now().Add(15 * time.Minute)
+
+	pollBody, err := json.Marshal(map[string]string{
+		"device_auth_id": deviceResp.DeviceAuthID,
+		"user_code":      deviceResp.UserCode,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("encoding device poll request: %w", err)
 	}
 
 	for time.Now().Before(deadline) {
@@ -223,48 +230,40 @@ func loginDeviceCode(ctx context.Context) (*Credentials, error) {
 		case <-time.After(interval):
 		}
 
-		pollData := url.Values{
-			"client_id":   {ClientID},
-			"device_code": {deviceResp.DeviceCode},
-		}
-		pollReq, err := http.NewRequestWithContext(ctx, http.MethodPost, deviceTokenEndpoint, strings.NewReader(pollData.Encode()))
+		pollReq, err := http.NewRequestWithContext(ctx, http.MethodPost, deviceTokenEndpoint, bytes.NewReader(pollBody))
 		if err != nil {
 			continue
 		}
-		pollReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		pollReq.Header.Set("Content-Type", "application/json")
 
 		tokenResp, err := http.DefaultClient.Do(pollReq)
 		if err != nil {
 			continue
 		}
-
 		body, _ := io.ReadAll(tokenResp.Body)
 		tokenResp.Body.Close()
+
+		// Pending authorization is signaled by status, not body:
+		// 403/404 until the user enters the code.
+		if tokenResp.StatusCode == http.StatusForbidden || tokenResp.StatusCode == http.StatusNotFound {
+			continue
+		}
+		if tokenResp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("device authorization failed (HTTP %d): %s", tokenResp.StatusCode, body)
+		}
 
 		var result struct {
 			AuthorizationCode string `json:"authorization_code"`
 			CodeVerifier      string `json:"code_verifier"`
 			CodeChallenge     string `json:"code_challenge"`
-			Error             string `json:"error"`
 		}
 		if err := json.Unmarshal(body, &result); err != nil {
-			continue
+			return nil, fmt.Errorf("decoding device token response: %w", err)
 		}
-
-		if result.Error == "authorization_pending" {
-			continue
+		if result.AuthorizationCode == "" {
+			return nil, fmt.Errorf("device token response missing authorization_code: %s", body)
 		}
-		if result.Error == "slow_down" {
-			interval += 5 * time.Second // RFC 8628: increase interval on slow_down
-			continue
-		}
-		if result.Error != "" {
-			return nil, fmt.Errorf("device authorization failed: %s", result.Error)
-		}
-
-		if result.AuthorizationCode != "" {
-			return exchangeCode(ctx, result.AuthorizationCode, "http://localhost:"+strconv.Itoa(defaultPort)+"/auth/callback", result.CodeVerifier)
-		}
+		return exchangeCode(ctx, result.AuthorizationCode, "https://auth.openai.com/deviceauth/callback", result.CodeVerifier)
 	}
 
 	return nil, errors.New("device authorization timed out")

--- a/auth/openai/oauth.go
+++ b/auth/openai/oauth.go
@@ -433,6 +433,12 @@ func SaveCredentials(creds *Credentials) error {
 }
 
 // SaveCredentialsTo writes credentials to a specific file path.
+//
+// The write is atomic (private temp file + rename): os.WriteFile
+// truncates in place, so a concurrent reader — or a second process
+// racing its own token refresh — could observe an empty or partial
+// file. Seen in the wild as a 0-byte auth.json that broke every
+// ChatGPT-auth consumer until re-login.
 func SaveCredentialsTo(creds *Credentials, path string) error {
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0700); err != nil {
@@ -442,7 +448,28 @@ func SaveCredentialsTo(creds *Credentials, path string) error {
 	if err != nil {
 		return fmt.Errorf("marshaling credentials: %w", err)
 	}
-	return os.WriteFile(path, data, 0600)
+	tmp, err := os.CreateTemp(dir, ".auth-*.json")
+	if err != nil {
+		return fmt.Errorf("creating temp credentials file: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }() // no-op once renamed
+	if err := tmp.Chmod(0600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("restricting credentials permissions: %w", err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("writing credentials: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("syncing credentials: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing credentials file: %w", err)
+	}
+	return os.Rename(tmpName, path) //nolint:gosec // tmpName is from os.CreateTemp in the target's own directory
 }
 
 // generatePKCE generates a PKCE code verifier and S256 challenge.

--- a/cmd/gollem/main.go
+++ b/cmd/gollem/main.go
@@ -697,12 +697,26 @@ func runAgent() {
 	}
 
 	// Enable reasoning by default for providers that support it.
-	// This is provider-agnostic: Anthropic uses ThinkingBudget,
-	// OpenAI uses ReasoningEffort. The reasoning sandwich middleware
-	// will vary these per-turn for optimal performance.
+	// This is provider-agnostic: Anthropic uses adaptive thinking on
+	// Claude 4.6+ (a manual ThinkingBudget on older models), OpenAI uses
+	// ReasoningEffort. The reasoning sandwich middleware will vary these
+	// per-turn for optimal performance.
 	if !f.noReasoning {
 		switch f.provider {
 		case "anthropic", "vertexai-anthropic":
+			if f.thinkingBudget < 0 && anthropicModelPrefersAdaptive(f.modelName) {
+				// Claude 4.6+ default: adaptive thinking. A manual budget
+				// is rejected outright on Opus 4.7+ and deprecated on 4.6,
+				// so the budget default would make these models unusable
+				// from the CLI. An explicit -thinking-budget still wins
+				// below (and gets the provider's clear rejection on
+				// adaptive-only models).
+				agentOpts = append(agentOpts, core.WithAdaptiveThinking[string](true))
+				maxTokens := defaultThinkingBudget + 16000
+				agentOpts = append(agentOpts, core.WithMaxTokens[string](maxTokens))
+				fmt.Fprintf(os.Stderr, "gollem: adaptive thinking enabled (max_tokens: %d)\n", maxTokens)
+				break
+			}
 			if f.thinkingBudget < 0 {
 				f.thinkingBudget = defaultThinkingBudget
 			}
@@ -1997,6 +2011,24 @@ func detectProvider() string {
 		return "vertexai"
 	}
 	return ""
+}
+
+// anthropicModelPrefersAdaptive reports whether the selected Claude model
+// should default to adaptive thinking instead of a manual budget: the 4.6
+// generation and newer (Opus/Sonnet 4.6, Opus 4.7/4.8, Fable, Mythos).
+// Manual budgets are rejected on 4.7+ and deprecated on 4.6. An empty
+// model means the provider default (Sonnet 4.6), which is adaptive-capable.
+func anthropicModelPrefersAdaptive(model string) bool {
+	m := strings.ToLower(strings.TrimSpace(model))
+	if m == "" || strings.Contains(m, "mythos") || strings.Contains(m, "fable") {
+		return true
+	}
+	for _, marker := range []string{"opus-4-6", "sonnet-4-6", "opus-4-7", "opus-4-8"} {
+		if strings.Contains(m, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 func deriveGeminiMaxOutputTokens() int {

--- a/cmd/gollem/reasoning_default_test.go
+++ b/cmd/gollem/reasoning_default_test.go
@@ -1,0 +1,30 @@
+package main
+
+import "testing"
+
+// TestAnthropicModelPrefersAdaptive pins the CLI's default thinking-mode
+// selection: Claude 4.6+ (and the empty string, i.e. the provider's
+// Sonnet 4.6 default) get adaptive thinking; older models keep the
+// manual-budget default, which they still accept.
+func TestAnthropicModelPrefersAdaptive(t *testing.T) {
+	cases := []struct {
+		model string
+		want  bool
+	}{
+		{"", true}, // provider default model (Sonnet 4.6)
+		{"claude-sonnet-4-6", true},
+		{"claude-opus-4-6", true},
+		{"claude-opus-4-7", true},
+		{"claude-opus-4-8", true},
+		{"claude-fable-5", true},
+		{"claude-sonnet-4-5", false},
+		{"claude-opus-4-5", false},
+		{"claude-haiku-4-5-20251001", false},
+		{"claude-3-5-sonnet-20241022", false},
+	}
+	for _, tc := range cases {
+		if got := anthropicModelPrefersAdaptive(tc.model); got != tc.want {
+			t.Errorf("anthropicModelPrefersAdaptive(%q) = %v, want %v", tc.model, got, tc.want)
+		}
+	}
+}

--- a/core/model.go
+++ b/core/model.go
@@ -26,11 +26,21 @@ type ModelSettings struct {
 	TopP           *float64    `json:"top_p,omitempty"`
 	ToolChoice     *ToolChoice `json:"tool_choice,omitempty"`
 	ThinkingBudget *int        `json:"thinking_budget,omitempty"` // Anthropic extended thinking budget tokens (manual mode)
+	// AdaptiveThinking, when true, lets the model decide when and how much
+	// to think before answering. Maps to Anthropic's
+	// {thinking: {type: "adaptive"}} — supported on the Claude 4.6
+	// generation and newer (Opus/Sonnet 4.6, Opus 4.7/4.8, Fable; the
+	// 4.7+ models accept no other thinking mode). Mutually exclusive with
+	// ThinkingBudget: the Anthropic providers reject requests setting
+	// both. Thinking tokens count toward MaxTokens, so size MaxTokens
+	// with headroom. Ignored by providers without an equivalent (OpenAI
+	// reasoning models think implicitly; see ReasoningEffort).
+	AdaptiveThinking *bool `json:"adaptive_thinking,omitempty"`
 	// ReasoningEffort controls thinking depth. Values: "low", "medium", "high",
 	// "xhigh", "max". Supported on OpenAI reasoning models and Anthropic effort-
-	// capable models (Claude 4.5 Opus+, 4.6 Opus/Sonnet, 4.7 Opus). Per-provider
-	// gating rejects values a given model doesn't accept (e.g., "xhigh" is
-	// Opus 4.7-only; "max" requires 4.6+).
+	// capable models (Claude 4.5 Opus+, 4.6 Opus/Sonnet, 4.7 Opus, 4.8 Opus,
+	// Fable). Per-provider gating rejects values a given model doesn't accept
+	// (e.g., "xhigh" requires Opus 4.7+; "max" requires 4.6+).
 	ReasoningEffort *string `json:"reasoning_effort,omitempty"`
 	// StopSequences causes generation to halt when the model would emit any
 	// listed string. Supported by Anthropic (stop_sequences) and Gemini

--- a/core/thinking_options.go
+++ b/core/thinking_options.go
@@ -1,0 +1,16 @@
+package core
+
+// WithAdaptiveThinking lets the model decide when and how much to think
+// before answering (Anthropic adaptive thinking, Claude 4.6 generation
+// and newer; the only thinking mode on Opus 4.7+). Mutually exclusive
+// with WithThinkingBudget — the Anthropic providers reject requests that
+// set both. Thinking tokens count toward MaxTokens, so pair this with a
+// generous WithMaxTokens. See ModelSettings.AdaptiveThinking.
+func WithAdaptiveThinking[T any](on bool) AgentOption[T] {
+	return func(a *Agent[T]) {
+		if a.modelSettings == nil {
+			a.modelSettings = &ModelSettings{}
+		}
+		a.modelSettings.AdaptiveThinking = &on
+	}
+}

--- a/core/thinking_options_test.go
+++ b/core/thinking_options_test.go
@@ -1,0 +1,17 @@
+package core
+
+import "testing"
+
+func TestWithAdaptiveThinking(t *testing.T) {
+	a := &Agent[string]{}
+	WithAdaptiveThinking[string](true)(a)
+	if a.modelSettings == nil || a.modelSettings.AdaptiveThinking == nil || !*a.modelSettings.AdaptiveThinking {
+		t.Fatalf("expected AdaptiveThinking=true on settings, got %+v", a.modelSettings)
+	}
+
+	a = &Agent[string]{}
+	WithAdaptiveThinking[string](false)(a)
+	if a.modelSettings == nil || a.modelSettings.AdaptiveThinking == nil || *a.modelSettings.AdaptiveThinking {
+		t.Fatalf("expected explicit AdaptiveThinking=false on settings, got %+v", a.modelSettings)
+	}
+}

--- a/provider/anthropic/anthropic.go
+++ b/provider/anthropic/anthropic.go
@@ -25,6 +25,8 @@ import (
 // WithModel; the provider falls back to the legacy manual-thinking path for
 // those, but does not expose them as symbolic constants.
 const (
+	ClaudeFable5   = "claude-fable-5"
+	ClaudeOpus48   = "claude-opus-4-8"
 	ClaudeOpus47   = "claude-opus-4-7"
 	ClaudeOpus46   = "claude-opus-4-6"
 	ClaudeSonnet46 = "claude-sonnet-4-6"
@@ -74,6 +76,15 @@ func isOpus47(model string) bool {
 	return strings.Contains(m, "opus-4-7")
 }
 
+// isOpus48OrFable reports whether the model string identifies a post-4.7
+// flagship — Claude Opus 4.8 or the Fable tier. Same thinking/effort
+// surface as Opus 4.7: adaptive-only thinking, full effort range
+// including "xhigh" and "max".
+func isOpus48OrFable(model string) bool {
+	m := strings.ToLower(strings.TrimSpace(model))
+	return strings.Contains(m, "opus-4-8") || strings.Contains(m, "fable")
+}
+
 // isOpus46OrSonnet46 reports whether the model string identifies Opus 4.6 or
 // Sonnet 4.6. These models accept both manual and adaptive thinking, and
 // support the "max" effort level.
@@ -83,38 +94,44 @@ func isOpus46OrSonnet46(model string) bool {
 }
 
 // supportsEffort reports whether the given model accepts the output_config.effort
-// parameter. Per Anthropic docs, supported on Mythos, Opus 4.7, Opus 4.6,
-// Sonnet 4.6, and Opus 4.5. Notably NOT supported on Haiku 4.5 or any 3.x model.
+// parameter. Per Anthropic docs, supported on Fable, Opus 4.8, Opus 4.7
+// (and Mythos), Opus 4.6, Sonnet 4.6, and Opus 4.5. Notably NOT supported
+// on Haiku 4.5 or any 3.x model.
 func supportsEffort(model string) bool {
 	m := strings.ToLower(strings.TrimSpace(model))
-	if strings.Contains(m, "mythos") {
-		return true
-	}
-	if isOpus47(m) || isOpus46OrSonnet46(m) {
+	if isOpus47(m) || isOpus48OrFable(m) || isOpus46OrSonnet46(m) {
 		return true
 	}
 	return strings.Contains(m, "opus-4-5")
 }
 
 // supportsManualThinking reports whether {thinking: {type: "enabled",
-// budget_tokens: N}} is accepted by the model. Opus 4.7 and Mythos reject it
-// (adaptive thinking is the only mode). Opus 4.6 / Sonnet 4.6 accept it but
-// deprecate it. Older models continue to accept it.
+// budget_tokens: N}} is accepted by the model. Opus 4.7+ (4.7, 4.8, Fable,
+// Mythos) rejects it — adaptive thinking is the only mode there. Opus 4.6 /
+// Sonnet 4.6 accept it but deprecate it. Older models continue to accept it.
 func supportsManualThinking(model string) bool {
-	return !isOpus47(model)
+	return !isOpus47(model) && !isOpus48OrFable(model)
+}
+
+// supportsAdaptiveThinking reports whether {thinking: {type: "adaptive"}}
+// is accepted by the model: the Claude 4.6 generation and newer (Opus 4.6,
+// Sonnet 4.6, Opus 4.7, Opus 4.8, Fable, Mythos). Models 4.5 and older,
+// and Haiku, only have manual thinking.
+func supportsAdaptiveThinking(model string) bool {
+	return isOpus47(model) || isOpus48OrFable(model) || isOpus46OrSonnet46(model)
 }
 
 // supportsEffortValue reports whether a given effort value is accepted by the
-// model. "xhigh" is Opus-4.7/Mythos-only. "max" requires Opus 4.6+, Sonnet 4.6+,
-// or Opus 4.7/Mythos.
+// model. "xhigh" requires Opus 4.7+ (4.7, 4.8, Fable, Mythos). "max" requires
+// Opus 4.6+, Sonnet 4.6+, or Opus 4.7+.
 func supportsEffortValue(model, effort string) bool {
 	switch effort {
 	case "low", "medium", "high":
 		return supportsEffort(model)
 	case "xhigh":
-		return isOpus47(model)
+		return isOpus47(model) || isOpus48OrFable(model)
 	case "max":
-		return isOpus47(model) || isOpus46OrSonnet46(model)
+		return isOpus47(model) || isOpus48OrFable(model) || isOpus46OrSonnet46(model)
 	default:
 		return false
 	}

--- a/provider/anthropic/anthropic_test.go
+++ b/provider/anthropic/anthropic_test.go
@@ -938,6 +938,138 @@ func TestOpus47RejectsThinkingBudget(t *testing.T) {
 	}
 }
 
+// --- Adaptive thinking unit tests ---
+
+// TestBuildRequestAdaptiveThinking verifies {thinking: {type: "adaptive"}}
+// is emitted on every model generation that accepts it, with no
+// budget_tokens on the wire.
+func TestBuildRequestAdaptiveThinking(t *testing.T) {
+	on := true
+	for _, model := range []string{
+		ClaudeSonnet46, ClaudeOpus46, ClaudeOpus47, ClaudeOpus48, ClaudeFable5,
+	} {
+		t.Run(model, func(t *testing.T) {
+			settings := &core.ModelSettings{AdaptiveThinking: &on}
+			req, err := buildRequest(nil, settings, nil, model, 4096, false, false, false)
+			if err != nil {
+				t.Fatalf("buildRequest: %v", err)
+			}
+			if req.Thinking == nil {
+				t.Fatal("expected Thinking to be set")
+			}
+			if req.Thinking.Type != "adaptive" {
+				t.Errorf("thinking type = %q, want 'adaptive'", req.Thinking.Type)
+			}
+			wire, err := json.Marshal(req)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if !strings.Contains(string(wire), `"thinking":{"type":"adaptive"}`) {
+				t.Errorf("wire thinking shape wrong: %s", wire)
+			}
+			if strings.Contains(string(wire), "budget_tokens") {
+				t.Errorf("budget_tokens must be absent for adaptive thinking: %s", wire)
+			}
+		})
+	}
+}
+
+func TestBuildRequestAdaptiveThinkingStripsTemperature(t *testing.T) {
+	on := true
+	temp := 0.7
+	settings := &core.ModelSettings{AdaptiveThinking: &on, Temperature: &temp}
+	req, err := buildRequest(nil, settings, nil, ClaudeSonnet46, 4096, false, false, false)
+	if err != nil {
+		t.Fatalf("buildRequest: %v", err)
+	}
+	if req.Temperature != nil {
+		t.Errorf("expected temperature to be nil when adaptive thinking enabled, got %v", *req.Temperature)
+	}
+}
+
+// TestBuildRequestAdaptiveThinkingKeepsMaxTokens verifies the adaptive path
+// never silently rewrites the caller's MaxTokens — there is no budget to
+// auto-adjust against (thinking tokens just count toward max_tokens).
+func TestBuildRequestAdaptiveThinkingKeepsMaxTokens(t *testing.T) {
+	on := true
+	maxTokens := 8192
+	settings := &core.ModelSettings{AdaptiveThinking: &on, MaxTokens: &maxTokens}
+	req, err := buildRequest(nil, settings, nil, ClaudeOpus47, 4096, false, false, false)
+	if err != nil {
+		t.Fatalf("buildRequest: %v", err)
+	}
+	if req.MaxTokens != 8192 {
+		t.Errorf("max_tokens = %d, want 8192 (untouched)", req.MaxTokens)
+	}
+}
+
+// TestBuildRequestAdaptiveThinkingFalseIsNoop verifies an explicit false
+// behaves exactly like an unset field.
+func TestBuildRequestAdaptiveThinkingFalseIsNoop(t *testing.T) {
+	off := false
+	settings := &core.ModelSettings{AdaptiveThinking: &off}
+	req, err := buildRequest(nil, settings, nil, ClaudeSonnet46, 4096, false, false, false)
+	if err != nil {
+		t.Fatalf("buildRequest: %v", err)
+	}
+	if req.Thinking != nil {
+		t.Errorf("expected no thinking for AdaptiveThinking=false, got %+v", req.Thinking)
+	}
+}
+
+// TestAdaptiveThinkingUnsupportedModels verifies pre-4.6 models reject
+// adaptive thinking at build time with a clear error.
+func TestAdaptiveThinkingUnsupportedModels(t *testing.T) {
+	on := true
+	for _, model := range []string{
+		"claude-sonnet-4-5", "claude-opus-4-5", ClaudeHaiku45, "claude-3-5-sonnet-20241022",
+	} {
+		t.Run(model, func(t *testing.T) {
+			settings := &core.ModelSettings{AdaptiveThinking: &on}
+			_, err := buildRequest(nil, settings, nil, model, 4096, false, false, false)
+			if err == nil {
+				t.Fatalf("expected error for adaptive thinking on %q", model)
+			}
+			if !strings.Contains(err.Error(), "adaptive thinking") {
+				t.Errorf("error should mention adaptive thinking, got: %v", err)
+			}
+		})
+	}
+}
+
+// TestAdaptiveAndManualThinkingConflict verifies the two thinking modes are
+// mutually exclusive regardless of model.
+func TestAdaptiveAndManualThinkingConflict(t *testing.T) {
+	on := true
+	budget := 2048
+	settings := &core.ModelSettings{AdaptiveThinking: &on, ThinkingBudget: &budget}
+	_, err := buildRequest(nil, settings, nil, ClaudeSonnet46, 4096, false, false, false)
+	if err == nil {
+		t.Fatal("expected error when both AdaptiveThinking and ThinkingBudget are set")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("error should say mutually exclusive, got: %v", err)
+	}
+}
+
+// TestOpus48AndFableRejectThinkingBudget verifies the post-4.7 flagships
+// reject manual thinking the same way Opus 4.7 does.
+func TestOpus48AndFableRejectThinkingBudget(t *testing.T) {
+	budget := 2048
+	for _, model := range []string{ClaudeOpus48, ClaudeFable5} {
+		t.Run(model, func(t *testing.T) {
+			settings := &core.ModelSettings{ThinkingBudget: &budget}
+			_, err := buildRequest(nil, settings, nil, model, 4096, false, false, false)
+			if err == nil {
+				t.Fatalf("expected error when ThinkingBudget is set on %q", model)
+			}
+			if !strings.Contains(err.Error(), "AdaptiveThinking") {
+				t.Errorf("error should point to AdaptiveThinking, got: %v", err)
+			}
+		})
+	}
+}
+
 // TestBuildRequestWithEffort verifies output_config.effort is emitted for each
 // valid value on models that accept it.
 func TestBuildRequestWithEffort(t *testing.T) {
@@ -950,6 +1082,12 @@ func TestBuildRequestWithEffort(t *testing.T) {
 		{ClaudeOpus47, "high"},
 		{ClaudeOpus47, "xhigh"},
 		{ClaudeOpus47, "max"},
+		{ClaudeOpus48, "medium"},
+		{ClaudeOpus48, "xhigh"},
+		{ClaudeOpus48, "max"},
+		{ClaudeFable5, "medium"},
+		{ClaudeFable5, "xhigh"},
+		{ClaudeFable5, "max"},
 		{ClaudeOpus46, "low"},
 		{ClaudeOpus46, "max"},
 		{ClaudeSonnet46, "medium"},

--- a/provider/anthropic/anthropic_test.go
+++ b/provider/anthropic/anthropic_test.go
@@ -1070,6 +1070,68 @@ func TestOpus48AndFableRejectThinkingBudget(t *testing.T) {
 	}
 }
 
+// TestBuildRequestStripsSamplingOnOpus47Plus verifies temperature and top_p
+// are stripped on models where the API removed sampling parameters
+// (Opus 4.7+, including Fable where thinking is always on server-side),
+// even when no thinking mode is requested — and preserved on 4.6.
+func TestBuildRequestStripsSamplingOnOpus47Plus(t *testing.T) {
+	temp := 0.7
+	topP := 0.95
+	for _, model := range []string{ClaudeOpus47, ClaudeOpus48, ClaudeFable5} {
+		t.Run(model, func(t *testing.T) {
+			settings := &core.ModelSettings{Temperature: &temp, TopP: &topP}
+			req, err := buildRequest(nil, settings, nil, model, 4096, false, false, false)
+			if err != nil {
+				t.Fatalf("buildRequest: %v", err)
+			}
+			if req.Temperature != nil || req.TopP != nil {
+				t.Errorf("sampling params must be stripped on %s, got temp=%v topP=%v", model, req.Temperature, req.TopP)
+			}
+		})
+	}
+	settings := &core.ModelSettings{Temperature: &temp, TopP: &topP}
+	req, err := buildRequest(nil, settings, nil, ClaudeSonnet46, 4096, false, false, false)
+	if err != nil {
+		t.Fatalf("buildRequest: %v", err)
+	}
+	if req.Temperature == nil || req.TopP == nil {
+		t.Error("sampling params must be preserved on Sonnet 4.6 without thinking")
+	}
+}
+
+// TestBuildRequestForcedToolChoiceWithThinkingErrors verifies the documented
+// incompatibility: tool_choice any/tool is rejected while thinking is
+// enabled (adaptive or manual); auto passes.
+func TestBuildRequestForcedToolChoiceWithThinkingErrors(t *testing.T) {
+	on := true
+	budget := 2048
+	cases := []struct {
+		name     string
+		settings *core.ModelSettings
+		wantErr  bool
+	}{
+		{"adaptive_required", &core.ModelSettings{AdaptiveThinking: &on, ToolChoice: &core.ToolChoice{Mode: "required"}}, true},
+		{"adaptive_specific_tool", &core.ModelSettings{AdaptiveThinking: &on, ToolChoice: &core.ToolChoice{ToolName: "search"}}, true},
+		{"manual_required", &core.ModelSettings{ThinkingBudget: &budget, ToolChoice: &core.ToolChoice{Mode: "required"}}, true},
+		{"adaptive_auto", &core.ModelSettings{AdaptiveThinking: &on, ToolChoice: &core.ToolChoice{Mode: "auto"}}, false},
+		{"no_thinking_required", &core.ModelSettings{ToolChoice: &core.ToolChoice{Mode: "required"}}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := buildRequest(nil, tc.settings, nil, ClaudeSonnet46, 4096, false, false, false)
+			if tc.wantErr && err == nil {
+				t.Fatal("expected forced tool_choice + thinking to error")
+			}
+			if tc.wantErr && !strings.Contains(err.Error(), "incompatible with extended thinking") {
+				t.Errorf("error should explain the incompatibility, got: %v", err)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
 // TestBuildRequestWithEffort verifies output_config.effort is emitted for each
 // valid value on models that accept it.
 func TestBuildRequestWithEffort(t *testing.T) {

--- a/provider/anthropic/message.go
+++ b/provider/anthropic/message.go
@@ -182,6 +182,16 @@ func buildRequest(messages []core.ModelMessage, settings *core.ModelSettings, pa
 		req.TopP = settings.TopP
 		req.StopSequences = settings.StopSequences
 
+		// Sampling parameters are removed on Opus 4.7+ (4.7, 4.8, Fable,
+		// Mythos): the API returns 400 on temperature/top_p regardless of
+		// the thinking config, and on Fable thinking is always on
+		// server-side. Strip rather than reject so swapping the model
+		// under existing middleware that sets temperature keeps working.
+		if isOpus47(model) || isOpus48OrFable(model) {
+			req.Temperature = nil
+			req.TopP = nil
+		}
+
 		// Extended thinking. Two modes, mutually exclusive:
 		//   - adaptive: the model decides when/how much to think. The only
 		//     mode on Opus 4.7+; recommended on 4.6.
@@ -303,6 +313,16 @@ func buildRequest(messages []core.ModelMessage, settings *core.ModelSettings, pa
 		case tc.Mode == "auto":
 			req.ToolChoice = &apiToolChoice{Type: "auto"}
 		}
+	}
+
+	// Forced tool use is incompatible with extended thinking (adaptive or
+	// manual): the API only accepts tool_choice auto/none while thinking.
+	// Fail fast with a clear error instead of letting the API 400.
+	if req.Thinking != nil && req.ToolChoice != nil && req.ToolChoice.Type != "auto" {
+		return nil, fmt.Errorf(
+			"anthropic: tool_choice %q is incompatible with extended thinking; use auto, or disable thinking",
+			req.ToolChoice.Type,
+		)
 	}
 
 	// Convert messages.

--- a/provider/anthropic/message.go
+++ b/provider/anthropic/message.go
@@ -34,17 +34,17 @@ type apiToolChoice struct {
 
 // apiThinking controls extended thinking. Two modes:
 //   - {type: "enabled", budget_tokens: N} — manual extended thinking. Rejected
-//     by Opus 4.7+; deprecated on Opus 4.6 / Sonnet 4.6.
-//   - {type: "adaptive"} — adaptive thinking. Required on Opus 4.7; recommended
-//     on 4.6 models. BudgetTokens is omitted on the wire.
+//     by Opus 4.7+ (4.7, 4.8, Fable); deprecated on Opus 4.6 / Sonnet 4.6.
+//   - {type: "adaptive"} — adaptive thinking. The only mode on Opus 4.7+;
+//     recommended on 4.6 models. BudgetTokens is omitted on the wire.
 type apiThinking struct {
 	Type         string `json:"type"`
 	BudgetTokens int    `json:"budget_tokens,omitempty"`
 }
 
 // apiOutputConfig is the nested object carrying the `effort` parameter.
-// Effort values: "low", "medium", "high", "xhigh" (Opus 4.7 only),
-// "max" (Opus 4.6+/Sonnet 4.6+/Opus 4.7).
+// Effort values: "low", "medium", "high", "xhigh" (Opus 4.7+ only),
+// "max" (Opus 4.6+/Sonnet 4.6+).
 type apiOutputConfig struct {
 	Effort string `json:"effort,omitempty"`
 }
@@ -182,13 +182,35 @@ func buildRequest(messages []core.ModelMessage, settings *core.ModelSettings, pa
 		req.TopP = settings.TopP
 		req.StopSequences = settings.StopSequences
 
-		// Extended thinking. Opus 4.7 (and Mythos) rejects manual thinking;
-		// adaptive is the only mode. Fail fast with a pointer to the correct
-		// option rather than letting the API return a generic 400.
-		if settings.ThinkingBudget != nil && *settings.ThinkingBudget > 0 {
+		// Extended thinking. Two modes, mutually exclusive:
+		//   - adaptive: the model decides when/how much to think. The only
+		//     mode on Opus 4.7+; recommended on 4.6.
+		//   - manual budget: legacy {type: "enabled", budget_tokens}.
+		//     Rejected by Opus 4.7+; deprecated on 4.6.
+		// Fail fast with a pointer to the correct option rather than
+		// letting the API return a generic 400.
+		adaptive := settings.AdaptiveThinking != nil && *settings.AdaptiveThinking
+		manual := settings.ThinkingBudget != nil && *settings.ThinkingBudget > 0
+		if adaptive && manual {
+			return nil, errors.New(
+				"anthropic: AdaptiveThinking and ThinkingBudget are mutually exclusive; pick one thinking mode",
+			)
+		}
+		if adaptive {
+			if !supportsAdaptiveThinking(model) {
+				return nil, fmt.Errorf(
+					"anthropic: model %q does not support adaptive thinking; use a Claude 4.6+ model, or ThinkingBudget for manual thinking on older models",
+					model,
+				)
+			}
+			req.Thinking = &apiThinking{Type: "adaptive"}
+			// Anthropic requires temperature to be omitted when thinking is enabled.
+			req.Temperature = nil
+		}
+		if manual {
 			if !supportsManualThinking(model) {
 				return nil, fmt.Errorf(
-					"anthropic: model %q does not support manual thinking; use WithReasoningEffort(\"high\"|\"xhigh\"|\"max\") instead",
+					"anthropic: model %q does not support manual thinking; set AdaptiveThinking or use WithReasoningEffort(\"high\"|\"xhigh\"|\"max\") instead",
 					model,
 				)
 			}

--- a/provider/vertexai_anthropic/message.go
+++ b/provider/vertexai_anthropic/message.go
@@ -154,6 +154,16 @@ func buildRequest(messages []core.ModelMessage, settings *core.ModelSettings, pa
 		req.TopP = settings.TopP
 		req.StopSequences = settings.StopSequences
 
+		// Sampling parameters are removed on Opus 4.7+ (4.7, 4.8, Fable,
+		// Mythos): the API returns 400 on temperature/top_p regardless of
+		// the thinking config, and on Fable thinking is always on
+		// server-side. Strip rather than reject so swapping the model
+		// under existing middleware that sets temperature keeps working.
+		if isOpus47(model) || isOpus48OrFable(model) {
+			req.Temperature = nil
+			req.TopP = nil
+		}
+
 		// Extended thinking. Two modes, mutually exclusive: adaptive (the
 		// model decides; the only mode on Opus 4.7+) and the legacy manual
 		// budget (rejected by Opus 4.7+). Fail fast with a pointer to the
@@ -240,6 +250,16 @@ func buildRequest(messages []core.ModelMessage, settings *core.ModelSettings, pa
 		case tc.Mode == "auto":
 			req.ToolChoice = &apiToolChoice{Type: "auto"}
 		}
+	}
+
+	// Forced tool use is incompatible with extended thinking (adaptive or
+	// manual): the API only accepts tool_choice auto/none while thinking.
+	// Fail fast with a clear error instead of letting the API 400.
+	if req.Thinking != nil && req.ToolChoice != nil && req.ToolChoice.Type != "auto" {
+		return nil, fmt.Errorf(
+			"vertexai_anthropic: tool_choice %q is incompatible with extended thinking; use auto, or disable thinking",
+			req.ToolChoice.Type,
+		)
 	}
 
 	var systemBlocks []apiSystemBlock

--- a/provider/vertexai_anthropic/message.go
+++ b/provider/vertexai_anthropic/message.go
@@ -41,8 +41,8 @@ type apiToolChoice struct {
 }
 
 // apiThinking controls extended thinking. Two modes:
-//   - {type: "enabled", budget_tokens: N} — manual. Rejected by Opus 4.7.
-//   - {type: "adaptive"} — adaptive thinking. Required on Opus 4.7.
+//   - {type: "enabled", budget_tokens: N} — manual. Rejected by Opus 4.7+.
+//   - {type: "adaptive"} — adaptive thinking. The only mode on Opus 4.7+.
 type apiThinking struct {
 	Type         string `json:"type"`
 	BudgetTokens int    `json:"budget_tokens,omitempty"`
@@ -154,12 +154,32 @@ func buildRequest(messages []core.ModelMessage, settings *core.ModelSettings, pa
 		req.TopP = settings.TopP
 		req.StopSequences = settings.StopSequences
 
-		// Extended thinking. Opus 4.7 / Mythos rejects manual thinking — fail
-		// fast with a pointer to WithReasoningEffort rather than a generic 400.
-		if settings.ThinkingBudget != nil && *settings.ThinkingBudget > 0 {
+		// Extended thinking. Two modes, mutually exclusive: adaptive (the
+		// model decides; the only mode on Opus 4.7+) and the legacy manual
+		// budget (rejected by Opus 4.7+). Fail fast with a pointer to the
+		// correct option rather than a generic 400.
+		adaptive := settings.AdaptiveThinking != nil && *settings.AdaptiveThinking
+		manual := settings.ThinkingBudget != nil && *settings.ThinkingBudget > 0
+		if adaptive && manual {
+			return nil, errors.New(
+				"vertexai_anthropic: AdaptiveThinking and ThinkingBudget are mutually exclusive; pick one thinking mode",
+			)
+		}
+		if adaptive {
+			if !supportsAdaptiveThinking(model) {
+				return nil, fmt.Errorf(
+					"vertexai_anthropic: model %q does not support adaptive thinking; use a Claude 4.6+ model, or ThinkingBudget for manual thinking on older models",
+					model,
+				)
+			}
+			req.Thinking = &apiThinking{Type: "adaptive"}
+			// Anthropic requires temperature to be omitted when thinking is enabled.
+			req.Temperature = nil
+		}
+		if manual {
 			if !supportsManualThinking(model) {
 				return nil, fmt.Errorf(
-					"vertexai_anthropic: model %q does not support manual thinking; use WithReasoningEffort(\"high\"|\"xhigh\"|\"max\") instead",
+					"vertexai_anthropic: model %q does not support manual thinking; set AdaptiveThinking or use WithReasoningEffort(\"high\"|\"xhigh\"|\"max\") instead",
 					model,
 				)
 			}

--- a/provider/vertexai_anthropic/vertexai_anthropic.go
+++ b/provider/vertexai_anthropic/vertexai_anthropic.go
@@ -53,6 +53,14 @@ func isOpus47(model string) bool {
 	return strings.Contains(m, "opus-4-7")
 }
 
+// isOpus48OrFable reports whether the model string identifies a post-4.7
+// flagship — Opus 4.8 or the Fable tier. Same thinking/effort surface as
+// Opus 4.7: adaptive-only thinking, full effort range.
+func isOpus48OrFable(model string) bool {
+	m := strings.ToLower(strings.TrimSpace(model))
+	return strings.Contains(m, "opus-4-8") || strings.Contains(m, "fable")
+}
+
 // isOpus46OrSonnet46 reports whether the model is Opus 4.6 or Sonnet 4.6.
 func isOpus46OrSonnet46(model string) bool {
 	m := strings.ToLower(strings.TrimSpace(model))
@@ -60,23 +68,28 @@ func isOpus46OrSonnet46(model string) bool {
 }
 
 // supportsEffort reports whether the model accepts the output_config.effort
-// parameter. Per Anthropic docs: Mythos, Opus 4.7/4.6/4.5, Sonnet 4.6.
-// Haiku 4.5 and Claude 3.x do NOT support it.
+// parameter. Per Anthropic docs: Fable, Opus 4.8/4.7/4.6/4.5 (and Mythos),
+// Sonnet 4.6. Haiku 4.5 and Claude 3.x do NOT support it.
 func supportsEffort(model string) bool {
 	m := strings.ToLower(strings.TrimSpace(model))
-	if strings.Contains(m, "mythos") {
-		return true
-	}
-	if isOpus47(m) || isOpus46OrSonnet46(m) {
+	if isOpus47(m) || isOpus48OrFable(m) || isOpus46OrSonnet46(m) {
 		return true
 	}
 	return strings.Contains(m, "opus-4-5")
 }
 
 // supportsManualThinking reports whether {thinking: {type: "enabled",
-// budget_tokens: N}} is accepted. Opus 4.7 and Mythos reject it.
+// budget_tokens: N}} is accepted. Opus 4.7+ (4.7, 4.8, Fable, Mythos)
+// rejects it.
 func supportsManualThinking(model string) bool {
-	return !isOpus47(model)
+	return !isOpus47(model) && !isOpus48OrFable(model)
+}
+
+// supportsAdaptiveThinking reports whether {thinking: {type: "adaptive"}}
+// is accepted: the Claude 4.6 generation and newer (Opus 4.6, Sonnet 4.6,
+// Opus 4.7, Opus 4.8, Fable, Mythos).
+func supportsAdaptiveThinking(model string) bool {
+	return isOpus47(model) || isOpus48OrFable(model) || isOpus46OrSonnet46(model)
 }
 
 // supportsEffortValue reports whether a given effort value is accepted.
@@ -85,9 +98,9 @@ func supportsEffortValue(model, effort string) bool {
 	case "low", "medium", "high":
 		return supportsEffort(model)
 	case "xhigh":
-		return isOpus47(model)
+		return isOpus47(model) || isOpus48OrFable(model)
 	case "max":
-		return isOpus47(model) || isOpus46OrSonnet46(model)
+		return isOpus47(model) || isOpus48OrFable(model) || isOpus46OrSonnet46(model)
 	default:
 		return false
 	}

--- a/provider/vertexai_anthropic/vertexai_anthropic_test.go
+++ b/provider/vertexai_anthropic/vertexai_anthropic_test.go
@@ -1343,6 +1343,50 @@ func TestOpus48RejectsThinkingBudget(t *testing.T) {
 	}
 }
 
+// TestBuildRequestStripsSamplingOnOpus47Plus verifies temperature and top_p
+// are stripped on models where the API removed sampling parameters
+// (Opus 4.7+, including Fable), even without thinking — and preserved on 4.6.
+func TestBuildRequestStripsSamplingOnOpus47Plus(t *testing.T) {
+	temp := 0.7
+	topP := 0.95
+	for _, model := range []string{ClaudeOpus47, "claude-opus-4-8", "claude-fable-5"} {
+		t.Run(model, func(t *testing.T) {
+			settings := &core.ModelSettings{Temperature: &temp, TopP: &topP}
+			req, err := buildRequest(nil, settings, nil, model, 4096, false)
+			if err != nil {
+				t.Fatalf("buildRequest: %v", err)
+			}
+			if req.Temperature != nil || req.TopP != nil {
+				t.Errorf("sampling params must be stripped on %s, got temp=%v topP=%v", model, req.Temperature, req.TopP)
+			}
+		})
+	}
+	settings := &core.ModelSettings{Temperature: &temp, TopP: &topP}
+	req, err := buildRequest(nil, settings, nil, ClaudeSonnet46, 4096, false)
+	if err != nil {
+		t.Fatalf("buildRequest: %v", err)
+	}
+	if req.Temperature == nil || req.TopP == nil {
+		t.Error("sampling params must be preserved on Sonnet 4.6 without thinking")
+	}
+}
+
+// TestBuildRequestForcedToolChoiceWithThinkingErrors verifies tool_choice
+// any/tool is rejected while thinking is enabled; auto passes.
+func TestBuildRequestForcedToolChoiceWithThinkingErrors(t *testing.T) {
+	on := true
+	settings := &core.ModelSettings{AdaptiveThinking: &on, ToolChoice: &core.ToolChoice{Mode: "required"}}
+	_, err := buildRequest(nil, settings, nil, ClaudeSonnet46, 4096, false)
+	if err == nil || !strings.Contains(err.Error(), "incompatible with extended thinking") {
+		t.Fatalf("expected incompatibility error, got: %v", err)
+	}
+
+	settings = &core.ModelSettings{AdaptiveThinking: &on, ToolChoice: &core.ToolChoice{Mode: "auto"}}
+	if _, err := buildRequest(nil, settings, nil, ClaudeSonnet46, 4096, false); err != nil {
+		t.Fatalf("auto tool_choice with thinking must pass, got: %v", err)
+	}
+}
+
 // TestBuildRequestWithEffort verifies output_config.effort is emitted for each
 // valid value on models that accept it.
 func TestBuildRequestWithEffort(t *testing.T) {

--- a/provider/vertexai_anthropic/vertexai_anthropic_test.go
+++ b/provider/vertexai_anthropic/vertexai_anthropic_test.go
@@ -1249,6 +1249,100 @@ func TestOpus47RejectsThinkingBudget(t *testing.T) {
 	}
 }
 
+// --- Adaptive thinking unit tests ---
+
+// TestBuildRequestAdaptiveThinking verifies {thinking: {type: "adaptive"}}
+// is emitted on every model generation that accepts it, with no
+// budget_tokens on the wire.
+func TestBuildRequestAdaptiveThinking(t *testing.T) {
+	on := true
+	for _, model := range []string{
+		ClaudeSonnet46, ClaudeOpus46, ClaudeOpus47, "claude-opus-4-8", "claude-fable-5",
+	} {
+		t.Run(model, func(t *testing.T) {
+			settings := &core.ModelSettings{AdaptiveThinking: &on}
+			req, err := buildRequest(nil, settings, nil, model, 4096, false)
+			if err != nil {
+				t.Fatalf("buildRequest: %v", err)
+			}
+			if req.Thinking == nil || req.Thinking.Type != "adaptive" {
+				t.Fatalf("expected adaptive thinking, got %+v", req.Thinking)
+			}
+			wire, err := json.Marshal(req)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if !strings.Contains(string(wire), `"thinking":{"type":"adaptive"}`) {
+				t.Errorf("wire thinking shape wrong: %s", wire)
+			}
+			if strings.Contains(string(wire), "budget_tokens") {
+				t.Errorf("budget_tokens must be absent for adaptive thinking: %s", wire)
+			}
+		})
+	}
+}
+
+func TestBuildRequestAdaptiveThinkingStripsTemperature(t *testing.T) {
+	on := true
+	temp := 0.7
+	settings := &core.ModelSettings{AdaptiveThinking: &on, Temperature: &temp}
+	req, err := buildRequest(nil, settings, nil, ClaudeSonnet46, 4096, false)
+	if err != nil {
+		t.Fatalf("buildRequest: %v", err)
+	}
+	if req.Temperature != nil {
+		t.Errorf("expected temperature to be nil when adaptive thinking enabled, got %v", *req.Temperature)
+	}
+}
+
+// TestAdaptiveThinkingUnsupportedModels verifies pre-4.6 models reject
+// adaptive thinking at build time with a clear error.
+func TestAdaptiveThinkingUnsupportedModels(t *testing.T) {
+	on := true
+	for _, model := range []string{"claude-sonnet-4-5", "claude-opus-4-5", "claude-haiku-4-5"} {
+		t.Run(model, func(t *testing.T) {
+			settings := &core.ModelSettings{AdaptiveThinking: &on}
+			_, err := buildRequest(nil, settings, nil, model, 4096, false)
+			if err == nil {
+				t.Fatalf("expected error for adaptive thinking on %q", model)
+			}
+			if !strings.Contains(err.Error(), "adaptive thinking") {
+				t.Errorf("error should mention adaptive thinking, got: %v", err)
+			}
+		})
+	}
+}
+
+// TestAdaptiveAndManualThinkingConflict verifies the two thinking modes are
+// mutually exclusive regardless of model.
+func TestAdaptiveAndManualThinkingConflict(t *testing.T) {
+	on := true
+	budget := 2048
+	settings := &core.ModelSettings{AdaptiveThinking: &on, ThinkingBudget: &budget}
+	_, err := buildRequest(nil, settings, nil, ClaudeSonnet46, 4096, false)
+	if err == nil {
+		t.Fatal("expected error when both AdaptiveThinking and ThinkingBudget are set")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("error should say mutually exclusive, got: %v", err)
+	}
+}
+
+// TestOpus48RejectsThinkingBudget verifies post-4.7 flagships reject manual
+// thinking the same way Opus 4.7 does.
+func TestOpus48RejectsThinkingBudget(t *testing.T) {
+	budget := 2048
+	for _, model := range []string{"claude-opus-4-8", "claude-fable-5"} {
+		t.Run(model, func(t *testing.T) {
+			settings := &core.ModelSettings{ThinkingBudget: &budget}
+			_, err := buildRequest(nil, settings, nil, model, 4096, false)
+			if err == nil {
+				t.Fatalf("expected error when ThinkingBudget is set on %q", model)
+			}
+		})
+	}
+}
+
 // TestBuildRequestWithEffort verifies output_config.effort is emitted for each
 // valid value on models that accept it.
 func TestBuildRequestWithEffort(t *testing.T) {


### PR DESCRIPTION
The Anthropic providers could parse and stream thinking blocks but
never request them adaptively: apiThinking documented the adaptive
mode, yet nothing constructed it, so callers had manual budget_tokens
(deprecated on 4.6, rejected on 4.7+) or nothing.

- core: ModelSettings.AdaptiveThinking *bool — provider-agnostic
  opt-in; thinking tokens count toward MaxTokens, documented.
- anthropic + vertexai_anthropic: emit {thinking: {type: "adaptive"}}
  gated per model (Claude 4.6 generation and newer, clear build-time
  error otherwise), mutually exclusive with ThinkingBudget, and
  temperature omitted on the wire as the API requires.
- Opus 4.8 / Fable recognized as post-4.7 flagships (new ClaudeOpus48
  and ClaudeFable5 constants): manual thinking rejected with a pointer
  to AdaptiveThinking, effort gating extended so low..xhigh and max
  pass on them. Previously effort on claude-opus-4-8 was rejected
  outright because the allowlist stopped at 4.7.

Tests: wire-shape (adaptive with no budget_tokens), temperature strip,
MaxTokens untouched, explicit-false no-op, per-generation gating
matrices, mode-conflict error, 4.8/Fable manual rejection + effort
acceptance, in both providers. Full module suite green.

---
Companion change: sleepy will pin this commit and enable adaptive thinking for Claude mutation calls. Local pre-push hook flags pre-existing lint findings outside this diff (ext/codetool typecheck, core/bugfix_test.go unused field) — this branch's packages lint clean.