### PR TITLE
[codex] Wire scoped filesystem runtime tools

### DIFF
--- a/appserver/approval.go
+++ b/appserver/approval.go
@@ -14,6 +14,7 @@ import (
 	toolfs "github.com/fugue-labs/gollem/appserver/tools/fs"
 	toolgit "github.com/fugue-labs/gollem/appserver/tools/git"
 	toolprocess "github.com/fugue-labs/gollem/appserver/tools/process"
+	"github.com/fugue-labs/gollem/core"
 )
 
 var ErrApprovalRequestDenied = errors.New("appserver: approval request denied")
@@ -42,6 +43,7 @@ type approvalResolution struct {
 }
 
 type approvalRequestBase struct {
+	requestID   string
 	ThreadID    string `json:"threadId"`
 	TurnID      string `json:"turnId"`
 	ItemID      string `json:"itemId"`
@@ -128,21 +130,21 @@ func (s *ApprovalService) DrainRequests() []protocol.Request {
 func (s *ApprovalService) FilesystemApproval(ctx context.Context, op toolfs.Operation) error {
 	reason := fmt.Sprintf("Approve filesystem %s for %s", op.Kind, op.Path)
 	params := fileChangeApprovalParams{
-		approvalRequestBase: s.base(reason),
+		approvalRequestBase: s.base(ctx, reason),
 		GrantRoot:           nil,
 		Operation:           string(op.Kind),
 		Path:                op.Path,
 		Destination:         op.Destination,
 		Destructive:         op.Destructive,
 	}
-	return s.requestApproval(ctx, "item/fileChange/requestApproval", params.ItemID, params)
+	return s.requestApproval(ctx, "item/fileChange/requestApproval", params.requestID, params)
 }
 
 func (s *ApprovalService) ProcessApproval(ctx context.Context, op toolprocess.Operation) error {
 	command := strings.TrimSpace(strings.Join(append([]string{op.Command}, op.Args...), " "))
 	reason := fmt.Sprintf("Approve process %s", op.Kind)
 	params := commandApprovalParams{
-		approvalRequestBase: s.base(reason),
+		approvalRequestBase: s.base(ctx, reason),
 		Command:             command,
 		Args:                append([]string(nil), op.Args...),
 		CWD:                 op.WorkDir,
@@ -150,7 +152,7 @@ func (s *ApprovalService) ProcessApproval(ctx context.Context, op toolprocess.Op
 		Signal:              op.Signal,
 		Destructive:         op.Destructive,
 	}
-	return s.requestApproval(ctx, "item/commandExecution/requestApproval", params.ItemID, params)
+	return s.requestApproval(ctx, "item/commandExecution/requestApproval", params.requestID, params)
 }
 
 func (s *ApprovalService) GitApproval(ctx context.Context, op toolgit.Operation) error {
@@ -160,7 +162,7 @@ func (s *ApprovalService) GitApproval(ctx context.Context, op toolgit.Operation)
 		cwd = "."
 	}
 	params := permissionsApprovalParams{
-		approvalRequestBase: s.base(reason),
+		approvalRequestBase: s.base(ctx, reason),
 		CWD:                 cwd,
 		Operation:           string(op.Kind),
 		Path:                op.Path,
@@ -174,7 +176,7 @@ func (s *ApprovalService) GitApproval(ctx context.Context, op toolgit.Operation)
 			"mutating":  op.Mutating,
 		},
 	}
-	return s.requestApproval(ctx, "item/permissions/requestApproval", params.ItemID, params)
+	return s.requestApproval(ctx, "item/permissions/requestApproval", params.requestID, params)
 }
 
 func (s *ApprovalService) MCPToolApproval(ctx context.Context, serverName, toolName string, args map[string]any) error {
@@ -185,7 +187,7 @@ func (s *ApprovalService) MCPToolApproval(ctx context.Context, serverName, toolN
 	}
 	slices.Sort(argKeys)
 	params := permissionsApprovalParams{
-		approvalRequestBase: s.base(reason),
+		approvalRequestBase: s.base(ctx, reason),
 		CWD:                 ".",
 		Operation:           "mcpToolCall",
 		Permissions: map[string]any{
@@ -196,7 +198,7 @@ func (s *ApprovalService) MCPToolApproval(ctx context.Context, serverName, toolN
 			"mutating":     true,
 		},
 	}
-	return s.requestApproval(ctx, "item/permissions/requestApproval", params.ItemID, params)
+	return s.requestApproval(ctx, "item/permissions/requestApproval", params.requestID, params)
 }
 
 func (s *Server) handleApprovalRespond(raw json.RawMessage) (any, *protocol.Error) {
@@ -244,12 +246,17 @@ type serverRequestResolvedParams struct {
 	RequestID string `json:"requestId"`
 }
 
-func (s *ApprovalService) base(reason string) approvalRequestBase {
+func (s *ApprovalService) base(ctx context.Context, reason string) approvalRequestBase {
 	requestID := s.nextRequestID()
+	runtimeContext := runtimeTurnContextFrom(ctx)
+	threadID := firstNonEmpty(runtimeContext.ThreadID, approvalThreadID)
+	turnID := firstNonEmpty(runtimeContext.TurnID, approvalTurnID)
+	itemID := firstNonEmpty(core.ToolCallIDFromContext(ctx), requestID)
 	return approvalRequestBase{
-		ThreadID:    approvalThreadID,
-		TurnID:      approvalTurnID,
-		ItemID:      requestID,
+		requestID:   requestID,
+		ThreadID:    threadID,
+		TurnID:      turnID,
+		ItemID:      itemID,
 		StartedAtMS: time.Now().UnixMilli(),
 		Reason:      reason,
 	}

--- a/appserver/protocol/methods_gen.go
+++ b/appserver/protocol/methods_gen.go
@@ -150,7 +150,7 @@ var methodRegistry = []MethodInfo{
 	{Method: "item/commandExecution/terminalInteraction", Surface: SurfaceServerNotification, State: MethodBlocked, Source: "json schema:ServerNotification, protocol crate:common.rs:1647, typescript:ServerNotification.ts"},
 	{Method: "item/completed", Surface: SurfaceServerNotification, State: MethodImplemented, Source: "json schema:ServerNotification, protocol crate:common.rs:1632, typescript:ServerNotification.ts"},
 	{Method: "item/fileChange/outputDelta", Surface: SurfaceServerNotification, State: MethodBlocked, Source: "json schema:ServerNotification, protocol crate:common.rs:1649, typescript:ServerNotification.ts"},
-	{Method: "item/fileChange/patchUpdated", Surface: SurfaceServerNotification, State: MethodBlocked, Source: "json schema:ServerNotification, protocol crate:common.rs:1650, typescript:ServerNotification.ts"},
+	{Method: "item/fileChange/patchUpdated", Surface: SurfaceServerNotification, State: MethodImplemented, Source: "json schema:ServerNotification, protocol crate:common.rs:1650, typescript:ServerNotification.ts"},
 	{Method: "item/mcpToolCall/progress", Surface: SurfaceServerNotification, State: MethodBlocked, Source: "json schema:ServerNotification, protocol crate:common.rs:1652, typescript:ServerNotification.ts"},
 	{Method: "item/plan/delta", Surface: SurfaceServerNotification, State: MethodBlocked, Source: "json schema:ServerNotification, protocol crate:common.rs:1637, typescript:ServerNotification.ts"},
 	{Method: "item/reasoning/summaryPartAdded", Surface: SurfaceServerNotification, State: MethodBlocked, Source: "json schema:ServerNotification, protocol crate:common.rs:1663, typescript:ServerNotification.ts"},

--- a/appserver/protocol/methods_test.go
+++ b/appserver/protocol/methods_test.go
@@ -106,6 +106,7 @@ func TestMethodRegistryCountsAndKeyMethods(t *testing.T) {
 	assertMethod(t, "item/agentMessage/delta", SurfaceServerNotification, MethodImplemented)
 	assertMethod(t, "item/reasoning/textDelta", SurfaceServerNotification, MethodImplemented)
 	assertMethod(t, "item/commandExecution/outputDelta", SurfaceServerNotification, MethodImplemented)
+	assertMethod(t, "item/fileChange/patchUpdated", SurfaceServerNotification, MethodImplemented)
 	assertMethod(t, "item/completed", SurfaceServerNotification, MethodImplemented)
 	assertMethod(t, "cache/benchmark/completed", SurfaceServerNotification, MethodImplemented)
 	assertMethod(t, "serverRequest/resolved", SurfaceServerNotification, MethodImplemented)

--- a/appserver/runtime.go
+++ b/appserver/runtime.go
@@ -257,6 +257,7 @@ func (s *RuntimeService) run(ctx context.Context, st store.Store, notifier runti
 		s.mu.Unlock()
 	}()
 
+	ctx = withRuntimeTurnContext(ctx, turn.ThreadID, turn.ID)
 	model, info, err := s.modelFactory(ctx, req.Selection)
 	if err != nil {
 		s.complete(st, notifier, turn, store.TurnFailed, nil, err, info)
@@ -284,6 +285,9 @@ func (s *RuntimeService) run(ctx context.Context, st store.Store, notifier runti
 	defer unsubscribeToolCompleted()
 	unsubscribeToolFailed := core.Subscribe(bus, toolItems.toolFailed)
 	defer unsubscribeToolFailed()
+	fileChangeItems := newRuntimeFileChangeTracker(st, notifier, turn, toolItems)
+	unsubscribeArtifactChanged := core.Subscribe(bus, fileChangeItems.artifactChanged)
+	defer unsubscribeArtifactChanged()
 
 	agentOptions := []core.AgentOption[string]{core.WithEventBus[string](bus)}
 	if len(s.tools) > 0 {
@@ -317,6 +321,9 @@ func (s *RuntimeService) run(ctx context.Context, st store.Store, notifier runti
 	}
 	if err == nil {
 		err = toolItems.Err()
+	}
+	if err == nil {
+		err = fileChangeItems.Err()
 	}
 	s.complete(st, notifier, turn, statusFromRuntimeError(err), result, err, info)
 }

--- a/appserver/runtime_context.go
+++ b/appserver/runtime_context.go
@@ -1,0 +1,28 @@
+package appserver
+
+import "context"
+
+type runtimeTurnContextKey struct{}
+
+type runtimeTurnContext struct {
+	ThreadID string
+	TurnID   string
+}
+
+func withRuntimeTurnContext(ctx context.Context, threadID, turnID string) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, runtimeTurnContextKey{}, runtimeTurnContext{
+		ThreadID: threadID,
+		TurnID:   turnID,
+	})
+}
+
+func runtimeTurnContextFrom(ctx context.Context) runtimeTurnContext {
+	if ctx == nil {
+		return runtimeTurnContext{}
+	}
+	value, _ := ctx.Value(runtimeTurnContextKey{}).(runtimeTurnContext)
+	return value
+}

--- a/appserver/runtime_file_change_items.go
+++ b/appserver/runtime_file_change_items.go
@@ -1,0 +1,249 @@
+package appserver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/fugue-labs/gollem/appserver/store"
+	"github.com/fugue-labs/gollem/core"
+)
+
+const (
+	runtimeFileChangeItemKind         = "fileChange"
+	runtimeFileChangeStatusInProgress = "inProgress"
+	runtimeFileChangeStatusCompleted  = "completed"
+
+	runtimePatchChangeAdd    = "add"
+	runtimePatchChangeDelete = "delete"
+	runtimePatchChangeUpdate = "update"
+)
+
+type runtimeFileChangePayload struct {
+	Type     string                              `json:"type"`
+	ID       string                              `json:"id,omitempty"`
+	Changes  []runtimeFileUpdateChange           `json:"changes"`
+	Status   string                              `json:"status"`
+	Evidence []runtimeFileChangeArtifactEvidence `json:"evidence,omitempty"`
+}
+
+type runtimeFileUpdateChange struct {
+	Path string                 `json:"path"`
+	Kind runtimePatchChangeKind `json:"kind"`
+	Diff string                 `json:"diff"`
+}
+
+type runtimePatchChangeKind struct {
+	Type     string
+	MovePath *string
+}
+
+func (k runtimePatchChangeKind) MarshalJSON() ([]byte, error) {
+	payload := map[string]any{"type": k.Type}
+	if k.Type == runtimePatchChangeUpdate {
+		payload["movePath"] = k.MovePath
+	}
+	return json.Marshal(payload)
+}
+
+func (k *runtimePatchChangeKind) UnmarshalJSON(data []byte) error {
+	var payload struct {
+		Type     string  `json:"type"`
+		MovePath *string `json:"movePath"`
+	}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return err
+	}
+	k.Type = payload.Type
+	k.MovePath = payload.MovePath
+	return nil
+}
+
+type runtimeFileChangeArtifactEvidence struct {
+	Path                 string `json:"path"`
+	Operation            string `json:"operation"`
+	Bytes                int64  `json:"bytes"`
+	BeforeSHA256         string `json:"beforeSha256,omitempty"`
+	AfterSHA256          string `json:"afterSha256,omitempty"`
+	DiffTruncated        bool   `json:"diffTruncated,omitempty"`
+	DiffOmittedReason    string `json:"diffOmittedReason,omitempty"`
+	ContentEncoding      string `json:"contentEncoding,omitempty"`
+	ContentTruncated     bool   `json:"contentTruncated,omitempty"`
+	ContentOmittedReason string `json:"contentOmittedReason,omitempty"`
+}
+
+type runtimeFileChangeItemStartedNotificationParams struct {
+	Item        runtimeFileChangePayload `json:"item"`
+	ThreadID    string                   `json:"threadId"`
+	TurnID      string                   `json:"turnId"`
+	StartedAtMS int64                    `json:"startedAtMs"`
+}
+
+type runtimeFileChangeItemCompletedNotificationParams struct {
+	Item          runtimeFileChangePayload `json:"item"`
+	ThreadID      string                   `json:"threadId"`
+	TurnID        string                   `json:"turnId"`
+	CompletedAtMS int64                    `json:"completedAtMs"`
+}
+
+type runtimeFileChangePatchUpdatedNotificationParams struct {
+	ThreadID string                    `json:"threadId"`
+	TurnID   string                    `json:"turnId"`
+	ItemID   string                    `json:"itemId"`
+	Changes  []runtimeFileUpdateChange `json:"changes"`
+}
+
+type runtimeFileChangeTracker struct {
+	mu        sync.Mutex
+	store     store.Store
+	notifier  runtimeNotifier
+	turn      *store.Turn
+	toolItems *runtimeToolItemTracker
+	turnDiffs []string
+	err       error
+}
+
+func newRuntimeFileChangeTracker(st store.Store, notifier runtimeNotifier, turn *store.Turn, toolItems *runtimeToolItemTracker) *runtimeFileChangeTracker {
+	return &runtimeFileChangeTracker{
+		store:     st,
+		notifier:  notifier,
+		turn:      turn,
+		toolItems: toolItems,
+	}
+}
+
+func (t *runtimeFileChangeTracker) artifactChanged(event core.ArtifactChangedEvent) {
+	if t == nil || t.store == nil || t.turn == nil || strings.TrimSpace(event.Path) == "" {
+		return
+	}
+	changedAt := event.ChangedAt
+	if changedAt.IsZero() {
+		changedAt = time.Now().UTC()
+	}
+	change := runtimeFileUpdateChange{
+		Path: event.Path,
+		Kind: runtimePatchChangeKind{Type: runtimeFileChangeKind(event.Operation)},
+		Diff: event.Diff,
+	}
+	payload := runtimeFileChangePayload{
+		Type:    runtimeFileChangeItemKind,
+		Changes: []runtimeFileUpdateChange{change},
+		Status:  runtimeFileChangeStatusInProgress,
+		Evidence: []runtimeFileChangeArtifactEvidence{{
+			Path:                 event.Path,
+			Operation:            event.Operation,
+			Bytes:                event.Bytes,
+			BeforeSHA256:         event.BeforeSHA256,
+			AfterSHA256:          event.AfterSHA256,
+			DiffTruncated:        event.DiffTruncated,
+			DiffOmittedReason:    event.DiffOmittedReason,
+			ContentEncoding:      event.ContentEncoding,
+			ContentTruncated:     event.ContentTruncated,
+			ContentOmittedReason: event.ContentOmittedReason,
+		}},
+	}
+	parentItemID := ""
+	if t.toolItems != nil {
+		parentItemID = t.toolItems.itemID(event.RunID, event.ToolCallID, event.ToolName)
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	item, err := t.store.AppendItem(context.Background(), store.AppendItemRequest{
+		ThreadID:     t.turn.ThreadID,
+		TurnID:       t.turn.ID,
+		ParentItemID: parentItemID,
+		Kind:         runtimeFileChangeItemKind,
+		Status:       runtimeFileChangeStatusInProgress,
+		Payload:      mustRuntimeJSON(payload),
+	})
+	if err != nil {
+		t.recordErrorLocked("append", err)
+		return
+	}
+	payload.ID = item.ID
+	item, err = t.store.UpdateItem(context.Background(), store.UpdateItemRequest{
+		ID:      item.ID,
+		Status:  runtimeFileChangeStatusInProgress,
+		Payload: mustRuntimeJSON(payload),
+	})
+	if err != nil {
+		t.recordErrorLocked("set id", err)
+		return
+	}
+	if t.notifier != nil {
+		t.notifier.PublishNotification("item/started", runtimeFileChangeItemStartedNotificationParams{
+			Item:        payload,
+			ThreadID:    t.turn.ThreadID,
+			TurnID:      t.turn.ID,
+			StartedAtMS: changedAt.UnixMilli(),
+		})
+	}
+
+	payload.Status = runtimeFileChangeStatusCompleted
+	item, err = t.store.UpdateItem(context.Background(), store.UpdateItemRequest{
+		ID:      item.ID,
+		Status:  runtimeFileChangeStatusCompleted,
+		Payload: mustRuntimeJSON(payload),
+	})
+	if err != nil {
+		t.recordErrorLocked("complete", err)
+		return
+	}
+	if event.Diff != "" {
+		t.turnDiffs = append(t.turnDiffs, event.Diff)
+	}
+	if t.notifier == nil {
+		return
+	}
+	t.notifier.PublishNotification("item/fileChange/patchUpdated", runtimeFileChangePatchUpdatedNotificationParams{
+		ThreadID: t.turn.ThreadID,
+		TurnID:   t.turn.ID,
+		ItemID:   item.ID,
+		Changes:  append([]runtimeFileUpdateChange(nil), payload.Changes...),
+	})
+	if len(t.turnDiffs) > 0 {
+		t.notifier.PublishNotification("turn/diff/updated", turnDiffUpdatedNotificationParams{
+			ThreadID: t.turn.ThreadID,
+			TurnID:   t.turn.ID,
+			Diff:     strings.Join(t.turnDiffs, "\n"),
+		})
+	}
+	t.notifier.PublishNotification("item/completed", runtimeFileChangeItemCompletedNotificationParams{
+		Item:          payload,
+		ThreadID:      t.turn.ThreadID,
+		TurnID:        t.turn.ID,
+		CompletedAtMS: changedAt.UnixMilli(),
+	})
+}
+
+func (t *runtimeFileChangeTracker) Err() error {
+	if t == nil {
+		return nil
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.err
+}
+
+func (t *runtimeFileChangeTracker) recordErrorLocked(operation string, err error) {
+	if err == nil || t.err != nil {
+		return
+	}
+	t.err = fmt.Errorf("persist runtime file change item (%s): %w", operation, err)
+	publishRuntimeError(t.notifier, t.turn, t.err.Error())
+}
+
+func runtimeFileChangeKind(operation string) string {
+	switch strings.ToLower(strings.TrimSpace(operation)) {
+	case "create", "add", "createdirectory":
+		return runtimePatchChangeAdd
+	case "delete", "remove":
+		return runtimePatchChangeDelete
+	default:
+		return runtimePatchChangeUpdate
+	}
+}

--- a/appserver/runtime_filesystem_tools.go
+++ b/appserver/runtime_filesystem_tools.go
@@ -1,0 +1,464 @@
+package appserver
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	toolfs "github.com/fugue-labs/gollem/appserver/tools/fs"
+	"github.com/fugue-labs/gollem/core"
+	"github.com/pmezard/go-difflib/difflib"
+)
+
+const (
+	runtimeFilesystemToolNamespace   = "workspace"
+	runtimeFilesystemContentMaxBytes = 64 * 1024
+)
+
+type runtimeFilesystemPathParams struct {
+	Path string `json:"path" jsonschema:"description=Workspace-relative or workspace-contained absolute path"`
+}
+
+type runtimeFilesystemWriteParams struct {
+	Path    string `json:"path" jsonschema:"description=Workspace-relative or workspace-contained absolute file path"`
+	Content string `json:"content" jsonschema:"description=Complete UTF-8 file content"`
+}
+
+type runtimeFilesystemCopyParams struct {
+	Source      string `json:"source" jsonschema:"description=Workspace-relative or workspace-contained source path"`
+	Destination string `json:"destination" jsonschema:"description=Workspace-relative or workspace-contained destination path"`
+}
+
+type runtimeFilesystemReadResult struct {
+	Path             string    `json:"path"`
+	Content          string    `json:"content,omitempty"`
+	ContentEncoding  string    `json:"contentEncoding,omitempty"`
+	ContentTruncated bool      `json:"contentTruncated,omitempty"`
+	OmittedReason    string    `json:"omittedReason,omitempty"`
+	SHA256           string    `json:"sha256"`
+	Size             int64     `json:"size"`
+	Mode             string    `json:"mode"`
+	ModifiedAt       time.Time `json:"modifiedAt"`
+}
+
+type runtimeFilesystemEntryResult struct {
+	Path       string    `json:"path"`
+	Name       string    `json:"name"`
+	IsDir      bool      `json:"isDir"`
+	Size       int64     `json:"size"`
+	Mode       string    `json:"mode"`
+	ModifiedAt time.Time `json:"modifiedAt"`
+}
+
+type runtimeFilesystemListResult struct {
+	Path    string                         `json:"path"`
+	Entries []runtimeFilesystemEntryResult `json:"entries"`
+}
+
+type runtimeFilesystemMetadataResult struct {
+	Path       string    `json:"path"`
+	IsDir      bool      `json:"isDir"`
+	Size       int64     `json:"size"`
+	Mode       string    `json:"mode"`
+	ModifiedAt time.Time `json:"modifiedAt"`
+}
+
+type runtimeFilesystemMutationResult struct {
+	Path        string `json:"path"`
+	Destination string `json:"destination,omitempty"`
+	Operation   string `json:"operation"`
+	Changed     bool   `json:"changed"`
+}
+
+// FilesystemRuntimeTools adapts the scoped app-server filesystem service into
+// provider-neutral model tools. Mutations retain the service's approval and
+// audit hooks and publish bounded artifact evidence on the active run bus.
+func FilesystemRuntimeTools(service *toolfs.Service) []core.Tool {
+	if service == nil {
+		return nil
+	}
+	tools := []core.Tool{
+		core.FuncTool[runtimeFilesystemPathParams](
+			"workspace_read_file",
+			"Read a workspace file. Text is bounded; binary or oversized content is represented by metadata and a digest.",
+			func(ctx context.Context, params runtimeFilesystemPathParams) (runtimeFilesystemReadResult, error) {
+				if strings.TrimSpace(params.Path) == "" {
+					return runtimeFilesystemReadResult{}, errors.New("path is required")
+				}
+				content, err := service.ReadFile(ctx, params.Path)
+				if err != nil {
+					return runtimeFilesystemReadResult{}, err
+				}
+				return newRuntimeFilesystemReadResult(content), nil
+			},
+			core.WithToolConcurrencySafe(true),
+			core.WithToolTimeout(30*time.Second),
+		),
+		core.FuncTool[runtimeFilesystemPathParams](
+			"workspace_list_directory",
+			"List one workspace directory with path, type, size, mode, and modification metadata.",
+			func(ctx context.Context, params runtimeFilesystemPathParams) (runtimeFilesystemListResult, error) {
+				if strings.TrimSpace(params.Path) == "" {
+					params.Path = "."
+				}
+				entries, err := service.ReadDirectory(ctx, params.Path)
+				if err != nil {
+					return runtimeFilesystemListResult{}, err
+				}
+				out := make([]runtimeFilesystemEntryResult, 0, len(entries))
+				for _, entry := range entries {
+					out = append(out, runtimeFilesystemEntryResult{
+						Path:       filepath.ToSlash(entry.Path),
+						Name:       entry.Name,
+						IsDir:      entry.IsDir,
+						Size:       entry.Size,
+						Mode:       entry.Mode.String(),
+						ModifiedAt: entry.ModTime,
+					})
+				}
+				return runtimeFilesystemListResult{Path: filepath.ToSlash(filepath.Clean(params.Path)), Entries: out}, nil
+			},
+			core.WithToolConcurrencySafe(true),
+			core.WithToolTimeout(30*time.Second),
+		),
+		core.FuncTool[runtimeFilesystemPathParams](
+			"workspace_file_metadata",
+			"Inspect workspace path metadata without reading file content.",
+			func(ctx context.Context, params runtimeFilesystemPathParams) (runtimeFilesystemMetadataResult, error) {
+				if strings.TrimSpace(params.Path) == "" {
+					return runtimeFilesystemMetadataResult{}, errors.New("path is required")
+				}
+				metadata, err := service.Metadata(ctx, params.Path)
+				if err != nil {
+					return runtimeFilesystemMetadataResult{}, err
+				}
+				return runtimeFilesystemMetadataResult{
+					Path:       filepath.ToSlash(metadata.Path),
+					IsDir:      metadata.IsDir,
+					Size:       metadata.Size,
+					Mode:       metadata.Mode.String(),
+					ModifiedAt: metadata.ModTime,
+				}, nil
+			},
+			core.WithToolConcurrencySafe(true),
+			core.WithToolTimeout(30*time.Second),
+		),
+		core.FuncTool[runtimeFilesystemWriteParams](
+			"workspace_write_file",
+			"Create or replace a UTF-8 workspace file through the configured mutation approval policy.",
+			func(ctx context.Context, rc *core.RunContext, params runtimeFilesystemWriteParams) (runtimeFilesystemMutationResult, error) {
+				if strings.TrimSpace(params.Path) == "" {
+					return runtimeFilesystemMutationResult{}, errors.New("path is required")
+				}
+				before, err := captureRuntimeArtifact(ctx, service, params.Path)
+				if err != nil {
+					return runtimeFilesystemMutationResult{}, err
+				}
+				if err := service.WriteFile(ctx, params.Path, []byte(params.Content), 0o644); err != nil {
+					return runtimeFilesystemMutationResult{}, err
+				}
+				after, err := captureRuntimeArtifact(ctx, service, params.Path)
+				if err != nil {
+					return runtimeFilesystemMutationResult{}, fmt.Errorf("capture written artifact: %w", err)
+				}
+				operation := "update"
+				if !before.Exists {
+					operation = "create"
+				}
+				changed := publishRuntimeArtifactChange(ctx, rc, before, after, operation)
+				return runtimeFilesystemMutationResult{Path: after.Path, Operation: operation, Changed: changed}, nil
+			},
+			core.WithToolSequential(true),
+			core.WithToolTimeout(2*time.Minute),
+		),
+		core.FuncTool[runtimeFilesystemPathParams](
+			"workspace_create_directory",
+			"Create a workspace directory through the configured mutation approval policy.",
+			func(ctx context.Context, rc *core.RunContext, params runtimeFilesystemPathParams) (runtimeFilesystemMutationResult, error) {
+				if strings.TrimSpace(params.Path) == "" {
+					return runtimeFilesystemMutationResult{}, errors.New("path is required")
+				}
+				before, err := captureRuntimeArtifact(ctx, service, params.Path)
+				if err != nil {
+					return runtimeFilesystemMutationResult{}, err
+				}
+				if err := service.CreateDirectory(ctx, params.Path); err != nil {
+					return runtimeFilesystemMutationResult{}, err
+				}
+				after, err := captureRuntimeArtifact(ctx, service, params.Path)
+				if err != nil {
+					return runtimeFilesystemMutationResult{}, fmt.Errorf("capture created directory: %w", err)
+				}
+				changed := publishRuntimeArtifactChange(ctx, rc, before, after, "create")
+				return runtimeFilesystemMutationResult{Path: after.Path, Operation: "createDirectory", Changed: changed}, nil
+			},
+			core.WithToolSequential(true),
+			core.WithToolTimeout(2*time.Minute),
+		),
+		core.FuncTool[runtimeFilesystemPathParams](
+			"workspace_remove_path",
+			"Remove a workspace file or directory through the configured destructive-mutation approval policy.",
+			func(ctx context.Context, rc *core.RunContext, params runtimeFilesystemPathParams) (runtimeFilesystemMutationResult, error) {
+				if strings.TrimSpace(params.Path) == "" {
+					return runtimeFilesystemMutationResult{}, errors.New("path is required")
+				}
+				before, err := captureRuntimeArtifact(ctx, service, params.Path)
+				if err != nil {
+					return runtimeFilesystemMutationResult{}, err
+				}
+				if err := service.Remove(ctx, params.Path); err != nil {
+					return runtimeFilesystemMutationResult{}, err
+				}
+				after, err := captureRuntimeArtifact(ctx, service, params.Path)
+				if err != nil {
+					return runtimeFilesystemMutationResult{}, fmt.Errorf("capture removed artifact: %w", err)
+				}
+				changed := publishRuntimeArtifactChange(ctx, rc, before, after, "delete")
+				return runtimeFilesystemMutationResult{Path: before.Path, Operation: "remove", Changed: changed}, nil
+			},
+			core.WithToolSequential(true),
+			core.WithToolTimeout(2*time.Minute),
+		),
+		core.FuncTool[runtimeFilesystemCopyParams](
+			"workspace_copy_path",
+			"Copy a workspace file or directory through the configured mutation approval policy.",
+			func(ctx context.Context, rc *core.RunContext, params runtimeFilesystemCopyParams) (runtimeFilesystemMutationResult, error) {
+				if strings.TrimSpace(params.Source) == "" || strings.TrimSpace(params.Destination) == "" {
+					return runtimeFilesystemMutationResult{}, errors.New("source and destination are required")
+				}
+				before, err := captureRuntimeArtifact(ctx, service, params.Destination)
+				if err != nil {
+					return runtimeFilesystemMutationResult{}, err
+				}
+				if err := service.Copy(ctx, params.Source, params.Destination); err != nil {
+					return runtimeFilesystemMutationResult{}, err
+				}
+				after, err := captureRuntimeArtifact(ctx, service, params.Destination)
+				if err != nil {
+					return runtimeFilesystemMutationResult{}, fmt.Errorf("capture copied artifact: %w", err)
+				}
+				operation := "update"
+				if !before.Exists {
+					operation = "create"
+				}
+				changed := publishRuntimeArtifactChange(ctx, rc, before, after, operation)
+				return runtimeFilesystemMutationResult{
+					Path:        filepath.ToSlash(filepath.Clean(params.Source)),
+					Destination: after.Path,
+					Operation:   "copy",
+					Changed:     changed,
+				}, nil
+			},
+			core.WithToolSequential(true),
+			core.WithToolTimeout(2*time.Minute),
+		),
+	}
+	for i := range tools {
+		tools[i].Definition.Namespace = runtimeFilesystemToolNamespace
+	}
+	return tools
+}
+
+func newRuntimeFilesystemReadResult(content *toolfs.FileContent) runtimeFilesystemReadResult {
+	result := runtimeFilesystemReadResult{
+		Path:       filepath.ToSlash(content.Path),
+		SHA256:     runtimeSHA256(content.Content),
+		Size:       content.Size,
+		Mode:       content.Mode.String(),
+		ModifiedAt: content.ModTime,
+	}
+	if !runtimeArtifactText(content.Content) {
+		result.OmittedReason = "binary content omitted"
+		return result
+	}
+	result.ContentEncoding = "utf-8"
+	result.Content, result.ContentTruncated = boundedRuntimeArtifactText(content.Content)
+	return result
+}
+
+type runtimeArtifactCapture struct {
+	Path    string
+	Exists  bool
+	IsDir   bool
+	Size    int64
+	Content []byte
+	SHA256  string
+}
+
+func captureRuntimeArtifact(ctx context.Context, service *toolfs.Service, path string) (runtimeArtifactCapture, error) {
+	metadata, err := service.Metadata(ctx, path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return runtimeArtifactCapture{Path: runtimeRelativeFilesystemPath(service.Root(), path)}, nil
+		}
+		return runtimeArtifactCapture{}, err
+	}
+	capture := runtimeArtifactCapture{
+		Path:   filepath.ToSlash(metadata.Path),
+		Exists: true,
+		IsDir:  metadata.IsDir,
+		Size:   metadata.Size,
+	}
+	if metadata.IsDir {
+		return capture, nil
+	}
+	content, err := service.ReadFile(ctx, path)
+	if err != nil {
+		return runtimeArtifactCapture{}, err
+	}
+	capture.Content = append([]byte(nil), content.Content...)
+	capture.SHA256 = runtimeSHA256(content.Content)
+	return capture, nil
+}
+
+func publishRuntimeArtifactChange(ctx context.Context, rc *core.RunContext, before, after runtimeArtifactCapture, operation string) bool {
+	if rc == nil || rc.EventBus == nil || runtimeArtifactCapturesEqual(before, after) {
+		return false
+	}
+	path := after.Path
+	if path == "" {
+		path = before.Path
+	}
+	diff, diffTruncated, diffOmitted := runtimeArtifactDiff(path, before, after)
+	beforeContent, afterContent, contentTruncated, contentOmitted := runtimeArtifactContents(before, after)
+	bytesChanged := after.Size
+	if !after.Exists {
+		bytesChanged = before.Size
+	}
+	core.Publish(rc.EventBus, core.ArtifactChangedEvent{
+		RunID:                rc.RunID,
+		ParentRunID:          rc.ParentRunID,
+		ToolCallID:           firstRuntimeNonEmpty(core.ToolCallIDFromContext(ctx), rc.ToolCallID),
+		ToolName:             rc.ToolName,
+		Path:                 filepath.ToSlash(path),
+		Operation:            operation,
+		Bytes:                bytesChanged,
+		BeforeSHA256:         before.SHA256,
+		AfterSHA256:          after.SHA256,
+		Diff:                 diff,
+		DiffTruncated:        diffTruncated,
+		DiffOmittedReason:    diffOmitted,
+		BeforeContent:        beforeContent,
+		AfterContent:         afterContent,
+		ContentEncoding:      runtimeArtifactContentEncoding(before, after, contentOmitted),
+		ContentTruncated:     contentTruncated,
+		ContentOmittedReason: contentOmitted,
+		ChangedAt:            time.Now().UTC(),
+	})
+	return true
+}
+
+func runtimeArtifactCapturesEqual(before, after runtimeArtifactCapture) bool {
+	if before.Exists != after.Exists || before.IsDir != after.IsDir || before.Size != after.Size {
+		return false
+	}
+	if !before.Exists {
+		return true
+	}
+	if before.IsDir {
+		return true
+	}
+	return before.SHA256 == after.SHA256
+}
+
+func runtimeArtifactDiff(path string, before, after runtimeArtifactCapture) (string, bool, string) {
+	if before.IsDir || after.IsDir {
+		return "", false, "directory content omitted"
+	}
+	if len(before.Content) > runtimeFilesystemContentMaxBytes || len(after.Content) > runtimeFilesystemContentMaxBytes {
+		return "", false, fmt.Sprintf("content exceeds %d byte diff limit", runtimeFilesystemContentMaxBytes)
+	}
+	if !runtimeArtifactText(before.Content) || !runtimeArtifactText(after.Content) {
+		return "", false, "binary content omitted"
+	}
+	fromFile := "a/" + runtimeDiffPath(path)
+	toFile := "b/" + runtimeDiffPath(path)
+	if !before.Exists {
+		fromFile = "/dev/null"
+	}
+	if !after.Exists {
+		toFile = "/dev/null"
+	}
+	diff, err := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
+		A:        difflib.SplitLines(string(before.Content)),
+		B:        difflib.SplitLines(string(after.Content)),
+		FromFile: fromFile,
+		ToFile:   toFile,
+		Context:  3,
+	})
+	if err != nil {
+		return "", false, "build unified diff: " + err.Error()
+	}
+	if len(diff) <= runtimeFilesystemContentMaxBytes {
+		return diff, false, ""
+	}
+	bounded, _ := boundedRuntimeArtifactText([]byte(diff))
+	return bounded + "\n... diff truncated ...\n", true, ""
+}
+
+func runtimeArtifactContents(before, after runtimeArtifactCapture) (string, string, bool, string) {
+	if before.IsDir || after.IsDir {
+		return "", "", false, "directory content omitted"
+	}
+	if !runtimeArtifactText(before.Content) || !runtimeArtifactText(after.Content) {
+		return "", "", false, "binary content omitted"
+	}
+	beforeText, beforeTruncated := boundedRuntimeArtifactText(before.Content)
+	afterText, afterTruncated := boundedRuntimeArtifactText(after.Content)
+	return beforeText, afterText, beforeTruncated || afterTruncated, ""
+}
+
+func runtimeArtifactContentEncoding(before, after runtimeArtifactCapture, omitted string) string {
+	if omitted != "" || before.IsDir || after.IsDir {
+		return ""
+	}
+	return "utf-8"
+}
+
+func boundedRuntimeArtifactText(data []byte) (string, bool) {
+	if len(data) <= runtimeFilesystemContentMaxBytes {
+		return string(data), false
+	}
+	end := runtimeFilesystemContentMaxBytes
+	for end > 0 && !utf8.RuneStart(data[end]) {
+		end--
+	}
+	return string(data[:end]), true
+}
+
+func runtimeArtifactText(data []byte) bool {
+	return !bytes.Contains(data, []byte{0}) && utf8.Valid(data)
+}
+
+func runtimeSHA256(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func runtimeRelativeFilesystemPath(root, path string) string {
+	if !filepath.IsAbs(path) {
+		return filepath.ToSlash(filepath.Clean(path))
+	}
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return filepath.ToSlash(filepath.Clean(path))
+	}
+	return filepath.ToSlash(rel)
+}
+
+func runtimeDiffPath(path string) string {
+	path = filepath.ToSlash(filepath.Clean(path))
+	path = strings.TrimPrefix(path, "/")
+	if path == "." || path == "" {
+		return "artifact"
+	}
+	return path
+}

--- a/appserver/runtime_filesystem_tools_test.go
+++ b/appserver/runtime_filesystem_tools_test.go
@@ -1,0 +1,552 @@
+package appserver
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/fugue-labs/gollem/appserver/protocol"
+	"github.com/fugue-labs/gollem/appserver/store"
+	toolfs "github.com/fugue-labs/gollem/appserver/tools/fs"
+	"github.com/fugue-labs/gollem/core"
+)
+
+func TestFilesystemRuntimeToolsExposeScopedOperations(t *testing.T) {
+	fsSvc, err := toolfs.NewService(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	defer fsSvc.Close()
+
+	tools := FilesystemRuntimeTools(fsSvc)
+	want := map[string]struct {
+		sequential      bool
+		concurrencySafe bool
+	}{
+		"workspace_read_file":        {concurrencySafe: true},
+		"workspace_list_directory":   {concurrencySafe: true},
+		"workspace_file_metadata":    {concurrencySafe: true},
+		"workspace_write_file":       {sequential: true},
+		"workspace_create_directory": {sequential: true},
+		"workspace_remove_path":      {sequential: true},
+		"workspace_copy_path":        {sequential: true},
+	}
+	if len(tools) != len(want) {
+		t.Fatalf("runtime filesystem tools = %d, want %d", len(tools), len(want))
+	}
+	for _, tool := range tools {
+		expected, ok := want[tool.Definition.Name]
+		if !ok {
+			t.Fatalf("unexpected runtime tool %q", tool.Definition.Name)
+		}
+		if tool.Definition.Namespace != runtimeFilesystemToolNamespace {
+			t.Fatalf("tool %q namespace = %q", tool.Definition.Name, tool.Definition.Namespace)
+		}
+		if tool.Definition.Sequential != expected.sequential || tool.Definition.ConcurrencySafe != expected.concurrencySafe {
+			t.Fatalf("tool %q scheduling = sequential %v concurrency-safe %v", tool.Definition.Name, tool.Definition.Sequential, tool.Definition.ConcurrencySafe)
+		}
+		delete(want, tool.Definition.Name)
+	}
+	if len(want) != 0 {
+		t.Fatalf("missing runtime tools: %v", want)
+	}
+}
+
+func TestFilesystemRuntimeReadToolRejectsWorkspaceEscape(t *testing.T) {
+	root := t.TempDir()
+	fsSvc, err := toolfs.NewService(root)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	defer fsSvc.Close()
+	tool := findRuntimeToolByName(t, FilesystemRuntimeTools(fsSvc), "workspace_read_file")
+
+	outside := filepath.Join(filepath.Dir(root), "outside.txt")
+	if err := os.WriteFile(outside, []byte("secret"), 0o600); err != nil {
+		t.Fatalf("write outside fixture: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(outside) })
+	_, err = tool.Handler(context.Background(), &core.RunContext{}, `{"path":"../outside.txt"}`)
+	if !errors.Is(err, toolfs.ErrPathOutsideRoot) {
+		t.Fatalf("read escape error = %v, want %v", err, toolfs.ErrPathOutsideRoot)
+	}
+}
+
+func TestFilesystemRuntimeToolsBoundEvidenceAndSuppressNoOpChanges(t *testing.T) {
+	binary := newRuntimeFilesystemReadResult(&toolfs.FileContent{
+		Path:    "image.bin",
+		Content: []byte{0, 1, 2, 3},
+		Size:    4,
+	})
+	if binary.Content != "" || binary.ContentEncoding != "" || binary.OmittedReason != "binary content omitted" || binary.SHA256 == "" {
+		t.Fatalf("binary read result = %#v", binary)
+	}
+	largeContent := strings.Repeat("x", runtimeFilesystemContentMaxBytes+100)
+	large := newRuntimeFilesystemReadResult(&toolfs.FileContent{
+		Path:    "large.txt",
+		Content: []byte(largeContent),
+		Size:    int64(len(largeContent)),
+	})
+	if !large.ContentTruncated || len(large.Content) > runtimeFilesystemContentMaxBytes || large.ContentEncoding != "utf-8" {
+		t.Fatalf("large read result = content bytes %d, truncated %v, encoding %q", len(large.Content), large.ContentTruncated, large.ContentEncoding)
+	}
+	_, _, omitted := runtimeArtifactDiff("large.txt",
+		runtimeArtifactCapture{Exists: true, Content: []byte("before\n")},
+		runtimeArtifactCapture{Exists: true, Content: []byte(largeContent)},
+	)
+	if !strings.Contains(omitted, "diff limit") {
+		t.Fatalf("large diff omitted reason = %q", omitted)
+	}
+
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "same.txt"), []byte("unchanged\n"), 0o644); err != nil {
+		t.Fatalf("write no-op fixture: %v", err)
+	}
+	fsSvc, err := toolfs.NewService(root)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	defer fsSvc.Close()
+	bus := core.NewEventBus()
+	defer bus.Close()
+	eventCount := 0
+	unsubscribe := core.Subscribe(bus, func(core.ArtifactChangedEvent) { eventCount++ })
+	defer unsubscribe()
+	tool := findRuntimeToolByName(t, FilesystemRuntimeTools(fsSvc), "workspace_write_file")
+	result, err := tool.Handler(
+		core.ContextWithToolCallID(context.Background(), "call-no-op"),
+		&core.RunContext{EventBus: bus, RunID: "run-no-op", ToolCallID: "call-no-op", ToolName: "workspace_write_file"},
+		`{"path":"same.txt","content":"unchanged\n"}`,
+	)
+	if err != nil {
+		t.Fatalf("no-op write: %v", err)
+	}
+	mutation, ok := result.(runtimeFilesystemMutationResult)
+	if !ok || mutation.Changed || eventCount != 0 {
+		t.Fatalf("no-op write result = %#v, artifact events = %d", result, eventCount)
+	}
+}
+
+func TestRuntimeToolTimelinePayloadsAreBounded(t *testing.T) {
+	large := strings.Repeat("payload", runtimeToolPayloadMaxBytes)
+	arguments := runtimeToolArguments(`{"content":"` + large + `"}`)
+	summary, ok := arguments.(runtimeToolPayloadSummary)
+	if !ok || !summary.Omitted || summary.Bytes <= runtimeToolPayloadMaxBytes || summary.SHA256 == "" {
+		t.Fatalf("large argument summary = %#v", arguments)
+	}
+	output := boundedRuntimeToolOutput("prefix-" + large + "-suffix")
+	if len(output) > runtimeToolPayloadMaxBytes || !strings.HasPrefix(output, "prefix-") || !strings.HasSuffix(output, "-suffix") || !strings.Contains(output, "output truncated") {
+		t.Fatalf("bounded output bytes = %d, prefix/suffix/marker missing", len(output))
+	}
+}
+
+func TestServerRuntimeApprovedFilesystemWritePersistsFileChange(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "preexisting.txt"), []byte("dirty before turn\n"), 0o644); err != nil {
+		t.Fatalf("write pre-existing fixture: %v", err)
+	}
+	st := newRuntimeTestStore(t)
+	approvals := NewApprovalService()
+	fsSvc, err := toolfs.NewService(root, toolfs.WithApproval(approvals.FilesystemApproval))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	defer fsSvc.Close()
+	model := core.NewTestModel(
+		core.ToolCallResponseWithID(
+			"workspace_write_file",
+			`{"path":"notes/result.txt","content":"runtime write\n"}`,
+			"call-write",
+		),
+		core.TextResponse("write complete"),
+	)
+	server := readyServer(
+		WithStore(st),
+		WithFilesystem(fsSvc),
+		WithApprovalService(approvals),
+		WithRuntimeService(NewRuntimeService(
+			WithRuntimeModel(model, RuntimeModelInfo{ProviderID: "test", Model: "test-model"}),
+			WithRuntimeTools(FilesystemRuntimeTools(fsSvc)...),
+		)),
+	)
+
+	resp := server.HandleRequest(ctx, request("thread/start", map[string]any{
+		"title":  "Runtime filesystem",
+		"prompt": "write the result",
+	}))
+	if resp.Error != nil {
+		t.Fatalf("thread/start error: %v", resp.Error)
+	}
+	var started struct {
+		Thread *store.Thread `json:"thread"`
+		Turn   *store.Turn   `json:"turn"`
+	}
+	decodeResult(t, resp, &started)
+
+	approvalRequest := waitForServerRequest(t, server)
+	if approvalRequest.Method != "item/fileChange/requestApproval" {
+		t.Fatalf("approval method = %q", approvalRequest.Method)
+	}
+	requestID, _ := approvalRequest.ID.Value().(string)
+	if requestID == "" {
+		t.Fatalf("approval request id = %#v", approvalRequest.ID.Value())
+	}
+	var approvalParams fileChangeApprovalParams
+	if err := json.Unmarshal(approvalRequest.Params, &approvalParams); err != nil {
+		t.Fatalf("decode approval params: %v", err)
+	}
+	if approvalParams.ThreadID != started.Thread.ID || approvalParams.TurnID != started.Turn.ID {
+		t.Fatalf("approval turn context = %q/%q, want %q/%q", approvalParams.ThreadID, approvalParams.TurnID, started.Thread.ID, started.Turn.ID)
+	}
+	if approvalParams.ItemID != "call-write" {
+		t.Fatalf("approval item id = %q, want tool call id", approvalParams.ItemID)
+	}
+	approvalResponse := server.HandleRequest(ctx, request("approval/respond", map[string]any{
+		"requestId": requestID,
+		"approved":  true,
+	}))
+	if approvalResponse.Error != nil {
+		t.Fatalf("approval/respond error: %v", approvalResponse.Error)
+	}
+
+	events := waitForNotificationSet(t, server,
+		"item/fileChange/patchUpdated",
+		"turn/diff/updated",
+		"turn/completed",
+	)
+	data, err := os.ReadFile(filepath.Join(root, "notes", "result.txt"))
+	if err != nil {
+		t.Fatalf("read runtime output: %v", err)
+	}
+	if string(data) != "runtime write\n" {
+		t.Fatalf("runtime output = %q", data)
+	}
+
+	items, err := st.ListItems(ctx, store.ItemFilter{ThreadID: started.Thread.ID, TurnID: started.Turn.ID})
+	if err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+	fileItem := findRuntimeFileChangeItem(t, items, "notes/result.txt")
+	toolItem := findRuntimeToolItem(t, items, "workspace_write_file", "path", "notes/result.txt")
+	if fileItem.Item.ParentItemID != toolItem.Item.ID {
+		t.Fatalf("file item parent = %q, want dynamic tool item %q", fileItem.Item.ParentItemID, toolItem.Item.ID)
+	}
+	if fileItem.Item.Status != runtimeFileChangeStatusCompleted || fileItem.Payload.Status != runtimeFileChangeStatusCompleted {
+		t.Fatalf("file item status = %q/%q", fileItem.Item.Status, fileItem.Payload.Status)
+	}
+	if len(fileItem.Payload.Changes) != 1 || fileItem.Payload.Changes[0].Kind.Type != runtimePatchChangeAdd {
+		t.Fatalf("file item changes = %#v", fileItem.Payload.Changes)
+	}
+	if !strings.Contains(fileItem.Payload.Changes[0].Diff, "+runtime write") {
+		t.Fatalf("file item diff = %q", fileItem.Payload.Changes[0].Diff)
+	}
+	if len(fileItem.Payload.Evidence) != 1 || fileItem.Payload.Evidence[0].AfterSHA256 == "" {
+		t.Fatalf("file item evidence = %#v", fileItem.Payload.Evidence)
+	}
+
+	patch := decodeRuntimeFileChangePatch(t, events)
+	if patch.ThreadID != started.Thread.ID || patch.TurnID != started.Turn.ID || patch.ItemID != fileItem.Item.ID {
+		t.Fatalf("patch ids = %#v", patch)
+	}
+	if len(patch.Changes) != 1 || patch.Changes[0].Path != "notes/result.txt" {
+		t.Fatalf("patch changes = %#v", patch.Changes)
+	}
+	diff := decodeRuntimeTurnDiff(t, events)
+	if !strings.Contains(diff.Diff, "notes/result.txt") || strings.Contains(diff.Diff, "preexisting.txt") {
+		t.Fatalf("turn-local diff = %q", diff.Diff)
+	}
+}
+
+func TestServerRuntimePersistsUpdateAndDeleteFileChanges(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "update.txt"), []byte("before\n"), 0o644); err != nil {
+		t.Fatalf("write update fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "delete.txt"), []byte("remove me\n"), 0o644); err != nil {
+		t.Fatalf("write delete fixture: %v", err)
+	}
+	st := newRuntimeTestStore(t)
+	fsSvc, err := toolfs.NewService(root)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	defer fsSvc.Close()
+	model := core.NewTestModel(
+		core.ToolCallResponseWithID(
+			"workspace_write_file",
+			`{"path":"update.txt","content":"after\n"}`,
+			"call-update",
+		),
+		core.ToolCallResponseWithID(
+			"workspace_remove_path",
+			`{"path":"delete.txt"}`,
+			"call-delete",
+		),
+		core.TextResponse("changes complete"),
+	)
+	server := readyServer(
+		WithStore(st),
+		WithFilesystem(fsSvc),
+		WithRuntimeService(NewRuntimeService(
+			WithRuntimeModel(model, RuntimeModelInfo{ProviderID: "test", Model: "test-model"}),
+			WithRuntimeTools(FilesystemRuntimeTools(fsSvc)...),
+		)),
+	)
+	resp := server.HandleRequest(ctx, request("thread/start", map[string]any{"prompt": "update and delete"}))
+	if resp.Error != nil {
+		t.Fatalf("thread/start error: %v", resp.Error)
+	}
+	var started struct {
+		Thread *store.Thread `json:"thread"`
+		Turn   *store.Turn   `json:"turn"`
+	}
+	decodeResult(t, resp, &started)
+	events := waitForNotificationSet(t, server,
+		"item/fileChange/patchUpdated",
+		"item/fileChange/patchUpdated",
+		"turn/completed",
+	)
+
+	items, err := st.ListItems(ctx, store.ItemFilter{ThreadID: started.Thread.ID, TurnID: started.Turn.ID})
+	if err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+	updated := findRuntimeFileChangeItem(t, items, "update.txt")
+	if updated.Payload.Changes[0].Kind.Type != runtimePatchChangeUpdate ||
+		!strings.Contains(updated.Payload.Changes[0].Diff, "-before") ||
+		!strings.Contains(updated.Payload.Changes[0].Diff, "+after") {
+		t.Fatalf("updated file change = %#v", updated.Payload.Changes[0])
+	}
+	deleted := findRuntimeFileChangeItem(t, items, "delete.txt")
+	if deleted.Payload.Changes[0].Kind.Type != runtimePatchChangeDelete || !strings.Contains(deleted.Payload.Changes[0].Diff, "-remove me") {
+		t.Fatalf("deleted file change = %#v", deleted.Payload.Changes[0])
+	}
+	if _, err := os.Stat(filepath.Join(root, "delete.txt")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("deleted file stat error = %v, want not-exist", err)
+	}
+	data, err := os.ReadFile(filepath.Join(root, "update.txt"))
+	if err != nil || string(data) != "after\n" {
+		t.Fatalf("updated file = %q, error %v", data, err)
+	}
+	var finalDiff string
+	for _, event := range events {
+		if event.Method != "turn/diff/updated" {
+			continue
+		}
+		var params turnDiffUpdatedNotificationParams
+		if err := json.Unmarshal(event.Params, &params); err != nil {
+			t.Fatalf("decode turn diff: %v", err)
+		}
+		finalDiff = params.Diff
+	}
+	if !strings.Contains(finalDiff, "update.txt") || !strings.Contains(finalDiff, "delete.txt") {
+		t.Fatalf("cumulative turn diff = %q", finalDiff)
+	}
+}
+
+func TestServerRuntimeDeniedFilesystemWriteDoesNotPersistFileChange(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	st := newRuntimeTestStore(t)
+	approvals := NewApprovalService()
+	fsSvc, err := toolfs.NewService(root, toolfs.WithApproval(approvals.FilesystemApproval))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	defer fsSvc.Close()
+	model := core.NewTestModel(
+		core.ToolCallResponseWithID(
+			"workspace_write_file",
+			`{"path":"denied.txt","content":"must not exist\n"}`,
+			"call-denied",
+		),
+		core.TextResponse("write was denied"),
+	)
+	server := readyServer(
+		WithStore(st),
+		WithFilesystem(fsSvc),
+		WithApprovalService(approvals),
+		WithRuntimeService(NewRuntimeService(
+			WithRuntimeModel(model, RuntimeModelInfo{ProviderID: "test", Model: "test-model"}),
+			WithRuntimeTools(FilesystemRuntimeTools(fsSvc)...),
+		)),
+	)
+
+	resp := server.HandleRequest(ctx, request("thread/start", map[string]any{"prompt": "try a denied write"}))
+	if resp.Error != nil {
+		t.Fatalf("thread/start error: %v", resp.Error)
+	}
+	var started struct {
+		Thread *store.Thread `json:"thread"`
+		Turn   *store.Turn   `json:"turn"`
+	}
+	decodeResult(t, resp, &started)
+	approvalRequest := waitForServerRequest(t, server)
+	requestID, _ := approvalRequest.ID.Value().(string)
+	approvalResponse := server.HandleRequest(ctx, request("approval/respond", map[string]any{
+		"requestId": requestID,
+		"approved":  false,
+		"message":   "denied by test",
+	}))
+	if approvalResponse.Error != nil {
+		t.Fatalf("approval/respond error: %v", approvalResponse.Error)
+	}
+	events := waitForNotificationSet(t, server, "turn/completed")
+	if _, err := os.Stat(filepath.Join(root, "denied.txt")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("denied file stat error = %v, want not-exist", err)
+	}
+	for _, event := range events {
+		if event.Method == "item/fileChange/patchUpdated" || event.Method == "turn/diff/updated" {
+			t.Fatalf("denied write emitted %s: %#v", event.Method, event)
+		}
+	}
+	items, err := st.ListItems(ctx, store.ItemFilter{ThreadID: started.Thread.ID, TurnID: started.Turn.ID})
+	if err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+	for _, item := range items {
+		if item.Kind == runtimeFileChangeItemKind {
+			t.Fatalf("denied write persisted file change item: %#v", item)
+		}
+	}
+	toolItem := findRuntimeToolItem(t, items, "workspace_write_file", "path", "denied.txt")
+	if toolItem.Status != runtimeToolStatusFailed {
+		t.Fatalf("denied dynamic tool status = %q, want failed", toolItem.Status)
+	}
+}
+
+func TestServerRuntimeInterruptCancelsPendingFilesystemApproval(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	st := newRuntimeTestStore(t)
+	approvals := NewApprovalService()
+	fsSvc, err := toolfs.NewService(root, toolfs.WithApproval(approvals.FilesystemApproval))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	defer fsSvc.Close()
+	model := core.NewTestModel(
+		core.ToolCallResponseWithID(
+			"workspace_write_file",
+			`{"path":"interrupted.txt","content":"must not exist\n"}`,
+			"call-interrupted",
+		),
+		core.TextResponse("should not run"),
+	)
+	server := readyServer(
+		WithStore(st),
+		WithFilesystem(fsSvc),
+		WithApprovalService(approvals),
+		WithRuntimeService(NewRuntimeService(
+			WithRuntimeModel(model, RuntimeModelInfo{ProviderID: "test", Model: "test-model"}),
+			WithRuntimeTools(FilesystemRuntimeTools(fsSvc)...),
+		)),
+	)
+
+	resp := server.HandleRequest(ctx, request("thread/start", map[string]any{"prompt": "interrupt this write"}))
+	if resp.Error != nil {
+		t.Fatalf("thread/start error: %v", resp.Error)
+	}
+	var started struct {
+		Thread *store.Thread `json:"thread"`
+		Turn   *store.Turn   `json:"turn"`
+	}
+	decodeResult(t, resp, &started)
+	approvalRequest := waitForServerRequest(t, server)
+	requestID, _ := approvalRequest.ID.Value().(string)
+	interrupt := server.HandleRequest(ctx, request("turn/interrupt", map[string]any{"turnId": started.Turn.ID}))
+	if interrupt.Error != nil {
+		t.Fatalf("turn/interrupt error: %v", interrupt.Error)
+	}
+	waitForNotificationSet(t, server, "turn/completed")
+
+	completed, err := st.GetTurn(ctx, started.Turn.ID)
+	if err != nil {
+		t.Fatalf("GetTurn: %v", err)
+	}
+	if completed.Status != store.TurnInterrupted {
+		t.Fatalf("interrupted turn status = %q", completed.Status)
+	}
+	if _, err := os.Stat(filepath.Join(root, "interrupted.txt")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("interrupted file stat error = %v, want not-exist", err)
+	}
+	lateApproval := server.HandleRequest(ctx, request("approval/respond", map[string]any{
+		"requestId": requestID,
+		"approved":  true,
+	}))
+	if lateApproval.Error == nil || lateApproval.Error.Code != protocol.CodeInvalidParams {
+		t.Fatalf("late approval error = %#v, want invalid params", lateApproval.Error)
+	}
+}
+
+func findRuntimeToolByName(t *testing.T, tools []core.Tool, name string) core.Tool {
+	t.Helper()
+	for _, tool := range tools {
+		if tool.Definition.Name == name {
+			return tool
+		}
+	}
+	t.Fatalf("runtime tool %q not found", name)
+	return core.Tool{}
+}
+
+type storedRuntimeFileChangeItem struct {
+	Item    *store.Item
+	Payload runtimeFileChangePayload
+}
+
+func findRuntimeFileChangeItem(t *testing.T, items []*store.Item, path string) storedRuntimeFileChangeItem {
+	t.Helper()
+	for _, item := range items {
+		if item == nil || item.Kind != runtimeFileChangeItemKind {
+			continue
+		}
+		var payload runtimeFileChangePayload
+		if err := json.Unmarshal(item.Payload, &payload); err != nil {
+			t.Fatalf("decode stored file change item: %v", err)
+		}
+		if len(payload.Changes) == 1 && payload.Changes[0].Path == path {
+			return storedRuntimeFileChangeItem{Item: item, Payload: payload}
+		}
+	}
+	t.Fatalf("file change item for %q not found in %#v", path, items)
+	return storedRuntimeFileChangeItem{}
+}
+
+func decodeRuntimeFileChangePatch(t *testing.T, notifications []protocol.Notification) runtimeFileChangePatchUpdatedNotificationParams {
+	t.Helper()
+	for _, notification := range notifications {
+		if notification.Method != "item/fileChange/patchUpdated" {
+			continue
+		}
+		var params runtimeFileChangePatchUpdatedNotificationParams
+		if err := json.Unmarshal(notification.Params, &params); err != nil {
+			t.Fatalf("decode item/fileChange/patchUpdated: %v", err)
+		}
+		return params
+	}
+	t.Fatalf("file change patch notification missing from %v", notificationMethods(notifications))
+	return runtimeFileChangePatchUpdatedNotificationParams{}
+}
+
+func decodeRuntimeTurnDiff(t *testing.T, notifications []protocol.Notification) turnDiffUpdatedNotificationParams {
+	t.Helper()
+	for _, notification := range notifications {
+		if notification.Method != "turn/diff/updated" {
+			continue
+		}
+		var params turnDiffUpdatedNotificationParams
+		if err := json.Unmarshal(notification.Params, &params); err != nil {
+			t.Fatalf("decode turn/diff/updated: %v", err)
+		}
+		return params
+	}
+	t.Fatalf("turn diff notification missing from %v", notificationMethods(notifications))
+	return turnDiffUpdatedNotificationParams{}
+}

--- a/appserver/runtime_tool_items.go
+++ b/appserver/runtime_tool_items.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/fugue-labs/gollem/appserver/store"
 	"github.com/fugue-labs/gollem/core"
@@ -17,6 +18,7 @@ const (
 	runtimeToolStatusInProgress    = "inProgress"
 	runtimeToolStatusCompleted     = "completed"
 	runtimeToolStatusFailed        = "failed"
+	runtimeToolPayloadMaxBytes     = 64 * 1024
 )
 
 type runtimeDynamicToolCallPayload struct {
@@ -34,6 +36,13 @@ type runtimeDynamicToolCallPayload struct {
 type runtimeDynamicToolCallContentItem struct {
 	Type string `json:"type"`
 	Text string `json:"text"`
+}
+
+type runtimeToolPayloadSummary struct {
+	Omitted bool   `json:"omitted"`
+	Reason  string `json:"reason"`
+	Bytes   int    `json:"bytes"`
+	SHA256  string `json:"sha256"`
 }
 
 type runtimeToolItemStartedNotificationParams struct {
@@ -170,7 +179,7 @@ func (t *runtimeToolItemTracker) complete(key, status, output string, success bo
 	}
 	delete(t.items, key)
 	state.payload.Status = status
-	state.payload.ContentItems = []runtimeDynamicToolCallContentItem{{Type: "inputText", Text: output}}
+	state.payload.ContentItems = []runtimeDynamicToolCallContentItem{{Type: "inputText", Text: boundedRuntimeToolOutput(output)}}
 	state.payload.Success = runtimeBoolPointer(success)
 	state.payload.DurationMS = runtimeInt64Pointer(durationMS)
 	item, err := t.store.UpdateItem(context.Background(), store.UpdateItemRequest{
@@ -204,6 +213,19 @@ func (t *runtimeToolItemTracker) Err() error {
 	return t.err
 }
 
+func (t *runtimeToolItemTracker) itemID(runID, toolCallID, toolName string) string {
+	if t == nil {
+		return ""
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	state, ok := t.items[runtimeToolItemKey(runID, toolCallID, toolName)]
+	if !ok || state.item == nil {
+		return ""
+	}
+	return state.item.ID
+}
+
 func (t *runtimeToolItemTracker) recordErrorLocked(operation string, err error) {
 	if err == nil || t.err != nil {
 		return
@@ -228,14 +250,58 @@ func runtimeToolNamespace(namespace string) *string {
 }
 
 func runtimeToolArguments(raw string) any {
-	if strings.TrimSpace(raw) == "" {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
 		return map[string]any{}
+	}
+	if len(raw) > runtimeToolPayloadMaxBytes {
+		return runtimeToolPayloadSummary{
+			Omitted: true,
+			Reason:  "tool arguments exceed persisted payload limit",
+			Bytes:   len(raw),
+			SHA256:  runtimeSHA256([]byte(raw)),
+		}
 	}
 	var value any
 	if err := json.Unmarshal([]byte(raw), &value); err != nil {
 		return raw
 	}
 	return value
+}
+
+func boundedRuntimeToolOutput(output string) string {
+	output = strings.ToValidUTF8(output, "\uFFFD")
+	if len(output) <= runtimeToolPayloadMaxBytes {
+		return output
+	}
+	marker := "\n... tool output truncated ...\n"
+	remaining := runtimeToolPayloadMaxBytes - len(marker)
+	headBytes := remaining / 2
+	tailBytes := remaining - headBytes
+	head := boundedRuntimeToolOutputPrefix(output, headBytes)
+	tail := boundedRuntimeToolOutputSuffix(output, tailBytes)
+	return head + marker + tail
+}
+
+func boundedRuntimeToolOutputPrefix(value string, limit int) string {
+	if limit >= len(value) {
+		return value
+	}
+	for limit > 0 && !utf8.RuneStart(value[limit]) {
+		limit--
+	}
+	return value[:limit]
+}
+
+func boundedRuntimeToolOutputSuffix(value string, limit int) string {
+	if limit >= len(value) {
+		return value
+	}
+	start := len(value) - limit
+	for start < len(value) && !utf8.RuneStart(value[start]) {
+		start++
+	}
+	return value[start:]
 }
 
 func runtimeBoolPointer(value bool) *bool {

--- a/cmd/gollem/app_server.go
+++ b/cmd/gollem/app_server.go
@@ -221,6 +221,10 @@ func newCLIAppServer(flags appServerFlags) (*appserver.Server, func(), error) {
 }
 
 func newCLIAppServerWithTransport(flags appServerFlags, transport string) (*appserver.Server, func(), error) {
+	return newCLIAppServerWithRuntimeFactory(flags, transport, appServerRuntimeModelFactory(flags))
+}
+
+func newCLIAppServerWithRuntimeFactory(flags appServerFlags, transport string, runtimeFactory appserver.RuntimeModelFactory) (*appserver.Server, func(), error) {
 	workDir, err := filepath.Abs(flags.workDir)
 	if err != nil {
 		return nil, nil, fmt.Errorf("resolve workdir: %w", err)
@@ -242,9 +246,6 @@ func newCLIAppServerWithTransport(flags appServerFlags, transport string) (*apps
 	gitOpts := []toolgit.Option{}
 	events := appserver.NewEventQueue()
 	approvals := appserver.NewApprovalService()
-	runtimeSvc := appserver.NewRuntimeService(
-		appserver.WithRuntimeModelFactory(appServerRuntimeModelFactory(flags)),
-	)
 	var server *appserver.Server
 	if !flags.allowMutations {
 		fsOpts = append(fsOpts, toolfs.WithApproval(approvals.FilesystemApproval))
@@ -304,6 +305,10 @@ func newCLIAppServerWithTransport(flags appServerFlags, transport string) (*apps
 	if err != nil {
 		gitSvc = nil
 	}
+	runtimeSvc := appserver.NewRuntimeService(
+		appserver.WithRuntimeModelFactory(runtimeFactory),
+		appserver.WithRuntimeTools(appserver.FilesystemRuntimeTools(fsSvc)...),
+	)
 
 	version := gitCommit
 	if version == "" {

--- a/cmd/gollem/app_server_test.go
+++ b/cmd/gollem/app_server_test.go
@@ -18,6 +18,7 @@ import (
 	appserver "github.com/fugue-labs/gollem/appserver"
 	"github.com/fugue-labs/gollem/appserver/catalog"
 	"github.com/fugue-labs/gollem/appserver/protocol"
+	"github.com/fugue-labs/gollem/core"
 )
 
 func TestParseAppServerFlags(t *testing.T) {
@@ -489,6 +490,66 @@ func TestCLIAppServerThreadStartUsesRuntimeProviderFlag(t *testing.T) {
 		t.Fatalf("thread/start error: %v", resp.Error)
 	}
 	waitCLINotification(t, server, "turn/completed")
+}
+
+func TestCLIAppServerRuntimeUsesApprovedScopedFilesystemTool(t *testing.T) {
+	workDir := t.TempDir()
+	model := core.NewTestModel(
+		core.ToolCallResponseWithID(
+			"workspace_write_file",
+			`{"path":"from-runtime.txt","content":"cli runtime write\n"}`,
+			"call-cli-write",
+		),
+		core.TextResponse("write complete"),
+	)
+	server, cleanup, err := newCLIAppServerWithRuntimeFactory(
+		appServerFlags{workDir: workDir, storePath: ":memory:", stdio: true},
+		"stdio",
+		func(context.Context, appserver.RuntimeModelSelection) (core.Model, appserver.RuntimeModelInfo, error) {
+			return model, appserver.RuntimeModelInfo{ProviderID: "test", Model: "test-model"}, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("newCLIAppServerWithRuntimeFactory: %v", err)
+	}
+	defer cleanup()
+	readyCLIAppServer(t, server)
+
+	resp := server.HandleRequest(context.Background(), protocol.Request{
+		ID:     protocol.NewStringID("start-runtime-write"),
+		Method: "thread/start",
+		Params: json.RawMessage(`{"prompt":"write the file"}`),
+	})
+	if resp.Error != nil {
+		t.Fatalf("thread/start error: %v", resp.Error)
+	}
+	select {
+	case <-server.RequestSignal():
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for runtime filesystem approval")
+	}
+	requests := server.DrainRequests()
+	if len(requests) != 1 || requests[0].Method != "item/fileChange/requestApproval" {
+		t.Fatalf("runtime approval requests = %#v", requests)
+	}
+	requestID, _ := requests[0].ID.Value().(string)
+	approval := server.HandleRequest(context.Background(), protocol.Request{
+		ID:     protocol.NewStringID("approve-runtime-write"),
+		Method: "approval/respond",
+		Params: json.RawMessage(`{"requestId":"` + requestID + `","approved":true}`),
+	})
+	if approval.Error != nil {
+		t.Fatalf("approval/respond error: %v", approval.Error)
+	}
+	waitCLINotification(t, server, "turn/completed")
+
+	data, err := os.ReadFile(filepath.Join(workDir, "from-runtime.txt"))
+	if err != nil {
+		t.Fatalf("read runtime-written file: %v", err)
+	}
+	if string(data) != "cli runtime write\n" {
+		t.Fatalf("runtime-written content = %q", data)
+	}
 }
 
 func TestCLIAppServerCleanupStopsActiveRuntimeBeforeStoreClose(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/labstack/echo/v4 v4.15.0
 	github.com/nexus-rpc/sdk-go v0.5.1
+	github.com/pmezard/go-difflib v1.0.0
 	go.opentelemetry.io/otel v1.40.0
 	go.opentelemetry.io/otel/metric v1.40.0
 	go.opentelemetry.io/otel/sdk v1.40.0
@@ -72,7 +73,6 @@ require (
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/quic-go/qpack v0.5.1 // indirect
 	github.com/quic-go/quic-go v0.54.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect


### PR DESCRIPTION
## Summary

- register seven provider-neutral workspace filesystem tools in CLI app-server turns through `WithRuntimeTools`
- route every read and mutation through the existing root-scoped filesystem service, preserving approval, audit, cancellation, traversal, and symlink protections
- attach active thread/turn/tool-call context to mutation approval requests
- map `core.ArtifactChangedEvent` into durable `fileChange` timeline items, `item/fileChange/patchUpdated`, and mutation-local `turn/diff/updated` notifications
- correlate file changes to their parent durable `dynamicToolCall` items
- bound runtime tool arguments, results, diffs, and artifact evidence; omit binary content while retaining hashes and metadata
- mark `item/fileChange/patchUpdated` implemented in the method registry

## Behavior

The runtime tools support scoped file read, directory list, metadata, write, directory creation, remove, and copy operations. CLI mutations remain approval-required by default; `--allow-mutations` remains the explicit development bypass.

Artifact diffs are generated from the mutation-local before/after state rather than the repository's ambient dirty diff, so pre-existing workspace changes are not attributed to the turn.

## Stack

Stacked on #83 (`codex/gollem-appserver-runtime-tool-items`).

## Verification

- `go test ./appserver/... ./cmd/gollem -count=1`
- `go test -race ./appserver -run 'TestFilesystemRuntime|TestServerRuntime(Approved|Denied|Interrupt).*Filesystem|TestServerRuntime(PersistsDynamicToolCallLifecycle|TracksConcurrentDynamicToolCalls)' -count=1`
- `go test ./... -count=1`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test -race ./appserver/... ./cmd/gollem -count=1`
- pre-push hook: full lint, repository-wide race suite with configured Monty skip, vet, and tidy verification