### PR TITLE
[codex] Reconstruct runtime tool transcripts

### DIFF
--- a/appserver/runtime.go
+++ b/appserver/runtime.go
@@ -700,49 +700,6 @@ func lastRuntimeAssistantText(messages []core.ModelMessage) string {
 	return ""
 }
 
-func runtimeMessagesFromItems(items []*store.Item) []core.ModelMessage {
-	messages := make([]core.ModelMessage, 0, len(items))
-	for _, item := range items {
-		if item == nil || len(item.Payload) == 0 {
-			continue
-		}
-		if item.Kind == threadInjectedResponseItemKind {
-			if message, ok := runtimeMessageFromInjectedResponseItem(item.Payload); ok {
-				messages = append(messages, message)
-			}
-			continue
-		}
-		if item.Kind == threadCompactionItemKind {
-			if message, ok := runtimeMessageFromCompactionItem(item.Payload); ok {
-				messages = append(messages, message)
-			}
-			continue
-		}
-		if item.Kind != "message" {
-			continue
-		}
-		var payload runtimeMessagePayload
-		if err := json.Unmarshal(item.Payload, &payload); err != nil {
-			continue
-		}
-		switch payload.Role {
-		case "user":
-			messages = append(messages, core.ModelRequest{
-				Parts:     []core.ModelRequestPart{core.UserPromptPart{Content: payload.Text, Timestamp: payload.CreatedAt}},
-				Timestamp: payload.CreatedAt,
-			})
-		case "assistant":
-			messages = append(messages, core.ModelResponse{
-				Parts:        []core.ModelResponsePart{core.TextPart{Content: payload.Text}},
-				ModelName:    payload.Model,
-				FinishReason: core.FinishReasonStop,
-				Timestamp:    payload.CreatedAt,
-			})
-		}
-	}
-	return messages
-}
-
 func runtimePromptFromInput(raw json.RawMessage) string {
 	if len(raw) == 0 {
 		return ""

--- a/appserver/runtime_history.go
+++ b/appserver/runtime_history.go
@@ -1,0 +1,427 @@
+package appserver
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/fugue-labs/gollem/appserver/store"
+	"github.com/fugue-labs/gollem/core"
+)
+
+const runtimeReplayIdentifierMaxBytes = 64
+
+type runtimeReplayToolRecord struct {
+	tool      string
+	arguments any
+	result    any
+	errorText string
+	success   bool
+}
+
+type runtimeHistoryBuilder struct {
+	dynamicParents map[string]struct{}
+	callIDCounts   map[string]int
+	generatedIDs   int
+}
+
+func runtimeMessagesFromItems(items []*store.Item) []core.ModelMessage {
+	builder := runtimeHistoryBuilder{
+		dynamicParents: make(map[string]struct{}),
+		callIDCounts:   make(map[string]int),
+	}
+	builder.collectDynamicParents(items)
+
+	messages := make([]core.ModelMessage, 0, len(items))
+	for _, item := range items {
+		if item == nil || len(item.Payload) == 0 {
+			continue
+		}
+		switch item.Kind {
+		case threadInjectedResponseItemKind:
+			if message, ok := runtimeMessageFromInjectedResponseItem(item.Payload); ok {
+				messages = append(messages, message)
+			}
+		case threadCompactionItemKind:
+			if message, ok := runtimeMessageFromCompactionItem(item.Payload); ok {
+				messages = append(messages, message)
+			}
+		case "message":
+			if message, ok := runtimeMessageFromStoredItem(item.Payload); ok {
+				messages = append(messages, message)
+			}
+		case runtimeDynamicToolCallItemKind:
+			if record, ok := runtimeReplayDynamicToolRecord(item); ok {
+				messages = append(messages, builder.toolMessages(item, record)...)
+			}
+		case threadShellCommandItemKind:
+			if builder.isReplayedChild(item) {
+				continue
+			}
+			if record, ok := runtimeReplayCommandRecord(item); ok {
+				messages = append(messages, builder.toolMessages(item, record)...)
+			}
+		case runtimeFileChangeItemKind:
+			if builder.isReplayedChild(item) {
+				continue
+			}
+			if record, ok := runtimeReplayFileChangeRecord(item); ok {
+				messages = append(messages, builder.toolMessages(item, record)...)
+			}
+		case runtimeMCPToolCallItemKind:
+			if builder.isReplayedChild(item) {
+				continue
+			}
+			if record, ok := runtimeReplayMCPRecord(item); ok {
+				messages = append(messages, builder.toolMessages(item, record)...)
+			}
+		}
+	}
+	return messages
+}
+
+func (b *runtimeHistoryBuilder) collectDynamicParents(items []*store.Item) {
+	for _, item := range items {
+		if item == nil || item.ID == "" || item.Kind != runtimeDynamicToolCallItemKind {
+			continue
+		}
+		if _, ok := runtimeReplayDynamicToolRecord(item); ok {
+			b.dynamicParents[item.ID] = struct{}{}
+		}
+	}
+}
+
+func (b *runtimeHistoryBuilder) isReplayedChild(item *store.Item) bool {
+	if item == nil || item.ParentItemID == "" {
+		return false
+	}
+	_, ok := b.dynamicParents[item.ParentItemID]
+	return ok
+}
+
+func (b *runtimeHistoryBuilder) toolMessages(item *store.Item, record runtimeReplayToolRecord) []core.ModelMessage {
+	callID := b.nextCallID(item)
+	toolName := runtimeReplayIdentifier(record.tool, "historical_tool")
+	calledAt := runtimeReplayItemTime(item, false)
+	completedAt := runtimeReplayItemTime(item, true)
+	call := core.ModelResponse{
+		Parts: []core.ModelResponsePart{core.ToolCallPart{
+			ToolName:   toolName,
+			ArgsJSON:   runtimeReplayArgumentsJSON(record.arguments),
+			ToolCallID: callID,
+		}},
+		FinishReason: core.FinishReasonToolCall,
+		Timestamp:    calledAt,
+	}
+	var result core.ModelRequestPart
+	if record.success {
+		result = core.ToolReturnPart{
+			ToolName:   toolName,
+			Content:    runtimeReplayBoundedValue(record.result),
+			ToolCallID: callID,
+			Timestamp:  completedAt,
+		}
+	} else {
+		result = core.RetryPromptPart{
+			ToolName:   toolName,
+			Content:    boundedRuntimeToolOutput(record.errorText),
+			ToolCallID: callID,
+			Timestamp:  completedAt,
+		}
+	}
+	return []core.ModelMessage{
+		call,
+		core.ModelRequest{Parts: []core.ModelRequestPart{result}, Timestamp: completedAt},
+	}
+}
+
+func (b *runtimeHistoryBuilder) nextCallID(item *store.Item) string {
+	base := ""
+	if item != nil {
+		base = item.ID
+		if strings.TrimSpace(base) == "" && item.Seq > 0 {
+			base = fmt.Sprintf("history_call_%d", item.Seq)
+		}
+	}
+	if strings.TrimSpace(base) == "" {
+		b.generatedIDs++
+		base = fmt.Sprintf("history_call_generated_%d", b.generatedIDs)
+	}
+	base = runtimeReplayIdentifier(base, "history_call")
+	b.callIDCounts[base]++
+	count := b.callIDCounts[base]
+	if count == 1 {
+		return base
+	}
+	suffix := fmt.Sprintf("_%d", count)
+	if len(base)+len(suffix) > runtimeReplayIdentifierMaxBytes {
+		base = base[:runtimeReplayIdentifierMaxBytes-len(suffix)]
+	}
+	return base + suffix
+}
+
+func runtimeMessageFromStoredItem(raw json.RawMessage) (core.ModelMessage, bool) {
+	var payload runtimeMessagePayload
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return nil, false
+	}
+	switch payload.Role {
+	case "user":
+		return core.ModelRequest{
+			Parts:     []core.ModelRequestPart{core.UserPromptPart{Content: payload.Text, Timestamp: payload.CreatedAt}},
+			Timestamp: payload.CreatedAt,
+		}, true
+	case "assistant":
+		return core.ModelResponse{
+			Parts:        []core.ModelResponsePart{core.TextPart{Content: payload.Text}},
+			ModelName:    payload.Model,
+			FinishReason: core.FinishReasonStop,
+			Timestamp:    payload.CreatedAt,
+		}, true
+	default:
+		return nil, false
+	}
+}
+
+func runtimeReplayDynamicToolRecord(item *store.Item) (runtimeReplayToolRecord, bool) {
+	var payload runtimeDynamicToolCallPayload
+	if item == nil || json.Unmarshal(item.Payload, &payload) != nil || strings.TrimSpace(payload.Tool) == "" {
+		return runtimeReplayToolRecord{}, false
+	}
+	status := firstRuntimeNonEmpty(item.Status, payload.Status, runtimeToolStatusInProgress)
+	outputParts := make([]string, 0, len(payload.ContentItems))
+	for _, content := range payload.ContentItems {
+		if content.Text != "" {
+			outputParts = append(outputParts, content.Text)
+		}
+	}
+	output := boundedRuntimeToolOutput(strings.Join(outputParts, "\n"))
+	success := status == runtimeToolStatusCompleted
+	if payload.Success != nil {
+		success = success && *payload.Success
+	}
+	result := runtimeReplayDecodedText(output)
+	if output == "" {
+		result = map[string]any{"status": status}
+	}
+	record := runtimeReplayToolRecord{
+		tool:      payload.Tool,
+		arguments: payload.Arguments,
+		result:    result,
+		success:   success,
+	}
+	if !success {
+		record.errorText = runtimeReplayFailureText(payload.Tool, status, output)
+	}
+	return record, true
+}
+
+func runtimeReplayCommandRecord(item *store.Item) (runtimeReplayToolRecord, bool) {
+	var payload threadShellCommandPayload
+	if item == nil || json.Unmarshal(item.Payload, &payload) != nil || strings.TrimSpace(payload.Command) == "" {
+		return runtimeReplayToolRecord{}, false
+	}
+	status := firstRuntimeNonEmpty(item.Status, payload.Status, commandExecutionStatusInProgress)
+	result := map[string]any{
+		"status":     status,
+		"processId":  payload.ProcessID,
+		"exitCode":   payload.ExitCode,
+		"durationMs": payload.DurationMS,
+	}
+	if payload.AggregatedOutput != nil {
+		result["output"] = boundedRuntimeToolOutput(*payload.AggregatedOutput)
+	}
+	success := status == commandExecutionStatusCompleted
+	record := runtimeReplayToolRecord{
+		tool: "thread_shell_command",
+		arguments: map[string]any{
+			"command": payload.Command,
+			"cwd":     payload.CWD,
+			"source":  payload.Source,
+		},
+		result:  result,
+		success: success,
+	}
+	if !success {
+		record.errorText = runtimeReplayFailureValue("thread_shell_command", status, result)
+	}
+	return record, true
+}
+
+func runtimeReplayFileChangeRecord(item *store.Item) (runtimeReplayToolRecord, bool) {
+	var payload runtimeFileChangePayload
+	if item == nil || json.Unmarshal(item.Payload, &payload) != nil || len(payload.Changes) == 0 {
+		return runtimeReplayToolRecord{}, false
+	}
+	status := firstRuntimeNonEmpty(item.Status, payload.Status, runtimeFileChangeStatusInProgress)
+	result := map[string]any{
+		"status":   status,
+		"changes":  payload.Changes,
+		"evidence": payload.Evidence,
+	}
+	success := status == runtimeFileChangeStatusCompleted
+	record := runtimeReplayToolRecord{
+		tool:      "file_change",
+		arguments: map[string]any{"changes": payload.Changes},
+		result:    result,
+		success:   success,
+	}
+	if !success {
+		record.errorText = runtimeReplayFailureValue("file_change", status, result)
+	}
+	return record, true
+}
+
+func runtimeReplayMCPRecord(item *store.Item) (runtimeReplayToolRecord, bool) {
+	var payload runtimeMCPToolCallPayload
+	if item == nil || json.Unmarshal(item.Payload, &payload) != nil || strings.TrimSpace(payload.Server) == "" || strings.TrimSpace(payload.Tool) == "" {
+		return runtimeReplayToolRecord{}, false
+	}
+	status := firstRuntimeNonEmpty(item.Status, payload.Status, runtimeMCPStatusInProgress)
+	result := map[string]any{
+		"server": payload.Server,
+		"tool":   payload.Tool,
+		"status": status,
+		"result": payload.Result,
+		"error":  payload.Error,
+	}
+	success := status == runtimeMCPStatusCompleted && payload.Error == nil
+	record := runtimeReplayToolRecord{
+		tool: "mcp_call_tool",
+		arguments: map[string]any{
+			"server":    payload.Server,
+			"tool":      payload.Tool,
+			"arguments": payload.Arguments,
+		},
+		result:  result,
+		success: success,
+	}
+	if !success {
+		record.errorText = runtimeReplayFailureValue("mcp_call_tool", status, result)
+	}
+	return record, true
+}
+
+func runtimeReplayArgumentsJSON(arguments any) string {
+	if arguments == nil {
+		return "{}"
+	}
+	raw, err := json.Marshal(arguments)
+	if err != nil {
+		return runtimeReplaySummaryJSON("tool arguments could not be serialized", nil)
+	}
+	if len(raw) > runtimeToolPayloadMaxBytes {
+		return runtimeReplaySummaryJSON("tool arguments exceed replay payload limit", raw)
+	}
+	var object map[string]any
+	if json.Unmarshal(raw, &object) == nil && object != nil {
+		return string(raw)
+	}
+	wrapped, err := json.Marshal(map[string]any{"persistedArguments": arguments})
+	if err != nil {
+		return runtimeReplaySummaryJSON("tool arguments could not be wrapped", raw)
+	}
+	if len(wrapped) > runtimeToolPayloadMaxBytes {
+		return runtimeReplaySummaryJSON("wrapped tool arguments exceed replay payload limit", wrapped)
+	}
+	return string(wrapped)
+}
+
+func runtimeReplaySummaryJSON(reason string, raw []byte) string {
+	summary := runtimeToolPayloadSummary{
+		Omitted: true,
+		Reason:  reason,
+		Bytes:   len(raw),
+	}
+	if len(raw) > 0 {
+		summary.SHA256 = runtimeSHA256(raw)
+	}
+	encoded, _ := json.Marshal(summary)
+	return string(encoded)
+}
+
+func runtimeReplayBoundedValue(value any) any {
+	if text, ok := value.(string); ok {
+		return boundedRuntimeToolOutput(text)
+	}
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return runtimeToolPayloadSummary{Omitted: true, Reason: "tool result could not be serialized"}
+	}
+	if len(raw) <= runtimeToolPayloadMaxBytes {
+		return value
+	}
+	return runtimeToolPayloadSummary{
+		Omitted: true,
+		Reason:  "tool result exceeds replay payload limit",
+		Bytes:   len(raw),
+		SHA256:  runtimeSHA256(raw),
+	}
+}
+
+func runtimeReplayDecodedText(text string) any {
+	trimmed := strings.TrimSpace(text)
+	if trimmed == "" {
+		return ""
+	}
+	var value any
+	if json.Unmarshal([]byte(trimmed), &value) == nil {
+		return value
+	}
+	return text
+}
+
+func runtimeReplayFailureText(tool, status, output string) string {
+	if strings.TrimSpace(output) == "" {
+		return fmt.Sprintf("historical tool %s ended with status %s", tool, status)
+	}
+	return fmt.Sprintf("historical tool %s ended with status %s: %s", tool, status, output)
+}
+
+func runtimeReplayFailureValue(tool, status string, value any) string {
+	return runtimeReplayFailureText(tool, status, runtimeReplayContentString(value))
+}
+
+func runtimeReplayContentString(value any) string {
+	if text, ok := value.(string); ok {
+		return text
+	}
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Sprint(value)
+	}
+	return string(encoded)
+}
+
+func runtimeReplayIdentifier(value, fallback string) string {
+	value = strings.TrimSpace(value)
+	var builder strings.Builder
+	for _, r := range value {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '_' || r == '-' {
+			builder.WriteRune(r)
+		} else {
+			builder.WriteByte('_')
+		}
+	}
+	identifier := builder.String()
+	if identifier == "" {
+		identifier = fallback
+	}
+	if len(identifier) <= runtimeReplayIdentifierMaxBytes {
+		return identifier
+	}
+	digest := runtimeSHA256([]byte(identifier))
+	prefixBytes := runtimeReplayIdentifierMaxBytes - 1 - 16
+	return identifier[:prefixBytes] + "_" + digest[:16]
+}
+
+func runtimeReplayItemTime(item *store.Item, completed bool) time.Time {
+	if item == nil {
+		return time.Time{}
+	}
+	if completed && !item.UpdatedAt.IsZero() {
+		return item.UpdatedAt
+	}
+	return item.CreatedAt
+}

--- a/appserver/runtime_history_test.go
+++ b/appserver/runtime_history_test.go
@@ -1,0 +1,633 @@
+package appserver
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/fugue-labs/gollem/appserver/store"
+	"github.com/fugue-labs/gollem/core"
+)
+
+func TestRuntimeMessagesFromItemsReconstructsMixedToolHistory(t *testing.T) {
+	now := time.Now().UTC()
+	success := true
+	failure := false
+	items := []*store.Item{
+		runtimeHistoryMessageItem("message-user", "user", "inspect the workspace", now),
+		runtimeHistoryDynamicToolItem("tool-success", runtimeDynamicToolCallPayload{
+			Type:      runtimeDynamicToolCallItemKind,
+			Tool:      "workspace_read_file",
+			Arguments: map[string]any{"path": "README.md"},
+			Status:    runtimeToolStatusCompleted,
+			ContentItems: []runtimeDynamicToolCallContentItem{{
+				Type: "inputText",
+				Text: `{"text":"contents"}`,
+			}},
+			Success: &success,
+		}, now.Add(time.Second)),
+		{
+			ID:           "command-child",
+			ParentItemID: "tool-success",
+			Kind:         threadShellCommandItemKind,
+			Status:       commandExecutionStatusCompleted,
+			Payload: mustRuntimeJSON(newCommandExecutionPayload(
+				"cat README.md", ".", "process-1", commandExecutionSourceAgent,
+				commandExecutionStatusCompleted, "contents", runtimeIntPointer(0), now, runtimeTimePointer(now.Add(time.Second)),
+			)),
+			CreatedAt: now.Add(2 * time.Second),
+			UpdatedAt: now.Add(2 * time.Second),
+		},
+		runtimeHistoryDynamicToolItem("tool-denied", runtimeDynamicToolCallPayload{
+			Type:      runtimeDynamicToolCallItemKind,
+			Tool:      "git_commit",
+			Arguments: map[string]any{"message": "do not commit"},
+			Status:    "declined",
+			ContentItems: []runtimeDynamicToolCallContentItem{{
+				Type: "inputText",
+				Text: "approval denied",
+			}},
+			Success: &failure,
+		}, now.Add(3*time.Second)),
+		{
+			ID:           "mcp-child",
+			ParentItemID: "tool-denied",
+			Kind:         runtimeMCPToolCallItemKind,
+			Status:       runtimeMCPStatusFailed,
+			Payload: mustRuntimeJSON(runtimeMCPToolCallPayload{
+				Type:      runtimeMCPToolCallItemKind,
+				Server:    "repo",
+				Tool:      "commit",
+				Status:    runtimeMCPStatusFailed,
+				Arguments: map[string]any{"message": "do not commit"},
+				Error:     &runtimeMCPToolCallErrorPayload{Message: "approval denied"},
+			}),
+			CreatedAt: now.Add(4 * time.Second),
+			UpdatedAt: now.Add(4 * time.Second),
+		},
+		runtimeHistoryDynamicToolItem("tool-interrupted", runtimeDynamicToolCallPayload{
+			Type:      runtimeDynamicToolCallItemKind,
+			Tool:      "workspace_run_command",
+			Arguments: map[string]any{"command": "go test ./..."},
+			Status:    runtimeToolStatusInProgress,
+		}, now.Add(5*time.Second)),
+		runtimeHistoryDynamicToolItem("tool-interaction", runtimeDynamicToolCallPayload{
+			Type:      runtimeDynamicToolCallItemKind,
+			Tool:      "request_user_input",
+			Arguments: map[string]any{"prompt": "Continue?"},
+			Status:    runtimeToolStatusCompleted,
+			ContentItems: []runtimeDynamicToolCallContentItem{{
+				Type: "inputText",
+				Text: `{"answer":"yes"}`,
+			}},
+			Success: &success,
+		}, now.Add(6*time.Second)),
+		runtimeHistoryMessageItem("message-assistant", "assistant", "workspace inspected", now.Add(7*time.Second)),
+	}
+
+	messages := runtimeMessagesFromItems(items)
+	if len(messages) != 10 {
+		t.Fatalf("messages = %#v, want user + four tool pairs + assistant", messages)
+	}
+	assertRuntimeUserPrompt(t, messages[0], "inspect the workspace")
+	assertRuntimeReplayPair(t, messages[1], messages[2], "workspace_read_file", "tool-success", false, "contents")
+	assertRuntimeReplayPair(t, messages[3], messages[4], "git_commit", "tool-denied", true, "approval denied")
+	assertRuntimeReplayPair(t, messages[5], messages[6], "workspace_run_command", "tool-interrupted", true, "inProgress")
+	assertRuntimeReplayPair(t, messages[7], messages[8], "request_user_input", "tool-interaction", false, "answer")
+	assertRuntimeAssistantText(t, messages[9], "workspace inspected")
+
+	normalized, err := core.NormalizeHistory()(context.Background(), messages)
+	if err != nil {
+		t.Fatalf("NormalizeHistory: %v", err)
+	}
+	if len(normalized) != len(messages) {
+		t.Fatalf("normalized messages = %#v, want every reconstructed pair retained", normalized)
+	}
+	encoded, err := core.MarshalMessages(messages)
+	if err != nil {
+		t.Fatalf("MarshalMessages: %v", err)
+	}
+	roundTripped, err := core.UnmarshalMessages(encoded)
+	if err != nil {
+		t.Fatalf("UnmarshalMessages: %v", err)
+	}
+	if len(roundTripped) != len(messages) {
+		t.Fatalf("round-tripped messages = %#v, want %d", roundTripped, len(messages))
+	}
+}
+
+func TestRuntimeMessagesFromItemsReconstructsStandaloneOperationalItems(t *testing.T) {
+	now := time.Now().UTC()
+	output := "tests passed\n... tool output truncated ...\nfinal line"
+	items := []*store.Item{
+		runtimeHistoryMessageItem("message-user", "user", "recover operations", now),
+		{
+			ID:     "standalone-command",
+			Kind:   threadShellCommandItemKind,
+			Status: commandExecutionStatusCompleted,
+			Payload: mustRuntimeJSON(newCommandExecutionPayload(
+				"go test ./...", "/workspace", "process-1", commandExecutionSourceUserShell,
+				commandExecutionStatusCompleted, output, runtimeIntPointer(0), now, runtimeTimePointer(now.Add(time.Second)),
+			)),
+			CreatedAt: now.Add(time.Second),
+			UpdatedAt: now.Add(time.Second),
+		},
+		{
+			ID:     "standalone-file",
+			Kind:   runtimeFileChangeItemKind,
+			Status: runtimeFileChangeStatusCompleted,
+			Payload: mustRuntimeJSON(runtimeFileChangePayload{
+				Type:   runtimeFileChangeItemKind,
+				Status: runtimeFileChangeStatusCompleted,
+				Changes: []runtimeFileUpdateChange{{
+					Path: "notes.txt",
+					Kind: runtimePatchChangeKind{Type: runtimePatchChangeAdd},
+					Diff: "+recovered\n",
+				}},
+			}),
+			CreatedAt: now.Add(2 * time.Second),
+			UpdatedAt: now.Add(2 * time.Second),
+		},
+		{
+			ID:     "standalone-mcp",
+			Kind:   runtimeMCPToolCallItemKind,
+			Status: runtimeMCPStatusFailed,
+			Payload: mustRuntimeJSON(runtimeMCPToolCallPayload{
+				Type:      runtimeMCPToolCallItemKind,
+				Server:    "repo",
+				Tool:      "search",
+				Status:    runtimeMCPStatusFailed,
+				Arguments: map[string]any{"query": "history"},
+				Error:     &runtimeMCPToolCallErrorPayload{Message: "connection interrupted"},
+			}),
+			CreatedAt: now.Add(3 * time.Second),
+			UpdatedAt: now.Add(3 * time.Second),
+		},
+		{
+			ID:        "malformed-dynamic",
+			Kind:      runtimeDynamicToolCallItemKind,
+			Status:    runtimeToolStatusCompleted,
+			Payload:   json.RawMessage(`{"tool":`),
+			CreatedAt: now.Add(4 * time.Second),
+			UpdatedAt: now.Add(4 * time.Second),
+		},
+		runtimeHistoryMessageItem("message-assistant", "assistant", "operations recovered", now.Add(5*time.Second)),
+	}
+
+	messages := runtimeMessagesFromItems(items)
+	if len(messages) != 8 {
+		t.Fatalf("messages = %#v, want user + three standalone pairs + assistant", messages)
+	}
+	assertRuntimeReplayPair(t, messages[1], messages[2], "thread_shell_command", "standalone-command", false, "tool output truncated")
+	assertRuntimeReplayPair(t, messages[3], messages[4], "file_change", "standalone-file", false, "notes.txt")
+	assertRuntimeReplayPair(t, messages[5], messages[6], "mcp_call_tool", "standalone-mcp", true, "connection interrupted")
+}
+
+func TestRuntimeMessagesFromItemsMakesDuplicateCallIDsAndMalformedArgumentsSafe(t *testing.T) {
+	now := time.Now().UTC()
+	success := true
+	items := []*store.Item{
+		runtimeHistoryMessageItem("message-user", "user", "recover duplicates", now),
+		runtimeHistoryDynamicToolItem("duplicate", runtimeDynamicToolCallPayload{
+			Tool:         "first_tool",
+			Arguments:    "{not-json",
+			Status:       runtimeToolStatusCompleted,
+			ContentItems: []runtimeDynamicToolCallContentItem{{Type: "inputText", Text: "first"}},
+			Success:      &success,
+		}, now.Add(time.Second)),
+		runtimeHistoryDynamicToolItem("duplicate", runtimeDynamicToolCallPayload{
+			Tool:         "second_tool",
+			Arguments:    map[string]any{"value": "second"},
+			Status:       runtimeToolStatusCompleted,
+			ContentItems: []runtimeDynamicToolCallContentItem{{Type: "inputText", Text: "second"}},
+			Success:      &success,
+		}, now.Add(2*time.Second)),
+		runtimeHistoryMessageItem("message-assistant", "assistant", "duplicates recovered", now.Add(3*time.Second)),
+	}
+
+	messages := runtimeMessagesFromItems(items)
+	firstCall, _ := runtimeReplayParts(t, messages[1], messages[2])
+	secondCall, _ := runtimeReplayParts(t, messages[3], messages[4])
+	if firstCall.ToolCallID != "duplicate" || secondCall.ToolCallID != "duplicate_2" {
+		t.Fatalf("call IDs = %q/%q, want duplicate/duplicate_2", firstCall.ToolCallID, secondCall.ToolCallID)
+	}
+	if !json.Valid([]byte(firstCall.ArgsJSON)) {
+		t.Fatalf("first args = %q, want valid JSON", firstCall.ArgsJSON)
+	}
+	var args map[string]any
+	if err := json.Unmarshal([]byte(firstCall.ArgsJSON), &args); err != nil || args["persistedArguments"] != "{not-json" {
+		t.Fatalf("first args = %q (%v), want wrapped persisted arguments", firstCall.ArgsJSON, err)
+	}
+}
+
+func TestRuntimeMessagesFromItemsUsesStoreStatusAfterPartialPersistence(t *testing.T) {
+	now := time.Now().UTC()
+	success := true
+	item := runtimeHistoryDynamicToolItem("partial-tool", runtimeDynamicToolCallPayload{
+		Tool:         "partially_persisted",
+		Arguments:    map[string]any{"value": "stale"},
+		Status:       runtimeToolStatusCompleted,
+		ContentItems: []runtimeDynamicToolCallContentItem{{Type: "inputText", Text: "stale success"}},
+		Success:      &success,
+	}, now)
+	item.Status = runtimeToolStatusFailed
+
+	messages := runtimeMessagesFromItems([]*store.Item{item})
+	if len(messages) != 2 {
+		t.Fatalf("messages = %#v, want one recovered pair", messages)
+	}
+	assertRuntimeReplayPair(t, messages[0], messages[1], "partially_persisted", "partial-tool", true, "failed")
+}
+
+func TestServerRuntimeThreadResumeReconstructsToolTranscriptWithoutReexecution(t *testing.T) {
+	ctx := context.Background()
+	st := newRuntimeTestStore(t)
+	var executions atomic.Int32
+	type echoParams struct {
+		Text string `json:"text"`
+	}
+	echo := core.FuncTool[echoParams]("echo", "Echo text.", func(_ context.Context, params echoParams) (string, error) {
+		executions.Add(1)
+		return `{"echo":` + runtimeJSONString(params.Text) + `}`, nil
+	})
+	model := core.NewTestModel(
+		core.ToolCallResponseWithID("echo", `{"text":"hello"}`, "provider-call-id"),
+		core.TextResponse("first answer"),
+		core.TextResponse("second answer"),
+	)
+	server := readyServer(
+		WithStore(st),
+		WithRuntimeService(NewRuntimeService(
+			WithRuntimeModel(model, RuntimeModelInfo{ProviderID: "test", Model: "test-model"}),
+			WithRuntimeTools(echo),
+		)),
+	)
+
+	startResp := server.HandleRequest(ctx, request("thread/start", map[string]any{"prompt": "first prompt"}))
+	if startResp.Error != nil {
+		t.Fatalf("thread/start error: %v", startResp.Error)
+	}
+	var started struct {
+		Thread *store.Thread `json:"thread"`
+	}
+	decodeResult(t, startResp, &started)
+	waitForNotificationSet(t, server, "turn/completed")
+	server = readyServer(
+		WithStore(st),
+		WithRuntimeService(NewRuntimeService(
+			WithRuntimeModel(model, RuntimeModelInfo{ProviderID: "test", Model: "test-model"}),
+			WithRuntimeTools(echo),
+		)),
+	)
+
+	resumeResp := server.HandleRequest(ctx, request("thread/resume", map[string]any{
+		"threadId": started.Thread.ID,
+		"prompt":   "second prompt",
+	}))
+	if resumeResp.Error != nil {
+		t.Fatalf("thread/resume error: %v", resumeResp.Error)
+	}
+	waitForNotificationSet(t, server, "turn/completed")
+
+	if got := executions.Load(); got != 1 {
+		t.Fatalf("tool executions = %d, want 1", got)
+	}
+	calls := model.Calls()
+	if len(calls) != 3 {
+		t.Fatalf("model calls = %d, want 3", len(calls))
+	}
+	messages := calls[2].Messages
+	if len(messages) != 5 {
+		t.Fatalf("resume messages = %#v, want prior user/tool pair/assistant plus prompt", messages)
+	}
+	assertRuntimeUserPrompt(t, messages[0], "first prompt")
+	call, result := runtimeReplayParts(t, messages[1], messages[2])
+	if call.ToolName != "echo" || call.ToolCallID == "provider-call-id" || result.ToolCallID != call.ToolCallID {
+		t.Fatalf("replayed pair = %#v/%#v", call, result)
+	}
+	assertRuntimeAssistantText(t, messages[3], "first answer")
+	assertRuntimeUserPrompt(t, messages[4], "second prompt")
+}
+
+func TestServerRuntimeTurnRetryReconstructsPriorToolTranscriptWithoutReexecution(t *testing.T) {
+	ctx := context.Background()
+	st := newRuntimeTestStore(t)
+	var executions atomic.Int32
+	type echoParams struct {
+		Text string `json:"text"`
+	}
+	echo := core.FuncTool[echoParams]("echo", "Echo text.", func(_ context.Context, params echoParams) (string, error) {
+		executions.Add(1)
+		return params.Text, nil
+	})
+	model := core.NewTestModel(
+		core.ToolCallResponseWithID("echo", `{"text":"hello"}`, "provider-call-id"),
+		core.TextResponse("first answer"),
+		core.TextResponse("second answer"),
+		core.TextResponse("retry answer"),
+	)
+	server := readyServer(
+		WithStore(st),
+		WithRuntimeService(NewRuntimeService(
+			WithRuntimeModel(model, RuntimeModelInfo{ProviderID: "test", Model: "test-model"}),
+			WithRuntimeTools(echo),
+		)),
+	)
+
+	startResp := server.HandleRequest(ctx, request("thread/start", map[string]any{"prompt": "first prompt"}))
+	if startResp.Error != nil {
+		t.Fatalf("thread/start error: %v", startResp.Error)
+	}
+	var started struct {
+		Thread *store.Thread `json:"thread"`
+	}
+	decodeResult(t, startResp, &started)
+	waitForNotificationSet(t, server, "turn/completed")
+
+	resumeResp := server.HandleRequest(ctx, request("thread/resume", map[string]any{
+		"threadId": started.Thread.ID,
+		"prompt":   "second prompt",
+	}))
+	if resumeResp.Error != nil {
+		t.Fatalf("thread/resume error: %v", resumeResp.Error)
+	}
+	var resumed struct {
+		Turn *store.Turn `json:"turn"`
+	}
+	decodeResult(t, resumeResp, &resumed)
+	waitForNotificationSet(t, server, "turn/completed")
+
+	retryResp := server.HandleRequest(ctx, request("turn/retry", map[string]any{"turnId": resumed.Turn.ID}))
+	if retryResp.Error != nil {
+		t.Fatalf("turn/retry error: %v", retryResp.Error)
+	}
+	waitForNotificationSet(t, server, "turn/completed")
+
+	if got := executions.Load(); got != 1 {
+		t.Fatalf("tool executions = %d, want 1", got)
+	}
+	calls := model.Calls()
+	if len(calls) != 4 {
+		t.Fatalf("model calls = %d, want 4", len(calls))
+	}
+	messages := calls[3].Messages
+	if len(messages) != 5 {
+		t.Fatalf("retry messages = %#v, want prior user/tool pair/assistant plus retried prompt", messages)
+	}
+	assertRuntimeReplayPair(t, messages[1], messages[2], "echo", "", false, "hello")
+	assertRuntimeUserPrompt(t, messages[4], "second prompt")
+}
+
+func TestServerRuntimeForkResumeRemapsChildItemsWithoutDuplicateReplay(t *testing.T) {
+	ctx := context.Background()
+	st := newRuntimeTestStore(t)
+	var executions atomic.Int32
+	type echoParams struct {
+		Text string `json:"text"`
+	}
+	echo := core.FuncTool[echoParams]("echo", "Echo text.", func(_ context.Context, params echoParams) (string, error) {
+		executions.Add(1)
+		return params.Text, nil
+	})
+	model := core.NewTestModel(
+		core.ToolCallResponseWithID("echo", `{"text":"hello"}`, "provider-call-id"),
+		core.TextResponse("first answer"),
+		core.TextResponse("fork answer"),
+	)
+	server := readyServer(
+		WithStore(st),
+		WithRuntimeService(NewRuntimeService(
+			WithRuntimeModel(model, RuntimeModelInfo{ProviderID: "test", Model: "test-model"}),
+			WithRuntimeTools(echo),
+		)),
+	)
+
+	startResp := server.HandleRequest(ctx, request("thread/start", map[string]any{"prompt": "first prompt"}))
+	if startResp.Error != nil {
+		t.Fatalf("thread/start error: %v", startResp.Error)
+	}
+	var started struct {
+		Thread *store.Thread `json:"thread"`
+	}
+	decodeResult(t, startResp, &started)
+	waitForNotificationSet(t, server, "turn/completed")
+	items, err := st.ListItems(ctx, store.ItemFilter{ThreadID: started.Thread.ID})
+	if err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+	parent := findRuntimeToolItem(t, items, "echo", "text", "hello")
+	if _, err := st.AppendItem(ctx, store.AppendItemRequest{
+		ThreadID:     started.Thread.ID,
+		TurnID:       parent.Item.TurnID,
+		ParentItemID: parent.Item.ID,
+		Kind:         runtimeFileChangeItemKind,
+		Status:       runtimeFileChangeStatusCompleted,
+		Payload: mustRuntimeJSON(runtimeFileChangePayload{
+			Type:   runtimeFileChangeItemKind,
+			Status: runtimeFileChangeStatusCompleted,
+			Changes: []runtimeFileUpdateChange{{
+				Path: "echo.txt",
+				Kind: runtimePatchChangeKind{Type: runtimePatchChangeAdd},
+				Diff: "+hello\n",
+			}},
+		}),
+	}); err != nil {
+		t.Fatalf("AppendItem child: %v", err)
+	}
+
+	forkResp := server.HandleRequest(ctx, request("thread/fork", map[string]any{
+		"threadId":     started.Thread.ID,
+		"includeItems": true,
+	}))
+	if forkResp.Error != nil {
+		t.Fatalf("thread/fork error: %v", forkResp.Error)
+	}
+	var forked struct {
+		Thread *store.Thread `json:"thread"`
+	}
+	decodeResult(t, forkResp, &forked)
+	server.DrainNotifications()
+
+	resumeResp := server.HandleRequest(ctx, request("thread/resume", map[string]any{
+		"threadId": forked.Thread.ID,
+		"prompt":   "continue fork",
+	}))
+	if resumeResp.Error != nil {
+		t.Fatalf("thread/resume fork error: %v", resumeResp.Error)
+	}
+	waitForNotificationSet(t, server, "turn/completed")
+
+	if got := executions.Load(); got != 1 {
+		t.Fatalf("tool executions = %d, want 1", got)
+	}
+	calls := model.Calls()
+	messages := calls[2].Messages
+	if len(messages) != 5 {
+		t.Fatalf("fork resume messages = %#v, want one reconstructed tool pair", messages)
+	}
+	assertRuntimeReplayPair(t, messages[1], messages[2], "echo", "", false, "hello")
+}
+
+func TestServerRuntimeCompactSummaryPreservesToolActivity(t *testing.T) {
+	ctx := context.Background()
+	st := newRuntimeTestStore(t)
+	var executions atomic.Int32
+	type echoParams struct {
+		Text string `json:"text"`
+	}
+	echo := core.FuncTool[echoParams]("echo", "Echo text.", func(_ context.Context, params echoParams) (string, error) {
+		executions.Add(1)
+		return `{"echo":` + runtimeJSONString(params.Text) + `}`, nil
+	})
+	model := core.NewTestModel(
+		core.ToolCallResponseWithID("echo", `{"text":"hello"}`, "provider-call-id"),
+		core.TextResponse("first answer"),
+		core.TextResponse("after compact"),
+	)
+	server := readyServer(
+		WithStore(st),
+		WithRuntimeService(NewRuntimeService(
+			WithRuntimeModel(model, RuntimeModelInfo{ProviderID: "test", Model: "test-model"}),
+			WithRuntimeTools(echo),
+		)),
+	)
+
+	startResp := server.HandleRequest(ctx, request("thread/start", map[string]any{"prompt": "first prompt"}))
+	if startResp.Error != nil {
+		t.Fatalf("thread/start error: %v", startResp.Error)
+	}
+	var started struct {
+		Thread *store.Thread `json:"thread"`
+	}
+	decodeResult(t, startResp, &started)
+	waitForNotificationSet(t, server, "turn/completed")
+
+	compactResp := server.HandleRequest(ctx, request("thread/compact/start", map[string]any{"threadId": started.Thread.ID}))
+	if compactResp.Error != nil {
+		t.Fatalf("thread/compact/start error: %v", compactResp.Error)
+	}
+	waitForNotificationSet(t, server, "thread/compacted")
+
+	resumeResp := server.HandleRequest(ctx, request("thread/resume", map[string]any{
+		"threadId": started.Thread.ID,
+		"prompt":   "after compact prompt",
+	}))
+	if resumeResp.Error != nil {
+		t.Fatalf("thread/resume error: %v", resumeResp.Error)
+	}
+	waitForNotificationSet(t, server, "turn/completed")
+
+	if got := executions.Load(); got != 1 {
+		t.Fatalf("tool executions = %d, want 1", got)
+	}
+	calls := model.Calls()
+	if len(calls) != 3 || len(calls[2].Messages) != 2 {
+		t.Fatalf("post-compact calls = %#v", calls)
+	}
+	assertRuntimeSystemPromptContains(t, calls[2].Messages[0], "tool call: echo", "tool result: echo", "hello")
+	assertRuntimeUserPrompt(t, calls[2].Messages[1], "after compact prompt")
+}
+
+func runtimeHistoryMessageItem(id, role, text string, at time.Time) *store.Item {
+	return &store.Item{
+		ID:        id,
+		Kind:      "message",
+		Status:    "completed",
+		Payload:   mustRuntimeJSON(runtimeMessagePayload{Role: role, Text: text, CreatedAt: at}),
+		CreatedAt: at,
+		UpdatedAt: at,
+	}
+}
+
+func runtimeHistoryDynamicToolItem(id string, payload runtimeDynamicToolCallPayload, at time.Time) *store.Item {
+	payload.ID = id
+	return &store.Item{
+		ID:        id,
+		Kind:      runtimeDynamicToolCallItemKind,
+		Status:    payload.Status,
+		Payload:   mustRuntimeJSON(payload),
+		CreatedAt: at,
+		UpdatedAt: at,
+	}
+}
+
+func runtimeReplayParts(t *testing.T, callMessage, resultMessage core.ModelMessage) (core.ToolCallPart, core.ToolReturnPart) {
+	t.Helper()
+	response, ok := callMessage.(core.ModelResponse)
+	if !ok || len(response.Parts) != 1 {
+		t.Fatalf("call message = %#v, want one-part model response", callMessage)
+	}
+	call, ok := response.Parts[0].(core.ToolCallPart)
+	if !ok {
+		t.Fatalf("call part = %#v, want ToolCallPart", response.Parts[0])
+	}
+	request, ok := resultMessage.(core.ModelRequest)
+	if !ok || len(request.Parts) != 1 {
+		t.Fatalf("result message = %#v, want one-part model request", resultMessage)
+	}
+	result, ok := request.Parts[0].(core.ToolReturnPart)
+	if !ok {
+		t.Fatalf("result part = %#v, want ToolReturnPart", request.Parts[0])
+	}
+	return call, result
+}
+
+func assertRuntimeReplayPair(t *testing.T, callMessage, resultMessage core.ModelMessage, tool, callID string, wantError bool, wantContent string) {
+	t.Helper()
+	response, ok := callMessage.(core.ModelResponse)
+	if !ok || len(response.Parts) != 1 {
+		t.Fatalf("call message = %#v, want one-part model response", callMessage)
+	}
+	call, ok := response.Parts[0].(core.ToolCallPart)
+	if !ok || call.ToolName != tool || (callID != "" && call.ToolCallID != callID) || !json.Valid([]byte(call.ArgsJSON)) {
+		t.Fatalf("call part = %#v, want tool %q id %q with valid arguments", response.Parts[0], tool, callID)
+	}
+	request, ok := resultMessage.(core.ModelRequest)
+	if !ok || len(request.Parts) != 1 {
+		t.Fatalf("result message = %#v, want one-part model request", resultMessage)
+	}
+	var content string
+	switch part := request.Parts[0].(type) {
+	case core.ToolReturnPart:
+		if wantError {
+			t.Fatalf("result part = %#v, want RetryPromptPart", part)
+		}
+		if part.ToolName != tool || part.ToolCallID != call.ToolCallID {
+			t.Fatalf("result part = %#v, want paired %q/%q", part, tool, call.ToolCallID)
+		}
+		encoded, err := json.Marshal(part.Content)
+		if err != nil {
+			t.Fatalf("marshal result content: %v", err)
+		}
+		content = string(encoded)
+	case core.RetryPromptPart:
+		if !wantError {
+			t.Fatalf("result part = %#v, want ToolReturnPart", part)
+		}
+		if part.ToolName != tool || part.ToolCallID != call.ToolCallID {
+			t.Fatalf("retry part = %#v, want paired %q/%q", part, tool, call.ToolCallID)
+		}
+		content = part.Content
+	default:
+		t.Fatalf("result part = %#v, want tool return or retry", request.Parts[0])
+	}
+	if !strings.Contains(content, wantContent) {
+		t.Fatalf("result content = %q, want substring %q", content, wantContent)
+	}
+}
+
+func runtimeIntPointer(value int) *int {
+	return &value
+}
+
+func runtimeTimePointer(value time.Time) *time.Time {
+	return &value
+}
+
+func runtimeJSONString(value string) string {
+	encoded, _ := json.Marshal(value)
+	return string(encoded)
+}

--- a/appserver/store/sqlite.go
+++ b/appserver/store/sqlite.go
@@ -1022,15 +1022,35 @@ func copyThreadHistoryTx(ctx context.Context, tx *sql.Tx, sourceThreadID, forkTh
 	if err != nil {
 		return fmt.Errorf("load source items: %w", err)
 	}
-	defer itemRows.Close()
+	var items []*Item
 	for itemRows.Next() {
 		item, err := scanItem(itemRows)
 		if err != nil {
+			itemRows.Close()
 			return err
 		}
-		item.ID = newID("item")
+		items = append(items, item)
+	}
+	if err := itemRows.Err(); err != nil {
+		itemRows.Close()
+		return fmt.Errorf("iterate source items: %w", err)
+	}
+	if err := itemRows.Close(); err != nil {
+		return fmt.Errorf("close source items: %w", err)
+	}
+
+	itemMap := make(map[string]string, len(items))
+	for _, item := range items {
+		itemMap[item.ID] = newID("item")
+	}
+	for _, item := range items {
+		oldID := item.ID
+		oldParentID := item.ParentItemID
+		item.ID = itemMap[oldID]
+		item.Payload = remapForkedItemPayloadID(item.Payload, oldID, item.ID)
 		item.ThreadID = forkThreadID
 		item.TurnID = turnMap[item.TurnID]
+		item.ParentItemID = itemMap[oldParentID]
 		item.Seq = 0
 		item.CreatedAt = now
 		item.UpdatedAt = now
@@ -1038,10 +1058,31 @@ func copyThreadHistoryTx(ctx context.Context, tx *sql.Tx, sourceThreadID, forkTh
 			return err
 		}
 	}
-	if err := itemRows.Err(); err != nil {
-		return fmt.Errorf("iterate source items: %w", err)
-	}
 	return nil
+}
+
+func remapForkedItemPayloadID(raw json.RawMessage, oldID, newID string) json.RawMessage {
+	if len(raw) == 0 || oldID == "" || newID == "" {
+		return raw
+	}
+	var payload map[string]json.RawMessage
+	if json.Unmarshal(raw, &payload) != nil {
+		return raw
+	}
+	var payloadID string
+	if json.Unmarshal(payload["id"], &payloadID) != nil || payloadID != oldID {
+		return raw
+	}
+	encodedID, err := json.Marshal(newID)
+	if err != nil {
+		return raw
+	}
+	payload["id"] = encodedID
+	updated, err := json.Marshal(payload)
+	if err != nil {
+		return raw
+	}
+	return updated
 }
 
 func matchesThreadFilter(thread *Thread, filter ThreadFilter) bool {

--- a/appserver/store/sqlite_test.go
+++ b/appserver/store/sqlite_test.go
@@ -333,8 +333,23 @@ func TestSQLiteStoreForkCopiesThreadHistory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateTurn: %v", err)
 	}
-	if _, err := s.AppendItem(ctx, AppendItemRequest{ThreadID: source.ID, TurnID: turn.ID, Kind: "message", Payload: json.RawMessage(`{"text":"fork me"}`)}); err != nil {
+	parent, err := s.AppendItem(ctx, AppendItemRequest{ThreadID: source.ID, TurnID: turn.ID, Kind: "dynamicToolCall", Payload: json.RawMessage(`{"tool":"echo"}`)})
+	if err != nil {
 		t.Fatalf("AppendItem: %v", err)
+	}
+	parent, err = s.UpdateItem(ctx, UpdateItemRequest{ID: parent.ID, Payload: json.RawMessage(`{"id":"` + parent.ID + `","tool":"echo"}`)})
+	if err != nil {
+		t.Fatalf("UpdateItem parent payload ID: %v", err)
+	}
+	child, err := s.AppendItem(ctx, AppendItemRequest{
+		ThreadID:     source.ID,
+		TurnID:       turn.ID,
+		ParentItemID: parent.ID,
+		Kind:         "commandExecution",
+		Payload:      json.RawMessage(`{"command":"echo fork"}`),
+	})
+	if err != nil {
+		t.Fatalf("AppendItem child: %v", err)
 	}
 
 	fork, err := s.ForkThread(ctx, ForkThreadRequest{
@@ -364,8 +379,23 @@ func TestSQLiteStoreForkCopiesThreadHistory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListItems fork: %v", err)
 	}
-	if len(forkItems) != 1 || forkItems[0].ThreadID != fork.ID || forkItems[0].TurnID != forkTurns[0].ID {
+	if len(forkItems) != 2 || forkItems[0].ThreadID != fork.ID || forkItems[0].TurnID != forkTurns[0].ID {
 		t.Fatalf("fork items = %+v turns = %+v", forkItems, forkTurns)
+	}
+	if forkItems[0].ID == parent.ID || forkItems[1].ID == child.ID {
+		t.Fatalf("fork item IDs were not regenerated: source=%q/%q fork=%q/%q", parent.ID, child.ID, forkItems[0].ID, forkItems[1].ID)
+	}
+	if forkItems[1].ParentItemID != forkItems[0].ID {
+		t.Fatalf("fork child parent = %q, want remapped parent %q", forkItems[1].ParentItemID, forkItems[0].ID)
+	}
+	var forkParentPayload struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(forkItems[0].Payload, &forkParentPayload); err != nil {
+		t.Fatalf("decode fork parent payload: %v", err)
+	}
+	if forkParentPayload.ID != forkItems[0].ID {
+		t.Fatalf("fork parent payload id = %q, want %q", forkParentPayload.ID, forkItems[0].ID)
 	}
 }
 

--- a/appserver/thread_compact.go
+++ b/appserver/thread_compact.go
@@ -148,11 +148,22 @@ func summarizeCompactionMessages(messages []core.ModelMessage, maxRunes int) str
 					lines = append(lines, "system: "+compactWhitespace(p.Content))
 				case core.UserPromptPart:
 					lines = append(lines, "user: "+compactWhitespace(p.Content))
+				case core.ToolReturnPart:
+					lines = append(lines, "tool result: "+p.ToolName+" "+compactWhitespace(runtimeReplayContentString(p.Content)))
+				case core.RetryPromptPart:
+					lines = append(lines, "tool error: "+p.ToolName+" "+compactWhitespace(p.Content))
 				}
 			}
 		case core.ModelResponse:
-			if text := compactWhitespace(typed.TextContent()); text != "" {
-				lines = append(lines, "assistant: "+text)
+			for _, part := range typed.Parts {
+				switch p := part.(type) {
+				case core.TextPart:
+					if text := compactWhitespace(p.Content); text != "" {
+						lines = append(lines, "assistant: "+text)
+					}
+				case core.ToolCallPart:
+					lines = append(lines, "tool call: "+p.ToolName+" "+compactWhitespace(p.ArgsJSON))
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

- reconstruct provider-neutral tool call/result pairs from durable dynamic tool items during resume, retry, fork, compaction, and restart-backed resume
- recover standalone command, file-change, and MCP items while suppressing duplicate child replay when a dynamic parent already carries the model-visible result
- remap forked item IDs, payload IDs, and parent links so copied histories remain internally consistent
- retain tool calls, successful results, and error results in deterministic compaction summaries

## Recovery behavior

- uses durable item IDs as replay call IDs and deterministically repairs missing, duplicate, overlong, or unsafe identifiers
- emits ToolReturnPart for successful history and RetryPromptPart for failed, denied, interrupted, or partially persisted history
- bounds replayed arguments/results and wraps malformed non-object arguments as valid provider input
- never invokes a historical tool handler while rebuilding history
- preserves existing injected-response and compaction history behavior

## Verification

- red/green unit coverage for mixed successful, failed, denied, interrupted, malformed, duplicate-ID, truncated, standalone, and partial-persistence histories
- integration coverage for restart-backed resume, retry, fork, and compaction with no duplicate tool execution
- fork store coverage for item, payload, turn, and parent ID remapping
- go test ./... -count=1
- go test -race ./appserver ./appserver/store ./provider/... -count=1
- go vet ./...
- golangci-lint run ./...
- .githooks/pre-push before commit and on push

## Stack

Base: #86
