### PR TITLE
[codex] Emit app-server turn diff updates

### DIFF
--- a/appserver/protocol/methods_gen.go
+++ b/appserver/protocol/methods_gen.go
@@ -189,7 +189,7 @@ var methodRegistry = []MethodInfo{
 	{Method: "thread/tokenUsage/updated", Surface: SurfaceServerNotification, State: MethodImplemented, Source: "json schema:ServerNotification, protocol crate:common.rs:1622, typescript:ServerNotification.ts"},
 	{Method: "thread/unarchived", Surface: SurfaceServerNotification, State: MethodImplemented, Source: "json schema:ServerNotification, protocol crate:common.rs:1614, typescript:ServerNotification.ts"},
 	{Method: "turn/completed", Surface: SurfaceServerNotification, State: MethodImplemented, Source: "json schema:ServerNotification, protocol crate:common.rs:1625, typescript:ServerNotification.ts"},
-	{Method: "turn/diff/updated", Surface: SurfaceServerNotification, State: MethodBlocked, Source: "json schema:ServerNotification, protocol crate:common.rs:1627, typescript:ServerNotification.ts"},
+	{Method: "turn/diff/updated", Surface: SurfaceServerNotification, State: MethodImplemented, Source: "json schema:ServerNotification, protocol crate:common.rs:1627, typescript:ServerNotification.ts"},
 	{Method: "turn/moderationMetadata", Surface: SurfaceServerNotification, State: MethodBlocked, Source: "json schema:ServerNotification, protocol crate:common.rs:1670, typescript:ServerNotification.ts"},
 	{Method: "turn/plan/updated", Surface: SurfaceServerNotification, State: MethodBlocked, Source: "json schema:ServerNotification, protocol crate:common.rs:1628, typescript:ServerNotification.ts"},
 	{Method: "turn/started", Surface: SurfaceServerNotification, State: MethodImplemented, Source: "json schema:ServerNotification, protocol crate:common.rs:1623, typescript:ServerNotification.ts"},

--- a/appserver/protocol/methods_test.go
+++ b/appserver/protocol/methods_test.go
@@ -101,6 +101,7 @@ func TestMethodRegistryCountsAndKeyMethods(t *testing.T) {
 	assertMethod(t, "thread/tokenUsage/updated", SurfaceServerNotification, MethodImplemented)
 	assertMethod(t, "turn/started", SurfaceServerNotification, MethodImplemented)
 	assertMethod(t, "turn/completed", SurfaceServerNotification, MethodImplemented)
+	assertMethod(t, "turn/diff/updated", SurfaceServerNotification, MethodImplemented)
 	assertMethod(t, "item/started", SurfaceServerNotification, MethodImplemented)
 	assertMethod(t, "item/agentMessage/delta", SurfaceServerNotification, MethodImplemented)
 	assertMethod(t, "item/reasoning/textDelta", SurfaceServerNotification, MethodImplemented)

--- a/appserver/server_test.go
+++ b/appserver/server_test.go
@@ -821,6 +821,79 @@ func TestServerThreadShellCommandHandler(t *testing.T) {
 	}
 }
 
+func TestServerThreadShellCommandPublishesTurnDiffUpdated(t *testing.T) {
+	ctx := context.Background()
+	repo := initRepo(t)
+	st, err := store.NewSQLiteStore(filepath.Join(t.TempDir(), "threads.db"))
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	thread, err := st.CreateThread(ctx, store.CreateThreadRequest{Title: "Shell diff", Workspace: repo})
+	if err != nil {
+		t.Fatalf("CreateThread: %v", err)
+	}
+	gitSvc, err := toolgit.NewService(repo, toolgit.WithWorktreeRoot(filepath.Join(t.TempDir(), "worktrees")))
+	if err != nil {
+		t.Fatalf("NewService git: %v", err)
+	}
+	var server *Server
+	processSvc, err := toolprocess.NewService(repo,
+		toolprocess.WithOutputSink(func(ev toolprocess.OutputEvent) {
+			server.PublishProcessOutput(ev)
+		}),
+		toolprocess.WithExitSink(func(ev toolprocess.ExitEvent) {
+			server.PublishProcessExited(ev)
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewService process: %v", err)
+	}
+	server = readyServer(WithStore(st), WithProcess(processSvc), WithGit(gitSvc))
+
+	resp := server.HandleRequest(ctx, request("thread/shellCommand", map[string]any{
+		"threadId": thread.ID,
+		"command":  "printf 'changed\\n' > README.md",
+	}))
+	if resp.Error != nil {
+		t.Fatalf("thread/shellCommand error: %v", resp.Error)
+	}
+	events := waitForNotificationSet(t, server,
+		"process/exited",
+		"turn/diff/updated",
+		"turn/completed",
+	)
+	var diffNotice turnDiffUpdatedNotificationParams
+	for _, event := range events {
+		if event.Method != "turn/diff/updated" {
+			continue
+		}
+		if err := json.Unmarshal(event.Params, &diffNotice); err != nil {
+			t.Fatalf("decode turn/diff/updated: %v", err)
+		}
+	}
+	if diffNotice.ThreadID != thread.ID || diffNotice.TurnID == "" {
+		t.Fatalf("turn diff ids = %#v", diffNotice)
+	}
+	if !strings.Contains(diffNotice.Diff, "README.md") || !strings.Contains(diffNotice.Diff, "-hello") || !strings.Contains(diffNotice.Diff, "+changed") {
+		t.Fatalf("turn diff = %q, want README.md hello->changed patch", diffNotice.Diff)
+	}
+
+	resp = server.HandleRequest(ctx, request("thread/shellCommand", map[string]any{
+		"threadId": thread.ID,
+		"command":  "true",
+	}))
+	if resp.Error != nil {
+		t.Fatalf("thread/shellCommand no-op error: %v", resp.Error)
+	}
+	events = waitForNotificationSet(t, server, "process/exited", "turn/completed")
+	for _, event := range events {
+		if event.Method == "turn/diff/updated" {
+			t.Fatalf("unexpected turn/diff/updated for unchanged git diff: %#v", event)
+		}
+	}
+}
+
 func TestServerThreadControlHandlers(t *testing.T) {
 	ctx := context.Background()
 	st, err := store.NewSQLiteStore(filepath.Join(t.TempDir(), "threads.db"))

--- a/appserver/thread_shell_command.go
+++ b/appserver/thread_shell_command.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/fugue-labs/gollem/appserver/protocol"
 	"github.com/fugue-labs/gollem/appserver/store"
+	toolgit "github.com/fugue-labs/gollem/appserver/tools/git"
 	toolprocess "github.com/fugue-labs/gollem/appserver/tools/process"
 )
 
@@ -35,13 +36,14 @@ func (p threadShellCommandParams) threadID() string {
 type threadShellCommandResponse struct{}
 
 type threadShellCommandRun struct {
-	ThreadID  string
-	TurnID    string
-	ItemID    string
-	Command   string
-	CWD       string
-	ProcessID string
-	StartedAt time.Time
+	ThreadID   string
+	TurnID     string
+	ItemID     string
+	Command    string
+	CWD        string
+	ProcessID  string
+	BeforeDiff string
+	StartedAt  time.Time
 }
 
 type threadShellCommandPayload struct {
@@ -69,6 +71,12 @@ type commandExecutionOutputDeltaNotificationParams struct {
 	TurnID   string `json:"turnId"`
 	ItemID   string `json:"itemId"`
 	Delta    string `json:"delta"`
+}
+
+type turnDiffUpdatedNotificationParams struct {
+	ThreadID string `json:"threadId"`
+	TurnID   string `json:"turnId"`
+	Diff     string `json:"diff"`
 }
 
 func (s *Server) handleThreadShellCommand(ctx context.Context, raw json.RawMessage) (any, *protocol.Error) {
@@ -150,6 +158,7 @@ func (s *Server) handleThreadShellCommand(ctx context.Context, raw json.RawMessa
 		At:       startedAt,
 	})
 
+	beforeDiff := s.currentTurnGitDiff(ctx)
 	snapshot, err := processSvc.Start(ctx, toolprocess.StartRequest{
 		Command: command,
 		Shell:   true,
@@ -161,23 +170,25 @@ func (s *Server) handleThreadShellCommand(ctx context.Context, raw json.RawMessa
 			status = commandExecutionStatusDeclined
 		}
 		s.completeThreadShellCommand(context.Background(), threadShellCommandRun{
-			ThreadID:  thread.ID,
-			TurnID:    startedTurn.ID,
-			ItemID:    item.ID,
-			Command:   command,
-			CWD:       cwd,
-			StartedAt: startedAt,
+			ThreadID:   thread.ID,
+			TurnID:     startedTurn.ID,
+			ItemID:     item.ID,
+			Command:    command,
+			CWD:        cwd,
+			BeforeDiff: beforeDiff,
+			StartedAt:  startedAt,
 		}, nil, status, err.Error())
 		return nil, mapError("thread/shellCommand", err)
 	}
 	run := threadShellCommandRun{
-		ThreadID:  thread.ID,
-		TurnID:    startedTurn.ID,
-		ItemID:    item.ID,
-		Command:   command,
-		CWD:       cwd,
-		ProcessID: snapshot.ID,
-		StartedAt: startedAt,
+		ThreadID:   thread.ID,
+		TurnID:     startedTurn.ID,
+		ItemID:     item.ID,
+		Command:    command,
+		CWD:        cwd,
+		ProcessID:  snapshot.ID,
+		BeforeDiff: beforeDiff,
+		StartedAt:  startedAt,
 	}
 	s.registerThreadShellCommandProcess(snapshot.ID, run)
 	if _, err := st.UpdateItem(ctx, store.UpdateItemRequest{
@@ -279,8 +290,35 @@ func (s *Server) completeThreadShellCommand(ctx context.Context, run threadShell
 	if err != nil {
 		return
 	}
+	s.publishTurnDiffUpdatedIfChanged(ctx, completedTurn, run.BeforeDiff)
 	publishItemCompleted(s, completedTurn, item)
 	publishTurnCompleted(s, completedTurn)
+}
+
+func (s *Server) currentTurnGitDiff(ctx context.Context) string {
+	if s == nil || s.git == nil {
+		return ""
+	}
+	diff, err := s.git.Diff(ctx, toolgit.DiffRequest{})
+	if err != nil || diff == nil {
+		return ""
+	}
+	return diff.Patch
+}
+
+func (s *Server) publishTurnDiffUpdatedIfChanged(ctx context.Context, turn *store.Turn, before string) {
+	if s == nil || turn == nil {
+		return
+	}
+	after := s.currentTurnGitDiff(ctx)
+	if after == "" || after == before {
+		return
+	}
+	s.PublishNotification("turn/diff/updated", turnDiffUpdatedNotificationParams{
+		ThreadID: turn.ThreadID,
+		TurnID:   turn.ID,
+		Diff:     after,
+	})
 }
 
 func newThreadShellCommandPayload(command, cwd, processID, status, output string, exitCode *int, startedAt time.Time, completedAt *time.Time) threadShellCommandPayload {


### PR DESCRIPTION
## Summary
- emit turn/diff/updated after shell-command turns when the worktree diff changes
- mark the app-server method registry entry implemented
- cover changed and unchanged shell-command diff behavior in server tests

## Verification
- go test ./appserver ./appserver/protocol -run 'TestServerThreadShellCommandPublishesTurnDiffUpdated|TestMethodRegistryCountsAndKeyMethods'
- go test ./appserver/... ./cmd/gollem
- golangci-lint run ./appserver/... ./cmd/gollem
- go test ./...
- go vet ./...
- golangci-lint run ./...
- go test -race ./appserver/... ./cmd/gollem
- go test -count=1 ./...
- pre-push hook: golangci-lint, go test -race ./... with ext/monty race skipped by hook config, go vet, go mod tidy verification