### PR TITLE
Resolve file change approvals from direct responses

### DIFF
--- a/appserver/approval.go
+++ b/appserver/approval.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"slices"
 	"strings"
 	"sync"
@@ -25,22 +26,41 @@ const (
 )
 
 // ApprovalService bridges synchronous tool approval hooks to app-server
-// server-to-client approval requests resolved by approval/respond.
+// server-to-client approval requests resolved directly or by approval/respond.
 type ApprovalService struct {
-	mu       sync.Mutex
-	counter  int64
-	pending  map[string]pendingApproval
-	requests *RequestQueue
+	mu                     sync.Mutex
+	counter                int64
+	pending                map[string]pendingApproval
+	fileChangeSessionPaths map[string]struct{}
+	requests               *RequestQueue
 }
 
 type pendingApproval struct {
-	ch       chan approvalResolution
-	threadID string
+	ch             chan approvalResolution
+	threadID       string
+	turnID         string
+	method         string
+	sessionTargets []string
 }
 
 type approvalResolution struct {
 	Approved bool
 	Message  string
+}
+
+type approvalResponseResult struct {
+	RequestID  string
+	ThreadID   string
+	TurnID     string
+	CancelTurn bool
+	ch         chan approvalResolution
+	resolution approvalResolution
+}
+
+func (r approvalResponseResult) resolve() {
+	if r.ch != nil {
+		r.ch <- r.resolution
+	}
 }
 
 type approvalRequestBase struct {
@@ -60,8 +80,9 @@ type approvalRespondResult struct {
 
 func NewApprovalService() *ApprovalService {
 	return &ApprovalService{
-		pending:  make(map[string]pendingApproval),
-		requests: NewRequestQueue(),
+		pending:                make(map[string]pendingApproval),
+		fileChangeSessionPaths: make(map[string]struct{}),
+		requests:               NewRequestQueue(),
 	}
 }
 
@@ -89,6 +110,10 @@ func (s *ApprovalService) DrainRequests() []protocol.Request {
 }
 
 func (s *ApprovalService) FilesystemApproval(ctx context.Context, op toolfs.Operation) error {
+	sessionTargets := fileChangeApprovalSessionTargets(op)
+	if s.fileChangeSessionApproved(sessionTargets) {
+		return nil
+	}
 	reason := fmt.Sprintf("Approve filesystem %s for %s", op.Kind, op.Path)
 	base := s.base(ctx, reason)
 	params := protocol.FileChangeApprovalRequestParams{
@@ -99,7 +124,7 @@ func (s *ApprovalService) FilesystemApproval(ctx context.Context, op toolfs.Oper
 		Destination:         op.Destination,
 		Destructive:         op.Destructive,
 	}
-	return s.requestApproval(ctx, "item/fileChange/requestApproval", base.requestID, params)
+	return s.requestApproval(ctx, "item/fileChange/requestApproval", base.requestID, params, sessionTargets)
 }
 
 func (s *ApprovalService) ProcessApproval(ctx context.Context, op toolprocess.Operation) error {
@@ -115,7 +140,7 @@ func (s *ApprovalService) ProcessApproval(ctx context.Context, op toolprocess.Op
 		Signal:              op.Signal,
 		Destructive:         op.Destructive,
 	}
-	return s.requestApproval(ctx, "item/commandExecution/requestApproval", base.requestID, params)
+	return s.requestApproval(ctx, "item/commandExecution/requestApproval", base.requestID, params, nil)
 }
 
 func (s *ApprovalService) GitApproval(ctx context.Context, op toolgit.Operation) error {
@@ -140,7 +165,7 @@ func (s *ApprovalService) GitApproval(ctx context.Context, op toolgit.Operation)
 			"mutating":  op.Mutating,
 		},
 	}
-	return s.requestApproval(ctx, "item/permissions/requestApproval", requestBase.requestID, params)
+	return s.requestApproval(ctx, "item/permissions/requestApproval", requestBase.requestID, params, nil)
 }
 
 func (s *ApprovalService) MCPToolApproval(ctx context.Context, serverName, toolName string, args map[string]any) error {
@@ -163,7 +188,7 @@ func (s *ApprovalService) MCPToolApproval(ctx context.Context, serverName, toolN
 			"mutating":     true,
 		},
 	}
-	return s.requestApproval(ctx, "item/permissions/requestApproval", base.requestID, params)
+	return s.requestApproval(ctx, "item/permissions/requestApproval", base.requestID, params, nil)
 }
 
 func (s *Server) handleApprovalRespond(raw json.RawMessage) (any, *protocol.Error) {
@@ -209,6 +234,67 @@ func (s *ApprovalService) Respond(params approvalRespondParams) (approvalRespond
 	}, nil
 }
 
+func (s *ApprovalService) RespondResponse(resp protocol.Response) (approvalResponseResult, bool, error) {
+	if s == nil {
+		return approvalResponseResult{}, false, errors.New("approval service is not configured")
+	}
+	requestID := requestIDString(resp.ID)
+	if requestID == "" {
+		return approvalResponseResult{}, false, errors.New("response id is required")
+	}
+
+	s.mu.Lock()
+	pending, ok := s.pending[requestID]
+	if !ok {
+		s.mu.Unlock()
+		return approvalResponseResult{}, false, nil
+	}
+	result := approvalResponseResult{
+		RequestID: requestID,
+		ThreadID:  pending.threadID,
+		TurnID:    pending.turnID,
+		ch:        pending.ch,
+	}
+	resolution := approvalResolution{Message: "approval response was rejected"}
+	var responseErr error
+	if pending.method != "item/fileChange/requestApproval" {
+		responseErr = fmt.Errorf("direct response is not implemented for %s", pending.method)
+	} else if resp.Error != nil {
+		resolution.Message = resp.Error.Message
+	} else {
+		var response protocol.FileChangeRequestApprovalResponse
+		if err := json.Unmarshal(resp.Result, &response); err != nil {
+			responseErr = fmt.Errorf("decode file-change approval response: %w", err)
+		} else {
+			switch response.Decision {
+			case protocol.FileChangeApprovalAccept:
+				resolution.Approved = true
+				resolution.Message = ""
+			case protocol.FileChangeApprovalAcceptForSession:
+				resolution.Approved = true
+				resolution.Message = ""
+				if s.fileChangeSessionPaths == nil {
+					s.fileChangeSessionPaths = make(map[string]struct{})
+				}
+				for _, target := range pending.sessionTargets {
+					s.fileChangeSessionPaths[target] = struct{}{}
+				}
+			case protocol.FileChangeApprovalDecline:
+				resolution.Message = "file change declined"
+			case protocol.FileChangeApprovalCancel:
+				resolution.Message = "file change canceled"
+				result.CancelTurn = true
+			default:
+				responseErr = fmt.Errorf("unsupported file-change approval decision %q", response.Decision)
+			}
+		}
+	}
+	delete(s.pending, requestID)
+	s.mu.Unlock()
+	result.resolution = resolution
+	return result, true, responseErr
+}
+
 type serverRequestResolvedParams = protocol.ServerRequestResolvedNotificationParams
 
 func (s *ApprovalService) base(ctx context.Context, reason string) approvalRequestBase {
@@ -239,7 +325,7 @@ func (s *ApprovalService) nextRequestID() string {
 	return fmt.Sprintf("approval-%d", s.counter)
 }
 
-func (s *ApprovalService) requestApproval(ctx context.Context, method, requestID string, params any) error {
+func (s *ApprovalService) requestApproval(ctx context.Context, method, requestID string, params any, sessionTargets []string) error {
 	if s == nil || s.requests == nil {
 		return errors.New("approval service is not configured")
 	}
@@ -248,8 +334,11 @@ func (s *ApprovalService) requestApproval(ctx context.Context, method, requestID
 	}
 	runtimeContext := runtimeTurnContextFrom(ctx)
 	pending := pendingApproval{
-		ch:       make(chan approvalResolution, 1),
-		threadID: firstNonEmpty(runtimeContext.ThreadID, approvalThreadID),
+		ch:             make(chan approvalResolution, 1),
+		threadID:       firstNonEmpty(runtimeContext.ThreadID, approvalThreadID),
+		turnID:         firstNonEmpty(runtimeContext.TurnID, approvalTurnID),
+		method:         method,
+		sessionTargets: append([]string(nil), sessionTargets...),
 	}
 	s.mu.Lock()
 	if s.pending == nil {
@@ -274,4 +363,34 @@ func (s *ApprovalService) requestApproval(ctx context.Context, method, requestID
 		s.mu.Unlock()
 		return ctx.Err()
 	}
+}
+
+func (s *ApprovalService) fileChangeSessionApproved(targets []string) bool {
+	if s == nil || len(targets) == 0 {
+		return false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, target := range targets {
+		if _, ok := s.fileChangeSessionPaths[target]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func fileChangeApprovalSessionTargets(op toolfs.Operation) []string {
+	paths := []string{op.Path}
+	if op.Kind == toolfs.OperationCopy {
+		paths = []string{op.Destination}
+	}
+	targets := make([]string, 0, len(paths))
+	for _, path := range paths {
+		path = strings.TrimSpace(path)
+		if path == "" {
+			continue
+		}
+		targets = append(targets, filepath.ToSlash(filepath.Clean(path)))
+	}
+	return targets
 }

--- a/appserver/approval_test.go
+++ b/appserver/approval_test.go
@@ -78,6 +78,145 @@ func TestApprovalServiceDeniedResponse(t *testing.T) {
 	}
 }
 
+func TestServerResolvesDirectFileChangeApprovalResponses(t *testing.T) {
+	tests := []struct {
+		name      string
+		decision  protocol.FileChangeApprovalDecision
+		response  *protocol.Error
+		malformed bool
+		wantOK    bool
+		wantError bool
+	}{
+		{name: "accept", decision: protocol.FileChangeApprovalAccept, wantOK: true},
+		{name: "decline", decision: protocol.FileChangeApprovalDecline},
+		{name: "cancel", decision: protocol.FileChangeApprovalCancel},
+		{name: "client error", response: &protocol.Error{Code: protocol.CodeInternalError, Message: "handler failed"}},
+		{name: "malformed", malformed: true, wantError: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			approvals := NewApprovalService()
+			server := readyServer(WithApprovalService(approvals))
+			errCh := make(chan error, 1)
+			go func() {
+				errCh <- approvals.FilesystemApproval(context.Background(), toolfs.Operation{
+					Kind: toolfs.OperationWriteFile,
+					Path: "note.txt",
+				})
+			}()
+			req := waitForApprovalRequest(t, approvals)
+			resp := protocol.Response{ID: req.ID, Error: tc.response}
+			if tc.response == nil {
+				if tc.malformed {
+					resp.Result = json.RawMessage(`{"decision":"unknown"}`)
+				} else {
+					resp.Result = mustApprovalJSON(t, protocol.FileChangeRequestApprovalResponse{Decision: tc.decision})
+				}
+			}
+			err := server.HandleResponse(context.Background(), resp)
+			if (err != nil) != tc.wantError {
+				t.Fatalf("HandleResponse error = %v, want error %t", err, tc.wantError)
+			}
+			select {
+			case approvalErr := <-errCh:
+				if tc.wantOK && approvalErr != nil {
+					t.Fatalf("approval error = %v", approvalErr)
+				}
+				if !tc.wantOK && !errors.Is(approvalErr, ErrApprovalRequestDenied) {
+					t.Fatalf("approval error = %v, want denied", approvalErr)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("direct approval response did not resolve")
+			}
+			events := waitForNotificationSet(t, server, "serverRequest/resolved")
+			if len(events) != 1 {
+				t.Fatalf("resolved events = %#v", events)
+			}
+			requestID, _ := req.ID.Value().(string)
+			if _, err := approvals.Respond(approvalRespondParams{RequestID: requestID, Approved: true}); err == nil {
+				t.Fatal("legacy response unexpectedly resolved an already completed request")
+			}
+		})
+	}
+}
+
+func TestFileChangeAcceptForSessionCachesOnlyTheSameTarget(t *testing.T) {
+	approvals := NewApprovalService()
+	server := readyServer(WithApprovalService(approvals))
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- approvals.FilesystemApproval(context.Background(), toolfs.Operation{
+			Kind: toolfs.OperationWriteFile,
+			Path: "notes/../note.txt",
+		})
+	}()
+	req := waitForApprovalRequest(t, approvals)
+	if err := server.HandleResponse(context.Background(), protocol.Response{
+		ID: req.ID,
+		Result: mustApprovalJSON(t, protocol.FileChangeRequestApprovalResponse{
+			Decision: protocol.FileChangeApprovalAcceptForSession,
+		}),
+	}); err != nil {
+		t.Fatalf("HandleResponse: %v", err)
+	}
+	if err := <-errCh; err != nil {
+		t.Fatalf("first approval: %v", err)
+	}
+	if err := approvals.FilesystemApproval(context.Background(), toolfs.Operation{
+		Kind: toolfs.OperationWriteFile,
+		Path: "note.txt",
+	}); err != nil {
+		t.Fatalf("cached same-target approval: %v", err)
+	}
+	if requests := approvals.DrainRequests(); len(requests) != 0 {
+		t.Fatalf("same-target approval emitted requests: %#v", requests)
+	}
+
+	go func() {
+		errCh <- approvals.FilesystemApproval(context.Background(), toolfs.Operation{
+			Kind: toolfs.OperationWriteFile,
+			Path: "other.txt",
+		})
+	}()
+	other := waitForApprovalRequest(t, approvals)
+	otherID, _ := other.ID.Value().(string)
+	if _, err := approvals.Respond(approvalRespondParams{RequestID: otherID, Approved: false}); err != nil {
+		t.Fatalf("cleanup response: %v", err)
+	}
+	if err := <-errCh; !errors.Is(err, ErrApprovalRequestDenied) {
+		t.Fatalf("different-target approval = %v, want denied", err)
+	}
+}
+
+func TestDirectResponseForUnboundApprovalFamilyFailsClosed(t *testing.T) {
+	approvals := NewApprovalService()
+	server := readyServer(WithApprovalService(approvals))
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- approvals.ProcessApproval(context.Background(), toolprocess.Operation{
+			Kind:    toolprocess.OperationStart,
+			Command: "true",
+		})
+	}()
+	req := waitForApprovalRequest(t, approvals)
+	err := server.HandleResponse(context.Background(), protocol.Response{ID: req.ID, Result: json.RawMessage(`{"decision":"accept"}`)})
+	if err == nil {
+		t.Fatal("unbound direct response unexpectedly succeeded")
+	}
+	if approvalErr := <-errCh; !errors.Is(approvalErr, ErrApprovalRequestDenied) {
+		t.Fatalf("unbound direct approval = %v, want denied", approvalErr)
+	}
+}
+
+func mustApprovalJSON(t *testing.T, value any) json.RawMessage {
+	t.Helper()
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal approval response: %v", err)
+	}
+	return data
+}
+
 func TestApprovalServicePublishesProcessAndGitApprovalRequests(t *testing.T) {
 	cases := []struct {
 		name   string

--- a/appserver/jsonl_test.go
+++ b/appserver/jsonl_test.go
@@ -201,6 +201,75 @@ func TestServeJSONLinesApprovalRespondFlow(t *testing.T) {
 	}
 }
 
+func TestServeJSONLinesDirectFileChangeApprovalResponseFlow(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	approvals := NewApprovalService()
+	fsSvc, err := toolfs.NewService(t.TempDir(), toolfs.WithApproval(approvals.FilesystemApproval))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	server := NewServer(WithFilesystem(fsSvc), WithApprovalService(approvals))
+	inR, inW := io.Pipe()
+	outR, outW := io.Pipe()
+	errCh := make(chan error, 1)
+	go func() {
+		err := ServeJSONLines(ctx, server, inR, outW)
+		if err != nil {
+			_ = outW.CloseWithError(err)
+		} else {
+			_ = outW.Close()
+		}
+		errCh <- err
+	}()
+	scanner := bufio.NewScanner(outR)
+	writeInputLine(t, inW, `{"id":"init","method":"initialize","params":{"clientInfo":{"name":"direct-approval-client","version":"1.0.0"}}}`)
+	writeInputLine(t, inW, `{"method":"initialized"}`)
+	writeInputLine(t, inW, `{"id":"write","method":"fs/writeFile","params":{"path":"approved.txt","content":"ok"}}`)
+
+	var initResp protocol.Response
+	if err := json.Unmarshal([]byte(readOutputLine(t, scanner)), &initResp); err != nil || initResp.Error != nil {
+		t.Fatalf("initialize response = %#v, error=%v", initResp, err)
+	}
+	var approvalReq protocol.Request
+	if err := json.Unmarshal([]byte(readOutputLine(t, scanner)), &approvalReq); err != nil {
+		t.Fatalf("decode approval request: %v", err)
+	}
+	requestID, _ := approvalReq.ID.Value().(string)
+	if approvalReq.Method != "item/fileChange/requestApproval" || requestID == "" {
+		t.Fatalf("approval request = %#v", approvalReq)
+	}
+	writeInputLine(t, inW, `{"id":"`+requestID+`","result":{"decision":"accept"}}`)
+	if err := inW.Close(); err != nil {
+		t.Fatalf("close input: %v", err)
+	}
+
+	seenWrite := false
+	seenResolved := false
+	seenChanged := false
+	for scanner.Scan() {
+		var envelope struct {
+			ID     any    `json:"id"`
+			Method string `json:"method"`
+		}
+		if err := json.Unmarshal(scanner.Bytes(), &envelope); err != nil {
+			t.Fatalf("decode output %q: %v", scanner.Text(), err)
+		}
+		seenWrite = seenWrite || envelope.ID == "write"
+		seenResolved = seenResolved || envelope.Method == "serverRequest/resolved"
+		seenChanged = seenChanged || envelope.Method == "fs/changed"
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan output: %v", err)
+	}
+	if err := <-errCh; err != nil {
+		t.Fatalf("ServeJSONLines: %v", err)
+	}
+	if !seenWrite || !seenResolved || !seenChanged {
+		t.Fatalf("outputs: write=%t resolved=%t changed=%t", seenWrite, seenResolved, seenChanged)
+	}
+}
+
 func TestServeJSONLinesBackpressureAllowsApprovalRespond(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/appserver/protocol/README.md
+++ b/appserver/protocol/README.md
@@ -126,6 +126,16 @@ notification remains the exact public `{ threadId }` shape. These lifecycle
 types intentionally do not make `thread/status/changed` public: that method
 still depends on the distinct Codex runtime `ThreadStatus` model.
 
+## Version 1 File-Change Approval Responses
+
+`item/fileChange/requestApproval` binds the public `accept`,
+`acceptForSession`, `decline`, and `cancel` decisions to its direct JSON-RPC
+response. Session acceptance is connection-scoped and suppresses later prompts
+only for the same normalized mutation target; cancel interrupts an active
+runtime turn. The `approval/respond` extension remains available for legacy
+clients. Command-execution and permissions direct responses remain unbound
+until their policy-amendment and granted-profile dependencies are implemented.
+
 ## Version 1 Command Exec Controls
 
 `command/exec/write`, `command/exec/resize`, and `command/exec/terminate` use

--- a/appserver/protocol/bindings.go
+++ b/appserver/protocol/bindings.go
@@ -33,7 +33,7 @@ var wireTypeBindings = []WireTypeBinding{
 	{Method: "item/commandExecution/requestApproval", Surface: SurfaceServerRequest, Params: []string{"CommandExecutionApprovalRequestParams"}},
 	{Method: "item/completed", Surface: SurfaceServerNotification, Params: []string{"ItemLifecycleNotificationParams", "DynamicToolCallItemCompletedNotificationParams", "CommandExecutionItemCompletedNotificationParams", "FileChangeItemCompletedNotificationParams", "MCPToolCallItemCompletedNotificationParams"}},
 	{Method: "item/fileChange/patchUpdated", Surface: SurfaceServerNotification, Params: []string{"FileChangePatchUpdatedNotificationParams"}},
-	{Method: "item/fileChange/requestApproval", Surface: SurfaceServerRequest, Params: []string{"FileChangeApprovalRequestParams"}},
+	{Method: "item/fileChange/requestApproval", Surface: SurfaceServerRequest, Params: []string{"FileChangeApprovalRequestParams"}, Result: []string{"FileChangeRequestApprovalResponse"}},
 	{Method: "item/mcpToolCall/progress", Surface: SurfaceServerNotification, Params: []string{"MCPToolCallProgressNotificationParams"}},
 	{Method: "item/permissions/requestApproval", Surface: SurfaceServerRequest, Params: []string{"PermissionsApprovalRequestParams"}},
 	{Method: "item/started", Surface: SurfaceServerNotification, Params: []string{"ItemLifecycleNotificationParams", "DynamicToolCallItemStartedNotificationParams", "CommandExecutionItemStartedNotificationParams", "FileChangeItemStartedNotificationParams", "MCPToolCallItemStartedNotificationParams"}},

--- a/appserver/protocol/file_change_approval_response_contract_test.go
+++ b/appserver/protocol/file_change_approval_response_contract_test.go
@@ -1,0 +1,20 @@
+package protocol
+
+import "testing"
+
+func TestFileChangeApprovalResponseSchemaAndBinding(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	for _, name := range []string{"FileChangeApprovalDecision", "FileChangeRequestApprovalResponse"} {
+		if _, ok := defs[name].(Schema); !ok {
+			t.Errorf("schema missing %s", name)
+		}
+	}
+	if t.Failed() {
+		t.FailNow()
+	}
+	assertStringEnum(t, defs["FileChangeApprovalDecision"], "accept", "acceptForSession", "decline", "cancel")
+	assertSchemaRequired(t, defs["FileChangeRequestApprovalResponse"].(Schema), "decision")
+	bindings := WireTypeBindings()
+	assertBinding(t, bindings, "item/fileChange/requestApproval", SurfaceServerRequest, "FileChangeApprovalRequestParams")
+	assertBinding(t, bindings, "item/fileChange/requestApproval", SurfaceServerRequest, "FileChangeRequestApprovalResponse")
+}

--- a/appserver/protocol/runtime_types.go
+++ b/appserver/protocol/runtime_types.go
@@ -307,6 +307,19 @@ type FileChangeApprovalRequestParams struct {
 	Destructive bool    `json:"destructive,omitempty"`
 }
 
+type FileChangeApprovalDecision string
+
+const (
+	FileChangeApprovalAccept           FileChangeApprovalDecision = "accept"
+	FileChangeApprovalAcceptForSession FileChangeApprovalDecision = "acceptForSession"
+	FileChangeApprovalDecline          FileChangeApprovalDecision = "decline"
+	FileChangeApprovalCancel           FileChangeApprovalDecision = "cancel"
+)
+
+type FileChangeRequestApprovalResponse struct {
+	Decision FileChangeApprovalDecision `json:"decision"`
+}
+
 type CommandExecutionApprovalRequestParams struct {
 	ApprovalRequestBase
 	ApprovalID     string                   `json:"approvalId,omitempty"`

--- a/appserver/protocol/runtime_wire_fixture_test.go
+++ b/appserver/protocol/runtime_wire_fixture_test.go
@@ -119,16 +119,17 @@ func TestRuntimeWireV1FixtureUsesExportedContracts(t *testing.T) {
 	}
 
 	wantCases := map[string]bool{
-		"dynamic-tool-started":    false,
-		"command-completed":       false,
-		"file-change-completed":   false,
-		"mcp-call-completed":      false,
-		"context-compaction-item": false,
-		"thread-compacted":        false,
-		"token-usage-updated":     false,
-		"turn-diff-updated":       false,
-		"file-change-approval":    false,
-		"daemon-status":           false,
+		"dynamic-tool-started":          false,
+		"command-completed":             false,
+		"file-change-completed":         false,
+		"mcp-call-completed":            false,
+		"context-compaction-item":       false,
+		"thread-compacted":              false,
+		"token-usage-updated":           false,
+		"turn-diff-updated":             false,
+		"file-change-approval":          false,
+		"file-change-approval-response": false,
+		"daemon-status":                 false,
 	}
 	bindings := WireTypeBindings()
 	payloadBindings := ItemPayloadBindings()
@@ -283,6 +284,8 @@ func runtimeFixtureTarget(name string) any {
 		return new(TurnDiffUpdatedNotificationParams)
 	case "FileChangeApprovalRequestParams":
 		return new(FileChangeApprovalRequestParams)
+	case "FileChangeRequestApprovalResponse":
+		return new(FileChangeRequestApprovalResponse)
 	case "DaemonStatus":
 		return new(DaemonStatus)
 	case "ThreadListParams":

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -112,6 +112,8 @@ func wireSchemaDefinitions() Schema {
 		{Name: "DynamicToolCallItemCompletedNotificationParams", Type: reflect.TypeFor[DynamicToolCallItemCompletedNotificationParams]()},
 		{Name: "DynamicToolCallItemStartedNotificationParams", Type: reflect.TypeFor[DynamicToolCallItemStartedNotificationParams]()},
 		{Name: "FileChangeApprovalRequestParams", Type: reflect.TypeFor[FileChangeApprovalRequestParams]()},
+		{Name: "FileChangeApprovalDecision", Type: reflect.TypeFor[FileChangeApprovalDecision]()},
+		{Name: "FileChangeRequestApprovalResponse", Type: reflect.TypeFor[FileChangeRequestApprovalResponse]()},
 		{Name: "FileChangeArtifactEvidence", Type: reflect.TypeFor[FileChangeArtifactEvidence]()},
 		{Name: "FileChangeItem", Type: reflect.TypeFor[FileChangeItem]()},
 		{Name: "FileChangeItemCompletedNotificationParams", Type: reflect.TypeFor[FileChangeItemCompletedNotificationParams]()},
@@ -228,6 +230,12 @@ func wireSchemaDefinitions() Schema {
 	)
 	schemas["CommandExecOutputStream"] = stringEnumSchema(
 		string(CommandExecOutputStdout), string(CommandExecOutputStderr),
+	)
+	schemas["FileChangeApprovalDecision"] = stringEnumSchema(
+		string(FileChangeApprovalAccept),
+		string(FileChangeApprovalAcceptForSession),
+		string(FileChangeApprovalDecline),
+		string(FileChangeApprovalCancel),
 	)
 	schemas["CommandExecWriteParams"] = schemaWithRequiredFieldAlternatives(
 		schemas["CommandExecWriteParams"].(Schema),

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -997,6 +997,15 @@
       ],
       "type": "object"
     },
+    "FileChangeApprovalDecision": {
+      "enum": [
+        "accept",
+        "acceptForSession",
+        "decline",
+        "cancel"
+      ],
+      "type": "string"
+    },
     "FileChangeApprovalRequestParams": {
       "additionalProperties": false,
       "properties": {
@@ -1220,6 +1229,18 @@
         "turnId",
         "itemId",
         "changes"
+      ],
+      "type": "object"
+    },
+    "FileChangeRequestApprovalResponse": {
+      "additionalProperties": false,
+      "properties": {
+        "decision": {
+          "$ref": "#/$defs/FileChangeApprovalDecision"
+        }
+      },
+      "required": [
+        "decision"
       ],
       "type": "object"
     },
@@ -5262,6 +5283,9 @@
       "surface": "server-request",
       "params": [
         "FileChangeApprovalRequestParams"
+      ],
+      "result": [
+        "FileChangeRequestApprovalResponse"
       ]
     },
     {

--- a/appserver/protocol/testdata/runtime_wire_v1.json
+++ b/appserver/protocol/testdata/runtime_wire_v1.json
@@ -229,6 +229,17 @@
       }
     },
     {
+      "name": "file-change-approval-response",
+      "surface": "server-request",
+      "method": "item/fileChange/requestApproval",
+      "envelope": "response",
+      "resultType": "FileChangeRequestApprovalResponse",
+      "message": {
+        "id": "approval-1",
+        "result": {"decision": "acceptForSession"}
+      }
+    },
+    {
       "name": "daemon-status",
       "surface": "gollem-extension",
       "method": "daemon/status",

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -743,6 +743,8 @@ export type Error = ({
   "message": string;
 } & Record<string, unknown>);
 
+export type FileChangeApprovalDecision = "accept" | "acceptForSession" | "decline" | "cancel";
+
 export type FileChangeApprovalRequestParams = {
   "destination"?: string;
   "destructive"?: boolean;
@@ -796,6 +798,10 @@ export type FileChangePatchUpdatedNotificationParams = {
   "itemId": string;
   "threadId": string;
   "turnId": string;
+};
+
+export type FileChangeRequestApprovalResponse = {
+  "decision": FileChangeApprovalDecision;
 };
 
 export type FileUpdateChange = {
@@ -1348,7 +1354,7 @@ export const wireTypeBindings = [
   { "method": "item/commandExecution/requestApproval", "surface": "server-request", "params": ["CommandExecutionApprovalRequestParams"] },
   { "method": "item/completed", "surface": "server-notification", "params": ["ItemLifecycleNotificationParams", "DynamicToolCallItemCompletedNotificationParams", "CommandExecutionItemCompletedNotificationParams", "FileChangeItemCompletedNotificationParams", "MCPToolCallItemCompletedNotificationParams"] },
   { "method": "item/fileChange/patchUpdated", "surface": "server-notification", "params": ["FileChangePatchUpdatedNotificationParams"] },
-  { "method": "item/fileChange/requestApproval", "surface": "server-request", "params": ["FileChangeApprovalRequestParams"] },
+  { "method": "item/fileChange/requestApproval", "surface": "server-request", "params": ["FileChangeApprovalRequestParams"], "result": ["FileChangeRequestApprovalResponse"] },
   { "method": "item/mcpToolCall/progress", "surface": "server-notification", "params": ["MCPToolCallProgressNotificationParams"] },
   { "method": "item/permissions/requestApproval", "surface": "server-request", "params": ["PermissionsApprovalRequestParams"] },
   { "method": "item/started", "surface": "server-notification", "params": ["ItemLifecycleNotificationParams", "DynamicToolCallItemStartedNotificationParams", "CommandExecutionItemStartedNotificationParams", "FileChangeItemStartedNotificationParams", "MCPToolCallItemStartedNotificationParams"] },
@@ -1438,6 +1444,7 @@ export interface MethodResultsByName {
   "daemon/stop": DaemonStopResult;
   "daemon/version": DaemonVersion;
   "initialize": InitializeResponse;
+  "item/fileChange/requestApproval": FileChangeRequestApprovalResponse;
   "thread/archive": ThreadArchiveResponse;
   "thread/compact/start": ThreadCompactStartResponse;
   "thread/delete": ThreadDeleteResponse;

--- a/appserver/protocol/typescript/testdata/runtime_wire_v1.ts
+++ b/appserver/protocol/typescript/testdata/runtime_wire_v1.ts
@@ -10,6 +10,7 @@ import type {
   DynamicToolCallItemStartedNotificationParams,
   FileChangeApprovalRequestParams,
   FileChangeItemCompletedNotificationParams,
+  FileChangeRequestApprovalResponse,
   ItemLifecycleNotificationParams,
   MCPToolCallItemCompletedNotificationParams,
   ThreadCompactedNotificationParams,
@@ -235,6 +236,14 @@ export const fileChangeApproval = {
   }
 } satisfies BoundRequest<"item/fileChange/requestApproval">;
 export const fileChangeApprovalParams = fileChangeApproval.params satisfies FileChangeApprovalRequestParams;
+
+export const fileChangeApprovalResponse = {
+  "id": "approval-1",
+  "result": {
+    "decision": "acceptForSession"
+  }
+} satisfies BoundResponse<"item/fileChange/requestApproval">;
+export const fileChangeApprovalResponseResult = fileChangeApprovalResponse.result satisfies FileChangeRequestApprovalResponse;
 
 export const daemonStatus = {
   "id": "daemon-status-1",

--- a/appserver/runtime_filesystem_tools_test.go
+++ b/appserver/runtime_filesystem_tools_test.go
@@ -485,6 +485,65 @@ func TestServerRuntimeInterruptCancelsPendingFilesystemApproval(t *testing.T) {
 	}
 }
 
+func TestFileChangeApprovalCancelInterruptsActiveTurn(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	st := newRuntimeTestStore(t)
+	approvals := NewApprovalService()
+	fsSvc, err := toolfs.NewService(root, toolfs.WithApproval(approvals.FilesystemApproval))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	defer fsSvc.Close()
+	model := core.NewTestModel(
+		core.ToolCallResponseWithID(
+			"workspace_write_file",
+			`{"path":"canceled.txt","content":"must not exist\n"}`,
+			"call-canceled",
+		),
+		core.TextResponse("should not run"),
+	)
+	server := readyServer(
+		WithStore(st),
+		WithFilesystem(fsSvc),
+		WithApprovalService(approvals),
+		WithRuntimeService(NewRuntimeService(
+			WithRuntimeModel(model, RuntimeModelInfo{ProviderID: "test", Model: "test-model"}),
+			WithRuntimeTools(FilesystemRuntimeTools(fsSvc)...),
+		)),
+	)
+
+	resp := server.HandleRequest(ctx, request("thread/start", map[string]any{"prompt": "cancel this write"}))
+	if resp.Error != nil {
+		t.Fatalf("thread/start error: %v", resp.Error)
+	}
+	var started struct {
+		Turn *store.Turn `json:"turn"`
+	}
+	decodeResult(t, resp, &started)
+	approvalRequest := waitForServerRequest(t, server)
+	if err := server.HandleResponse(ctx, protocol.Response{
+		ID: approvalRequest.ID,
+		Result: mustApprovalJSON(t, protocol.FileChangeRequestApprovalResponse{
+			Decision: protocol.FileChangeApprovalCancel,
+		}),
+	}); err != nil {
+		t.Fatalf("HandleResponse: %v", err)
+	}
+	waitForNotificationSet(t, server, "serverRequest/resolved", "turn/completed")
+
+	completed, err := st.GetTurn(ctx, started.Turn.ID)
+	if err != nil {
+		t.Fatalf("GetTurn: %v", err)
+	}
+	if completed.Status != store.TurnInterrupted {
+		t.Fatalf("canceled turn status = %q, want interrupted", completed.Status)
+	}
+	if _, err := os.Stat(filepath.Join(root, "canceled.txt")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("canceled file stat error = %v, want not-exist", err)
+	}
+}
+
 func findRuntimeToolByName(t *testing.T, tools []core.Tool, name string) core.Tool {
 	t.Helper()
 	for _, tool := range tools {

--- a/appserver/server.go
+++ b/appserver/server.go
@@ -326,12 +326,30 @@ func (s *Server) HandleNotification(ctx context.Context, notification protocol.N
 
 // HandleResponse handles one client response to a server-to-client request.
 func (s *Server) HandleResponse(ctx context.Context, resp protocol.Response) error {
-	_ = ctx
 	if s == nil {
 		return rpcError(protocol.CodeInternalError, "server not configured", nil)
 	}
 	if err := s.requireReady(); err != nil {
 		return err
+	}
+	if s.approvals != nil {
+		result, ok, err := s.approvals.RespondResponse(resp)
+		if ok {
+			if result.CancelTurn {
+				if cancelErr := s.cancelApprovalTurn(ctx, result.TurnID); err == nil {
+					err = cancelErr
+				}
+			}
+			result.resolve()
+			s.PublishNotification("serverRequest/resolved", serverRequestResolvedParams{
+				ThreadID:  firstNonEmpty(result.ThreadID, approvalThreadID),
+				RequestID: result.RequestID,
+			})
+			if err != nil {
+				return invalidParams("invalid approval response", err)
+			}
+			return nil
+		}
 	}
 	if s.interact == nil {
 		return protocol.MethodUnavailableErrorWithReason("server response", "interaction service is not configured")
@@ -348,6 +366,24 @@ func (s *Server) HandleResponse(ctx context.Context, resp protocol.Response) err
 		RequestID: result.RequestID,
 	})
 	return nil
+}
+
+func (s *Server) cancelApprovalTurn(ctx context.Context, turnID string) error {
+	turnID = strings.TrimSpace(turnID)
+	if turnID == "" || turnID == approvalTurnID {
+		return nil
+	}
+	if s.runtime == nil || s.store == nil {
+		return errors.New("turn runtime is not configured for canceled approval")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	_, err := s.runtime.Interrupt(ctx, s.store, turnID)
+	if errors.Is(err, ErrRuntimeTurnNotActive) {
+		return nil
+	}
+	return err
 }
 
 // NotificationEnabled reports whether the connected client opted out of a


### PR DESCRIPTION
## Summary
- export and bind exact file-change approval decision/result contracts
- resolve direct JSON-RPC approval responses before generic interactions while preserving `approval/respond`
- implement same-target connection-scoped `acceptForSession` caching and active-turn cancellation
- fail closed on malformed responses and still resolve pending mutations
- add schema/TypeScript fixtures, repeated race coverage, JSONL tests, and real CLI smoke

Command-execution and permissions approval results remain intentionally unbound until their policy-amendment and granted-profile dependencies are implemented.

## Verification
- `go test -race ./... -count=1`
- `go test -race ./appserver/... -count=1`
- focused approval/JSONL/cancel race tests, 30 repetitions
- deterministic schema and TypeScript generation/compile
- `go vet ./...`
- `golangci-lint run ./...`
- `go mod tidy` with no diff
- trimpath CLI JSONL smoke without `--allow-mutations`
- focused coverage: resolver 89.2%, cache 87.5%, response routing 83.3%