### PR TITLE
Export exact live notification types

### DIFF
--- a/appserver/events.go
+++ b/appserver/events.go
@@ -206,12 +206,8 @@ type threadNotLoadedStatusNotificationParams struct {
 	At       time.Time         `json:"at"`
 }
 
-type deprecationNoticeNotificationParams struct {
-	Summary string  `json:"summary"`
-	Details *string `json:"details"`
-}
-
-type contextCompactedNotificationParams = protocol.ThreadCompactedNotificationParams
+type deprecationNoticeNotificationParams = protocol.DeprecationNoticeNotification
+type contextCompactedNotificationParams = protocol.ContextCompactedNotification
 
 func ProcessOutputNotification(event toolprocess.OutputEvent) (string, any) {
 	data, encoding := encodeContent(event.Data)

--- a/appserver/protocol/README.md
+++ b/appserver/protocol/README.md
@@ -126,6 +126,18 @@ notification remains the exact public `{ threadId }` shape. These lifecycle
 types intentionally do not make `thread/status/changed` public: that method
 still depends on the distinct Codex runtime `ThreadStatus` model.
 
+## Version 1 Exact Live Notification Values
+
+`deprecationNotice`, `thread/compacted`, `thread/tokenUsage/updated`, and
+`turn/diff/updated` bind the exact public `DeprecationNoticeNotification`,
+`ContextCompactedNotification`, `ThreadTokenUsageUpdatedNotification`, and
+`TurnDiffUpdatedNotification` names. Token usage uses the exact public
+`ThreadTokenUsage` value and keeps both `modelContextWindow` and deprecation
+`details` required and nullable on the wire. Gollem's original
+`ThreadCompactedNotificationParams`, `ThreadTokenUsageUpdatedNotificationParams`,
+`TokenUsage`, and `TurnDiffUpdatedNotificationParams` exports remain aliases so
+existing protocol-v1 generated clients continue to compile.
+
 ## Version 1 File-Change Approval Responses
 
 `item/fileChange/requestApproval` binds the public `accept`,

--- a/appserver/protocol/bindings.go
+++ b/appserver/protocol/bindings.go
@@ -27,6 +27,7 @@ var wireTypeBindings = []WireTypeBinding{
 	{Method: "daemon/status", Surface: SurfaceGollemExtension, Result: []string{"DaemonStatus"}},
 	{Method: "daemon/stop", Surface: SurfaceGollemExtension, Params: []string{"DaemonShutdownParams"}, Result: []string{"DaemonStopResult"}},
 	{Method: "daemon/version", Surface: SurfaceGollemExtension, Result: []string{"DaemonVersion"}},
+	{Method: "deprecationNotice", Surface: SurfaceServerNotification, Params: []string{"DeprecationNoticeNotification"}},
 	{Method: "initialize", Surface: SurfaceClientRequest, Params: []string{"InitializeParams"}, Result: []string{"InitializeResponse"}},
 	{Method: "initialized", Surface: SurfaceClientNotification},
 	{Method: "item/commandExecution/outputDelta", Surface: SurfaceServerNotification, Params: []string{"CommandExecutionOutputDeltaNotificationParams"}},
@@ -45,7 +46,7 @@ var wireTypeBindings = []WireTypeBinding{
 	{Method: "thread/archived", Surface: SurfaceServerNotification, Params: []string{"ThreadArchivedNotification"}},
 	{Method: "thread/closed", Surface: SurfaceServerNotification, Params: []string{"ThreadClosedNotification"}},
 	{Method: "thread/compact/start", Surface: SurfaceClientRequest, Params: []string{"ThreadCompactStartParams"}, Result: []string{"ThreadCompactStartResponse"}},
-	{Method: "thread/compacted", Surface: SurfaceServerNotification, Params: []string{"ThreadCompactedNotificationParams"}},
+	{Method: "thread/compacted", Surface: SurfaceServerNotification, Params: []string{"ContextCompactedNotification"}},
 	{Method: "thread/delete", Surface: SurfaceClientRequest, Params: []string{"ThreadDeleteParams"}, Result: []string{"ThreadDeleteResponse"}},
 	{Method: "thread/deleted", Surface: SurfaceServerNotification, Params: []string{"ThreadDeletedNotification"}},
 	{Method: "thread/goal/clear", Surface: SurfaceClientRequest, Params: []string{"ThreadGoalClearParams"}, Result: []string{"ThreadGoalClearResponse"}},
@@ -60,11 +61,11 @@ var wireTypeBindings = []WireTypeBinding{
 	{Method: "thread/name/set", Surface: SurfaceClientRequest, Params: []string{"ThreadSetNameParams"}, Result: []string{"ThreadSetNameResponse"}},
 	{Method: "thread/name/updated", Surface: SurfaceServerNotification, Params: []string{"ThreadNameUpdatedNotification"}},
 	{Method: "thread/read", Surface: SurfaceClientRequest, Params: []string{"ThreadReadParams"}, Result: []string{"ThreadReadResponse"}},
-	{Method: "thread/tokenUsage/updated", Surface: SurfaceServerNotification, Params: []string{"ThreadTokenUsageUpdatedNotificationParams"}},
+	{Method: "thread/tokenUsage/updated", Surface: SurfaceServerNotification, Params: []string{"ThreadTokenUsageUpdatedNotification"}},
 	{Method: "thread/unarchive", Surface: SurfaceClientRequest, Params: []string{"ThreadUnarchiveParams"}, Result: []string{"ThreadUnarchiveResponse"}},
 	{Method: "thread/unarchived", Surface: SurfaceServerNotification, Params: []string{"ThreadUnarchivedNotification"}},
 	{Method: "thread/unsubscribe", Surface: SurfaceClientRequest, Params: []string{"ThreadUnsubscribeParams"}, Result: []string{"ThreadUnsubscribeResponse"}},
-	{Method: "turn/diff/updated", Surface: SurfaceServerNotification, Params: []string{"TurnDiffUpdatedNotificationParams"}},
+	{Method: "turn/diff/updated", Surface: SurfaceServerNotification, Params: []string{"TurnDiffUpdatedNotification"}},
 }
 
 var itemPayloadBindings = []ItemPayloadBinding{

--- a/appserver/protocol/exact_live_notification_contract_test.go
+++ b/appserver/protocol/exact_live_notification_contract_test.go
@@ -1,0 +1,173 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestExactLiveNotificationSchemasAndBindings(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	for _, name := range []string{
+		"ContextCompactedNotification",
+		"DeprecationNoticeNotification",
+		"ThreadTokenUsage",
+		"ThreadTokenUsageUpdatedNotification",
+		"TurnDiffUpdatedNotification",
+		// Keep the Gollem v1 names available to existing generated clients.
+		"ThreadCompactedNotificationParams",
+		"ThreadTokenUsageUpdatedNotificationParams",
+		"TokenUsage",
+		"TurnDiffUpdatedNotificationParams",
+	} {
+		if _, ok := defs[name]; !ok {
+			t.Errorf("schema missing %s", name)
+		}
+	}
+	if t.Failed() {
+		t.FailNow()
+	}
+
+	assertSchemaRequired(t, defs["ContextCompactedNotification"].(Schema), "threadId", "turnId")
+	assertSchemaRequired(t, defs["DeprecationNoticeNotification"].(Schema), "summary", "details")
+	assertSchemaRequired(t, defs["ThreadTokenUsage"].(Schema), "total", "last", "modelContextWindow")
+	assertSchemaRequired(t, defs["ThreadTokenUsageUpdatedNotification"].(Schema), "threadId", "turnId", "tokenUsage")
+	assertSchemaRequired(t, defs["TurnDiffUpdatedNotification"].(Schema), "threadId", "turnId", "diff")
+	assertExactLiveNotificationNullableField(t, defs["DeprecationNoticeNotification"].(Schema), "details")
+	assertExactLiveNotificationNullableField(t, defs["ThreadTokenUsage"].(Schema), "modelContextWindow")
+	tokenUsageProperty := defs["ThreadTokenUsageUpdatedNotification"].(Schema)["properties"].(Schema)["tokenUsage"].(Schema)
+	if tokenUsageProperty["$ref"] != "#/$defs/ThreadTokenUsage" {
+		t.Fatalf("notification tokenUsage schema = %#v", tokenUsageProperty)
+	}
+	for alias, canonical := range map[string]string{
+		"ThreadCompactedNotificationParams":         "ContextCompactedNotification",
+		"ThreadTokenUsageUpdatedNotificationParams": "ThreadTokenUsageUpdatedNotification",
+		"TokenUsage":                        "ThreadTokenUsage",
+		"TurnDiffUpdatedNotificationParams": "TurnDiffUpdatedNotification",
+	} {
+		if got := defs[alias].(Schema)["$ref"]; got != "#/$defs/"+canonical {
+			t.Errorf("%s alias = %#v", alias, defs[alias])
+		}
+	}
+
+	wantBindings := map[string]string{
+		"deprecationNotice":         "DeprecationNoticeNotification",
+		"thread/compacted":          "ContextCompactedNotification",
+		"thread/tokenUsage/updated": "ThreadTokenUsageUpdatedNotification",
+		"turn/diff/updated":         "TurnDiffUpdatedNotification",
+	}
+	for method, want := range wantBindings {
+		binding, ok := exactLiveNotificationBinding(WireTypeBindings(), method)
+		if !ok {
+			t.Errorf("missing %s binding", method)
+			continue
+		}
+		if binding.Surface != SurfaceServerNotification || !reflect.DeepEqual(binding.Params, []string{want}) || len(binding.Result) != 0 {
+			t.Errorf("%s binding = %+v, want server-notification params [%s]", method, binding, want)
+		}
+	}
+}
+
+func TestExactLiveNotificationValuesPreserveWireShape(t *testing.T) {
+	usage := ThreadTokenUsage{
+		Total: TokenUsageBreakdown{
+			TotalTokens:           180,
+			InputTokens:           120,
+			CachedInputTokens:     20,
+			OutputTokens:          60,
+			ReasoningOutputTokens: 10,
+		},
+		Last: TokenUsageBreakdown{
+			TotalTokens:           80,
+			InputTokens:           50,
+			CachedInputTokens:     10,
+			OutputTokens:          30,
+			ReasoningOutputTokens: 5,
+		},
+		ModelContextWindow: nil,
+	}
+	values := []struct {
+		name string
+		got  any
+		want string
+	}{
+		{
+			name: "context compacted",
+			got:  ContextCompactedNotification{ThreadID: "thread-1", TurnID: "turn-1"},
+			want: `{"threadId":"thread-1","turnId":"turn-1"}`,
+		},
+		{
+			name: "deprecation notice",
+			got:  DeprecationNoticeNotification{Summary: "deprecated", Details: nil},
+			want: `{"summary":"deprecated","details":null}`,
+		},
+		{
+			name: "thread token usage",
+			got:  usage,
+			want: `{"total":{"totalTokens":180,"inputTokens":120,"cachedInputTokens":20,"outputTokens":60,"reasoningOutputTokens":10},"last":{"totalTokens":80,"inputTokens":50,"cachedInputTokens":10,"outputTokens":30,"reasoningOutputTokens":5},"modelContextWindow":null}`,
+		},
+		{
+			name: "thread token usage updated",
+			got:  ThreadTokenUsageUpdatedNotification{ThreadID: "thread-1", TurnID: "turn-1", TokenUsage: usage},
+			want: `{"threadId":"thread-1","turnId":"turn-1","tokenUsage":{"total":{"totalTokens":180,"inputTokens":120,"cachedInputTokens":20,"outputTokens":60,"reasoningOutputTokens":10},"last":{"totalTokens":80,"inputTokens":50,"cachedInputTokens":10,"outputTokens":30,"reasoningOutputTokens":5},"modelContextWindow":null}}`,
+		},
+		{
+			name: "turn diff updated",
+			got:  TurnDiffUpdatedNotification{ThreadID: "thread-1", TurnID: "turn-1", Diff: "diff\n"},
+			want: `{"threadId":"thread-1","turnId":"turn-1","diff":"diff\n"}`,
+		},
+	}
+	for _, tc := range values {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := json.Marshal(tc.got)
+			if err != nil {
+				t.Fatalf("Marshal: %v", err)
+			}
+			if string(got) != tc.want {
+				t.Fatalf("wire = %s, want %s", got, tc.want)
+			}
+		})
+	}
+
+	for legacy, canonical := range map[reflect.Type]reflect.Type{
+		reflect.TypeFor[ThreadCompactedNotificationParams]():         reflect.TypeFor[ContextCompactedNotification](),
+		reflect.TypeFor[ThreadTokenUsageUpdatedNotificationParams](): reflect.TypeFor[ThreadTokenUsageUpdatedNotification](),
+		reflect.TypeFor[TokenUsage]():                                reflect.TypeFor[ThreadTokenUsage](),
+		reflect.TypeFor[TurnDiffUpdatedNotificationParams]():         reflect.TypeFor[TurnDiffUpdatedNotification](),
+	} {
+		if legacy != canonical {
+			t.Errorf("legacy type %s is not an alias of %s", legacy, canonical)
+		}
+	}
+}
+
+func exactLiveNotificationBinding(bindings []WireTypeBinding, method string) (WireTypeBinding, bool) {
+	for _, binding := range bindings {
+		if binding.Method == method {
+			return binding, true
+		}
+	}
+	return WireTypeBinding{}, false
+}
+
+func assertExactLiveNotificationNullableField(t *testing.T, definition Schema, field string) {
+	t.Helper()
+	properties, ok := definition["properties"].(Schema)
+	if !ok {
+		t.Fatalf("definition properties = %T", definition["properties"])
+	}
+	property, ok := properties[field].(Schema)
+	if !ok {
+		t.Fatalf("%s schema = %T", field, properties[field])
+	}
+	variants, ok := property["anyOf"].([]any)
+	if !ok || len(variants) != 2 {
+		t.Fatalf("%s nullable variants = %#v", field, property["anyOf"])
+	}
+	for _, variant := range variants {
+		if schema, ok := variant.(Schema); ok && schema["type"] == "null" {
+			return
+		}
+	}
+	t.Fatalf("%s is not nullable: %#v", field, property)
+}

--- a/appserver/protocol/runtime_types.go
+++ b/appserver/protocol/runtime_types.go
@@ -328,18 +328,17 @@ type ContextCompactionItem struct {
 	CreatedAt time.Time `json:"createdAt"`
 }
 
-type ThreadCompactedNotificationParams struct {
+type ContextCompactedNotification struct {
 	ThreadID string `json:"threadId"`
 	TurnID   string `json:"turnId"`
 }
 
-type ThreadTokenUsageUpdatedNotificationParams struct {
-	ThreadID   string     `json:"threadId"`
-	TurnID     string     `json:"turnId"`
-	TokenUsage TokenUsage `json:"tokenUsage"`
+type DeprecationNoticeNotification struct {
+	Summary string  `json:"summary" jsonschema:"description=Concise summary of what is deprecated."`
+	Details *string `json:"details" jsonschema:"description=Optional extra guidance such as migration steps or rationale."`
 }
 
-type TokenUsage struct {
+type ThreadTokenUsage struct {
 	Total              TokenUsageBreakdown `json:"total"`
 	Last               TokenUsageBreakdown `json:"last"`
 	ModelContextWindow *int64              `json:"modelContextWindow"`
@@ -353,11 +352,23 @@ type TokenUsageBreakdown struct {
 	ReasoningOutputTokens int64 `json:"reasoningOutputTokens"`
 }
 
-type TurnDiffUpdatedNotificationParams struct {
+type ThreadTokenUsageUpdatedNotification struct {
+	ThreadID   string           `json:"threadId"`
+	TurnID     string           `json:"turnId"`
+	TokenUsage ThreadTokenUsage `json:"tokenUsage"`
+}
+
+type TurnDiffUpdatedNotification struct {
 	ThreadID string `json:"threadId"`
 	TurnID   string `json:"turnId"`
 	Diff     string `json:"diff"`
 }
+
+// Gollem v1 compatibility aliases. New bindings use the exact public names.
+type ThreadCompactedNotificationParams = ContextCompactedNotification
+type ThreadTokenUsageUpdatedNotificationParams = ThreadTokenUsageUpdatedNotification
+type TokenUsage = ThreadTokenUsage
+type TurnDiffUpdatedNotificationParams = TurnDiffUpdatedNotification
 
 type ItemLifecycleNotificationParams struct {
 	ThreadID string        `json:"threadId"`

--- a/appserver/protocol/runtime_wire_fixture_test.go
+++ b/appserver/protocol/runtime_wire_fixture_test.go
@@ -248,6 +248,7 @@ func TestRuntimeWireV1FixtureUsesExportedContracts(t *testing.T) {
 		"file-change-completed":         false,
 		"mcp-call-completed":            false,
 		"context-compaction-item":       false,
+		"deprecation-notice":            false,
 		"thread-compacted":              false,
 		"token-usage-updated":           false,
 		"turn-diff-updated":             false,
@@ -420,6 +421,14 @@ func runtimeFixtureTarget(name string) any {
 		return new(ItemLifecycleNotificationParams)
 	case "ContextCompactionItem":
 		return new(ContextCompactionItem)
+	case "ContextCompactedNotification":
+		return new(ContextCompactedNotification)
+	case "DeprecationNoticeNotification":
+		return new(DeprecationNoticeNotification)
+	case "ThreadTokenUsageUpdatedNotification":
+		return new(ThreadTokenUsageUpdatedNotification)
+	case "TurnDiffUpdatedNotification":
+		return new(TurnDiffUpdatedNotification)
 	case "ThreadCompactedNotificationParams":
 		return new(ThreadCompactedNotificationParams)
 	case "ThreadTokenUsageUpdatedNotificationParams":

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -114,6 +114,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "DaemonStatus", Type: reflect.TypeFor[DaemonStatus]()},
 		{Name: "DaemonStopResult", Type: reflect.TypeFor[DaemonStopResult]()},
 		{Name: "DaemonVersion", Type: reflect.TypeFor[DaemonVersion]()},
+		{Name: "DeprecationNoticeNotification", Type: reflect.TypeFor[DeprecationNoticeNotification]()},
 		{Name: "DynamicToolCallContentItem", Type: reflect.TypeFor[DynamicToolCallContentItem]()},
 		{Name: "DynamicToolCallOutputContentItem", Type: reflect.TypeFor[DynamicToolCallOutputContentItem]()},
 		{Name: "DynamicToolCallParams", Type: reflect.TypeFor[DynamicToolCallParams]()},
@@ -248,6 +249,12 @@ func wireSchemaDefinitions() Schema {
 		{Name: "TurnDiffUpdatedNotificationParams", Type: reflect.TypeFor[TurnDiffUpdatedNotificationParams]()},
 		{Name: "TurnLifecycleStatus", Type: reflect.TypeFor[TurnLifecycleStatus]()},
 		{Name: "TurnRecord", Type: reflect.TypeFor[TurnRecord]()},
+		// Register exact public names after their aliases so nested schemas refer
+		// to the public names. JSON and TypeScript output remain key-sorted.
+		{Name: "ContextCompactedNotification", Type: reflect.TypeFor[ContextCompactedNotification]()},
+		{Name: "ThreadTokenUsage", Type: reflect.TypeFor[ThreadTokenUsage]()},
+		{Name: "ThreadTokenUsageUpdatedNotification", Type: reflect.TypeFor[ThreadTokenUsageUpdatedNotification]()},
+		{Name: "TurnDiffUpdatedNotification", Type: reflect.TypeFor[TurnDiffUpdatedNotification]()},
 	}
 	names := make(map[reflect.Type]string, len(definitions))
 	for _, definition := range definitions {
@@ -299,6 +306,14 @@ func wireSchemaDefinitions() Schema {
 	schemas["PermissionGrantScope"] = stringEnumSchema(
 		string(PermissionGrantTurn), string(PermissionGrantSession),
 	)
+	for alias, canonical := range map[string]string{
+		"ThreadCompactedNotificationParams":         "ContextCompactedNotification",
+		"ThreadTokenUsageUpdatedNotificationParams": "ThreadTokenUsageUpdatedNotification",
+		"TokenUsage":                        "ThreadTokenUsage",
+		"TurnDiffUpdatedNotificationParams": "TurnDiffUpdatedNotification",
+	} {
+		schemas[alias] = Schema{"$ref": "#/$defs/" + canonical}
+	}
 	setSchemaIntegerMinimum(schemas["AdditionalFileSystemPermissions"].(Schema), 1, "globScanMaxDepth")
 	if response, ok := schemas["PermissionsRequestApprovalResponse"].(Schema); ok {
 		if properties, ok := response["properties"].(Schema); ok {

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -861,6 +861,22 @@
       ],
       "type": "object"
     },
+    "ContextCompactedNotification": {
+      "additionalProperties": false,
+      "properties": {
+        "threadId": {
+          "type": "string"
+        },
+        "turnId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "threadId",
+        "turnId"
+      ],
+      "type": "object"
+    },
     "ContextCompactionItem": {
       "additionalProperties": false,
       "properties": {
@@ -1046,6 +1062,31 @@
         "goVersion",
         "goos",
         "goarch"
+      ],
+      "type": "object"
+    },
+    "DeprecationNoticeNotification": {
+      "additionalProperties": false,
+      "properties": {
+        "details": {
+          "anyOf": [
+            {
+              "description": "Optional extra guidance such as migration steps or rationale.",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "summary": {
+          "description": "Concise summary of what is deprecated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "summary",
+        "details"
       ],
       "type": "object"
     },
@@ -3670,20 +3711,7 @@
       "type": "object"
     },
     "ThreadCompactedNotificationParams": {
-      "additionalProperties": false,
-      "properties": {
-        "threadId": {
-          "type": "string"
-        },
-        "turnId": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "threadId",
-        "turnId"
-      ],
-      "type": "object"
+      "$ref": "#/$defs/ContextCompactedNotification"
     },
     "ThreadDeleteParams": {
       "additionalProperties": false,
@@ -4892,14 +4920,41 @@
       ],
       "type": "string"
     },
-    "ThreadTokenUsageUpdatedNotificationParams": {
+    "ThreadTokenUsage": {
+      "additionalProperties": false,
+      "properties": {
+        "last": {
+          "$ref": "#/$defs/TokenUsageBreakdown"
+        },
+        "modelContextWindow": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "total": {
+          "$ref": "#/$defs/TokenUsageBreakdown"
+        }
+      },
+      "required": [
+        "total",
+        "last",
+        "modelContextWindow"
+      ],
+      "type": "object"
+    },
+    "ThreadTokenUsageUpdatedNotification": {
       "additionalProperties": false,
       "properties": {
         "threadId": {
           "type": "string"
         },
         "tokenUsage": {
-          "$ref": "#/$defs/TokenUsage"
+          "$ref": "#/$defs/ThreadTokenUsage"
         },
         "turnId": {
           "type": "string"
@@ -4911,6 +4966,9 @@
         "tokenUsage"
       ],
       "type": "object"
+    },
+    "ThreadTokenUsageUpdatedNotificationParams": {
+      "$ref": "#/$defs/ThreadTokenUsageUpdatedNotification"
     },
     "ThreadUnarchiveParams": {
       "additionalProperties": false,
@@ -5055,31 +5113,7 @@
       "type": "object"
     },
     "TokenUsage": {
-      "additionalProperties": false,
-      "properties": {
-        "last": {
-          "$ref": "#/$defs/TokenUsageBreakdown"
-        },
-        "modelContextWindow": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "total": {
-          "$ref": "#/$defs/TokenUsageBreakdown"
-        }
-      },
-      "required": [
-        "total",
-        "last",
-        "modelContextWindow"
-      ],
-      "type": "object"
+      "$ref": "#/$defs/ThreadTokenUsage"
     },
     "TokenUsageBreakdown": {
       "additionalProperties": false,
@@ -5301,7 +5335,7 @@
       ],
       "type": "object"
     },
-    "TurnDiffUpdatedNotificationParams": {
+    "TurnDiffUpdatedNotification": {
       "additionalProperties": false,
       "properties": {
         "diff": {
@@ -5320,6 +5354,9 @@
         "diff"
       ],
       "type": "object"
+    },
+    "TurnDiffUpdatedNotificationParams": {
+      "$ref": "#/$defs/TurnDiffUpdatedNotification"
     },
     "TurnLifecycleStatus": {
       "enum": [
@@ -6866,6 +6903,13 @@
       ]
     },
     {
+      "method": "deprecationNotice",
+      "surface": "server-notification",
+      "params": [
+        "DeprecationNoticeNotification"
+      ]
+    },
+    {
       "method": "initialize",
       "surface": "client-request",
       "params": [
@@ -7024,7 +7068,7 @@
       "method": "thread/compacted",
       "surface": "server-notification",
       "params": [
-        "ThreadCompactedNotificationParams"
+        "ContextCompactedNotification"
       ]
     },
     {
@@ -7159,7 +7203,7 @@
       "method": "thread/tokenUsage/updated",
       "surface": "server-notification",
       "params": [
-        "ThreadTokenUsageUpdatedNotificationParams"
+        "ThreadTokenUsageUpdatedNotification"
       ]
     },
     {
@@ -7193,7 +7237,7 @@
       "method": "turn/diff/updated",
       "surface": "server-notification",
       "params": [
-        "TurnDiffUpdatedNotificationParams"
+        "TurnDiffUpdatedNotification"
       ]
     }
   ]

--- a/appserver/protocol/schema_test.go
+++ b/appserver/protocol/schema_test.go
@@ -58,8 +58,11 @@ func TestJSONSchemaExportsRuntimeDefinitionsAndBindings(t *testing.T) {
 		"FileChangeItem",
 		"MCPToolCallItem",
 		"ContextCompactionItem",
-		"ThreadTokenUsageUpdatedNotificationParams",
-		"TurnDiffUpdatedNotificationParams",
+		"ContextCompactedNotification",
+		"DeprecationNoticeNotification",
+		"ThreadTokenUsage",
+		"ThreadTokenUsageUpdatedNotification",
+		"TurnDiffUpdatedNotification",
 		"FileChangeApprovalRequestParams",
 		"DaemonStatus",
 	} {
@@ -74,7 +77,8 @@ func TestJSONSchemaExportsRuntimeDefinitionsAndBindings(t *testing.T) {
 	}
 	assertBinding(t, bindings, "item/started", SurfaceServerNotification, "DynamicToolCallItemStartedNotificationParams")
 	assertBinding(t, bindings, "item/completed", SurfaceServerNotification, "MCPToolCallItemCompletedNotificationParams")
-	assertBinding(t, bindings, "thread/tokenUsage/updated", SurfaceServerNotification, "ThreadTokenUsageUpdatedNotificationParams")
+	assertBinding(t, bindings, "deprecationNotice", SurfaceServerNotification, "DeprecationNoticeNotification")
+	assertBinding(t, bindings, "thread/tokenUsage/updated", SurfaceServerNotification, "ThreadTokenUsageUpdatedNotification")
 	assertBinding(t, bindings, "item/fileChange/requestApproval", SurfaceServerRequest, "FileChangeApprovalRequestParams")
 	assertBinding(t, bindings, "daemon/status", SurfaceGollemExtension, "DaemonStatus")
 

--- a/appserver/protocol/testdata/runtime_wire_v1.json
+++ b/appserver/protocol/testdata/runtime_wire_v1.json
@@ -154,10 +154,23 @@
       }
     },
     {
+      "name": "deprecation-notice",
+      "surface": "server-notification",
+      "method": "deprecationNotice",
+      "paramsType": "DeprecationNoticeNotification",
+      "message": {
+        "method": "deprecationNotice",
+        "params": {
+          "summary": "thread/rollback is deprecated; use thread/fork instead",
+          "details": null
+        }
+      }
+    },
+    {
       "name": "thread-compacted",
       "surface": "server-notification",
       "method": "thread/compacted",
-      "paramsType": "ThreadCompactedNotificationParams",
+      "paramsType": "ContextCompactedNotification",
       "message": {
         "method": "thread/compacted",
         "params": {"threadId": "thread-1", "turnId": "turn-compact"}
@@ -167,7 +180,7 @@
       "name": "token-usage-updated",
       "surface": "server-notification",
       "method": "thread/tokenUsage/updated",
-      "paramsType": "ThreadTokenUsageUpdatedNotificationParams",
+      "paramsType": "ThreadTokenUsageUpdatedNotification",
       "message": {
         "method": "thread/tokenUsage/updated",
         "params": {
@@ -197,7 +210,7 @@
       "name": "turn-diff-updated",
       "surface": "server-notification",
       "method": "turn/diff/updated",
-      "paramsType": "TurnDiffUpdatedNotificationParams",
+      "paramsType": "TurnDiffUpdatedNotification",
       "message": {
         "method": "turn/diff/updated",
         "params": {

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -690,6 +690,11 @@ export type CommandExecutionRequestApprovalResponse = {
   "decision": CommandExecutionApprovalDecision;
 };
 
+export type ContextCompactedNotification = {
+  "threadId": string;
+  "turnId": string;
+};
+
 export type ContextCompactionItem = {
   "createdAt": string;
   "summary"?: string;
@@ -742,6 +747,11 @@ export type DaemonVersion = {
   "name": string;
   "protocolVersion": string;
   "version": string;
+};
+
+export type DeprecationNoticeNotification = {
+  "details": string | null;
+  "summary": string;
 };
 
 export type DynamicToolCallContentItem = {
@@ -1310,10 +1320,7 @@ export type ThreadCompactStartParams = {
 
 export type ThreadCompactStartResponse = Record<string, never>;
 
-export type ThreadCompactedNotificationParams = {
-  "threadId": string;
-  "turnId": string;
-};
+export type ThreadCompactedNotificationParams = ContextCompactedNotification;
 
 export type ThreadDeleteParams = {
   "id"?: string;
@@ -1560,11 +1567,19 @@ export type ThreadSortKey = "created_at" | "updated_at" | "recency_at";
 
 export type ThreadSourceKind = "cli" | "vscode" | "exec" | "appServer" | "subAgent" | "subAgentReview" | "subAgentCompact" | "subAgentThreadSpawn" | "subAgentOther" | "unknown";
 
-export type ThreadTokenUsageUpdatedNotificationParams = {
+export type ThreadTokenUsage = {
+  "last": TokenUsageBreakdown;
+  "modelContextWindow": number | null;
+  "total": TokenUsageBreakdown;
+};
+
+export type ThreadTokenUsageUpdatedNotification = {
   "threadId": string;
-  "tokenUsage": TokenUsage;
+  "tokenUsage": ThreadTokenUsage;
   "turnId": string;
 };
+
+export type ThreadTokenUsageUpdatedNotificationParams = ThreadTokenUsageUpdatedNotification;
 
 export type ThreadUnarchiveParams = {
   "id"?: string;
@@ -1606,11 +1621,7 @@ export type TimelineItem = {
   "updatedAt": string;
 };
 
-export type TokenUsage = {
-  "last": TokenUsageBreakdown;
-  "modelContextWindow": number | null;
-  "total": TokenUsageBreakdown;
-};
+export type TokenUsage = ThreadTokenUsage;
 
 export type TokenUsageBreakdown = {
   "cachedInputTokens": number;
@@ -1665,11 +1676,13 @@ export type ToolRequestUserInputResponse = {
   "answers": Record<string, ToolRequestUserInputAnswer>;
 };
 
-export type TurnDiffUpdatedNotificationParams = {
+export type TurnDiffUpdatedNotification = {
   "diff": string;
   "threadId": string;
   "turnId": string;
 };
+
+export type TurnDiffUpdatedNotificationParams = TurnDiffUpdatedNotification;
 
 export type TurnLifecycleStatus = "queued" | "running" | "completed" | "failed" | "interrupted";
 
@@ -1707,6 +1720,7 @@ export const wireTypeBindings = [
   { "method": "daemon/status", "surface": "gollem-extension", "result": ["DaemonStatus"] },
   { "method": "daemon/stop", "surface": "gollem-extension", "params": ["DaemonShutdownParams"], "result": ["DaemonStopResult"] },
   { "method": "daemon/version", "surface": "gollem-extension", "result": ["DaemonVersion"] },
+  { "method": "deprecationNotice", "surface": "server-notification", "params": ["DeprecationNoticeNotification"] },
   { "method": "initialize", "surface": "client-request", "params": ["InitializeParams"], "result": ["InitializeResponse"] },
   { "method": "initialized", "surface": "client-notification" },
   { "method": "item/commandExecution/outputDelta", "surface": "server-notification", "params": ["CommandExecutionOutputDeltaNotificationParams"] },
@@ -1725,7 +1739,7 @@ export const wireTypeBindings = [
   { "method": "thread/archived", "surface": "server-notification", "params": ["ThreadArchivedNotification"] },
   { "method": "thread/closed", "surface": "server-notification", "params": ["ThreadClosedNotification"] },
   { "method": "thread/compact/start", "surface": "client-request", "params": ["ThreadCompactStartParams"], "result": ["ThreadCompactStartResponse"] },
-  { "method": "thread/compacted", "surface": "server-notification", "params": ["ThreadCompactedNotificationParams"] },
+  { "method": "thread/compacted", "surface": "server-notification", "params": ["ContextCompactedNotification"] },
   { "method": "thread/delete", "surface": "client-request", "params": ["ThreadDeleteParams"], "result": ["ThreadDeleteResponse"] },
   { "method": "thread/deleted", "surface": "server-notification", "params": ["ThreadDeletedNotification"] },
   { "method": "thread/goal/clear", "surface": "client-request", "params": ["ThreadGoalClearParams"], "result": ["ThreadGoalClearResponse"] },
@@ -1740,11 +1754,11 @@ export const wireTypeBindings = [
   { "method": "thread/name/set", "surface": "client-request", "params": ["ThreadSetNameParams"], "result": ["ThreadSetNameResponse"] },
   { "method": "thread/name/updated", "surface": "server-notification", "params": ["ThreadNameUpdatedNotification"] },
   { "method": "thread/read", "surface": "client-request", "params": ["ThreadReadParams"], "result": ["ThreadReadResponse"] },
-  { "method": "thread/tokenUsage/updated", "surface": "server-notification", "params": ["ThreadTokenUsageUpdatedNotificationParams"] },
+  { "method": "thread/tokenUsage/updated", "surface": "server-notification", "params": ["ThreadTokenUsageUpdatedNotification"] },
   { "method": "thread/unarchive", "surface": "client-request", "params": ["ThreadUnarchiveParams"], "result": ["ThreadUnarchiveResponse"] },
   { "method": "thread/unarchived", "surface": "server-notification", "params": ["ThreadUnarchivedNotification"] },
   { "method": "thread/unsubscribe", "surface": "client-request", "params": ["ThreadUnsubscribeParams"], "result": ["ThreadUnsubscribeResponse"] },
-  { "method": "turn/diff/updated", "surface": "server-notification", "params": ["TurnDiffUpdatedNotificationParams"] },
+  { "method": "turn/diff/updated", "surface": "server-notification", "params": ["TurnDiffUpdatedNotification"] },
 ] as const satisfies readonly WireTypeBinding[];
 
 export interface MethodParamsByName {
@@ -1758,6 +1772,7 @@ export interface MethodParamsByName {
   "daemon/status": undefined;
   "daemon/stop": DaemonShutdownParams;
   "daemon/version": undefined;
+  "deprecationNotice": DeprecationNoticeNotification;
   "initialize": InitializeParams;
   "initialized": undefined;
   "item/commandExecution/outputDelta": CommandExecutionOutputDeltaNotificationParams;
@@ -1776,7 +1791,7 @@ export interface MethodParamsByName {
   "thread/archived": ThreadArchivedNotification;
   "thread/closed": ThreadClosedNotification;
   "thread/compact/start": ThreadCompactStartParams;
-  "thread/compacted": ThreadCompactedNotificationParams;
+  "thread/compacted": ContextCompactedNotification;
   "thread/delete": ThreadDeleteParams;
   "thread/deleted": ThreadDeletedNotification;
   "thread/goal/clear": ThreadGoalClearParams;
@@ -1791,11 +1806,11 @@ export interface MethodParamsByName {
   "thread/name/set": ThreadSetNameParams;
   "thread/name/updated": ThreadNameUpdatedNotification;
   "thread/read": ThreadReadParams;
-  "thread/tokenUsage/updated": ThreadTokenUsageUpdatedNotificationParams;
+  "thread/tokenUsage/updated": ThreadTokenUsageUpdatedNotification;
   "thread/unarchive": ThreadUnarchiveParams;
   "thread/unarchived": ThreadUnarchivedNotification;
   "thread/unsubscribe": ThreadUnsubscribeParams;
-  "turn/diff/updated": TurnDiffUpdatedNotificationParams;
+  "turn/diff/updated": TurnDiffUpdatedNotification;
 }
 
 export interface MethodResultsByName {

--- a/appserver/protocol/typescript/testdata/runtime_wire_v1.ts
+++ b/appserver/protocol/typescript/testdata/runtime_wire_v1.ts
@@ -5,17 +5,18 @@ import type {
   BoundRequest,
   BoundResponse,
   CommandExecutionItemCompletedNotificationParams,
+  ContextCompactedNotification,
   ContextCompactionItem,
   DaemonStatus,
+  DeprecationNoticeNotification,
   DynamicToolCallItemStartedNotificationParams,
   FileChangeApprovalRequestParams,
   FileChangeItemCompletedNotificationParams,
   FileChangeRequestApprovalResponse,
   ItemLifecycleNotificationParams,
   MCPToolCallItemCompletedNotificationParams,
-  ThreadCompactedNotificationParams,
-  ThreadTokenUsageUpdatedNotificationParams,
-  TurnDiffUpdatedNotificationParams,
+  ThreadTokenUsageUpdatedNotification,
+  TurnDiffUpdatedNotification,
 } from "../gollem_appserver_protocol";
 
 export const fixtureProtocolVersion = "gollem.appserver.v1" as const;
@@ -176,6 +177,15 @@ export const contextCompactionItemPayload = {
   "createdAt": "2026-07-10T20:31:00Z"
 } satisfies ContextCompactionItem;
 
+export const deprecationNotice = {
+  "method": "deprecationNotice",
+  "params": {
+    "summary": "thread/rollback is deprecated; use thread/fork instead",
+    "details": null
+  }
+} satisfies BoundNotification<"deprecationNotice">;
+export const deprecationNoticeParams = deprecationNotice.params satisfies DeprecationNoticeNotification;
+
 export const threadCompacted = {
   "method": "thread/compacted",
   "params": {
@@ -183,7 +193,7 @@ export const threadCompacted = {
     "turnId": "turn-compact"
   }
 } satisfies BoundNotification<"thread/compacted">;
-export const threadCompactedParams = threadCompacted.params satisfies ThreadCompactedNotificationParams;
+export const threadCompactedParams = threadCompacted.params satisfies ContextCompactedNotification;
 
 export const tokenUsageUpdated = {
   "method": "thread/tokenUsage/updated",
@@ -209,7 +219,7 @@ export const tokenUsageUpdated = {
     }
   }
 } satisfies BoundNotification<"thread/tokenUsage/updated">;
-export const tokenUsageUpdatedParams = tokenUsageUpdated.params satisfies ThreadTokenUsageUpdatedNotificationParams;
+export const tokenUsageUpdatedParams = tokenUsageUpdated.params satisfies ThreadTokenUsageUpdatedNotification;
 
 export const turnDiffUpdated = {
   "method": "turn/diff/updated",
@@ -219,7 +229,7 @@ export const turnDiffUpdated = {
     "diff": "diff --git a/README.md b/README.md\n"
   }
 } satisfies BoundNotification<"turn/diff/updated">;
-export const turnDiffUpdatedParams = turnDiffUpdated.params satisfies TurnDiffUpdatedNotificationParams;
+export const turnDiffUpdatedParams = turnDiffUpdated.params satisfies TurnDiffUpdatedNotification;
 
 export const fileChangeApproval = {
   "id": "approval-1",

--- a/appserver/runtime.go
+++ b/appserver/runtime.go
@@ -471,8 +471,8 @@ type runtimeErrorNotificationParams struct {
 	At       time.Time `json:"at"`
 }
 
-type threadTokenUsageUpdatedNotificationParams = protocol.ThreadTokenUsageUpdatedNotificationParams
-type threadTokenUsagePayload = protocol.TokenUsage
+type threadTokenUsageUpdatedNotificationParams = protocol.ThreadTokenUsageUpdatedNotification
+type threadTokenUsagePayload = protocol.ThreadTokenUsage
 type tokenUsageBreakdown = protocol.TokenUsageBreakdown
 
 func publishTurnStarted(notifier runtimeNotifier, turn *store.Turn) {

--- a/appserver/thread_shell_command.go
+++ b/appserver/thread_shell_command.go
@@ -50,7 +50,7 @@ type threadShellCommandRun struct {
 type threadShellCommandPayload = protocol.CommandExecutionItem
 type threadShellCommandAction = protocol.CommandExecutionAction
 type commandExecutionOutputDeltaNotificationParams = protocol.CommandExecutionOutputDeltaNotificationParams
-type turnDiffUpdatedNotificationParams = protocol.TurnDiffUpdatedNotificationParams
+type turnDiffUpdatedNotificationParams = protocol.TurnDiffUpdatedNotification
 
 func (s *Server) handleThreadShellCommand(ctx context.Context, raw json.RawMessage) (any, *protocol.Error) {
 	st, rpcErr := s.requireStore("thread/shellCommand")


### PR DESCRIPTION
## Summary

- export and bind the exact public `ContextCompactedNotification`, `DeprecationNoticeNotification`, `ThreadTokenUsage`, `ThreadTokenUsageUpdatedNotification`, and `TurnDiffUpdatedNotification` names
- keep Gollem's four original generated names as schema and TypeScript aliases
- route the live compacted, deprecation, token-usage, and diff publishers through the exact protocol types
- extend the versioned runtime fixture and regenerate JSON Schema and strict TypeScript artifacts

The wire payloads are unchanged. `details` and `modelContextWindow` remain required nullable fields.

## Validation

- `go test ./... -count=1`
- `go test -race ./... -count=1`
- `go vet ./...`
- `golangci-lint run ./...`
- strict generated TypeScript fixture checks
- 50 focused exact-notification contract repetitions
- existing Slang full stdio integration suite against the built branch binary
- pre-push lint, race, vet, and tidy hook

The advisory vulnerability scan reports only existing Go 1.25.1 and dependency findings; this change adds no dependencies.