### PR TITLE
Fix agent history and codetool regressions

### DIFF
--- a/core/agent.go
+++ b/core/agent.go
@@ -988,18 +988,28 @@ func (a *Agent[T]) processResponse(
 				toolName:   tc.ToolName,
 				toolCallID: tc.ToolCallID,
 			}
+			// Answer the output tool call in both end strategies so its
+			// tool_use never dangles in history.
+			resultParts = append(resultParts, ToolReturnPart{
+				ToolName:   tc.ToolName,
+				Content:    "output accepted",
+				ToolCallID: tc.ToolCallID,
+				Timestamp:  time.Now(),
+			})
 			if a.endStrategy == EndStrategyEarly {
-				// Return tool result part and skip remaining.
-				resultParts = append(resultParts, ToolReturnPart{
-					ToolName:   tc.ToolName,
-					Content:    "output accepted",
-					ToolCallID: tc.ToolCallID,
-					Timestamp:  time.Now(),
-				})
 				// Skip remaining function calls in early mode.
 				return result, resultParts, nil, nil
 			}
+			continue
 		}
+		// A result was already accepted; answer the duplicate call so it
+		// isn't left dangling in history.
+		resultParts = append(resultParts, ToolReturnPart{
+			ToolName:   tc.ToolName,
+			Content:    "output already accepted; duplicate ignored",
+			ToolCallID: tc.ToolCallID,
+			Timestamp:  time.Now(),
+		})
 	}
 
 	// Execute function tool calls.

--- a/core/bugfix_test.go
+++ b/core/bugfix_test.go
@@ -1,0 +1,372 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"sync"
+	"testing"
+)
+
+// Regression tests for bugs found in the June 2026 audit.
+
+// collectToolCallPairing returns the set of tool call IDs issued in
+// responses and the set of tool call IDs answered by a ToolReturnPart or
+// RetryPromptPart in requests.
+func collectToolCallPairing(messages []ModelMessage) (called, answered map[string]bool) {
+	called = make(map[string]bool)
+	answered = make(map[string]bool)
+	for _, msg := range messages {
+		switch m := msg.(type) {
+		case ModelResponse:
+			for _, tc := range m.ToolCalls() {
+				called[tc.ToolCallID] = true
+			}
+		case ModelRequest:
+			for _, part := range m.Parts {
+				switch p := part.(type) {
+				case ToolReturnPart:
+					answered[p.ToolCallID] = true
+				case RetryPromptPart:
+					if p.ToolCallID != "" {
+						answered[p.ToolCallID] = true
+					}
+				}
+			}
+		}
+	}
+	return called, answered
+}
+
+func assertNoDanglingToolCalls(t *testing.T, messages []ModelMessage) {
+	t.Helper()
+	called, answered := collectToolCallPairing(messages)
+	for id := range called {
+		if !answered[id] {
+			t.Errorf("tool call %q has no tool result in history", id)
+		}
+	}
+}
+
+type bugfixAnswer struct {
+	Answer string `json:"answer"`
+}
+
+// Run must record a tool result for the final_result call so
+// RunResult.Messages round-trips through WithMessages without dangling
+// tool_use blocks.
+func TestRunFinalResultToolReturnRecorded(t *testing.T) {
+	for _, strategy := range []EndStrategy{EndStrategyEarly, EndStrategyExhaustive} {
+		t.Run(string(strategy), func(t *testing.T) {
+			model := NewTestModel(ToolCallResponse("final_result", `{"answer":"42"}`))
+			agent := NewAgent[bugfixAnswer](model, WithEndStrategy[bugfixAnswer](strategy))
+
+			result, err := agent.Run(context.Background(), "q")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			assertNoDanglingToolCalls(t, result.Messages)
+
+			last, ok := result.Messages[len(result.Messages)-1].(ModelRequest)
+			if !ok {
+				t.Fatalf("last message = %T, want ModelRequest with tool result", result.Messages[len(result.Messages)-1])
+			}
+			found := false
+			for _, part := range last.Parts {
+				if p, ok := part.(ToolReturnPart); ok && p.ToolName == "final_result" {
+					found = true
+				}
+			}
+			if !found {
+				t.Error("final_result tool call was not answered in history")
+			}
+		})
+	}
+}
+
+// RunStream must record the same final-turn tool results as Run.
+func TestRunStreamFinalResultToolReturnRecorded(t *testing.T) {
+	model := NewTestModel(ToolCallResponse("final_result", `{"answer":"42"}`))
+	agent := NewAgent[bugfixAnswer](model)
+
+	stream, err := agent.RunStream(context.Background(), "q")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer stream.Close()
+
+	result, err := stream.Result()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertNoDanglingToolCalls(t, result.Messages)
+}
+
+// In exhaustive mode, function tools executed in the final turn must have
+// their results recorded in history alongside the final_result answer.
+func TestRunExhaustiveFinalTurnToolResultsRecorded(t *testing.T) {
+	type addParams struct {
+		A int `json:"a"`
+		B int `json:"b"`
+	}
+	executed := false
+	addTool := FuncTool[addParams]("add", "Add numbers",
+		func(_ context.Context, p addParams) (string, error) {
+			executed = true
+			return "3", nil
+		},
+	)
+	model := NewTestModel(
+		MultiToolCallResponse(
+			ToolCallPart{ToolName: "add", ArgsJSON: `{"a":1,"b":2}`, ToolCallID: "call_add"},
+			ToolCallPart{ToolName: "final_result", ArgsJSON: `{"answer":"3"}`, ToolCallID: "call_final"},
+		),
+	)
+	agent := NewAgent[bugfixAnswer](model,
+		WithTools[bugfixAnswer](addTool),
+		WithEndStrategy[bugfixAnswer](EndStrategyExhaustive),
+	)
+
+	result, err := agent.Run(context.Background(), "add 1+2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !executed {
+		t.Fatal("add tool was not executed in exhaustive mode")
+	}
+	assertNoDanglingToolCalls(t, result.Messages)
+
+	_, answered := collectToolCallPairing(result.Messages)
+	if !answered["call_add"] {
+		t.Error("executed tool's result missing from history")
+	}
+	if !answered["call_final"] {
+		t.Error("final_result call missing its result in history")
+	}
+}
+
+// Run must not mutate the agent's stored ModelSettings when injecting the
+// agent-level tool choice, and concurrent runs must not race on it.
+func TestRunDoesNotMutateAgentModelSettings(t *testing.T) {
+	model := NewTestModel(TextResponse("done"))
+	agent := NewAgent[string](model,
+		WithModelSettings[string](ModelSettings{}),
+		WithToolChoice[string](ToolChoiceAuto()),
+	)
+
+	if _, err := agent.Run(context.Background(), "q"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if agent.modelSettings.ToolChoice != nil {
+		t.Error("Run leaked ToolChoice into the agent's shared ModelSettings")
+	}
+
+	// Concurrent runs against one agent must be race-free (run with -race).
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = agent.Run(context.Background(), "q")
+		}()
+	}
+	wg.Wait()
+	if agent.modelSettings.ToolChoice != nil {
+		t.Error("concurrent Run leaked ToolChoice into the agent's ModelSettings")
+	}
+}
+
+// ProviderMetadataPart must round-trip through message serialization.
+func TestProviderMetadataPartSerializeRoundTrip(t *testing.T) {
+	original := []ModelMessage{
+		ModelResponse{
+			Parts: []ModelResponsePart{
+				TextPart{Content: "hi"},
+				ProviderMetadataPart{
+					Provider: "anthropic",
+					Kind:     "server_tool_use",
+					Payload:  json.RawMessage(`{"id":"srvtoolu_1","name":"web_search"}`),
+				},
+				ProviderMetadataPart{Provider: "openai", Kind: "annotation"},
+			},
+		},
+	}
+
+	data, err := MarshalMessages(original)
+	if err != nil {
+		t.Fatalf("MarshalMessages: %v", err)
+	}
+	decoded, err := UnmarshalMessages(data)
+	if err != nil {
+		t.Fatalf("UnmarshalMessages: %v", err)
+	}
+	if len(decoded) != 1 {
+		t.Fatalf("decoded %d messages, want 1", len(decoded))
+	}
+	resp, ok := decoded[0].(ModelResponse)
+	if !ok {
+		t.Fatalf("decoded message = %T, want ModelResponse", decoded[0])
+	}
+	if len(resp.Parts) != 3 {
+		t.Fatalf("decoded %d parts, want 3", len(resp.Parts))
+	}
+	meta, ok := resp.Parts[1].(ProviderMetadataPart)
+	if !ok {
+		t.Fatalf("part 1 = %T, want ProviderMetadataPart", resp.Parts[1])
+	}
+	if meta.Provider != "anthropic" || meta.Kind != "server_tool_use" {
+		t.Errorf("provider/kind = %q/%q, want anthropic/server_tool_use", meta.Provider, meta.Kind)
+	}
+	if string(meta.Payload) != `{"id":"srvtoolu_1","name":"web_search"}` {
+		t.Errorf("payload = %s", meta.Payload)
+	}
+	empty, ok := resp.Parts[2].(ProviderMetadataPart)
+	if !ok || empty.Provider != "openai" {
+		t.Errorf("empty-payload part did not round-trip: %#v", resp.Parts[2])
+	}
+}
+
+// Clone must preserve the tool output truncation config.
+func TestCloneCopiesTruncationConfig(t *testing.T) {
+	model := NewTestModel(TextResponse("done"))
+	agent := NewAgent[string](model,
+		WithToolOutputTruncation[string](DefaultTruncationConfig()),
+	)
+	clone := agent.Clone()
+	if clone.truncationConfig == nil {
+		t.Fatal("Clone dropped truncationConfig")
+	}
+	if *clone.truncationConfig != *agent.truncationConfig {
+		t.Errorf("clone truncationConfig = %+v, want %+v", *clone.truncationConfig, *agent.truncationConfig)
+	}
+}
+
+type selfEmbed struct {
+	*selfEmbed
+	Name string `json:"name"`
+}
+
+type mutualA struct {
+	*mutualB
+	A string `json:"a"`
+}
+
+type mutualB struct {
+	*mutualA
+	B string `json:"b"`
+}
+
+// SchemaFor must not overflow the stack on self- or mutually-embedded types.
+func TestSchemaSelfEmbeddedNoOverflow(t *testing.T) {
+	var se selfEmbed
+	se.selfEmbed = &selfEmbed{Name: "parent"}
+	if se.selfEmbed == nil {
+		t.Fatal("self-embedded field should be addressable")
+	}
+
+	schema := SchemaFor[selfEmbed]()
+	props, _ := schema["properties"].(map[string]any)
+	if _, ok := props["name"]; !ok {
+		t.Errorf("schema missing 'name' property: %v", schema)
+	}
+
+	schema = SchemaFor[mutualA]()
+	props, _ = schema["properties"].(map[string]any)
+	if _, ok := props["a"]; !ok {
+		t.Errorf("schema missing 'a' property: %v", schema)
+	}
+	if _, ok := props["b"]; !ok {
+		t.Errorf("schema missing promoted 'b' property: %v", schema)
+	}
+}
+
+type embedInner struct {
+	Val string `json:"val"`
+}
+
+type embedTagged struct {
+	embedInner `json:"inner"`
+}
+
+type embedFlat struct {
+	embedInner
+	Extra string `json:"extra"`
+}
+
+type embedUnexported struct {
+	hiddenInner
+}
+
+type hiddenInner struct {
+	Shown string `json:"shown"`
+}
+
+// Schema generation must match encoding/json embedding semantics: a name
+// tag nests the embedded struct, no tag flattens it, and exported fields
+// of unexported embedded struct types are promoted.
+func TestSchemaEmbeddedMatchesEncodingJSON(t *testing.T) {
+	schema := SchemaFor[embedTagged]()
+	props, _ := schema["properties"].(map[string]any)
+	inner, ok := props["inner"].(Schema)
+	if !ok {
+		t.Fatalf("tagged embedded struct not nested under 'inner': %v", schema)
+	}
+	innerProps, _ := inner["properties"].(map[string]any)
+	if _, ok := innerProps["val"]; !ok {
+		t.Errorf("nested schema missing 'val': %v", inner)
+	}
+	if _, leaked := props["val"]; leaked {
+		t.Errorf("tagged embedded struct was flattened: %v", schema)
+	}
+	// Sanity-check against encoding/json behavior.
+	encoded, _ := json.Marshal(embedTagged{embedInner{Val: "x"}})
+	var asMap map[string]any
+	_ = json.Unmarshal(encoded, &asMap)
+	if _, ok := asMap["inner"]; !ok {
+		t.Fatalf("encoding/json baseline changed: %s", encoded)
+	}
+
+	schema = SchemaFor[embedFlat]()
+	props, _ = schema["properties"].(map[string]any)
+	if _, ok := props["val"]; !ok {
+		t.Errorf("untagged embedded struct not flattened: %v", schema)
+	}
+
+	schema = SchemaFor[embedUnexported]()
+	props, _ = schema["properties"].(map[string]any)
+	if _, ok := props["shown"]; !ok {
+		t.Errorf("exported field of unexported embedded struct not promoted: %v", schema)
+	}
+}
+
+// Variables must see fields in trim-marker actions, control flow, and
+// pipelines, as its contract promises.
+func TestTemplateVariablesTreeWalk(t *testing.T) {
+	cases := []struct {
+		tmpl string
+		want []string
+	}{
+		{"Hello {{.Name}}!", []string{"Name"}},
+		{"Hello {{- .Name -}} !", []string{"Name"}},
+		{"{{if .Flag}}yes{{else}}{{.Alt}}{{end}}", []string{"Alt", "Flag"}},
+		{"{{range .Items}}{{.}}{{end}}", []string{"Items"}},
+		{"{{with .X}}{{.}}{{end}}", []string{"X"}},
+		{`{{.X | printf "%s"}}`, []string{"X"}},
+		{`{{printf "%s %s" .A .B}}`, []string{"A", "B"}},
+		{"{{.Outer.Inner}}", []string{"Outer"}},
+		{"no vars", nil},
+	}
+	for _, tc := range cases {
+		pt, err := NewPromptTemplate("t", tc.tmpl)
+		if err != nil {
+			t.Fatalf("parse %q: %v", tc.tmpl, err)
+		}
+		got := pt.Variables()
+		if len(got) == 0 && len(tc.want) == 0 {
+			continue
+		}
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("Variables(%q) = %v, want %v", tc.tmpl, got, tc.want)
+		}
+	}
+}

--- a/core/compose.go
+++ b/core/compose.go
@@ -57,6 +57,10 @@ func (a *Agent[T]) Clone(opts ...AgentOption[T]) *Agent[T] {
 		s := *a.modelSettings
 		clone.modelSettings = &s
 	}
+	if a.truncationConfig != nil {
+		tc := *a.truncationConfig
+		clone.truncationConfig = &tc
+	}
 	clone.outputSchema = a.outputSchema
 	clone.toolApprovalFunc = a.toolApprovalFunc
 	clone.maxConcurrency = a.maxConcurrency

--- a/core/run_engine.go
+++ b/core/run_engine.go
@@ -43,9 +43,16 @@ func (a *Agent[T]) initializeRunExecution(ctx context.Context, cfg *runConfig) *
 		a.restoreToolState(restoreToolState)
 	}
 
-	settings := a.modelSettings
+	// Copy settings so per-run mutations (e.g. tool-choice injection in Step
+	// and startTurn) never write through to the agent's or the caller's
+	// ModelSettings — runs may execute concurrently against one agent.
+	var settings *ModelSettings
 	if cfg.modelSettings != nil {
-		settings = cfg.modelSettings
+		s := *cfg.modelSettings
+		settings = &s
+	} else if a.modelSettings != nil {
+		s := *a.modelSettings
+		settings = &s
 	}
 
 	deps := a.deps
@@ -501,13 +508,16 @@ func (e *turnEngine[T]) Step() (*ModelResponse, *RunResult[T], error) {
 			e.emitTurnCompleted(resp, err)
 			return resp, nil, err
 		}
+		// Record tool results in history for every outcome (deferred, final
+		// result, or continue) so no tool_use is left without a paired
+		// tool_result when Messages round-trips through WithMessages.
+		if len(nextParts) > 0 {
+			e.state.messages = append(e.state.messages, ModelRequest{
+				Parts:     nextParts,
+				Timestamp: time.Now(),
+			})
+		}
 		if len(deferredReqs) > 0 {
-			if len(nextParts) > 0 {
-				e.state.messages = append(e.state.messages, ModelRequest{
-					Parts:     nextParts,
-					Timestamp: time.Now(),
-				})
-			}
 			fireTurnEnd()
 			e.emitTurnCompleted(resp, nil)
 			if e.agent.eventBus != nil {
@@ -552,12 +562,6 @@ func (e *turnEngine[T]) Step() (*ModelResponse, *RunResult[T], error) {
 			return resp, e.agent.buildRunResult(e.state, result.output), nil
 		}
 		// No result — tool calls processed, continue to next turn.
-		if len(nextParts) > 0 {
-			e.state.messages = append(e.state.messages, ModelRequest{
-				Parts:     nextParts,
-				Timestamp: time.Now(),
-			})
-		}
 		fireTurnEnd()
 		e.emitTurnCompleted(resp, nil)
 		return resp, nil, nil

--- a/core/schema.go
+++ b/core/schema.go
@@ -130,21 +130,38 @@ func collectFields(t reflect.Type, properties map[string]any, required *[]string
 	for i := range t.NumField() {
 		field := t.Field(i)
 
-		// Skip unexported fields.
-		if !field.IsExported() {
-			continue
-		}
-
-		// Handle embedded structs by flattening.
+		// Handle embedded structs by flattening, matching encoding/json
+		// semantics: an embedded struct without a json name tag is
+		// flattened (its exported fields promoted, even when the embedded
+		// type itself is unexported), while a name tag turns it into a
+		// regular nested property.
+		embeddedStruct := false
 		if field.Anonymous {
 			ft := field.Type
 			for ft.Kind() == reflect.Ptr {
 				ft = ft.Elem()
 			}
 			if ft.Kind() == reflect.Struct && ft != timeType {
-				collectFields(ft, properties, required, visited)
-				continue
+				embeddedStruct = true
+				tagName, _, _ := strings.Cut(field.Tag.Get("json"), ",")
+				if tagName == "" {
+					// Consult the visited guard so self- or mutually-embedded
+					// types don't recurse forever (schemaForStruct only
+					// guards its own entry point).
+					if !visited[ft] {
+						visited[ft] = true
+						collectFields(ft, properties, required, visited)
+						delete(visited, ft)
+					}
+					continue
+				}
 			}
+		}
+
+		// Skip unexported fields. An embedded struct of unexported type is
+		// exempt: encoding/json still nests it under its json name tag.
+		if !field.IsExported() && !embeddedStruct {
+			continue
 		}
 
 		name, fieldSchema, isRequired := schemaForField(field, visited)

--- a/core/serialize.go
+++ b/core/serialize.go
@@ -107,6 +107,12 @@ type thinkingPartJSON struct {
 	Signature string `json:"signature,omitempty"`
 }
 
+type providerMetadataPartJSON struct {
+	Provider string          `json:"provider"`
+	Kind     string          `json:"kind"`
+	Payload  json.RawMessage `json:"payload,omitempty"`
+}
+
 // MarshalMessages serializes a conversation ([]ModelMessage) to JSON.
 func MarshalMessages(messages []ModelMessage) ([]byte, error) {
 	envelopes, err := EncodeMessages(messages)
@@ -383,6 +389,13 @@ func encodeResponsePart(part ModelResponsePart) (partEnvelope, error) {
 		}
 		return partEnvelope{Type: "thinking", Data: data}, nil
 
+	case ProviderMetadataPart:
+		data, err := json.Marshal(providerMetadataPartJSON(p))
+		if err != nil {
+			return partEnvelope{}, err
+		}
+		return partEnvelope{Type: "provider-metadata", Data: data}, nil
+
 	default:
 		return partEnvelope{}, fmt.Errorf("unknown response part type: %T", part)
 	}
@@ -503,6 +516,13 @@ func decodeResponsePart(env partEnvelope) (ModelResponsePart, error) {
 			return nil, fmt.Errorf("unmarshaling thinking: %w", err)
 		}
 		return ThinkingPart(p), nil
+
+	case "provider-metadata":
+		var p providerMetadataPartJSON
+		if err := json.Unmarshal(env.Data, &p); err != nil {
+			return nil, fmt.Errorf("unmarshaling provider-metadata: %w", err)
+		}
+		return ProviderMetadataPart(p), nil
 
 	default:
 		return nil, fmt.Errorf("unknown response part type: %q", env.Type)

--- a/core/stream.go
+++ b/core/stream.go
@@ -705,13 +705,16 @@ func (s *agentStream[T]) completeTurn() error {
 		s.completeActiveTurn(resp, err)
 		return err
 	}
+	// Record tool results in history for every outcome (deferred, final
+	// result, or continue) so no tool_use is left without a paired
+	// tool_result when Messages round-trips through WithMessages.
+	if len(nextParts) > 0 {
+		s.state.messages = append(s.state.messages, ModelRequest{
+			Parts:     nextParts,
+			Timestamp: time.Now(),
+		})
+	}
 	if len(deferredReqs) > 0 {
-		if len(nextParts) > 0 {
-			s.state.messages = append(s.state.messages, ModelRequest{
-				Parts:     nextParts,
-				Timestamp: time.Now(),
-			})
-		}
 		fireTurnEnd()
 		s.completeActiveTurn(resp, nil)
 		if s.agent.eventBus != nil {
@@ -764,12 +767,6 @@ func (s *agentStream[T]) completeTurn() error {
 	}
 
 	// No result — tool calls processed, continue to next turn.
-	if len(nextParts) > 0 {
-		s.state.messages = append(s.state.messages, ModelRequest{
-			Parts:     nextParts,
-			Timestamp: time.Now(),
-		})
-	}
 	fireTurnEnd()
 	s.completeActiveTurn(resp, nil)
 

--- a/core/template.go
+++ b/core/template.go
@@ -5,8 +5,8 @@ import (
 	"context"
 	"fmt"
 	"sort"
-	"strings"
 	"text/template"
+	"text/template/parse"
 )
 
 // PromptTemplate is a prompt with named variable placeholders using {{.VarName}} syntax.
@@ -78,29 +78,15 @@ func (t *PromptTemplate) Partial(vars map[string]string) *PromptTemplate {
 }
 
 // Variables returns the set of variable names used in the template.
-// It parses the template tree to extract field names from actions.
+// It parses the template tree to extract field names from actions,
+// including those inside trim-marker actions ({{- .X -}}), pipelines,
+// and if/range/with control flow.
 func (t *PromptTemplate) Variables() []string {
-	// Simple extraction: find all {{.VarName}} patterns in the raw template.
 	varSet := make(map[string]bool)
-	raw := t.raw
-	for {
-		idx := strings.Index(raw, "{{")
-		if idx < 0 {
-			break
+	for _, tmpl := range t.tmpl.Templates() {
+		if tree := tmpl.Tree; tree != nil && tree.Root != nil {
+			collectTemplateVars(tree.Root, varSet)
 		}
-		end := strings.Index(raw[idx:], "}}")
-		if end < 0 {
-			break
-		}
-		action := strings.TrimSpace(raw[idx+2 : idx+end])
-		if strings.HasPrefix(action, ".") {
-			varName := strings.TrimPrefix(action, ".")
-			// Handle cases like {{.Foo}} and ignore pipeline actions.
-			if varName != "" && !strings.ContainsAny(varName, " |()") {
-				varSet[varName] = true
-			}
-		}
-		raw = raw[idx+end+2:]
 	}
 
 	vars := make([]string, 0, len(varSet))
@@ -109,6 +95,51 @@ func (t *PromptTemplate) Variables() []string {
 	}
 	sort.Strings(vars)
 	return vars
+}
+
+// collectTemplateVars walks a template parse tree and records the top-level
+// identifier of every field reference ({{.Name}}, {{.Name.Sub}}, ...).
+func collectTemplateVars(node parse.Node, varSet map[string]bool) {
+	switch n := node.(type) {
+	case *parse.ListNode:
+		if n == nil {
+			return
+		}
+		for _, item := range n.Nodes {
+			collectTemplateVars(item, varSet)
+		}
+	case *parse.ActionNode:
+		collectTemplateVars(n.Pipe, varSet)
+	case *parse.PipeNode:
+		if n == nil {
+			return
+		}
+		for _, cmd := range n.Cmds {
+			for _, arg := range cmd.Args {
+				collectTemplateVars(arg, varSet)
+			}
+		}
+	case *parse.FieldNode:
+		if len(n.Ident) > 0 {
+			varSet[n.Ident[0]] = true
+		}
+	case *parse.ChainNode:
+		collectTemplateVars(n.Node, varSet)
+	case *parse.IfNode:
+		collectTemplateVars(n.Pipe, varSet)
+		collectTemplateVars(n.List, varSet)
+		collectTemplateVars(n.ElseList, varSet)
+	case *parse.RangeNode:
+		collectTemplateVars(n.Pipe, varSet)
+		collectTemplateVars(n.List, varSet)
+		collectTemplateVars(n.ElseList, varSet)
+	case *parse.WithNode:
+		collectTemplateVars(n.Pipe, varSet)
+		collectTemplateVars(n.List, varSet)
+		collectTemplateVars(n.ElseList, varSet)
+	case *parse.TemplateNode:
+		collectTemplateVars(n.Pipe, varSet)
+	}
 }
 
 // TemplateVars provides template variable values. Implement on your deps type.

--- a/ext/codetool/edit.go
+++ b/ext/codetool/edit.go
@@ -100,8 +100,11 @@ func Edit(opts ...Option) core.Tool {
 			// Normalize CRLF → LF for matching. Models generate LF-only
 			// strings; Windows-style files with \r\n cause silent match
 			// failures without this. The original line endings are restored
-			// when writing back.
-			hasCRLF := strings.Contains(content, "\r\n")
+			// when writing back. Only uniformly-CRLF files are normalized:
+			// for mixed-ending files the whole-file LF→CRLF restore would
+			// silently rewrite the endings of untouched lines, so they are
+			// matched as-is.
+			hasCRLF := isUniformCRLF(content)
 			if hasCRLF {
 				content = strings.ReplaceAll(content, "\r\n", "\n")
 			}
@@ -120,6 +123,7 @@ func Edit(opts ...Option) core.Tool {
 				// adjust indentation and apply the edit. This saves a full
 				// round-trip — whitespace mismatches are the #1 edit failure.
 				if actualOld, adjustedNew, ok := autoCorrectWhitespace(content, oldStr, newStr); ok {
+					editIdx := strings.Index(content, actualOld)
 					newContent := strings.Replace(content, actualOld, adjustedNew, 1)
 					writeContent := newContent
 					if hasCRLF {
@@ -128,7 +132,7 @@ func Edit(opts ...Option) core.Tool {
 					if err := writeFileAndTrace(ctx, rc, cfg, path, []byte(writeContent), filePerm, "edit", "edit"); err != nil {
 						return "", fmt.Errorf("write file: %w", err)
 					}
-					result := editResultWithContext(newContent, adjustedNew, 1, params.Path)
+					result := editResultWithContext(newContent, adjustedNew, editIdx, 1, params.Path)
 					result += "\n[auto-corrected whitespace mismatch]"
 					return result, nil
 				}
@@ -140,6 +144,7 @@ func Edit(opts ...Option) core.Tool {
 				if trimmedOld, trimmedNew, ok := autoCorrectBlankLines(content, oldStr, newStr); ok {
 					// Try exact match with stripped version first.
 					if strings.Count(content, trimmedOld) == 1 {
+						editIdx := strings.Index(content, trimmedOld)
 						newContent := strings.Replace(content, trimmedOld, trimmedNew, 1)
 						writeContent := newContent
 						if hasCRLF {
@@ -148,12 +153,13 @@ func Edit(opts ...Option) core.Tool {
 						if err := writeFileAndTrace(ctx, rc, cfg, path, []byte(writeContent), filePerm, "edit", "edit"); err != nil {
 							return "", fmt.Errorf("write file: %w", err)
 						}
-						result := editResultWithContext(newContent, trimmedNew, 1, params.Path)
+						result := editResultWithContext(newContent, trimmedNew, editIdx, 1, params.Path)
 						result += "\n[auto-corrected extra blank lines in old_string]"
 						return result, nil
 					}
 					// Also try whitespace auto-correct on the stripped version.
 					if actualOld, adjustedNew, ok := autoCorrectWhitespace(content, trimmedOld, trimmedNew); ok {
+						editIdx := strings.Index(content, actualOld)
 						newContent := strings.Replace(content, actualOld, adjustedNew, 1)
 						writeContent := newContent
 						if hasCRLF {
@@ -162,7 +168,7 @@ func Edit(opts ...Option) core.Tool {
 						if err := writeFileAndTrace(ctx, rc, cfg, path, []byte(writeContent), filePerm, "edit", "edit"); err != nil {
 							return "", fmt.Errorf("write file: %w", err)
 						}
-						result := editResultWithContext(newContent, adjustedNew, 1, params.Path)
+						result := editResultWithContext(newContent, adjustedNew, editIdx, 1, params.Path)
 						result += "\n[auto-corrected blank lines and whitespace]"
 						return result, nil
 					}
@@ -174,6 +180,7 @@ func Edit(opts ...Option) core.Tool {
 				// and retry — this is the #3 edit failure.
 				if normalizedOld, normalizedNew, ok := autoCorrectInternalBlankLines(content, oldStr, newStr); ok {
 					if strings.Count(content, normalizedOld) == 1 {
+						editIdx := strings.Index(content, normalizedOld)
 						newContent := strings.Replace(content, normalizedOld, normalizedNew, 1)
 						writeContent := newContent
 						if hasCRLF {
@@ -182,7 +189,7 @@ func Edit(opts ...Option) core.Tool {
 						if err := writeFileAndTrace(ctx, rc, cfg, path, []byte(writeContent), filePerm, "edit", "edit"); err != nil {
 							return "", fmt.Errorf("write file: %w", err)
 						}
-						result := editResultWithContext(newContent, normalizedNew, 1, params.Path)
+						result := editResultWithContext(newContent, normalizedNew, editIdx, 1, params.Path)
 						result += "\n[auto-corrected internal blank line count]"
 						return result, nil
 					}
@@ -198,6 +205,7 @@ func Edit(opts ...Option) core.Tool {
 					blankNormNew := normalizeBlankRuns(newStr)
 					if blankNormOld != oldStr { // blank line normalization changed something
 						if actualOld, adjustedNew, ok := autoCorrectWhitespace(content, blankNormOld, blankNormNew); ok {
+							editIdx := strings.Index(content, actualOld)
 							newContent := strings.Replace(content, actualOld, adjustedNew, 1)
 							writeContent := newContent
 							if hasCRLF {
@@ -206,7 +214,7 @@ func Edit(opts ...Option) core.Tool {
 							if err := writeFileAndTrace(ctx, rc, cfg, path, []byte(writeContent), filePerm, "edit", "edit"); err != nil {
 								return "", fmt.Errorf("write file: %w", err)
 							}
-							result := editResultWithContext(newContent, adjustedNew, 1, params.Path)
+							result := editResultWithContext(newContent, adjustedNew, editIdx, 1, params.Path)
 							result += "\n[auto-corrected internal blank lines and whitespace]"
 							return result, nil
 						}
@@ -218,6 +226,7 @@ func Edit(opts ...Option) core.Tool {
 				// doesn't exist in the file or has slightly different content.
 				// Only trims lines that are identical in old and new (pure context).
 				if actualOld, adjustedNew, ok := autoCorrectLineTrim(content, oldStr, newStr); ok {
+					editIdx := strings.Index(content, actualOld)
 					newContent := strings.Replace(content, actualOld, adjustedNew, 1)
 					writeContent := newContent
 					if hasCRLF {
@@ -226,7 +235,7 @@ func Edit(opts ...Option) core.Tool {
 					if err := writeFileAndTrace(ctx, rc, cfg, path, []byte(writeContent), filePerm, "edit", "edit"); err != nil {
 						return "", fmt.Errorf("write file: %w", err)
 					}
-					result := editResultWithContext(newContent, adjustedNew, 1, params.Path)
+					result := editResultWithContext(newContent, adjustedNew, editIdx, 1, params.Path)
 					result += "\n[auto-corrected by trimming extra context line]"
 					return result, nil
 				}
@@ -265,6 +274,9 @@ func Edit(opts ...Option) core.Tool {
 				return "", &core.ModelRetryError{Message: msg}
 			}
 
+			// The first occurrence of oldStr is always a genuine edit site,
+			// and the bytes before it are unchanged by the replacement.
+			editIdx := strings.Index(content, oldStr)
 			var newContent string
 			if params.ReplaceAll {
 				newContent = strings.ReplaceAll(content, oldStr, newStr)
@@ -284,15 +296,29 @@ func Edit(opts ...Option) core.Tool {
 			if params.ReplaceAll {
 				replacements = count
 			}
-			return editResultWithContext(newContent, newStr, replacements, params.Path), nil
+			return editResultWithContext(newContent, newStr, editIdx, replacements, params.Path), nil
 		},
 	)
 }
 
+// isUniformCRLF reports whether content uses CRLF line endings exclusively
+// (at least one CRLF and no bare LF). Mixed-ending files must not be
+// CRLF-normalized: restoring with a whole-file LF→CRLF replacement would
+// silently rewrite the endings of lines the edit never touched.
+func isUniformCRLF(content string) bool {
+	if !strings.Contains(content, "\r\n") {
+		return false
+	}
+	return !strings.Contains(strings.ReplaceAll(content, "\r\n", ""), "\n")
+}
+
 // editResultWithContext returns a success message with surrounding file context
 // so the model can verify the edit without a separate view call. This saves
-// one turn per edit — a significant efficiency gain.
-func editResultWithContext(content, newString string, replacements int, path string) string {
+// one turn per edit — a significant efficiency gain. editIdx is the byte
+// offset of the replacement within content; it anchors the context to the
+// actual edit site rather than an identical earlier occurrence of newString.
+// Pass -1 to fall back to searching for newString.
+func editResultWithContext(content, newString string, editIdx, replacements int, path string) string {
 	header := fmt.Sprintf("Replaced %d occurrence(s) in %s", replacements, path)
 
 	// For replace_all with many replacements, skip context — too many locations.
@@ -300,8 +326,11 @@ func editResultWithContext(content, newString string, replacements int, path str
 		return header
 	}
 
-	// Find the location of the new string in the content.
-	idx := strings.Index(content, newString)
+	// Locate the edit in the content.
+	idx := editIdx
+	if idx < 0 {
+		idx = strings.Index(content, newString)
+	}
 	if idx < 0 || newString == "" {
 		return header
 	}
@@ -535,6 +564,7 @@ func MultiEdit(opts ...Option) core.Tool {
 				relPath    string
 				newContent string
 				newString  string
+				editIdx    int
 				message    string
 			}
 			var pending []pendingWrite
@@ -584,8 +614,9 @@ func MultiEdit(opts ...Option) core.Tool {
 						return "", &core.ModelRetryError{Message: fmt.Sprintf("edit[%d]: %v", i, err)}
 					}
 					content = string(data)
-					// Normalize CRLF → LF for matching (same as single edit).
-					if strings.Contains(content, "\r\n") {
+					// Normalize CRLF → LF for matching (same as single edit;
+					// mixed-ending files are matched as-is).
+					if isUniformCRLF(content) {
 						fileCRLF[path] = true
 						content = strings.ReplaceAll(content, "\r\n", "\n")
 					}
@@ -593,32 +624,47 @@ func MultiEdit(opts ...Option) core.Tool {
 
 				var newContent string
 				var msg string
+				editIdx := -1
+				// corrected tracks whether an auto-correction succeeded. An
+				// explicit flag rather than newContent == "" — a successful
+				// correction can legitimately produce empty content (e.g.
+				// deleting the entire file content).
+				corrected := false
 				if !strings.Contains(content, oldStr) {
 					// Try auto-correcting whitespace mismatch.
 					if actualOld, adjustedNew, okWs := autoCorrectWhitespace(content, oldStr, newStr); okWs {
+						editIdx = strings.Index(content, actualOld)
 						newContent = strings.Replace(content, actualOld, adjustedNew, 1)
 						msg = fmt.Sprintf("edit[%d]: auto-corrected whitespace mismatch", i)
+						corrected = true
 					} else if trimmedOld, trimmedNew, okBl := autoCorrectBlankLines(content, oldStr, newStr); okBl && strings.Count(content, trimmedOld) == 1 {
+						editIdx = strings.Index(content, trimmedOld)
 						newContent = strings.Replace(content, trimmedOld, trimmedNew, 1)
 						msg = fmt.Sprintf("edit[%d]: auto-corrected extra blank lines", i)
+						corrected = true
 					} else if normalizedOld, normalizedNew, okIbl := autoCorrectInternalBlankLines(content, oldStr, newStr); okIbl && strings.Count(content, normalizedOld) == 1 {
+						editIdx = strings.Index(content, normalizedOld)
 						newContent = strings.Replace(content, normalizedOld, normalizedNew, 1)
 						msg = fmt.Sprintf("edit[%d]: auto-corrected internal blank line count", i)
+						corrected = true
 					}
 					// Combined internal blank line + whitespace correction.
-					if newContent == "" {
+					if !corrected {
 						blankNormOld := normalizeBlankRuns(oldStr)
 						blankNormNew := normalizeBlankRuns(newStr)
 						if blankNormOld != oldStr {
 							if actualOld2, adjustedNew2, okWs2 := autoCorrectWhitespace(content, blankNormOld, blankNormNew); okWs2 {
+								editIdx = strings.Index(content, actualOld2)
 								newContent = strings.Replace(content, actualOld2, adjustedNew2, 1)
 								msg = fmt.Sprintf("edit[%d]: auto-corrected internal blank lines and whitespace", i)
+								corrected = true
 							}
 						}
 					}
-					// If we still don't have a newContent, try line trim.
-					if newContent == "" {
+					// If we still don't have a correction, try line trim.
+					if !corrected {
 						if actualOld, adjustedNew, okLt := autoCorrectLineTrim(content, oldStr, newStr); okLt {
+							editIdx = strings.Index(content, actualOld)
 							newContent = strings.Replace(content, actualOld, adjustedNew, 1)
 							msg = fmt.Sprintf("edit[%d]: auto-corrected by trimming extra context line", i)
 						} else {
@@ -648,6 +694,7 @@ func MultiEdit(opts ...Option) core.Tool {
 							i, count, edit.Path, locations)
 						return "", &core.ModelRetryError{Message: errMsg}
 					}
+					editIdx = strings.Index(content, oldStr)
 					newContent = strings.Replace(content, oldStr, newStr, 1)
 				}
 				fileContents[path] = newContent
@@ -656,6 +703,7 @@ func MultiEdit(opts ...Option) core.Tool {
 					relPath:    edit.Path,
 					newContent: newContent,
 					newString:  newStr,
+					editIdx:    editIdx,
 					message:    msg,
 				})
 			}
@@ -677,7 +725,7 @@ func MultiEdit(opts ...Option) core.Tool {
 				if pw.message != "" {
 					results = append(results, pw.message)
 				}
-				results = append(results, editResultWithContext(pw.newContent, pw.newString, 1, pw.relPath))
+				results = append(results, editResultWithContext(pw.newContent, pw.newString, pw.editIdx, 1, pw.relPath))
 			}
 
 			return strings.Join(results, "\n\n"), nil
@@ -709,6 +757,12 @@ func autoCorrectWhitespace(content, oldStr, newStr string) (actualOld, adjustedN
 	}
 
 	normalizedOld := normalizeBlock(oldStr)
+	// A whitespace-only old_string normalizes to "" — nothing to anchor a
+	// match on, and strings.Index(s, "") returning 0 would make the
+	// uniqueness slice below go out of range on empty content.
+	if normalizedOld == "" {
+		return "", "", false
+	}
 	normalizedContent := normalizeBlock(content)
 
 	// Must match exactly once (unique).
@@ -1005,6 +1059,12 @@ func normalizeBlankRuns(s string) string {
 
 func autoCorrectInternalBlankLines(content, oldStr, newStr string) (actualOld, adjustedNew string, ok bool) {
 	normalizedOld := normalizeBlankRuns(oldStr)
+	// An all-blank old_string normalizes to "" — nothing meaningful to
+	// locate, and strings.Index(s, "") returning 0 would make the
+	// uniqueness slice below go out of range on empty content.
+	if normalizedOld == "" {
+		return "", "", false
+	}
 	normalizedContent := normalizeBlankRuns(content)
 
 	// Only proceed if normalization actually changed something.

--- a/ext/codetool/edit_bugfix_test.go
+++ b/ext/codetool/edit_bugfix_test.go
@@ -1,0 +1,256 @@
+package codetool
+
+// Regression tests for edit/multi_edit/write bug fixes:
+//   - panic guards for whitespace-only / all-blank old_string on empty files
+//   - mixed line-ending preservation
+//   - multi_edit empty-string sentinel discarding valid auto-corrections
+//   - chmod auto-upgrade when overwriting an existing script
+//   - edit success context anchoring to the actual edit site
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/fugue-labs/gollem/core"
+)
+
+// TestEdit_BlankOldStringNoPanic covers the autoCorrectWhitespace and
+// autoCorrectInternalBlankLines panics: editing an empty or whitespace-only
+// file with an old_string that normalizes to "" used to hit
+// strings.Index(s, "") == 0 followed by an out-of-range [idx+1:] slice.
+// Both edit and multi_edit must return a retry error instead of panicking.
+func TestEdit_BlankOldStringNoPanic(t *testing.T) {
+	tests := []struct {
+		name      string
+		content   string
+		oldString string
+	}{
+		{"empty file, space old_string", "", " "},
+		{"empty file, tab old_string", "", "\t"},
+		{"whitespace-only file, tab old_string", "   ", "\t"},
+		{"empty file, blank line old_string", "", "\n"},
+		{"empty file, two blank lines old_string", "", "\n\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "f.txt")
+			if err := os.WriteFile(path, []byte(tt.content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			editTool := Edit(WithWorkDir(dir))
+			args := fmt.Sprintf(`{"path": "f.txt", "old_string": %q, "new_string": "x"}`, tt.oldString)
+			err := callErr(t, editTool, args)
+			if err == nil {
+				t.Fatal("edit: expected error, got success")
+			}
+			var retry *core.ModelRetryError
+			if !errors.As(err, &retry) {
+				t.Errorf("edit: expected ModelRetryError, got %T: %v", err, err)
+			}
+
+			multiTool := MultiEdit(WithWorkDir(dir))
+			margs := fmt.Sprintf(`{"edits": [{"path": "f.txt", "old_string": %q, "new_string": "x"}]}`, tt.oldString)
+			err = callErr(t, multiTool, margs)
+			if err == nil {
+				t.Fatal("multi_edit: expected error, got success")
+			}
+			retry = nil
+			if !errors.As(err, &retry) {
+				t.Errorf("multi_edit: expected ModelRetryError, got %T: %v", err, err)
+			}
+
+			// The file must be left unmodified.
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(data) != tt.content {
+				t.Errorf("file modified: got %q, want %q", data, tt.content)
+			}
+		})
+	}
+}
+
+// TestAutoCorrectHelpers_EmptyNormalizedOldString exercises the exact panic
+// paths at the helper level: a needle that normalizes to "" against content
+// that normalizes to "" used to panic with slice bounds out of range [1:0].
+func TestAutoCorrectHelpers_EmptyNormalizedOldString(t *testing.T) {
+	if _, _, ok := autoCorrectWhitespace("", " ", "x"); ok {
+		t.Error("autoCorrectWhitespace: whitespace-only old_string on empty content must not match")
+	}
+	if _, _, ok := autoCorrectWhitespace("   ", "\t", "x"); ok {
+		t.Error("autoCorrectWhitespace: whitespace-only old_string on whitespace-only content must not match")
+	}
+	if _, _, ok := autoCorrectInternalBlankLines("", "\n", "x"); ok {
+		t.Error("autoCorrectInternalBlankLines: blank old_string on empty content must not match")
+	}
+	if _, _, ok := autoCorrectInternalBlankLines("", "\n\n", "x"); ok {
+		t.Error("autoCorrectInternalBlankLines: all-blank old_string on empty content must not match")
+	}
+}
+
+// TestEdit_MixedLineEndingsPreserved verifies that editing one line of a
+// mixed-ending file leaves the line endings of untouched lines byte-for-byte
+// intact. Previously a single CRLF anywhere caused EVERY LF to be rewritten
+// to CRLF on write-back.
+func TestEdit_MixedLineEndingsPreserved(t *testing.T) {
+	dir := t.TempDir()
+	mixed := "lineA\nlineB\r\nlineC\n"
+	path := filepath.Join(dir, "mixed.txt")
+	if err := os.WriteFile(path, []byte(mixed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tool := Edit(WithWorkDir(dir))
+	result := call(t, tool, `{"path": "mixed.txt", "old_string": "lineC", "new_string": "lineC2"}`)
+	assertContains(t, result, "Replaced 1")
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "lineA\nlineB\r\nlineC2\n"
+	if string(data) != want {
+		t.Errorf("mixed-endings file corrupted: got %q, want %q", data, want)
+	}
+}
+
+// TestMultiEdit_MixedLineEndingsPreserved is the multi_edit variant of the
+// mixed line-ending regression.
+func TestMultiEdit_MixedLineEndingsPreserved(t *testing.T) {
+	dir := t.TempDir()
+	mixed := "lineA\nlineB\r\nlineC\n"
+	path := filepath.Join(dir, "mixed.txt")
+	if err := os.WriteFile(path, []byte(mixed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tool := MultiEdit(WithWorkDir(dir))
+	result := call(t, tool, `{"edits": [{"path": "mixed.txt", "old_string": "lineC", "new_string": "lineC2"}]}`)
+	assertContains(t, result, "Replaced 1")
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "lineA\nlineB\r\nlineC2\n"
+	if string(data) != want {
+		t.Errorf("mixed-endings file corrupted: got %q, want %q", data, want)
+	}
+}
+
+// TestMultiEdit_WhitespaceCorrectedDeletionOfEntireContent verifies that an
+// auto-correction whose result is empty content is honored. The old
+// newContent == "" sentinel discarded the successful whitespace correction
+// and reported "old_string not found", diverging from the single edit tool.
+func TestMultiEdit_WhitespaceCorrectedDeletionOfEntireContent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.txt")
+	// Double space in the file, single space in old_string — triggers the
+	// whitespace auto-correction; new_string "" deletes the whole content.
+	if err := os.WriteFile(path, []byte("hello  world"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tool := MultiEdit(WithWorkDir(dir))
+	result := call(t, tool, `{"edits": [{"path": "f.txt", "old_string": "hello world", "new_string": ""}]}`)
+	assertContains(t, result, "auto-corrected whitespace mismatch")
+	assertContains(t, result, "Replaced 1")
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(data) != 0 {
+		t.Errorf("expected file to be emptied, got %q", data)
+	}
+}
+
+// TestWrite_UpgradesExistingScriptToExecutable verifies the documented script
+// auto-upgrade actually lands for existing files. os.WriteFile only applies
+// perm on creation, so overwriting a 0644 script previously left it
+// non-executable despite the upgrade being computed.
+func TestWrite_UpgradesExistingScriptToExecutable(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "run.sh")
+	if err := os.WriteFile(path, []byte("echo old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tool := Write(WithWorkDir(dir))
+	call(t, tool, `{"path": "run.sh", "content": "#!/bin/sh\necho hi\n"}`)
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm&0o111 == 0 {
+		t.Errorf("expected existing script to be upgraded to executable, got %o", perm)
+	}
+
+	// A non-script overwrite must keep its existing permissions untouched.
+	dataPath := filepath.Join(dir, "data.txt")
+	if err := os.WriteFile(dataPath, []byte("old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	call(t, tool, `{"path": "data.txt", "content": "new"}`)
+	info, err = os.Stat(dataPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("expected non-script permissions preserved as 600, got %o", perm)
+	}
+}
+
+// dupLineContent has text at line 1 that is identical to the new_string used
+// to replace line 10 — the success context must anchor to line 10 (the edit
+// site), not the pre-existing occurrence at line 1.
+const dupLineContent = "x = compute()\n" +
+	"b := 2\n" +
+	"c := 3\n" +
+	"d := 4\n" +
+	"e := 5\n" +
+	"f := 6\n" +
+	"g := 7\n" +
+	"h := 8\n" +
+	"i := 9\n" +
+	"y = old()\n" +
+	"k := 11\n" +
+	"l := 12\n" +
+	"m := 13\n"
+
+// TestEdit_ContextAnchorsToActualEditSite verifies the success context shows
+// the replacement location instead of the first occurrence of new_string.
+func TestEdit_ContextAnchorsToActualEditSite(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "dup.txt"), []byte(dupLineContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tool := Edit(WithWorkDir(dir))
+	result := call(t, tool, `{"path": "dup.txt", "old_string": "y = old()", "new_string": "x = compute()"}`)
+	assertContains(t, result, "Context:")
+	assertContains(t, result, "    10\tx = compute()")
+	assertNotContains(t, result, "     1\tx = compute()")
+}
+
+// TestMultiEdit_ContextAnchorsToActualEditSite is the multi_edit variant of
+// the context-anchoring regression.
+func TestMultiEdit_ContextAnchorsToActualEditSite(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "dup.txt"), []byte(dupLineContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tool := MultiEdit(WithWorkDir(dir))
+	result := call(t, tool, `{"edits": [{"path": "dup.txt", "old_string": "y = old()", "new_string": "x = compute()"}]}`)
+	assertContains(t, result, "Context:")
+	assertContains(t, result, "    10\tx = compute()")
+	assertNotContains(t, result, "     1\tx = compute()")
+}

--- a/ext/codetool/glob.go
+++ b/ext/codetool/glob.go
@@ -75,7 +75,10 @@ func Glob(opts ...Option) core.Tool {
 						return ctx.Err()
 					}
 					if d.IsDir() {
-						if isSkippableDir(d.Name()) {
+						// Never prune the walk root — the caller explicitly
+						// asked to search this directory, even if its basename
+						// is skippable (e.g. path="vendor").
+						if path != searchPath && isSkippableDir(d.Name()) {
 							return filepath.SkipDir
 						}
 						return nil
@@ -102,40 +105,61 @@ func Glob(opts ...Option) core.Tool {
 					return "", fmt.Errorf("walking directory: %w", err)
 				}
 			} else {
-				// Simple glob without **. Expand braces first since
-				// filepath.Glob doesn't support {a,b} patterns.
-				expandedPatterns := expandBraces(params.Pattern)
-				seen := make(map[string]bool)
-				var globMatches []string
-				for _, ep := range expandedPatterns {
-					p := filepath.Join(searchPath, ep)
-					matches, err := filepath.Glob(p)
-					if err != nil {
-						return "", &core.ModelRetryError{Message: fmt.Sprintf("invalid glob pattern: %v", err)}
-					}
-					for _, m := range matches {
-						if !seen[m] {
-							seen[m] = true
-							globMatches = append(globMatches, m)
+				// Simple glob without **. filepath.Glob would interpret
+				// glob metacharacters in searchPath itself (e.g. Next.js
+				// "[slug]" route directories), so walk the tree and match
+				// the pattern against the path relative to searchPath
+				// instead. matchDoublestar requires an exact segment count
+				// for patterns without **, preserving non-recursive glob
+				// semantics. Expand braces up front to validate the pattern
+				// and bound the walk depth.
+				maxDepth := 1
+				for _, ep := range expandBraces(filepath.ToSlash(params.Pattern)) {
+					for _, seg := range strings.Split(ep, "/") {
+						if _, err := filepath.Match(seg, ""); err != nil {
+							return "", &core.ModelRetryError{Message: fmt.Sprintf("invalid glob pattern: %v", err)}
 						}
+					}
+					if d := strings.Count(ep, "/") + 1; d > maxDepth {
+						maxDepth = d
 					}
 				}
-				for _, m := range globMatches {
-					info, err := os.Stat(m)
-					if err != nil {
-						continue
+				err := filepath.WalkDir(searchPath, func(path string, d os.DirEntry, walkErr error) error {
+					if walkErr != nil {
+						return walkErr
 					}
-					if info.IsDir() {
-						continue
+					if ctx.Err() != nil {
+						return ctx.Err()
 					}
+					if d.IsDir() {
+						if path == searchPath {
+							return nil
+						}
+						// Don't descend deeper than the pattern can match.
+						relDir, _ := filepath.Rel(searchPath, path)
+						if strings.Count(filepath.ToSlash(relDir), "/")+1 >= maxDepth {
+							return filepath.SkipDir
+						}
+						return nil
+					}
+
 					// Apply exclude filter (with brace expansion).
 					if params.Exclude != "" {
-						if matchWithBraces(params.Exclude, info.Name()) {
-							continue
+						if matchWithBraces(params.Exclude, d.Name()) {
+							return nil
 						}
 					}
-					relPath, _ := filepath.Rel(searchPath, m)
-					results = append(results, fileEntry{relPath, info.ModTime().Unix(), info.Size()})
+
+					relPath, _ := filepath.Rel(searchPath, path)
+					if matchDoublestar(params.Pattern, relPath) {
+						if info, err := d.Info(); err == nil {
+							results = append(results, fileEntry{relPath, info.ModTime().Unix(), info.Size()})
+						}
+					}
+					return nil
+				})
+				if err != nil && !errors.Is(err, context.Canceled) {
+					return "", fmt.Errorf("walking directory: %w", err)
 				}
 			}
 
@@ -189,11 +213,17 @@ func matchDoublestar(pattern, path string) bool {
 	return false
 }
 
-// expandBraces expands a single brace group in a pattern.
+// maxBraceExpansions bounds the cartesian product of sequential brace
+// groups so a pathological pattern cannot explode memory.
+const maxBraceExpansions = 64
+
+// expandBraces expands brace groups in a pattern.
 // "*.{go,py}" → ["*.go", "*.py"]
 // "src/{a,b}/*.ts" → ["src/a/*.ts", "src/b/*.ts"]
+// "{a,b}/*.{go,py}" → ["a/*.go", "a/*.py", "b/*.go", "b/*.py"]
 // Patterns without braces return a single-element slice.
-// Only the first brace group is expanded (nested braces are not supported).
+// Sequential groups expand as a cartesian product (capped at
+// maxBraceExpansions); nested braces are not supported.
 func expandBraces(pattern string) []string {
 	open := strings.IndexByte(pattern, '{')
 	if open < 0 {
@@ -205,11 +235,17 @@ func expandBraces(pattern string) []string {
 	}
 	close += open
 	prefix := pattern[:open]
-	suffix := pattern[close+1:]
+	// Recurse on the suffix so later groups expand too.
+	suffixes := expandBraces(pattern[close+1:])
 	alternatives := strings.Split(pattern[open+1:close], ",")
+	if len(alternatives)*len(suffixes) > maxBraceExpansions {
+		return []string{pattern} // pathological — leave braces literal
+	}
 	var result []string
 	for _, alt := range alternatives {
-		result = append(result, prefix+strings.TrimSpace(alt)+suffix)
+		for _, suffix := range suffixes {
+			result = append(result, prefix+strings.TrimSpace(alt)+suffix)
+		}
 	}
 	return result
 }

--- a/ext/codetool/glob_bugfix_test.go
+++ b/ext/codetool/glob_bugfix_test.go
@@ -1,0 +1,162 @@
+package codetool
+
+// Regression tests for search-tool bugs:
+//   - grep/glob pruning an explicitly requested search root whose basename
+//     is a skippable directory name (vendor, build, dist, ...)
+//   - glob's non-** branch interpreting glob metacharacters in the search
+//     path itself (e.g. Next.js "[slug]" route directories)
+//   - expandBraces only expanding the first brace group
+//   - ls emitting duplicate truncation markers and exceeding the 500-entry cap
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// TestGrep_SkippableNamedSearchRoot verifies that grep searches a directory
+// the caller explicitly asked for, even when its basename is in the skip
+// list (e.g. path="vendor"), while still pruning skippable subdirectories
+// during recursion from other roots.
+func TestGrep_SkippableNamedSearchRoot(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, dir, "vendor/dep.go", "package dep\n\nfunc FindMeInVendor() {}\n")
+
+	tool := Grep(WithWorkDir(dir))
+
+	// Explicitly requested skippable-named root must be searched.
+	result := call(t, tool, `{"pattern": "FindMeInVendor", "path": "vendor"}`)
+	assertContains(t, result, "dep.go")
+	assertContains(t, result, "FindMeInVendor")
+
+	// But vendor/ must still be pruned when searching from the parent.
+	result = call(t, tool, `{"pattern": "FindMeInVendor"}`)
+	assertContains(t, result, "No matches found")
+}
+
+// TestGlob_SkippableNamedSearchRoot verifies the ** branch of glob does not
+// prune the explicitly requested search root (e.g. path="vendor"), while
+// skippable directories beneath the root are still pruned.
+func TestGlob_SkippableNamedSearchRoot(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, dir, "vendor/a.go", "package a\n")
+	writeTestFile(t, dir, "vendor/node_modules/b.go", "package b\n")
+
+	tool := Glob(WithWorkDir(dir))
+	result := call(t, tool, `{"pattern": "**/*.go", "path": "vendor"}`)
+	assertContains(t, result, "a.go")
+	assertNotContains(t, result, "b.go") // nested skippable dir still pruned
+}
+
+// TestGlob_MetacharactersInSearchPath verifies the non-** branch treats the
+// search path literally instead of passing it through filepath.Glob, where
+// "[slug]" becomes a character class and an unbalanced bracket is an error.
+func TestGlob_MetacharactersInSearchPath(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, dir, "app/[slug]/page.tsx", "export default function Page() {}\n")
+
+	tool := Glob(WithWorkDir(dir))
+	result := call(t, tool, `{"pattern": "*.tsx", "path": "app/[slug]"}`)
+	assertContains(t, result, "page.tsx")
+
+	// Unbalanced bracket in the path is legal on disk and must not be
+	// misreported as an invalid glob pattern.
+	writeTestFile(t, dir, "ba[d/file.txt", "data\n")
+	result = call(t, tool, `{"pattern": "*.txt", "path": "ba[d"}`)
+	assertContains(t, result, "file.txt")
+
+	// A genuinely malformed pattern still gets a retry error.
+	if err := callErr(t, tool, `{"pattern": "[unclosed", "path": "app"}`); err == nil {
+		t.Fatal("expected error for malformed pattern")
+	}
+}
+
+// TestExpandBraces_MultipleGroups verifies sequential brace groups expand as
+// a cartesian product instead of leaving later groups literal.
+func TestExpandBraces_MultipleGroups(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected []string
+	}{
+		{"{a,b}/*.{go,mod}", []string{"a/*.go", "a/*.mod", "b/*.go", "b/*.mod"}},
+		{"*.{a,b}.{c,d}", []string{"*.a.c", "*.a.d", "*.b.c", "*.b.d"}},
+		{"{x,y}/{p,q}/z", []string{"x/p/z", "x/q/z", "y/p/z", "y/q/z"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := expandBraces(tt.input)
+			if len(got) != len(tt.expected) {
+				t.Fatalf("expandBraces(%q) = %v, want %v", tt.input, got, tt.expected)
+			}
+			for i := range got {
+				if got[i] != tt.expected[i] {
+					t.Fatalf("expandBraces(%q)[%d] = %q, want %q", tt.input, i, got[i], tt.expected[i])
+				}
+			}
+		})
+	}
+}
+
+// TestGlob_MultipleBraceGroups exercises a two-group pattern end to end.
+func TestGlob_MultipleBraceGroups(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, dir, "cmd/x.go", "package x\n")
+	writeTestFile(t, dir, "internal/y.mod", "module y\n")
+	writeTestFile(t, dir, "internal/z.txt", "text\n")
+
+	tool := Glob(WithWorkDir(dir))
+	result := call(t, tool, `{"pattern": "{cmd,internal}/*.{go,mod}"}`)
+	assertContains(t, result, "x.go")
+	assertContains(t, result, "y.mod")
+	assertNotContains(t, result, "z.txt")
+}
+
+// TestLs_TruncationSingleMarker verifies that when the 500-entry cap is
+// crossed inside a nested directory, ls emits exactly one truncation marker
+// and at most 500 entry lines (no per-recursion-level duplicates).
+func TestLs_TruncationSingleMarker(t *testing.T) {
+	dir := t.TempDir()
+	// 497 top-level files sort before "sub", so the cap is crossed two
+	// directory levels deep: 497 files + sub/ + sub/deep/ = 499 lines,
+	// then deep's files push past 500.
+	for i := range 497 {
+		writeTestFile(t, dir, fmt.Sprintf("f%03d.txt", i), "x\n")
+	}
+	for i := range 20 {
+		writeTestFile(t, dir, fmt.Sprintf("sub/deep/g%03d.txt", i), "x\n")
+	}
+
+	tool := Ls(WithWorkDir(dir))
+	result := call(t, tool, `{"depth": 3}`)
+
+	const marker = "... (truncated at 500 entries)"
+	if n := strings.Count(result, marker); n != 1 {
+		t.Fatalf("expected exactly 1 truncation marker, got %d:\n%s", n, result)
+	}
+	lines := strings.Split(result, "\n")
+	if lines[len(lines)-1] != marker {
+		t.Fatalf("expected output to end with the truncation marker, got %q", lines[len(lines)-1])
+	}
+	if entries := len(lines) - 1; entries != 500 {
+		t.Fatalf("expected exactly 500 entry lines, got %d", entries)
+	}
+	// Truncated output must not also carry the "(N entries)" footer.
+	if strings.Contains(result, "\n(") {
+		t.Fatalf("unexpected entry-count footer in truncated output:\n%s", result)
+	}
+}
+
+// TestLs_ExactlyAtCapNotTruncated verifies a tree with exactly 500 entries
+// is reported in full with the entry-count footer and no truncation marker.
+func TestLs_ExactlyAtCapNotTruncated(t *testing.T) {
+	dir := t.TempDir()
+	for i := range 500 {
+		writeTestFile(t, dir, fmt.Sprintf("f%03d.txt", i), "x\n")
+	}
+
+	tool := Ls(WithWorkDir(dir))
+	result := call(t, tool, `{}`)
+
+	assertNotContains(t, result, "truncated at 500 entries")
+	assertContains(t, result, "(500 entries)")
+}

--- a/ext/codetool/grep.go
+++ b/ext/codetool/grep.go
@@ -115,7 +115,10 @@ func Grep(opts ...Option) core.Tool {
 					return ctx.Err()
 				}
 				if d.IsDir() {
-					if isSkippableDir(d.Name()) {
+					// Never prune the walk root — the caller explicitly
+					// asked to search this directory, even if its basename
+					// is skippable (e.g. path="vendor").
+					if path != searchPath && isSkippableDir(d.Name()) {
 						return filepath.SkipDir
 					}
 					return nil

--- a/ext/codetool/ls.go
+++ b/ext/codetool/ls.go
@@ -56,15 +56,15 @@ func Ls(opts ...Option) core.Tool {
 			}
 
 			var lines []string
-			listDir(ctx, dir, dir, "", depth, &lines)
+			truncated := listDir(ctx, dir, dir, "", depth, &lines)
 
 			if len(lines) == 0 {
 				return "(empty directory)", nil
 			}
 
 			result := strings.Join(lines, "\n")
-			// Don't add count if truncated (listDir already appends a truncation notice).
-			if len(lines) <= 500 {
+			// Don't add count if truncated (listDir already appended a truncation notice).
+			if !truncated {
 				result += fmt.Sprintf("\n(%d entries)", len(lines))
 			}
 			return result, nil
@@ -85,22 +85,26 @@ func compactSize(bytes int64) string {
 	}
 }
 
-func listDir(ctx context.Context, basePath, currentPath, prefix string, remainingDepth int, lines *[]string) {
+// listDir appends directory entries to lines, recursing up to
+// remainingDepth levels. It returns true once output is truncated at the
+// 500-entry cap so ancestor levels unwind without appending duplicate
+// truncation markers.
+func listDir(ctx context.Context, basePath, currentPath, prefix string, remainingDepth int, lines *[]string) bool {
 	if ctx.Err() != nil {
-		return
+		return false
 	}
 	if remainingDepth <= 0 {
-		return
+		return false
 	}
 
 	entries, err := os.ReadDir(currentPath)
 	if err != nil {
-		return
+		return false
 	}
 
 	for _, entry := range entries {
 		if ctx.Err() != nil {
-			return
+			return false
 		}
 
 		name := entry.Name()
@@ -110,11 +114,20 @@ func listDir(ctx context.Context, basePath, currentPath, prefix string, remainin
 			continue
 		}
 
+		// Check before appending so the cap is exact: at most 500 entry
+		// lines plus a single truncation marker.
+		if len(*lines) >= 500 {
+			*lines = append(*lines, "... (truncated at 500 entries)")
+			return true
+		}
+
 		display := prefix + name
 		if entry.IsDir() {
 			display += "/"
 			*lines = append(*lines, display)
-			listDir(ctx, basePath, filepath.Join(currentPath, name), prefix+name+"/", remainingDepth-1, lines)
+			if listDir(ctx, basePath, filepath.Join(currentPath, name), prefix+name+"/", remainingDepth-1, lines) {
+				return true
+			}
 		} else {
 			// Show file size to save agents from needing `ls -la` via bash.
 			if info, err := entry.Info(); err == nil {
@@ -122,10 +135,6 @@ func listDir(ctx context.Context, basePath, currentPath, prefix string, remainin
 			}
 			*lines = append(*lines, display)
 		}
-
-		if len(*lines) > 500 {
-			*lines = append(*lines, "... (truncated at 500 entries)")
-			return
-		}
 	}
+	return false
 }

--- a/ext/codetool/lsp.go
+++ b/ext/codetool/lsp.go
@@ -451,18 +451,21 @@ func startServer(ctx context.Context, lang, workDir string) (*lspServer, error) 
 	// handled automatically during initialization.
 	go srv.readLoop(bufio.NewReaderSize(stdout, 256*1024))
 
+	// Background goroutine: detect server crashes by calling Wait().
+	// This sets srv.dead so getServer can detect and restart. Started
+	// BEFORE the initialize handshake so the child is always reaped —
+	// otherwise the kill() on handshake failure would leave a zombie
+	// and leak the pipe FDs.
+	go func() {
+		srv.cmd.Wait() //nolint:errcheck
+		srv.dead.Store(true)
+	}()
+
 	// Initialize handshake (uses the caller's context for timeout).
 	if err := srv.initialize(ctx, workDir); err != nil {
 		srv.kill()
 		return nil, fmt.Errorf("LSP initialize: %w", err)
 	}
-
-	// Background goroutine: detect server crashes by calling Wait().
-	// This sets srv.dead so getServer can detect and restart.
-	go func() {
-		srv.cmd.Wait() //nolint:errcheck
-		srv.dead.Store(true)
-	}()
 
 	return srv, nil
 }
@@ -1419,6 +1422,26 @@ func lspCodeAction(ctx context.Context, srv *lspServer, filePath string, line, c
 	return b.String(), nil
 }
 
+// utf16OffsetToByte converts a UTF-16 code-unit offset — the default LSP
+// position encoding — into a byte offset within line. Runes outside the
+// Basic Multilingual Plane count as two UTF-16 units (a surrogate pair);
+// all others count as one. Offsets past the end of the line clamp to
+// len(line).
+func utf16OffsetToByte(line string, utf16Off int) int {
+	units := 0
+	for i, r := range line {
+		if units >= utf16Off {
+			return i
+		}
+		if r > 0xFFFF {
+			units += 2
+		} else {
+			units++
+		}
+	}
+	return len(line)
+}
+
 // applyWorkspaceEdit applies a WorkspaceEdit to disk and syncs changed files
 // back to the LSP server. Returns the total number of edits applied and a
 // per-file summary. This is shared by rename and code_action.
@@ -1454,16 +1477,16 @@ func applyWorkspaceEdit(edit *lspWorkspaceEdit, srv *lspServer, absWorkDir strin
 			}
 
 			// Build the content before the edit range, the new text, and after.
+			// LSP character offsets are UTF-16 code units, not bytes — convert
+			// before slicing or edits on lines with multibyte runes corrupt
+			// the file.
 			before := ""
 			if startLine > 0 {
 				before = strings.Join(lines[:startLine], "\n") + "\n"
 			}
-			before += lines[startLine][:min(startChar, len(lines[startLine]))]
+			before += lines[startLine][:utf16OffsetToByte(lines[startLine], startChar)]
 
-			after := ""
-			if endChar <= len(lines[endLine]) {
-				after = lines[endLine][endChar:]
-			}
+			after := lines[endLine][utf16OffsetToByte(lines[endLine], endChar):]
 			if endLine+1 < len(lines) {
 				after += "\n" + strings.Join(lines[endLine+1:], "\n")
 			}
@@ -1692,16 +1715,27 @@ func lspOutline(ctx context.Context, srv *lspServer, filePath, workDir string) (
 		relPath = rel
 	}
 
-	// Try DocumentSymbol[] (hierarchical) first.
-	var docSymbols []lspDocumentSymbol
-	if err := json.Unmarshal(result, &docSymbols); err == nil && len(docSymbols) > 0 {
-		var b strings.Builder
-		fmt.Fprintf(&b, "Outline of %s:\n", relPath)
-		formatDocumentSymbols(&b, docSymbols, 0)
-		return strings.TrimRight(b.String(), "\n"), nil
+	// Servers return either DocumentSymbol[] (hierarchical) or
+	// SymbolInformation[] (flat). The flat shape also unmarshals cleanly
+	// into []lspDocumentSymbol (its `location` field is silently ignored,
+	// leaving Range zero), so probe for a `location` key to pick the
+	// right parse instead of trusting the first successful unmarshal.
+	var probe []struct {
+		Location json.RawMessage `json:"location"`
+	}
+	flat := json.Unmarshal(result, &probe) == nil && len(probe) > 0 && len(probe[0].Location) > 0
+
+	if !flat {
+		var docSymbols []lspDocumentSymbol
+		if err := json.Unmarshal(result, &docSymbols); err == nil && len(docSymbols) > 0 {
+			var b strings.Builder
+			fmt.Fprintf(&b, "Outline of %s:\n", relPath)
+			formatDocumentSymbols(&b, docSymbols, 0)
+			return strings.TrimRight(b.String(), "\n"), nil
+		}
 	}
 
-	// Fallback: try SymbolInformation[] (flat, older servers).
+	// SymbolInformation[] (flat, older servers).
 	var symbols []lspSymbolInfo
 	if err := json.Unmarshal(result, &symbols); err == nil && len(symbols) > 0 {
 		var b strings.Builder

--- a/ext/codetool/lsp_bugfix_test.go
+++ b/ext/codetool/lsp_bugfix_test.go
@@ -1,0 +1,238 @@
+package codetool
+
+// Regression tests for three lsp.go bugs:
+//  1. applyWorkspaceEdit treated LSP UTF-16 character offsets as byte
+//     offsets, corrupting files with multibyte runes on rename/code_action.
+//  2. lspOutline misparsed flat SymbolInformation[] responses — every
+//     symbol was reported at line 1 because the payload also unmarshals
+//     cleanly into []lspDocumentSymbol with a zero Range.
+//  3. startServer leaked a zombie process when the initialize handshake
+//     failed (kill without a corresponding Wait to reap the child).
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestUTF16OffsetToByte(t *testing.T) {
+	// "héllo 🚀 wörld old": é and ö are 1 UTF-16 unit / 2 bytes,
+	// 🚀 is 2 UTF-16 units (surrogate pair) / 4 bytes.
+	line := "héllo 🚀 wörld old"
+	tests := []struct {
+		name     string
+		line     string
+		utf16Off int
+		want     int
+	}{
+		{"zero", line, 0, 0},
+		{"ascii prefix", "hello", 3, 3},
+		{"after accented rune", line, 2, 3},                     // "hé" = 2 units, 3 bytes
+		{"before emoji", line, 6, 7},                            // "héllo " = 6 units, 7 bytes
+		{"after emoji", line, 8, 11},                            // 🚀 = 2 units, 4 bytes
+		{"start of old", line, 15, 19},                          // "héllo 🚀 wörld " = 15 units, 19 bytes
+		{"end of old", line, 18, 22},                            // full line = 18 units, 22 bytes
+		{"clamped past end", line, 100, len(line)},              // offsets past EOL clamp
+		{"mid surrogate pair rounds to next rune", line, 7, 11}, // malformed input never splits mid-rune
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := utf16OffsetToByte(tt.line, tt.utf16Off); got != tt.want {
+				t.Errorf("utf16OffsetToByte(%q, %d) = %d, want %d", tt.line, tt.utf16Off, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestApplyWorkspaceEditUTF16Offsets verifies that edits on a line with
+// multibyte runes (é, ö: 2 bytes/1 unit; 🚀: 4 bytes/2 units) before the
+// edit range splice at the correct byte position. Before the fix the raw
+// UTF-16 offsets were used as byte indices, landing the edit 4 bytes early.
+func TestApplyWorkspaceEditUTF16Offsets(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "lsp-utf16-test-*.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+	tmpFile.WriteString("héllo 🚀 wörld old\nsecond line\n")
+	tmpFile.Close()
+
+	uri := fileURI(tmpFile.Name())
+
+	// Pipes so ensureFileOpen doesn't panic on nil stdin.
+	clientRead, clientWrite, _ := os.Pipe()
+	defer clientRead.Close()
+	defer clientWrite.Close()
+
+	srv := &lspServer{
+		stdin:       clientWrite,
+		lang:        "go",
+		openFiles:   make(map[string]fileState),
+		diagnostics: make(map[string][]lspDiagnostic),
+	}
+
+	// "old" spans UTF-16 units [15, 18) on line 0 (byte range [19, 22)).
+	edit := &lspWorkspaceEdit{
+		Changes: map[string][]lspTextEdit{
+			uri: {
+				{
+					Range: lspRange{
+						Start: lspPosition{Line: 0, Character: 15},
+						End:   lspPosition{Line: 0, Character: 18},
+					},
+					NewText: "renamed",
+				},
+			},
+		},
+	}
+
+	totalEdits, _, err := applyWorkspaceEdit(edit, srv, "/tmp")
+	if err != nil {
+		t.Fatalf("applyWorkspaceEdit: %v", err)
+	}
+	if totalEdits != 1 {
+		t.Errorf("expected 1 edit, got %d", totalEdits)
+	}
+
+	data, err := os.ReadFile(tmpFile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "héllo 🚀 wörld renamed\nsecond line\n"
+	if string(data) != want {
+		t.Errorf("file content corrupted by UTF-16/byte offset mismatch:\ngot:  %q\nwant: %q", string(data), want)
+	}
+}
+
+// TestLspOutlineFlatSymbolInformation verifies that a flat
+// SymbolInformation[] response (servers without hierarchical documentSymbol
+// support) reports real line numbers. Before the fix the payload was
+// accepted by the []lspDocumentSymbol parse — its `location` field was
+// silently dropped — so every symbol printed as L1.
+func TestLspOutlineFlatSymbolInformation(t *testing.T) {
+	clientRead, serverWrite, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	serverRead, clientWrite, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clientRead.Close()
+	defer serverWrite.Close()
+	defer serverRead.Close()
+	defer clientWrite.Close()
+
+	srv := &lspServer{
+		stdin:       clientWrite,
+		lang:        "go",
+		workDir:     "/project",
+		openFiles:   map[string]fileState{},
+		diagnostics: map[string][]lspDiagnostic{},
+		responses:   make(chan jsonrpcResponse, 16),
+		readDone:    make(chan struct{}),
+	}
+
+	go srv.readLoop(bufio.NewReaderSize(clientRead, 64*1024))
+
+	// Flat SymbolInformation[]: line numbers live under `location`, and
+	// there is no `range`/`selectionRange` at the top level.
+	flatSymbols := `[
+		{"name":"Foo","kind":12,"location":{"uri":"file:///project/main.go","range":{"start":{"line":41,"character":0},"end":{"line":50,"character":1}}}},
+		{"name":"Bar","kind":5,"location":{"uri":"file:///project/main.go","range":{"start":{"line":7,"character":0},"end":{"line":9,"character":1}}}}
+	]`
+
+	go func() {
+		readMessage(bufio.NewReader(serverRead)) // discard the request
+
+		resp := map[string]any{
+			"jsonrpc": "2.0",
+			"id":      1,
+			"result":  json.RawMessage(flatSymbols),
+		}
+		respJSON, _ := json.Marshal(resp)
+		writeMessage(serverWrite, respJSON)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	result, err := lspOutline(ctx, srv, "/project/main.go", "/project")
+	if err != nil {
+		t.Fatalf("lspOutline error: %v", err)
+	}
+	if !strings.Contains(result, "L42: Foo [function]") {
+		t.Errorf("expected 'L42: Foo [function]' in output, got:\n%s", result)
+	}
+	if !strings.Contains(result, "L8: Bar [class]") {
+		t.Errorf("expected 'L8: Bar [class]' in output, got:\n%s", result)
+	}
+	if strings.Contains(result, "L1:") {
+		t.Errorf("symbols reported at line 1 — flat response parsed as DocumentSymbol[]:\n%s", result)
+	}
+}
+
+// TestStartServerReapsProcessOnInitializeFailure verifies that a server
+// killed because the initialize handshake failed is reaped (waited on)
+// rather than left as a zombie. Before the fix the cmd.Wait goroutine was
+// only started after a successful handshake, so the SIGKILLed child stayed
+// a zombie for the life of the parent process.
+func TestStartServerReapsProcessOnInitializeFailure(t *testing.T) {
+	dir := t.TempDir()
+
+	// Fake "LSP server" that records its PID then sleeps without ever
+	// speaking LSP, so the initialize handshake times out via ctx.
+	pidFile := filepath.Join(dir, "server.pid")
+	script := filepath.Join(dir, "fake-lsp.sh")
+	content := fmt.Sprintf("#!/bin/sh\necho $$ > %q\nexec sleep 60\n", pidFile)
+	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	const lang = "zombie-regression-test"
+	serverConfigs[lang] = []lspServerConfig{{command: script}}
+	defer delete(serverConfigs, lang)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	if _, err := startServer(ctx, lang, dir); err == nil {
+		t.Fatal("expected startServer to fail when the handshake times out")
+	}
+
+	// The server wrote its PID before sleeping; read it back.
+	var pid int
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if data, err := os.ReadFile(pidFile); err == nil {
+			if pid, err = strconv.Atoi(strings.TrimSpace(string(data))); err == nil && pid > 0 {
+				break
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("fake server never wrote its pid file")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Once reaped, signal 0 fails with ESRCH. A zombie still "exists",
+	// so without the Wait the process would be found indefinitely.
+	deadline = time.Now().Add(5 * time.Second)
+	for {
+		if err := syscall.Kill(pid, 0); err == syscall.ESRCH {
+			return // reaped — no zombie
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("process %d still exists after kill — zombie not reaped", pid)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}

--- a/ext/codetool/write.go
+++ b/ext/codetool/write.go
@@ -82,6 +82,7 @@ func Write(opts ...Option) core.Tool {
 					perm = fi.Mode().Perm()
 				}
 			}
+			origPerm := perm
 			// Auto-upgrade to executable for scripts (both new and existing).
 			lower := strings.ToLower(filepath.Base(path))
 			isScript := strings.HasPrefix(params.Content, "#!") ||
@@ -114,6 +115,14 @@ func Write(opts ...Option) core.Tool {
 			}
 			if err := writeFileAndTrace(ctx, rc, cfg, path, []byte(writeContent), perm, operation, "write"); err != nil {
 				return "", fmt.Errorf("write file: %w", err)
+			}
+			// os.WriteFile only applies perm when creating a file — overwriting
+			// leaves the existing mode untouched, so the script auto-upgrade
+			// above needs an explicit chmod for existing files.
+			if prevSize >= 0 && perm != origPerm {
+				if err := os.Chmod(path, perm); err != nil {
+					return "", fmt.Errorf("chmod file: %w", err)
+				}
 			}
 
 			// Return a summary with line count. For small files, include a


### PR DESCRIPTION
## Summary

This PR carries the existing local Gollem fixes onto a focused Codex branch. It fixes several regression classes found during the Slang/Gollem app-server audit:

- records tool return parts for accepted output tool calls so conversation history does not contain dangling tool_use blocks after Run/RunStream or WithMessages round trips
- avoids mutating shared agent/caller ModelSettings during a run and preserves output truncation config when cloning agents
- aligns schema embedding behavior with encoding/json, including self/mutual embedded struct guards
- serializes ProviderMetadataPart values through MarshalMessages/UnmarshalMessages
- hardens codetool edit/multi_edit/write/glob/grep/ls/lsp behavior around mixed line endings, whitespace-only edit needles, context anchoring, literal glob roots, skippable explicit roots, truncation markers, UTF-16 LSP offsets, flat outline results, and failed LSP startup reaping

## Validation

- `git diff --check`
- `go test -count=1 ./...`
- `go test -race ./core`
- `golangci-lint run`
- push hook: `golangci-lint`, `go test -race` with configured Monty race skip, `go vet`, tidy verification
