### PR TITLE
[codex] Emit app-server thread token usage updates

### DIFF
--- a/appserver/protocol/methods_gen.go
+++ b/appserver/protocol/methods_gen.go
@@ -186,7 +186,7 @@ var methodRegistry = []MethodInfo{
 	{Method: "thread/settings/updated", Surface: SurfaceServerNotification, State: MethodImplemented, Source: "json schema:ServerNotification, protocol crate:common.rs:1621, typescript:ServerNotification.ts"},
 	{Method: "thread/started", Surface: SurfaceServerNotification, State: MethodImplemented, Source: "json schema:ServerNotification, protocol crate:common.rs:1610, typescript:ServerNotification.ts"},
 	{Method: "thread/status/changed", Surface: SurfaceServerNotification, State: MethodImplemented, Source: "json schema:ServerNotification, protocol crate:common.rs:1611, typescript:ServerNotification.ts"},
-	{Method: "thread/tokenUsage/updated", Surface: SurfaceServerNotification, State: MethodBlocked, Source: "json schema:ServerNotification, protocol crate:common.rs:1622, typescript:ServerNotification.ts"},
+	{Method: "thread/tokenUsage/updated", Surface: SurfaceServerNotification, State: MethodImplemented, Source: "json schema:ServerNotification, protocol crate:common.rs:1622, typescript:ServerNotification.ts"},
 	{Method: "thread/unarchived", Surface: SurfaceServerNotification, State: MethodImplemented, Source: "json schema:ServerNotification, protocol crate:common.rs:1614, typescript:ServerNotification.ts"},
 	{Method: "turn/completed", Surface: SurfaceServerNotification, State: MethodImplemented, Source: "json schema:ServerNotification, protocol crate:common.rs:1625, typescript:ServerNotification.ts"},
 	{Method: "turn/diff/updated", Surface: SurfaceServerNotification, State: MethodBlocked, Source: "json schema:ServerNotification, protocol crate:common.rs:1627, typescript:ServerNotification.ts"},

--- a/appserver/protocol/methods_test.go
+++ b/appserver/protocol/methods_test.go
@@ -98,6 +98,7 @@ func TestMethodRegistryCountsAndKeyMethods(t *testing.T) {
 	assertMethod(t, "thread/goal/cleared", SurfaceServerNotification, MethodImplemented)
 	assertMethod(t, "thread/name/updated", SurfaceServerNotification, MethodImplemented)
 	assertMethod(t, "deprecationNotice", SurfaceServerNotification, MethodImplemented)
+	assertMethod(t, "thread/tokenUsage/updated", SurfaceServerNotification, MethodImplemented)
 	assertMethod(t, "turn/started", SurfaceServerNotification, MethodImplemented)
 	assertMethod(t, "turn/completed", SurfaceServerNotification, MethodImplemented)
 	assertMethod(t, "item/started", SurfaceServerNotification, MethodImplemented)

--- a/appserver/runtime.go
+++ b/appserver/runtime.go
@@ -346,6 +346,9 @@ func (s *RuntimeService) complete(st store.Store, notifier runtimeNotifier, turn
 		Usage:  usage,
 	})
 	if err == nil {
+		if result != nil {
+			publishThreadTokenUsage(notifier, st, completed, result.Usage)
+		}
 		publishTurnCompleted(notifier, completed)
 	}
 }
@@ -419,6 +422,26 @@ type runtimeErrorNotificationParams struct {
 	At       time.Time `json:"at"`
 }
 
+type threadTokenUsageUpdatedNotificationParams struct {
+	ThreadID   string                  `json:"threadId"`
+	TurnID     string                  `json:"turnId"`
+	TokenUsage threadTokenUsagePayload `json:"tokenUsage"`
+}
+
+type threadTokenUsagePayload struct {
+	Total              tokenUsageBreakdown `json:"total"`
+	Last               tokenUsageBreakdown `json:"last"`
+	ModelContextWindow *int64              `json:"modelContextWindow"`
+}
+
+type tokenUsageBreakdown struct {
+	TotalTokens           int64 `json:"totalTokens"`
+	InputTokens           int64 `json:"inputTokens"`
+	CachedInputTokens     int64 `json:"cachedInputTokens"`
+	OutputTokens          int64 `json:"outputTokens"`
+	ReasoningOutputTokens int64 `json:"reasoningOutputTokens"`
+}
+
 func publishTurnStarted(notifier runtimeNotifier, turn *store.Turn) {
 	if notifier == nil || turn == nil {
 		return
@@ -458,6 +481,22 @@ func publishItemCompleted(notifier runtimeNotifier, turn *store.Turn, item *stor
 	})
 }
 
+func publishThreadTokenUsage(notifier runtimeNotifier, st store.Store, turn *store.Turn, last core.RunUsage) {
+	if notifier == nil || st == nil || turn == nil {
+		return
+	}
+	total := threadTokenUsageTotal(context.Background(), st, turn.ThreadID, last)
+	notifier.PublishNotification("thread/tokenUsage/updated", threadTokenUsageUpdatedNotificationParams{
+		ThreadID: turn.ThreadID,
+		TurnID:   turn.ID,
+		TokenUsage: threadTokenUsagePayload{
+			Total:              tokenUsageBreakdownFromUsage(total.Usage),
+			Last:               tokenUsageBreakdownFromUsage(last.Usage),
+			ModelContextWindow: nil,
+		},
+	})
+}
+
 func publishModelDelta(notifier runtimeNotifier, turn *store.Turn, event core.ModelDeltaEvent) {
 	if notifier == nil || turn == nil || event.ContentDelta == "" {
 		return
@@ -488,16 +527,115 @@ func publishRuntimeError(notifier runtimeNotifier, turn *store.Turn, text string
 }
 
 func runtimeUsageMap(usage core.RunUsage) map[string]any {
-	return map[string]any{
-		"requests": usage.Requests,
-		"usage": map[string]any{
-			"inputTokens":      usage.InputTokens,
-			"outputTokens":     usage.OutputTokens,
-			"cacheWriteTokens": usage.CacheWriteTokens,
-			"cacheReadTokens":  usage.CacheReadTokens,
-			"totalTokens":      usage.TotalTokens(),
-		},
+	usageMap := map[string]any{
+		"inputTokens":      usage.InputTokens,
+		"outputTokens":     usage.OutputTokens,
+		"cacheWriteTokens": usage.CacheWriteTokens,
+		"cacheReadTokens":  usage.CacheReadTokens,
+		"totalTokens":      usage.TotalTokens(),
 	}
+	if len(usage.Details) > 0 {
+		details := make(map[string]any, len(usage.Details))
+		for key, value := range usage.Details {
+			details[key] = value
+		}
+		usageMap["details"] = details
+	}
+	return map[string]any{
+		"requests":  usage.Requests,
+		"toolCalls": usage.ToolCalls,
+		"usage":     usageMap,
+	}
+}
+
+func threadTokenUsageTotal(ctx context.Context, st store.Store, threadID string, fallback core.RunUsage) core.RunUsage {
+	turns, err := st.ListTurns(ctx, store.TurnFilter{ThreadID: threadID})
+	if err != nil {
+		return fallback
+	}
+	var total core.RunUsage
+	for _, turn := range turns {
+		if turn == nil || len(turn.Usage) == 0 {
+			continue
+		}
+		total.IncrRun(runtimeUsageFromStoredMap(turn.Usage))
+	}
+	if total.Requests == 0 && total.ToolCalls == 0 && total.TotalTokens() == 0 {
+		return fallback
+	}
+	return total
+}
+
+func runtimeUsageFromStoredMap(values map[string]any) core.RunUsage {
+	var usage core.RunUsage
+	if len(values) == 0 {
+		return usage
+	}
+	usage.Requests = runtimeIntFromAny(values["requests"])
+	usage.ToolCalls = runtimeIntFromAny(values["toolCalls"])
+	tokenValues := runtimeMapFromAny(values["usage"])
+	if tokenValues == nil {
+		tokenValues = values
+	}
+	usage.InputTokens = runtimeIntFromAny(tokenValues["inputTokens"])
+	usage.OutputTokens = runtimeIntFromAny(tokenValues["outputTokens"])
+	usage.CacheWriteTokens = runtimeIntFromAny(tokenValues["cacheWriteTokens"])
+	usage.CacheReadTokens = runtimeIntFromAny(tokenValues["cacheReadTokens"])
+	if details := runtimeMapFromAny(tokenValues["details"]); len(details) > 0 {
+		usage.Details = make(map[string]int, len(details))
+		for key, value := range details {
+			usage.Details[key] = runtimeIntFromAny(value)
+		}
+	}
+	return usage
+}
+
+func tokenUsageBreakdownFromUsage(usage core.Usage) tokenUsageBreakdown {
+	return tokenUsageBreakdown{
+		TotalTokens:           int64(usage.TotalTokens()),
+		InputTokens:           int64(usage.InputTokens),
+		CachedInputTokens:     int64(usage.CacheReadTokens),
+		OutputTokens:          int64(usage.OutputTokens),
+		ReasoningOutputTokens: int64(runtimeReasoningOutputTokens(usage.Details)),
+	}
+}
+
+func runtimeReasoningOutputTokens(details map[string]int) int {
+	for _, key := range []string{"reasoning_tokens", "reasoningTokens", "reasoningOutputTokens"} {
+		if value := details[key]; value != 0 {
+			return value
+		}
+	}
+	return 0
+}
+
+func runtimeMapFromAny(value any) map[string]any {
+	if value == nil {
+		return nil
+	}
+	if mapped, ok := value.(map[string]any); ok {
+		return mapped
+	}
+	return nil
+}
+
+func runtimeIntFromAny(value any) int {
+	switch typed := value.(type) {
+	case int:
+		return typed
+	case int64:
+		return int(typed)
+	case float64:
+		return int(typed)
+	case json.Number:
+		if i, err := typed.Int64(); err == nil {
+			return int(i)
+		}
+		if f, err := typed.Float64(); err == nil {
+			return int(f)
+		}
+	}
+	return 0
 }
 
 func lastRuntimeAssistantText(messages []core.ModelMessage) string {

--- a/appserver/runtime_test.go
+++ b/appserver/runtime_test.go
@@ -103,6 +103,76 @@ func TestServerRuntimeThreadResumeUsesPersistedHistory(t *testing.T) {
 	assertRuntimeUserPrompt(t, secondMessages[2], "second prompt")
 }
 
+func TestServerRuntimePublishesThreadTokenUsageUpdated(t *testing.T) {
+	ctx := context.Background()
+	st := newRuntimeTestStore(t)
+	first := core.TextResponse("first answer")
+	first.Usage = core.Usage{
+		InputTokens:     10,
+		OutputTokens:    4,
+		CacheReadTokens: 3,
+		Details: map[string]int{
+			"reasoning_tokens": 2,
+		},
+	}
+	second := core.TextResponse("second answer")
+	second.Usage = core.Usage{
+		InputTokens:     5,
+		OutputTokens:    6,
+		CacheReadTokens: 1,
+		Details: map[string]int{
+			"reasoning_tokens": 1,
+		},
+	}
+	model := core.NewTestModel(first, second)
+	server := readyServer(
+		WithStore(st),
+		WithRuntimeService(NewRuntimeService(WithRuntimeModel(model, RuntimeModelInfo{ProviderID: "test", Model: "test-model"}))),
+	)
+
+	startResp := server.HandleRequest(ctx, request("thread/start", map[string]any{"prompt": "first prompt"}))
+	if startResp.Error != nil {
+		t.Fatalf("thread/start error: %v", startResp.Error)
+	}
+	var started struct {
+		Thread *store.Thread `json:"thread"`
+		Turn   *store.Turn   `json:"turn"`
+	}
+	decodeResult(t, startResp, &started)
+	firstEvents := waitForNotificationSet(t, server, "thread/tokenUsage/updated", "turn/completed")
+	firstUsage := decodeThreadTokenUsageNotification(t, firstEvents)
+	if firstUsage.ThreadID != started.Thread.ID || firstUsage.TurnID != started.Turn.ID {
+		t.Fatalf("first usage ids = thread %q turn %q, want %q/%q", firstUsage.ThreadID, firstUsage.TurnID, started.Thread.ID, started.Turn.ID)
+	}
+	if firstUsage.TokenUsage.ModelContextWindow != nil {
+		t.Fatalf("first modelContextWindow = %v, want nil", *firstUsage.TokenUsage.ModelContextWindow)
+	}
+	assertTokenUsageBreakdown(t, "first last", firstUsage.TokenUsage.Last, 14, 10, 3, 4, 2)
+	assertTokenUsageBreakdown(t, "first total", firstUsage.TokenUsage.Total, 14, 10, 3, 4, 2)
+
+	resumeResp := server.HandleRequest(ctx, request("thread/resume", map[string]any{
+		"threadId": started.Thread.ID,
+		"prompt":   "second prompt",
+	}))
+	if resumeResp.Error != nil {
+		t.Fatalf("thread/resume error: %v", resumeResp.Error)
+	}
+	var resumed struct {
+		Turn *store.Turn `json:"turn"`
+	}
+	decodeResult(t, resumeResp, &resumed)
+	secondEvents := waitForNotificationSet(t, server, "thread/tokenUsage/updated", "turn/completed")
+	secondUsage := decodeThreadTokenUsageNotification(t, secondEvents)
+	if secondUsage.ThreadID != started.Thread.ID || secondUsage.TurnID != resumed.Turn.ID {
+		t.Fatalf("second usage ids = thread %q turn %q, want %q/%q", secondUsage.ThreadID, secondUsage.TurnID, started.Thread.ID, resumed.Turn.ID)
+	}
+	if secondUsage.TokenUsage.ModelContextWindow != nil {
+		t.Fatalf("second modelContextWindow = %v, want nil", *secondUsage.TokenUsage.ModelContextWindow)
+	}
+	assertTokenUsageBreakdown(t, "second last", secondUsage.TokenUsage.Last, 11, 5, 1, 6, 1)
+	assertTokenUsageBreakdown(t, "second total", secondUsage.TokenUsage.Total, 25, 15, 4, 10, 3)
+}
+
 func TestServerRuntimeThreadResumeUsesInjectedResponseItems(t *testing.T) {
 	ctx := context.Background()
 	st := newRuntimeTestStore(t)
@@ -440,6 +510,36 @@ func notificationMethods(notifications []protocol.Notification) []string {
 		methods[i] = notification.Method
 	}
 	return methods
+}
+
+func decodeThreadTokenUsageNotification(t *testing.T, notifications []protocol.Notification) threadTokenUsageUpdatedNotificationParams {
+	t.Helper()
+	for _, notification := range notifications {
+		if notification.Method != "thread/tokenUsage/updated" {
+			continue
+		}
+		var params threadTokenUsageUpdatedNotificationParams
+		if err := json.Unmarshal(notification.Params, &params); err != nil {
+			t.Fatalf("decode thread/tokenUsage/updated params: %v", err)
+		}
+		return params
+	}
+	t.Fatalf("thread/tokenUsage/updated notification missing from %v", notificationMethods(notifications))
+	return threadTokenUsageUpdatedNotificationParams{}
+}
+
+func assertTokenUsageBreakdown(t *testing.T, label string, got tokenUsageBreakdown, total, input, cachedInput, output, reasoningOutput int64) {
+	t.Helper()
+	want := tokenUsageBreakdown{
+		TotalTokens:           total,
+		InputTokens:           input,
+		CachedInputTokens:     cachedInput,
+		OutputTokens:          output,
+		ReasoningOutputTokens: reasoningOutput,
+	}
+	if got != want {
+		t.Fatalf("%s usage = %+v, want %+v", label, got, want)
+	}
 }
 
 func assertRuntimeUserPrompt(t *testing.T, message core.ModelMessage, want string) {


### PR DESCRIPTION
## Summary
- emit thread/tokenUsage/updated after runtime turns complete
- aggregate persisted per-turn usage into protocol-compatible total/last token breakdowns
- mark thread/tokenUsage/updated implemented in the app-server protocol registry

## Verification
- go test ./appserver ./appserver/protocol -run 'TestServerRuntimePublishesThreadTokenUsageUpdated|TestMethodRegistryCountsAndKeyMethods'
- go test ./appserver/... ./cmd/gollem
- go vet ./...
- golangci-lint run ./appserver ./appserver/protocol
- go test ./...
- golangci-lint run ./...
- go test -race ./appserver/... ./cmd/gollem
- go test -count=1 ./...
- pre-push hook: golangci-lint, go test -race ./... (skipping ext/monty per hook config), go vet ./..., go mod tidy verification