### PR TITLE
Add exact thread-item message prerequisite contracts

### DIFF
--- a/appserver/protocol/README.md
+++ b/appserver/protocol/README.md
@@ -244,6 +244,24 @@ asynchronously and returns a process snapshot, while the public contract
 requires argv, PTY/sandbox/stream/cap/timeout controls and a deferred buffered
 result after process exit.
 
+## Exported Thread-Item Message Prerequisites
+
+The schema exports the exact public `ByteRange`, `TextElement`, `ImageDetail`,
+`UserInput`, `MessagePhase`, `MemoryCitationEntry`, `MemoryCitation`, and
+`HookPromptFragment` contracts. Byte and citation offsets are nonnegative but
+do not impose range ordering. Text elements retain a required nullable
+placeholder, text input retains the public snake-case `text_elements` field,
+and image detail remains optional but rejects explicit null. Citation and hook
+fields use their public camel-case spellings, and paths remain uninterpreted
+strings rather than gaining absolute-path requirements.
+
+These definitions are prerequisites only. They do not alias Gollem's durable
+`ThreadRecord`, `TurnRecord`, or `TimelineItem`; bind `item/started` or
+`item/completed` to the still-incomplete public `ThreadItem`; or claim that the
+runtime emits message, memory-citation, or hook-prompt items. Those bindings
+remain separate work after the full item family and its runtime data paths are
+implemented.
+
 ## Generation
 
 Run:
@@ -271,14 +289,16 @@ binding metadata. It also rewrites the TypeScript compile fixtures at
 permission profile fixture at
 `typescript/testdata/permission_profile_wire_v1.ts`. File-change item, dynamic
 tool-call, user-input, MCP-elicitation, command-approval, and permission-profile
-variants also have strict negative compile contracts. Tests compare generated
+variants also have strict negative compile contracts. The exported thread-item
+message prerequisites have a separate strict compile contract at
+`typescript/testdata/thread_item_message_contract.ts`. Tests compare generated
 bytes with the checked-in files, verify every type binding references a known
 method and definition, and enforce a compatibility floor for runtime items,
 daemon status, initialization, thread discovery, thread controls, thread goals,
 metadata, lifecycle notifications, command-exec controls, and file changes.
 Dynamic client-tool, structured user-input, MCP-elicitation, command approval,
-and permission-profile contracts are covered by the same floor and strict
-fixtures.
+permission-profile, and thread-item prerequisite contracts are covered by the
+same floor and strict fixtures.
 
 `testdata/runtime_wire_v1.json` contains versioned request, response, and
 notification examples for generated-client compatibility tests.

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -89,6 +89,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "ApprovalRequestBase", Type: reflect.TypeFor[ApprovalRequestBase]()},
 		{Name: "ApprovalRespondParams", Type: reflect.TypeFor[ApprovalRespondParams]()},
 		{Name: "ApprovalRespondResult", Type: reflect.TypeFor[ApprovalRespondResult]()},
+		{Name: "ByteRange", Type: reflect.TypeFor[ByteRange]()},
 		{Name: "ClientInfo", Type: reflect.TypeFor[ClientInfo]()},
 		{Name: "CommandExecOutputDeltaNotification", Type: reflect.TypeFor[CommandExecOutputDeltaNotification]()},
 		{Name: "CommandExecOutputStream", Type: reflect.TypeFor[CommandExecOutputStream]()},
@@ -158,6 +159,8 @@ func wireSchemaDefinitions() Schema {
 		{Name: "FsWriteFileParams", Type: reflect.TypeFor[FsWriteFileParams]()},
 		{Name: "FsWriteFileResponse", Type: reflect.TypeFor[FsWriteFileResponse]()},
 		{Name: "GrantedPermissionProfile", Type: reflect.TypeFor[GrantedPermissionProfile]()},
+		{Name: "HookPromptFragment", Type: reflect.TypeFor[HookPromptFragment]()},
+		{Name: "ImageDetail", Type: reflect.TypeFor[ImageDetail]()},
 		{Name: "ImplementationInfo", Type: reflect.TypeFor[ImplementationInfo]()},
 		{Name: "InitializeCapabilities", Type: reflect.TypeFor[InitializeCapabilities]()},
 		{Name: "InitializeParams", Type: reflect.TypeFor[InitializeParams]()},
@@ -171,6 +174,9 @@ func wireSchemaDefinitions() Schema {
 		{Name: "MCPToolCallItemStartedNotificationParams", Type: reflect.TypeFor[MCPToolCallItemStartedNotificationParams]()},
 		{Name: "MCPToolCallProgressNotificationParams", Type: reflect.TypeFor[MCPToolCallProgressNotificationParams]()},
 		{Name: "MCPToolCallResult", Type: reflect.TypeFor[MCPToolCallResult]()},
+		{Name: "MemoryCitation", Type: reflect.TypeFor[MemoryCitation]()},
+		{Name: "MemoryCitationEntry", Type: reflect.TypeFor[MemoryCitationEntry]()},
+		{Name: "MessagePhase", Type: reflect.TypeFor[MessagePhase]()},
 		{Name: "McpElicitationArrayType", Type: reflect.TypeFor[McpElicitationArrayType]()},
 		{Name: "McpElicitationBooleanSchema", Type: reflect.TypeFor[McpElicitationBooleanSchema]()},
 		{Name: "McpElicitationBooleanType", Type: reflect.TypeFor[McpElicitationBooleanType]()},
@@ -258,6 +264,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "ThreadUnsubscribeParams", Type: reflect.TypeFor[ThreadUnsubscribeParams]()},
 		{Name: "ThreadUnsubscribeResponse", Type: reflect.TypeFor[ThreadUnsubscribeResponse]()},
 		{Name: "ThreadUnsubscribeStatus", Type: reflect.TypeFor[ThreadUnsubscribeStatus]()},
+		{Name: "TextElement", Type: reflect.TypeFor[TextElement]()},
 		{Name: "TimelineItem", Type: reflect.TypeFor[TimelineItem]()},
 		{Name: "TokenUsage", Type: reflect.TypeFor[TokenUsage]()},
 		{Name: "TokenUsageBreakdown", Type: reflect.TypeFor[TokenUsageBreakdown]()},
@@ -270,6 +277,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "TurnDiffUpdatedNotificationParams", Type: reflect.TypeFor[TurnDiffUpdatedNotificationParams]()},
 		{Name: "TurnLifecycleStatus", Type: reflect.TypeFor[TurnLifecycleStatus]()},
 		{Name: "TurnRecord", Type: reflect.TypeFor[TurnRecord]()},
+		{Name: "UserInput", Type: reflect.TypeFor[UserInput]()},
 		// Register exact public names after their aliases so nested schemas refer
 		// to the public names. JSON and TypeScript output remain key-sorted.
 		{Name: "ContextCompactedNotification", Type: reflect.TypeFor[ContextCompactedNotification]()},
@@ -309,6 +317,15 @@ func wireSchemaDefinitions() Schema {
 		string(SurfaceGollemExtension),
 	)
 	schemas["SortDirection"] = stringEnumSchema(string(SortDirectionAsc), string(SortDirectionDesc))
+	setSchemaIntegerMinimum(schemas["ByteRange"].(Schema), 0, "start", "end")
+	schemas["ImageDetail"] = stringEnumSchema(
+		string(ImageDetailAuto), string(ImageDetailLow), string(ImageDetailHigh), string(ImageDetailOriginal),
+	)
+	setSchemaIntegerMinimum(schemas["MemoryCitationEntry"].(Schema), 0, "lineStart", "lineEnd")
+	schemas["MessagePhase"] = stringEnumSchema(
+		string(MessagePhaseCommentary), string(MessagePhaseFinalAnswer),
+	)
+	schemas["UserInput"] = userInputSchema()
 	schemas["ThreadLifecycleStatus"] = stringEnumSchema(
 		string(ThreadLifecycleActive), string(ThreadLifecycleArchived), string(ThreadLifecycleDeleted),
 	)
@@ -474,6 +491,51 @@ func wireSchemaDefinitions() Schema {
 		string(TurnLifecycleFailed), string(TurnLifecycleInterrupted),
 	)
 	return schemas
+}
+
+func userInputSchema() Schema {
+	return Schema{"oneOf": []any{
+		userInputVariantSchema("text", []string{"text", "text_elements"}, Schema{
+			"text": Schema{"type": "string"},
+			"text_elements": Schema{
+				"type":  "array",
+				"items": Schema{"$ref": "#/$defs/TextElement"},
+			},
+		}),
+		userInputVariantSchema("image", []string{"url"}, Schema{
+			"detail": Schema{"$ref": "#/$defs/ImageDetail"},
+			"url":    Schema{"type": "string"},
+		}),
+		userInputVariantSchema("localImage", []string{"path"}, Schema{
+			"detail": Schema{"$ref": "#/$defs/ImageDetail"},
+			"path":   Schema{"type": "string"},
+		}),
+		userInputVariantSchema("skill", []string{"name", "path"}, Schema{
+			"name": Schema{"type": "string"},
+			"path": Schema{"type": "string"},
+		}),
+		userInputVariantSchema("mention", []string{"name", "path"}, Schema{
+			"name": Schema{"type": "string"},
+			"path": Schema{"type": "string"},
+		}),
+	}}
+}
+
+func userInputVariantSchema(inputType string, requiredFields []string, fields Schema) Schema {
+	properties := Schema{
+		"type": Schema{"type": "string", "enum": []any{inputType}},
+	}
+	for name, schema := range fields {
+		properties[name] = schema
+	}
+	required := []string{"type"}
+	required = append(required, requiredFields...)
+	return Schema{
+		"type":                 "object",
+		"properties":           properties,
+		"required":             required,
+		"additionalProperties": false,
+	}
 }
 
 func fileSystemSpecialPathSchema() Schema {

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -193,6 +193,24 @@
       ],
       "type": "object"
     },
+    "ByteRange": {
+      "additionalProperties": false,
+      "properties": {
+        "end": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "start": {
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "start",
+        "end"
+      ],
+      "type": "object"
+    },
     "ClientInfo": {
       "additionalProperties": false,
       "properties": {
@@ -2265,6 +2283,31 @@
       },
       "type": "object"
     },
+    "HookPromptFragment": {
+      "additionalProperties": false,
+      "properties": {
+        "hookRunId": {
+          "type": "string"
+        },
+        "text": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "text",
+        "hookRunId"
+      ],
+      "type": "object"
+    },
+    "ImageDetail": {
+      "enum": [
+        "auto",
+        "low",
+        "high",
+        "original"
+      ],
+      "type": "string"
+    },
     "ImplementationInfo": {
       "additionalProperties": false,
       "properties": {
@@ -3338,6 +3381,61 @@
       ],
       "type": "string"
     },
+    "MemoryCitation": {
+      "additionalProperties": false,
+      "properties": {
+        "entries": {
+          "items": {
+            "$ref": "#/$defs/MemoryCitationEntry"
+          },
+          "type": "array"
+        },
+        "threadIds": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "entries",
+        "threadIds"
+      ],
+      "type": "object"
+    },
+    "MemoryCitationEntry": {
+      "additionalProperties": false,
+      "properties": {
+        "lineEnd": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "lineStart": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "note": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "lineStart",
+        "lineEnd",
+        "note"
+      ],
+      "type": "object"
+    },
+    "MessagePhase": {
+      "enum": [
+        "commentary",
+        "final_answer"
+      ],
+      "type": "string"
+    },
     "MethodInfo": {
       "additionalProperties": false,
       "properties": {
@@ -4031,6 +4129,29 @@
         "gollem-extension"
       ],
       "type": "string"
+    },
+    "TextElement": {
+      "additionalProperties": false,
+      "properties": {
+        "byteRange": {
+          "$ref": "#/$defs/ByteRange"
+        },
+        "placeholder": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "byteRange",
+        "placeholder"
+      ],
+      "type": "object"
     },
     "ThreadArchiveParams": {
       "additionalProperties": false,
@@ -5855,6 +5976,126 @@
         "updatedAt"
       ],
       "type": "object"
+    },
+    "UserInput": {
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "text": {
+              "type": "string"
+            },
+            "text_elements": {
+              "items": {
+                "$ref": "#/$defs/TextElement"
+              },
+              "type": "array"
+            },
+            "type": {
+              "enum": [
+                "text"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "text",
+            "text_elements"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "detail": {
+              "$ref": "#/$defs/ImageDetail"
+            },
+            "type": {
+              "enum": [
+                "image"
+              ],
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "url"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "detail": {
+              "$ref": "#/$defs/ImageDetail"
+            },
+            "path": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "localImage"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "path"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "path": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "skill"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "name",
+            "path"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "path": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "mention"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "name",
+            "path"
+          ],
+          "type": "object"
+        }
+      ]
     }
   },
   "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/appserver/protocol/thread_item_message_contract_test.go
+++ b/appserver/protocol/thread_item_message_contract_test.go
@@ -1,0 +1,295 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"testing"
+)
+
+func TestThreadItemMessagePrerequisiteSchemasAreExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	for _, name := range []string{
+		"ByteRange",
+		"HookPromptFragment",
+		"ImageDetail",
+		"MemoryCitation",
+		"MemoryCitationEntry",
+		"MessagePhase",
+		"TextElement",
+		"UserInput",
+	} {
+		if _, ok := defs[name]; !ok {
+			t.Fatalf("$defs missing %s", name)
+		}
+	}
+
+	byteRange := defs["ByteRange"].(Schema)
+	assertSchemaRequiredNames(t, byteRange, "start", "end")
+	for _, name := range []string{"start", "end"} {
+		property := byteRange["properties"].(Schema)[name].(Schema)
+		if property["type"] != "integer" || property["minimum"] != 0 {
+			t.Fatalf("ByteRange.%s = %#v", name, property)
+		}
+	}
+
+	textElement := defs["TextElement"].(Schema)
+	assertSchemaRequiredNames(t, textElement, "byteRange", "placeholder")
+	textProperties := textElement["properties"].(Schema)
+	if textProperties["byteRange"].(Schema)["$ref"] != "#/$defs/ByteRange" {
+		t.Fatalf("TextElement.byteRange = %#v", textProperties["byteRange"])
+	}
+	assertNullableStringSchema(t, textProperties["placeholder"])
+
+	assertStringEnum(t, defs["ImageDetail"], "auto", "low", "high", "original")
+	assertStringEnum(t, defs["MessagePhase"], "commentary", "final_answer")
+
+	entry := defs["MemoryCitationEntry"].(Schema)
+	assertSchemaRequiredNames(t, entry, "path", "lineStart", "lineEnd", "note")
+	for _, name := range []string{"lineStart", "lineEnd"} {
+		property := entry["properties"].(Schema)[name].(Schema)
+		if property["type"] != "integer" || property["minimum"] != 0 {
+			t.Fatalf("MemoryCitationEntry.%s = %#v", name, property)
+		}
+	}
+
+	citation := defs["MemoryCitation"].(Schema)
+	assertSchemaRequiredNames(t, citation, "entries", "threadIds")
+	for _, name := range []string{"entries", "threadIds"} {
+		property := citation["properties"].(Schema)[name].(Schema)
+		if property["type"] != "array" {
+			t.Fatalf("MemoryCitation.%s = %#v", name, property)
+		}
+		if variants, ok := property["anyOf"]; ok {
+			t.Fatalf("MemoryCitation.%s is nullable: %#v", name, variants)
+		}
+	}
+
+	hook := defs["HookPromptFragment"].(Schema)
+	assertSchemaRequiredNames(t, hook, "text", "hookRunId")
+
+	input := defs["UserInput"].(Schema)
+	variants, ok := input["oneOf"].([]any)
+	if !ok || len(variants) != 5 {
+		t.Fatalf("UserInput variants = %#v", input["oneOf"])
+	}
+	want := []struct {
+		inputType string
+		required  []string
+	}{
+		{inputType: "text", required: []string{"type", "text", "text_elements"}},
+		{inputType: "image", required: []string{"type", "url"}},
+		{inputType: "localImage", required: []string{"type", "path"}},
+		{inputType: "skill", required: []string{"type", "name", "path"}},
+		{inputType: "mention", required: []string{"type", "name", "path"}},
+	}
+	for index, expected := range want {
+		variant := variants[index].(Schema)
+		if variant["additionalProperties"] != false {
+			t.Fatalf("UserInput %s allows extra fields", expected.inputType)
+		}
+		properties := variant["properties"].(Schema)
+		if !reflect.DeepEqual(properties["type"].(Schema)["enum"], []any{expected.inputType}) {
+			t.Fatalf("UserInput variant %d type = %#v", index, properties["type"])
+		}
+		if !slices.Equal(schemaRequiredNames(variant), expected.required) {
+			t.Fatalf("UserInput %s required = %v, want %v", expected.inputType, schemaRequiredNames(variant), expected.required)
+		}
+		if detail, exists := properties["detail"]; exists {
+			detailSchema := detail.(Schema)
+			if detailSchema["$ref"] != "#/$defs/ImageDetail" || slices.Contains(schemaRequiredNames(variant), "detail") {
+				t.Fatalf("UserInput %s detail = %#v", expected.inputType, detailSchema)
+			}
+		}
+	}
+}
+
+func TestThreadItemMessagePrerequisiteWireValidation(t *testing.T) {
+	t.Run("ByteRange", func(t *testing.T) {
+		assertJSONAccepts[ByteRange](t, `{"start":0,"end":0}`)
+		assertJSONAccepts[ByteRange](t, `{"start":9,"end":2}`)
+		for _, input := range []string{
+			`{}`, `{"start":0}`, `{"end":0}`, `{"start":-1,"end":0}`,
+			`{"start":0,"end":-1}`, `{"start":0,"end":0,"extra":true}`,
+		} {
+			assertJSONRejects[ByteRange](t, input)
+		}
+	})
+
+	t.Run("TextElement", func(t *testing.T) {
+		assertJSONAccepts[TextElement](t, `{"byteRange":{"start":0,"end":4},"placeholder":null}`)
+		assertJSONAccepts[TextElement](t, `{"byteRange":{"start":0,"end":4},"placeholder":"@file"}`)
+		for _, input := range []string{
+			`{"placeholder":null}`, `{"byteRange":{"start":0,"end":4}}`,
+			`{"byteRange":{"start":0,"end":4},"placeholder":1}`,
+			`{"byteRange":{"start":0,"end":4},"placeholder":null,"extra":true}`,
+		} {
+			assertJSONRejects[TextElement](t, input)
+		}
+	})
+
+	t.Run("Enums", func(t *testing.T) {
+		for _, input := range []string{`"auto"`, `"low"`, `"high"`, `"original"`} {
+			assertJSONAccepts[ImageDetail](t, input)
+		}
+		for _, input := range []string{`null`, `"medium"`, `1`} {
+			assertJSONRejects[ImageDetail](t, input)
+		}
+		for _, input := range []string{`"commentary"`, `"final_answer"`} {
+			assertJSONAccepts[MessagePhase](t, input)
+		}
+		for _, input := range []string{`null`, `"finalAnswer"`, `"analysis"`} {
+			assertJSONRejects[MessagePhase](t, input)
+		}
+	})
+
+	t.Run("MemoryCitation", func(t *testing.T) {
+		assertJSONAccepts[MemoryCitation](t, `{"entries":[],"threadIds":[]}`)
+		assertJSONAccepts[MemoryCitation](t, `{"entries":[{"path":"relative.md","lineStart":9,"lineEnd":2,"note":"context"}],"threadIds":["thread-1"]}`)
+		for _, input := range []string{
+			`{}`, `{"entries":[],"threadIds":null}`, `{"entries":null,"threadIds":[]}`,
+			`{"entries":[{"path":"x","lineStart":-1,"lineEnd":0,"note":""}],"threadIds":[]}`,
+			`{"entries":[{"path":"x","lineStart":0,"lineEnd":0}],"threadIds":[]}`,
+			`{"entries":[],"threadIds":[],"extra":true}`,
+		} {
+			assertJSONRejects[MemoryCitation](t, input)
+		}
+	})
+
+	t.Run("HookPromptFragment", func(t *testing.T) {
+		assertJSONAccepts[HookPromptFragment](t, `{"text":"review","hookRunId":"hook-1"}`)
+		for _, input := range []string{
+			`{}`, `{"text":"review"}`, `{"hookRunId":"hook-1"}`,
+			`{"text":"review","hook_run_id":"hook-1"}`,
+			`{"text":"review","hookRunId":"hook-1","extra":true}`,
+		} {
+			assertJSONRejects[HookPromptFragment](t, input)
+		}
+	})
+
+	t.Run("UserInput", func(t *testing.T) {
+		valid := []string{
+			`{"type":"text","text":"hello","text_elements":[]}`,
+			`{"type":"text","text":"@file","text_elements":[{"byteRange":{"start":0,"end":5},"placeholder":null}]}`,
+			`{"type":"image","url":"https://example.test/image.png"}`,
+			`{"type":"image","detail":"original","url":"data:image/png;base64,AA=="}`,
+			`{"type":"localImage","path":"relative.png"}`,
+			`{"type":"localImage","detail":"low","path":"/tmp/image.png"}`,
+			`{"type":"skill","name":"review","path":"skills/review/SKILL.md"}`,
+			`{"type":"mention","name":"guide","path":"docs/guide.md"}`,
+		}
+		for _, input := range valid {
+			assertJSONAccepts[UserInput](t, input)
+		}
+		invalid := []string{
+			`{}`, `{"type":"audio","url":"x"}`,
+			`{"type":"text","text":"hello"}`,
+			`{"type":"text","text":"hello","text_elements":null}`,
+			`{"type":"text","text":"hello","textElements":[]}`,
+			`{"type":"text","text":"hello","text_elements":[],"url":"x"}`,
+			`{"type":"image","url":"x","detail":null}`,
+			`{"type":"image","url":"x","detail":"medium"}`,
+			`{"type":"image","path":"x"}`,
+			`{"type":"localImage","url":"x"}`,
+			`{"type":"skill","name":"review"}`,
+			`{"type":"mention","name":"guide","path":"docs/guide.md","extra":true}`,
+		}
+		for _, input := range invalid {
+			assertJSONRejects[UserInput](t, input)
+		}
+	})
+}
+
+func TestThreadItemMessagePrerequisiteMarshalIsCanonical(t *testing.T) {
+	placeholder := "@file"
+	detail := ImageDetailOriginal
+	cases := []struct {
+		value any
+		want  string
+	}{
+		{ByteRange{Start: 9, End: 2}, `{"start":9,"end":2}`},
+		{TextElement{ByteRange: ByteRange{Start: 0, End: 5}}, `{"byteRange":{"start":0,"end":5},"placeholder":null}`},
+		{TextElement{ByteRange: ByteRange{Start: 0, End: 5}, Placeholder: &placeholder}, `{"byteRange":{"start":0,"end":5},"placeholder":"@file"}`},
+		{MemoryCitation{}, `{"entries":[],"threadIds":[]}`},
+		{HookPromptFragment{Text: "review", HookRunID: "hook-1"}, `{"text":"review","hookRunId":"hook-1"}`},
+		{UserInput{Type: "text", Text: "hello"}, `{"type":"text","text":"hello","text_elements":[]}`},
+		{UserInput{Type: "image", Detail: &detail, URL: "image.png"}, `{"type":"image","detail":"original","url":"image.png"}`},
+	}
+	for _, testCase := range cases {
+		encoded, err := json.Marshal(testCase.value)
+		if err != nil {
+			t.Fatalf("Marshal(%#v): %v", testCase.value, err)
+		}
+		if string(encoded) != testCase.want {
+			t.Fatalf("Marshal(%#v) = %s, want %s", testCase.value, encoded, testCase.want)
+		}
+	}
+
+	invalidDetail := ImageDetail("medium")
+	for _, value := range []any{
+		ImageDetail("medium"),
+		MessagePhase("analysis"),
+		UserInput{Type: "image", Detail: &invalidDetail, URL: "image.png"},
+		UserInput{Type: "audio", URL: "audio.wav"},
+		UserInput{Type: "text", Text: "hello", URL: "crossed"},
+	} {
+		if _, err := json.Marshal(value); err == nil {
+			t.Errorf("Marshal(%#v) succeeded", value)
+		}
+	}
+}
+
+func TestThreadItemMessagePrerequisiteNilReceiversRejectJSON(t *testing.T) {
+	var byteRange *ByteRange
+	var textElement *TextElement
+	var imageDetail *ImageDetail
+	var messagePhase *MessagePhase
+	var entry *MemoryCitationEntry
+	var citation *MemoryCitation
+	var hook *HookPromptFragment
+	var input *UserInput
+	for name, decode := range map[string]func() error{
+		"ByteRange": func() error { return byteRange.UnmarshalJSON([]byte(`{"start":0,"end":0}`)) },
+		"TextElement": func() error {
+			return textElement.UnmarshalJSON([]byte(`{"byteRange":{"start":0,"end":0},"placeholder":null}`))
+		},
+		"ImageDetail":         func() error { return imageDetail.UnmarshalJSON([]byte(`"auto"`)) },
+		"MessagePhase":        func() error { return messagePhase.UnmarshalJSON([]byte(`"commentary"`)) },
+		"MemoryCitationEntry": func() error { return entry.UnmarshalJSON([]byte(`{"path":"x","lineStart":0,"lineEnd":0,"note":""}`)) },
+		"MemoryCitation":      func() error { return citation.UnmarshalJSON([]byte(`{"entries":[],"threadIds":[]}`)) },
+		"HookPromptFragment":  func() error { return hook.UnmarshalJSON([]byte(`{"text":"x","hookRunId":"h"}`)) },
+		"UserInput":           func() error { return input.UnmarshalJSON([]byte(`{"type":"text","text":"x","text_elements":[]}`)) },
+	} {
+		if err := decode(); err == nil {
+			t.Errorf("%s nil receiver succeeded", name)
+		}
+	}
+}
+
+func assertJSONAccepts[T any](t *testing.T, input string) {
+	t.Helper()
+	var value T
+	if err := json.Unmarshal([]byte(input), &value); err != nil {
+		t.Errorf("Unmarshal %T from %s: %v", value, input, err)
+	}
+}
+
+func assertJSONRejects[T any](t *testing.T, input string) {
+	t.Helper()
+	var value T
+	if err := json.Unmarshal([]byte(input), &value); err == nil {
+		t.Errorf("Unmarshal %T from %s succeeded: %#v", value, input, value)
+	}
+}
+
+func assertNullableStringSchema(t *testing.T, value any) {
+	t.Helper()
+	schema, ok := value.(Schema)
+	if !ok {
+		t.Fatalf("nullable string schema = %#v", value)
+	}
+	variants, ok := schema["anyOf"].([]any)
+	if !ok || len(variants) != 2 || variants[0].(Schema)["type"] != "string" || variants[1].(Schema)["type"] != "null" {
+		t.Fatalf("nullable string schema = %#v", schema)
+	}
+}

--- a/appserver/protocol/thread_item_message_types.go
+++ b/appserver/protocol/thread_item_message_types.go
@@ -1,0 +1,457 @@
+package protocol
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+type ByteRange struct {
+	Start uint64 `json:"start"`
+	End   uint64 `json:"end"`
+}
+
+func (r *ByteRange) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("decode byte range into nil receiver")
+	}
+	payload, err := decodeExactThreadItemObject(data, "byte range", "start", "end")
+	if err != nil {
+		return err
+	}
+	start, err := decodeRequiredThreadItemValue[uint64](payload, "byte range", "start")
+	if err != nil {
+		return err
+	}
+	end, err := decodeRequiredThreadItemValue[uint64](payload, "byte range", "end")
+	if err != nil {
+		return err
+	}
+	*r = ByteRange{Start: start, End: end}
+	return nil
+}
+
+type TextElement struct {
+	ByteRange   ByteRange `json:"byteRange"`
+	Placeholder *string   `json:"placeholder"`
+}
+
+func (e *TextElement) UnmarshalJSON(data []byte) error {
+	if e == nil {
+		return errors.New("decode text element into nil receiver")
+	}
+	payload, err := decodeExactThreadItemObject(data, "text element", "byteRange", "placeholder")
+	if err != nil {
+		return err
+	}
+	byteRange, err := decodeRequiredThreadItemValue[ByteRange](payload, "text element", "byteRange")
+	if err != nil {
+		return err
+	}
+	placeholderRaw, ok := payload["placeholder"]
+	if !ok {
+		return errors.New("text element requires placeholder")
+	}
+	var placeholder *string
+	if !isJSONNull(placeholderRaw) {
+		var value string
+		if err := json.Unmarshal(placeholderRaw, &value); err != nil {
+			return fmt.Errorf("decode text element placeholder: %w", err)
+		}
+		placeholder = &value
+	}
+	*e = TextElement{ByteRange: byteRange, Placeholder: placeholder}
+	return nil
+}
+
+type ImageDetail string
+
+const (
+	ImageDetailAuto     ImageDetail = "auto"
+	ImageDetailLow      ImageDetail = "low"
+	ImageDetailHigh     ImageDetail = "high"
+	ImageDetailOriginal ImageDetail = "original"
+)
+
+func (d ImageDetail) MarshalJSON() ([]byte, error) {
+	if !d.valid() {
+		return nil, fmt.Errorf("unknown image detail %q", d)
+	}
+	return json.Marshal(string(d))
+}
+
+func (d *ImageDetail) UnmarshalJSON(data []byte) error {
+	if d == nil {
+		return errors.New("decode image detail into nil receiver")
+	}
+	if isJSONNull(data) {
+		return errors.New("image detail cannot be null")
+	}
+	var value string
+	if err := json.Unmarshal(data, &value); err != nil {
+		return fmt.Errorf("decode image detail: %w", err)
+	}
+	detail := ImageDetail(value)
+	if !detail.valid() {
+		return fmt.Errorf("unknown image detail %q", value)
+	}
+	*d = detail
+	return nil
+}
+
+func (d ImageDetail) valid() bool {
+	switch d {
+	case ImageDetailAuto, ImageDetailLow, ImageDetailHigh, ImageDetailOriginal:
+		return true
+	default:
+		return false
+	}
+}
+
+type MessagePhase string
+
+const (
+	MessagePhaseCommentary  MessagePhase = "commentary"
+	MessagePhaseFinalAnswer MessagePhase = "final_answer"
+)
+
+func (p MessagePhase) MarshalJSON() ([]byte, error) {
+	if !p.valid() {
+		return nil, fmt.Errorf("unknown message phase %q", p)
+	}
+	return json.Marshal(string(p))
+}
+
+func (p *MessagePhase) UnmarshalJSON(data []byte) error {
+	if p == nil {
+		return errors.New("decode message phase into nil receiver")
+	}
+	if isJSONNull(data) {
+		return errors.New("message phase cannot be null")
+	}
+	var value string
+	if err := json.Unmarshal(data, &value); err != nil {
+		return fmt.Errorf("decode message phase: %w", err)
+	}
+	phase := MessagePhase(value)
+	if !phase.valid() {
+		return fmt.Errorf("unknown message phase %q", value)
+	}
+	*p = phase
+	return nil
+}
+
+func (p MessagePhase) valid() bool {
+	switch p {
+	case MessagePhaseCommentary, MessagePhaseFinalAnswer:
+		return true
+	default:
+		return false
+	}
+}
+
+type MemoryCitationEntry struct {
+	Path      string `json:"path"`
+	LineStart uint32 `json:"lineStart"`
+	LineEnd   uint32 `json:"lineEnd"`
+	Note      string `json:"note"`
+}
+
+func (e *MemoryCitationEntry) UnmarshalJSON(data []byte) error {
+	if e == nil {
+		return errors.New("decode memory citation entry into nil receiver")
+	}
+	payload, err := decodeExactThreadItemObject(data, "memory citation entry", "path", "lineStart", "lineEnd", "note")
+	if err != nil {
+		return err
+	}
+	path, err := decodeRequiredThreadItemValue[string](payload, "memory citation entry", "path")
+	if err != nil {
+		return err
+	}
+	lineStart, err := decodeRequiredThreadItemValue[uint32](payload, "memory citation entry", "lineStart")
+	if err != nil {
+		return err
+	}
+	lineEnd, err := decodeRequiredThreadItemValue[uint32](payload, "memory citation entry", "lineEnd")
+	if err != nil {
+		return err
+	}
+	note, err := decodeRequiredThreadItemValue[string](payload, "memory citation entry", "note")
+	if err != nil {
+		return err
+	}
+	*e = MemoryCitationEntry{Path: path, LineStart: lineStart, LineEnd: lineEnd, Note: note}
+	return nil
+}
+
+type MemoryCitation struct {
+	Entries   []MemoryCitationEntry `json:"entries" jsonschema:"nonnullable=true"`
+	ThreadIDs []string              `json:"threadIds" jsonschema:"nonnullable=true"`
+}
+
+func (c MemoryCitation) MarshalJSON() ([]byte, error) {
+	entries := c.Entries
+	if entries == nil {
+		entries = []MemoryCitationEntry{}
+	}
+	threadIDs := c.ThreadIDs
+	if threadIDs == nil {
+		threadIDs = []string{}
+	}
+	return json.Marshal(struct {
+		Entries   []MemoryCitationEntry `json:"entries"`
+		ThreadIDs []string              `json:"threadIds"`
+	}{Entries: entries, ThreadIDs: threadIDs})
+}
+
+func (c *MemoryCitation) UnmarshalJSON(data []byte) error {
+	if c == nil {
+		return errors.New("decode memory citation into nil receiver")
+	}
+	payload, err := decodeExactThreadItemObject(data, "memory citation", "entries", "threadIds")
+	if err != nil {
+		return err
+	}
+	entries, err := decodeRequiredThreadItemValue[[]MemoryCitationEntry](payload, "memory citation", "entries")
+	if err != nil {
+		return err
+	}
+	threadIDs, err := decodeRequiredThreadItemValue[[]string](payload, "memory citation", "threadIds")
+	if err != nil {
+		return err
+	}
+	*c = MemoryCitation{Entries: entries, ThreadIDs: threadIDs}
+	return nil
+}
+
+type HookPromptFragment struct {
+	Text      string `json:"text"`
+	HookRunID string `json:"hookRunId"`
+}
+
+func (f *HookPromptFragment) UnmarshalJSON(data []byte) error {
+	if f == nil {
+		return errors.New("decode hook prompt fragment into nil receiver")
+	}
+	payload, err := decodeExactThreadItemObject(data, "hook prompt fragment", "text", "hookRunId")
+	if err != nil {
+		return err
+	}
+	text, err := decodeRequiredThreadItemValue[string](payload, "hook prompt fragment", "text")
+	if err != nil {
+		return err
+	}
+	hookRunID, err := decodeRequiredThreadItemValue[string](payload, "hook prompt fragment", "hookRunId")
+	if err != nil {
+		return err
+	}
+	*f = HookPromptFragment{Text: text, HookRunID: hookRunID}
+	return nil
+}
+
+// UserInput is the closed public turn-input union. TextElements intentionally
+// retains the public snake_case wire name.
+type UserInput struct {
+	Type         string        `json:"type"`
+	Text         string        `json:"text,omitempty"`
+	TextElements []TextElement `json:"text_elements,omitempty"`
+	Detail       *ImageDetail  `json:"detail,omitempty"`
+	URL          string        `json:"url,omitempty"`
+	Name         string        `json:"name,omitempty"`
+	Path         string        `json:"path,omitempty"`
+}
+
+func (i UserInput) MarshalJSON() ([]byte, error) {
+	switch i.Type {
+	case "text":
+		if i.Detail != nil || i.URL != "" || i.Name != "" || i.Path != "" {
+			return nil, errors.New("text user input contains fields from another variant")
+		}
+		elements := i.TextElements
+		if elements == nil {
+			elements = []TextElement{}
+		}
+		return json.Marshal(struct {
+			Type         string        `json:"type"`
+			Text         string        `json:"text"`
+			TextElements []TextElement `json:"text_elements"`
+		}{Type: i.Type, Text: i.Text, TextElements: elements})
+	case "image":
+		if i.Text != "" || i.TextElements != nil || i.Name != "" || i.Path != "" {
+			return nil, errors.New("image user input contains fields from another variant")
+		}
+		return marshalImageUserInput(i.Type, i.Detail, "url", i.URL)
+	case "localImage":
+		if i.Text != "" || i.TextElements != nil || i.URL != "" || i.Name != "" {
+			return nil, errors.New("localImage user input contains fields from another variant")
+		}
+		return marshalImageUserInput(i.Type, i.Detail, "path", i.Path)
+	case "skill", "mention":
+		if i.Text != "" || i.TextElements != nil || i.Detail != nil || i.URL != "" {
+			return nil, fmt.Errorf("%s user input contains fields from another variant", i.Type)
+		}
+		return json.Marshal(struct {
+			Type string `json:"type"`
+			Name string `json:"name"`
+			Path string `json:"path"`
+		}{Type: i.Type, Name: i.Name, Path: i.Path})
+	default:
+		return nil, fmt.Errorf("unknown user input type %q", i.Type)
+	}
+}
+
+func (i *UserInput) UnmarshalJSON(data []byte) error {
+	if i == nil {
+		return errors.New("decode user input into nil receiver")
+	}
+	payload, err := decodeExactThreadItemObject(data, "user input", "type", "text", "text_elements", "detail", "url", "name", "path")
+	if err != nil {
+		return err
+	}
+	inputType, err := decodeRequiredThreadItemValue[string](payload, "user input", "type")
+	if err != nil {
+		return err
+	}
+	switch inputType {
+	case "text":
+		if err := rejectThreadItemFields(payload, "text user input", "type", "text", "text_elements"); err != nil {
+			return err
+		}
+		text, err := decodeRequiredThreadItemValue[string](payload, "text user input", "text")
+		if err != nil {
+			return err
+		}
+		elements, err := decodeRequiredThreadItemValue[[]TextElement](payload, "text user input", "text_elements")
+		if err != nil {
+			return err
+		}
+		*i = UserInput{Type: inputType, Text: text, TextElements: elements}
+		return nil
+	case "image":
+		if err := rejectThreadItemFields(payload, "image user input", "type", "detail", "url"); err != nil {
+			return err
+		}
+		url, err := decodeRequiredThreadItemValue[string](payload, "image user input", "url")
+		if err != nil {
+			return err
+		}
+		detail, err := decodeOptionalImageDetail(payload, "image user input")
+		if err != nil {
+			return err
+		}
+		*i = UserInput{Type: inputType, Detail: detail, URL: url}
+		return nil
+	case "localImage":
+		if err := rejectThreadItemFields(payload, "localImage user input", "type", "detail", "path"); err != nil {
+			return err
+		}
+		path, err := decodeRequiredThreadItemValue[string](payload, "localImage user input", "path")
+		if err != nil {
+			return err
+		}
+		detail, err := decodeOptionalImageDetail(payload, "localImage user input")
+		if err != nil {
+			return err
+		}
+		*i = UserInput{Type: inputType, Detail: detail, Path: path}
+		return nil
+	case "skill", "mention":
+		if err := rejectThreadItemFields(payload, inputType+" user input", "type", "name", "path"); err != nil {
+			return err
+		}
+		name, err := decodeRequiredThreadItemValue[string](payload, inputType+" user input", "name")
+		if err != nil {
+			return err
+		}
+		path, err := decodeRequiredThreadItemValue[string](payload, inputType+" user input", "path")
+		if err != nil {
+			return err
+		}
+		*i = UserInput{Type: inputType, Name: name, Path: path}
+		return nil
+	default:
+		return fmt.Errorf("unknown user input type %q", inputType)
+	}
+}
+
+func marshalImageUserInput(inputType string, detail *ImageDetail, valueName, value string) ([]byte, error) {
+	if detail != nil && !detail.valid() {
+		return nil, fmt.Errorf("unknown image detail %q", *detail)
+	}
+	if valueName == "url" {
+		return json.Marshal(struct {
+			Type   string       `json:"type"`
+			Detail *ImageDetail `json:"detail,omitempty"`
+			URL    string       `json:"url"`
+		}{Type: inputType, Detail: detail, URL: value})
+	}
+	return json.Marshal(struct {
+		Type   string       `json:"type"`
+		Detail *ImageDetail `json:"detail,omitempty"`
+		Path   string       `json:"path"`
+	}{Type: inputType, Detail: detail, Path: value})
+}
+
+func decodeOptionalImageDetail(payload map[string]json.RawMessage, objectName string) (*ImageDetail, error) {
+	raw, ok := payload["detail"]
+	if !ok {
+		return nil, nil
+	}
+	if isJSONNull(raw) {
+		return nil, fmt.Errorf("%s detail cannot be null", objectName)
+	}
+	var detail ImageDetail
+	if err := json.Unmarshal(raw, &detail); err != nil {
+		return nil, fmt.Errorf("decode %s detail: %w", objectName, err)
+	}
+	return &detail, nil
+}
+
+func decodeExactThreadItemObject(data []byte, objectName string, allowed ...string) (map[string]json.RawMessage, error) {
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return nil, fmt.Errorf("decode %s: %w", objectName, err)
+	}
+	if payload == nil {
+		return nil, fmt.Errorf("%s must be an object", objectName)
+	}
+	if err := rejectThreadItemFields(payload, objectName, allowed...); err != nil {
+		return nil, err
+	}
+	return payload, nil
+}
+
+func rejectThreadItemFields(payload map[string]json.RawMessage, objectName string, allowed ...string) error {
+	for name := range payload {
+		known := false
+		for _, candidate := range allowed {
+			if name == candidate {
+				known = true
+				break
+			}
+		}
+		if !known {
+			return fmt.Errorf("unknown %s field %q", objectName, name)
+		}
+	}
+	return nil
+}
+
+func decodeRequiredThreadItemValue[T any](payload map[string]json.RawMessage, objectName, fieldName string) (T, error) {
+	var zero T
+	raw, ok := payload[fieldName]
+	if !ok || isJSONNull(raw) {
+		return zero, fmt.Errorf("%s requires %s", objectName, fieldName)
+	}
+	var value T
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return zero, fmt.Errorf("decode %s %s: %w", objectName, fieldName, err)
+	}
+	return value, nil
+}
+
+func isJSONNull(data []byte) bool {
+	return bytes.Equal(bytes.TrimSpace(data), []byte("null"))
+}

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -536,6 +536,11 @@ export type ApprovalRespondResult = {
   "requestId": string;
 };
 
+export type ByteRange = {
+  "end": number;
+  "start": number;
+};
+
 export type ClientInfo = {
   "name": string;
   "title"?: string | null;
@@ -1060,6 +1065,13 @@ export type GrantedPermissionProfile = {
   "network"?: AdditionalNetworkPermissions;
 };
 
+export type HookPromptFragment = {
+  "hookRunId": string;
+  "text": string;
+};
+
+export type ImageDetail = "auto" | "low" | "high" | "original";
+
 export type ImplementationInfo = {
   "name": string;
   "version"?: string;
@@ -1324,6 +1336,20 @@ export type McpToolCallProgressNotification = {
 
 export type McpToolCallStatus = "inProgress" | "completed" | "failed";
 
+export type MemoryCitation = {
+  "entries": Array<MemoryCitationEntry>;
+  "threadIds": Array<string>;
+};
+
+export type MemoryCitationEntry = {
+  "lineEnd": number;
+  "lineStart": number;
+  "note": string;
+  "path": string;
+};
+
+export type MessagePhase = "commentary" | "final_answer";
+
 export type MethodInfo = {
   "method": string;
   "source"?: string;
@@ -1433,6 +1459,11 @@ export type ServerRequestResolvedNotificationParams = ServerRequestResolvedNotif
 export type SortDirection = "asc" | "desc";
 
 export type Surface = "client-request" | "server-notification" | "server-request" | "client-notification" | "gollem-extension";
+
+export type TextElement = {
+  "byteRange": ByteRange;
+  "placeholder": string | null;
+};
 
 export type ThreadArchiveParams = {
   "id"?: string;
@@ -1841,6 +1872,28 @@ export type TurnRecord = {
   "threadId": string;
   "updatedAt": string;
   "usage"?: Record<string, unknown> | null;
+};
+
+export type UserInput = {
+  "text": string;
+  "text_elements": Array<TextElement>;
+  "type": "text";
+} | {
+  "detail"?: ImageDetail;
+  "type": "image";
+  "url": string;
+} | {
+  "detail"?: ImageDetail;
+  "path": string;
+  "type": "localImage";
+} | {
+  "name": string;
+  "path": string;
+  "type": "skill";
+} | {
+  "name": string;
+  "path": string;
+  "type": "mention";
 };
 
 export type WireTypeBinding = {

--- a/appserver/protocol/typescript/testdata/thread_item_message_contract.ts
+++ b/appserver/protocol/typescript/testdata/thread_item_message_contract.ts
@@ -1,0 +1,51 @@
+import type {
+  ByteRange,
+  HookPromptFragment,
+  ImageDetail,
+  MemoryCitation,
+  MemoryCitationEntry,
+  MessagePhase,
+  TextElement,
+  UserInput,
+} from "../gollem_appserver_protocol";
+
+export const byteRange = { start: 9, end: 2 } satisfies ByteRange;
+export const textElement = { byteRange, placeholder: null } satisfies TextElement;
+export const imageDetail = "original" satisfies ImageDetail;
+export const messagePhase = "final_answer" satisfies MessagePhase;
+export const memoryEntry = {
+  path: "relative.md",
+  lineStart: 9,
+  lineEnd: 2,
+  note: "context",
+} satisfies MemoryCitationEntry;
+export const memoryCitation = {
+  entries: [memoryEntry],
+  threadIds: ["thread-1"],
+} satisfies MemoryCitation;
+export const hookPrompt = { text: "review", hookRunId: "hook-1" } satisfies HookPromptFragment;
+export const inputs = [
+  { type: "text", text: "hello", text_elements: [textElement] },
+  { type: "image", url: "image.png" },
+  { type: "image", detail: "high", url: "image.png" },
+  { type: "localImage", path: "relative.png" },
+  { type: "skill", name: "review", path: "skills/review/SKILL.md" },
+  { type: "mention", name: "guide", path: "docs/guide.md" },
+] satisfies UserInput[];
+
+// @ts-expect-error placeholder is required nullable, not optional.
+export const rejectMissingPlaceholder = { byteRange } satisfies TextElement;
+// @ts-expect-error image detail is a closed public enum.
+export const rejectImageDetail = "medium" satisfies ImageDetail;
+// @ts-expect-error message phase uses the public snake_case literal.
+export const rejectMessagePhase = "finalAnswer" satisfies MessagePhase;
+// @ts-expect-error citation arrays are required.
+export const rejectMissingCitationThreads = { entries: [memoryEntry] } satisfies MemoryCitation;
+// @ts-expect-error hook fields use camelCase.
+export const rejectHookSnakeCase = { text: "review", hook_run_id: "hook-1" } satisfies HookPromptFragment;
+// @ts-expect-error text input requires the public snake_case text_elements field.
+export const rejectMissingTextElements = { type: "text", text: "hello" } satisfies UserInput;
+// @ts-expect-error explicit null is not valid for optional image detail.
+export const rejectNullDetail = { type: "image", detail: null, url: "image.png" } satisfies UserInput;
+// @ts-expect-error user-input variants cannot cross fields.
+export const rejectCrossedInput = { type: "image", url: "image.png", path: "local.png" } satisfies UserInput;


### PR DESCRIPTION
## Summary

- export exact public ByteRange, TextElement, ImageDetail, UserInput, MessagePhase, MemoryCitationEntry, MemoryCitation, and HookPromptFragment contracts
- enforce strict JSON decoding, canonical non-null collection encoding, closed enum and union variants, and the public snake_case/camelCase wire names
- generate JSON Schema and TypeScript definitions with strict positive/negative Go and TypeScript contracts
- document that these are prerequisites only and do not rebind ThreadItem, lifecycle notifications, or runtime emission

## Validation

- `go test ./...`
- `go vet ./appserver/...`
- pre-push `golangci-lint` (0 issues)
- pre-push `go test -race`
- strict TypeScript fixture compilation through `go test ./appserver/protocol -run TypeScript`
- `git diff --cached --check`