### PR TITLE
Add exact public CommandAction union

### DIFF
--- a/appserver/protocol/README.md
+++ b/appserver/protocol/README.md
@@ -244,7 +244,7 @@ asynchronously and returns a process snapshot, while the public contract
 requires argv, PTY/sandbox/stream/cap/timeout controls and a deferred buffered
 result after process exit.
 
-## Exported Thread-Item Message Prerequisites
+## Exported Thread-Item Prerequisites
 
 The schema exports the exact public `ByteRange`, `TextElement`, `ImageDetail`,
 `UserInput`, `MessagePhase`, `MemoryCitationEntry`, `MemoryCitation`, and
@@ -261,6 +261,14 @@ These definitions are prerequisites only. They do not alias Gollem's durable
 runtime emits message, memory-citation, or hook-prompt items. Those bindings
 remain separate work after the full item family and its runtime data paths are
 implemented.
+
+The exact public `CommandAction` union is also exported independently. Its
+`read` path reuses the absolute normalized `AbsolutePathBuf` contract, while
+`listFiles.path`, `search.query`, and `search.path` are required nullable
+unrestricted strings. The four read/listFiles/search/unknown variants reject
+crossed and unknown fields. Exporting this parsed-command value does not parse
+live commands, change `CommandExecutionSource`, bind it into Gollem's legacy
+command item, or claim that the runtime emits public command actions.
 
 ## Generation
 

--- a/appserver/protocol/command_action_contract_test.go
+++ b/appserver/protocol/command_action_contract_test.go
@@ -1,0 +1,138 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"testing"
+)
+
+func TestCommandActionSchemaIsExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	action, ok := defs["CommandAction"].(Schema)
+	if !ok {
+		t.Fatal("$defs missing CommandAction")
+	}
+	variants, ok := action["oneOf"].([]any)
+	if !ok || len(variants) != 4 {
+		t.Fatalf("CommandAction variants = %#v", action["oneOf"])
+	}
+	want := []struct {
+		actionType string
+		required   []string
+	}{
+		{actionType: "read", required: []string{"type", "command", "name", "path"}},
+		{actionType: "listFiles", required: []string{"type", "command", "path"}},
+		{actionType: "search", required: []string{"type", "command", "query", "path"}},
+		{actionType: "unknown", required: []string{"type", "command"}},
+	}
+	for index, expected := range want {
+		variant := variants[index].(Schema)
+		if variant["additionalProperties"] != false {
+			t.Fatalf("CommandAction %s allows extra fields", expected.actionType)
+		}
+		properties := variant["properties"].(Schema)
+		if !reflect.DeepEqual(properties["type"].(Schema)["enum"], []any{expected.actionType}) {
+			t.Fatalf("CommandAction variant %d type = %#v", index, properties["type"])
+		}
+		if !slices.Equal(schemaRequiredNames(variant), expected.required) {
+			t.Fatalf("CommandAction %s required = %v, want %v", expected.actionType, schemaRequiredNames(variant), expected.required)
+		}
+	}
+
+	readProperties := variants[0].(Schema)["properties"].(Schema)
+	if readProperties["path"].(Schema)["$ref"] != "#/$defs/AbsolutePathBuf" {
+		t.Fatalf("read path = %#v", readProperties["path"])
+	}
+	listProperties := variants[1].(Schema)["properties"].(Schema)
+	assertNullableStringSchema(t, listProperties["path"])
+	searchProperties := variants[2].(Schema)["properties"].(Schema)
+	assertNullableStringSchema(t, searchProperties["query"])
+	assertNullableStringSchema(t, searchProperties["path"])
+}
+
+func TestCommandActionWireValidationAndCanonicalization(t *testing.T) {
+	valid := []struct {
+		input string
+		want  string
+	}{
+		{
+			input: `{"type":"read","command":"cat file","name":"cat","path":"/workspace/dir/../file"}`,
+			want:  `{"type":"read","command":"cat file","name":"cat","path":"/workspace/file"}`,
+		},
+		{
+			input: `{"type":"listFiles","command":"ls","path":null}`,
+			want:  `{"type":"listFiles","command":"ls","path":null}`,
+		},
+		{
+			input: `{"type":"listFiles","command":"ls src","path":"relative/src"}`,
+			want:  `{"type":"listFiles","command":"ls src","path":"relative/src"}`,
+		},
+		{
+			input: `{"type":"search","command":"rg needle","query":null,"path":null}`,
+			want:  `{"type":"search","command":"rg needle","query":null,"path":null}`,
+		},
+		{
+			input: `{"type":"search","command":"rg needle src","query":"needle","path":"relative/src"}`,
+			want:  `{"type":"search","command":"rg needle src","query":"needle","path":"relative/src"}`,
+		},
+		{
+			input: `{"type":"unknown","command":"custom --flag"}`,
+			want:  `{"type":"unknown","command":"custom --flag"}`,
+		},
+	}
+	for _, testCase := range valid {
+		var action CommandAction
+		if err := json.Unmarshal([]byte(testCase.input), &action); err != nil {
+			t.Errorf("Unmarshal(%s): %v", testCase.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(action)
+		if err != nil {
+			t.Errorf("Marshal(%s): %v", testCase.input, err)
+			continue
+		}
+		if string(encoded) != testCase.want {
+			t.Errorf("round trip %s = %s, want %s", testCase.input, encoded, testCase.want)
+		}
+	}
+
+	invalid := []string{
+		`null`, `[]`, `{}`,
+		`{"type":"read","command":"cat","name":"cat"}`,
+		`{"type":"read","command":"cat","name":"cat","path":null}`,
+		`{"type":"read","command":"cat","name":"cat","path":"relative"}`,
+		`{"type":"read","command":null,"name":"cat","path":"/file"}`,
+		`{"type":"read","command":"cat","name":null,"path":"/file"}`,
+		`{"type":"read","command":"cat","name":"cat","path":"/file","query":null}`,
+		`{"type":"listFiles","command":"ls"}`,
+		`{"type":"listFiles","command":"ls","path":1}`,
+		`{"type":"listFiles","command":"ls","path":null,"name":"ls"}`,
+		`{"type":"search","command":"rg","path":null}`,
+		`{"type":"search","command":"rg","query":null}`,
+		`{"type":"search","command":"rg","query":1,"path":null}`,
+		`{"type":"search","command":"rg","query":null,"path":false}`,
+		`{"type":"search","command":"rg","query":null,"path":null,"name":"rg"}`,
+		`{"type":"unknown"}`,
+		`{"type":"unknown","command":"custom","path":null}`,
+		`{"type":"execute","command":"run"}`,
+		`{"type":1,"command":"run"}`,
+		`{"type":"unknown","command":"run","extra":true}`,
+	}
+	for _, input := range invalid {
+		var action CommandAction
+		if err := json.Unmarshal([]byte(input), &action); err == nil {
+			t.Errorf("Unmarshal(%s) succeeded", input)
+		}
+	}
+}
+
+func TestCommandActionEmptyAndNilReceiversFailClosed(t *testing.T) {
+	if _, err := json.Marshal(CommandAction{}); err == nil {
+		t.Fatal("Marshal empty CommandAction succeeded")
+	}
+	var action *CommandAction
+	if err := action.UnmarshalJSON([]byte(`{"type":"unknown","command":"run"}`)); err == nil {
+		t.Fatal("nil CommandAction receiver succeeded")
+	}
+}

--- a/appserver/protocol/command_action_types.go
+++ b/appserver/protocol/command_action_types.go
@@ -1,0 +1,131 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// CommandAction retains one validated public command-action variant without
+// flattening its variant-specific path types into an invalid Go state.
+type CommandAction struct {
+	raw json.RawMessage
+}
+
+func (a CommandAction) MarshalJSON() ([]byte, error) {
+	if len(a.raw) == 0 {
+		return nil, errors.New("command action has no value")
+	}
+	return validateCommandActionJSON(a.raw)
+}
+
+func (a *CommandAction) UnmarshalJSON(data []byte) error {
+	if a == nil {
+		return errors.New("decode command action into nil receiver")
+	}
+	canonical, err := validateCommandActionJSON(data)
+	if err != nil {
+		return err
+	}
+	a.raw = canonical
+	return nil
+}
+
+func validateCommandActionJSON(data []byte) (json.RawMessage, error) {
+	payload, err := decodeExactThreadItemObject(
+		data,
+		"command action",
+		"type",
+		"command",
+		"name",
+		"path",
+		"query",
+	)
+	if err != nil {
+		return nil, err
+	}
+	actionType, err := decodeRequiredThreadItemValue[string](payload, "command action", "type")
+	if err != nil {
+		return nil, err
+	}
+	command, err := decodeRequiredThreadItemValue[string](payload, "command action", "command")
+	if err != nil {
+		return nil, err
+	}
+	switch actionType {
+	case "read":
+		if err := rejectThreadItemFields(payload, "read command action", "type", "command", "name", "path"); err != nil {
+			return nil, err
+		}
+		name, err := decodeRequiredThreadItemValue[string](payload, "read command action", "name")
+		if err != nil {
+			return nil, err
+		}
+		path, err := decodeRequiredThreadItemValue[AbsolutePathBuf](payload, "read command action", "path")
+		if err != nil {
+			return nil, err
+		}
+		return json.Marshal(struct {
+			Type    string          `json:"type"`
+			Command string          `json:"command"`
+			Name    string          `json:"name"`
+			Path    AbsolutePathBuf `json:"path"`
+		}{Type: actionType, Command: command, Name: name, Path: path})
+	case "listFiles":
+		if err := rejectThreadItemFields(payload, "listFiles command action", "type", "command", "path"); err != nil {
+			return nil, err
+		}
+		path, err := decodeRequiredNullableCommandActionString(payload, "listFiles command action", "path")
+		if err != nil {
+			return nil, err
+		}
+		return json.Marshal(struct {
+			Type    string  `json:"type"`
+			Command string  `json:"command"`
+			Path    *string `json:"path"`
+		}{Type: actionType, Command: command, Path: path})
+	case "search":
+		if err := rejectThreadItemFields(payload, "search command action", "type", "command", "query", "path"); err != nil {
+			return nil, err
+		}
+		query, err := decodeRequiredNullableCommandActionString(payload, "search command action", "query")
+		if err != nil {
+			return nil, err
+		}
+		path, err := decodeRequiredNullableCommandActionString(payload, "search command action", "path")
+		if err != nil {
+			return nil, err
+		}
+		return json.Marshal(struct {
+			Type    string  `json:"type"`
+			Command string  `json:"command"`
+			Query   *string `json:"query"`
+			Path    *string `json:"path"`
+		}{Type: actionType, Command: command, Query: query, Path: path})
+	case "unknown":
+		if err := rejectThreadItemFields(payload, "unknown command action", "type", "command"); err != nil {
+			return nil, err
+		}
+		return json.Marshal(struct {
+			Type    string `json:"type"`
+			Command string `json:"command"`
+		}{Type: actionType, Command: command})
+	default:
+		return nil, fmt.Errorf("unknown command action type %q", actionType)
+	}
+}
+
+func decodeRequiredNullableCommandActionString(payload map[string]json.RawMessage, objectName, fieldName string) (*string, error) {
+	raw, ok := payload[fieldName]
+	if !ok {
+		return nil, fmt.Errorf("%s requires %s", objectName, fieldName)
+	}
+	if isJSONNull(raw) {
+		return nil, nil
+	}
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return nil, fmt.Errorf("decode %s %s: %w", objectName, fieldName, err)
+	}
+	return &value, nil
+}

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -91,6 +91,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "ApprovalRespondResult", Type: reflect.TypeFor[ApprovalRespondResult]()},
 		{Name: "ByteRange", Type: reflect.TypeFor[ByteRange]()},
 		{Name: "ClientInfo", Type: reflect.TypeFor[ClientInfo]()},
+		{Name: "CommandAction", Type: reflect.TypeFor[CommandAction]()},
 		{Name: "CommandExecOutputDeltaNotification", Type: reflect.TypeFor[CommandExecOutputDeltaNotification]()},
 		{Name: "CommandExecOutputStream", Type: reflect.TypeFor[CommandExecOutputStream]()},
 		{Name: "CommandExecResizeParams", Type: reflect.TypeFor[CommandExecResizeParams]()},
@@ -340,6 +341,7 @@ func wireSchemaDefinitions() Schema {
 		string(CommandExecOutputStdout), string(CommandExecOutputStderr),
 	)
 	schemas["CommandExecutionApprovalDecision"] = commandExecutionApprovalDecisionSchema()
+	schemas["CommandAction"] = commandActionSchema()
 	schemas["AbsolutePathBuf"] = Schema{
 		"type":        "string",
 		"description": "An absolute, lexically normalized local path.",
@@ -491,6 +493,45 @@ func wireSchemaDefinitions() Schema {
 		string(TurnLifecycleFailed), string(TurnLifecycleInterrupted),
 	)
 	return schemas
+}
+
+func commandActionSchema() Schema {
+	return Schema{"oneOf": []any{
+		commandActionVariantSchema("read", []string{"command", "name", "path"}, Schema{
+			"command": Schema{"type": "string"},
+			"name":    Schema{"type": "string"},
+			"path":    Schema{"$ref": "#/$defs/AbsolutePathBuf"},
+		}),
+		commandActionVariantSchema("listFiles", []string{"command", "path"}, Schema{
+			"command": Schema{"type": "string"},
+			"path":    nullableStringSchema(),
+		}),
+		commandActionVariantSchema("search", []string{"command", "query", "path"}, Schema{
+			"command": Schema{"type": "string"},
+			"query":   nullableStringSchema(),
+			"path":    nullableStringSchema(),
+		}),
+		commandActionVariantSchema("unknown", []string{"command"}, Schema{
+			"command": Schema{"type": "string"},
+		}),
+	}}
+}
+
+func commandActionVariantSchema(actionType string, requiredFields []string, fields Schema) Schema {
+	properties := Schema{
+		"type": Schema{"type": "string", "enum": []any{actionType}},
+	}
+	for name, schema := range fields {
+		properties[name] = schema
+	}
+	required := []string{"type"}
+	required = append(required, requiredFields...)
+	return Schema{
+		"type":                 "object",
+		"properties":           properties,
+		"required":             required,
+		"additionalProperties": false,
+	}
 }
 
 func userInputSchema() Schema {

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -237,6 +237,127 @@
       ],
       "type": "object"
     },
+    "CommandAction": {
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "command": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "path": {
+              "$ref": "#/$defs/AbsolutePathBuf"
+            },
+            "type": {
+              "enum": [
+                "read"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "command",
+            "name",
+            "path"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "command": {
+              "type": "string"
+            },
+            "path": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "type": {
+              "enum": [
+                "listFiles"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "command",
+            "path"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "command": {
+              "type": "string"
+            },
+            "path": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "query": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "type": {
+              "enum": [
+                "search"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "command",
+            "query",
+            "path"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "command": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "unknown"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "command"
+          ],
+          "type": "object"
+        }
+      ]
+    },
     "CommandExecOutputDeltaNotification": {
       "additionalProperties": false,
       "properties": {

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -547,6 +547,25 @@ export type ClientInfo = {
   "version": string;
 };
 
+export type CommandAction = {
+  "command": string;
+  "name": string;
+  "path": AbsolutePathBuf;
+  "type": "read";
+} | {
+  "command": string;
+  "path": string | null;
+  "type": "listFiles";
+} | {
+  "command": string;
+  "path": string | null;
+  "query": string | null;
+  "type": "search";
+} | {
+  "command": string;
+  "type": "unknown";
+};
+
 export type CommandExecOutputDeltaNotification = {
   "capReached": boolean;
   "deltaBase64": string;

--- a/appserver/protocol/typescript/testdata/command_action_contract.ts
+++ b/appserver/protocol/typescript/testdata/command_action_contract.ts
@@ -1,0 +1,29 @@
+import type {
+  AbsolutePathBuf,
+  CommandAction,
+} from "../gollem_appserver_protocol";
+
+const readPath = "/workspace/file" satisfies AbsolutePathBuf;
+export const actions = [
+  { type: "read", command: "cat file", name: "cat", path: readPath },
+  { type: "listFiles", command: "ls", path: null },
+  { type: "listFiles", command: "ls src", path: "relative/src" },
+  { type: "search", command: "rg needle", query: null, path: null },
+  { type: "search", command: "rg needle src", query: "needle", path: "relative/src" },
+  { type: "unknown", command: "custom --flag" },
+] satisfies CommandAction[];
+
+// @ts-expect-error read requires a path.
+export const rejectReadWithoutPath = { type: "read", command: "cat", name: "cat" } satisfies CommandAction;
+// @ts-expect-error read path cannot be null.
+export const rejectNullReadPath = { type: "read", command: "cat", name: "cat", path: null } satisfies CommandAction;
+// @ts-expect-error listFiles path is required nullable, not optional.
+export const rejectListWithoutPath = { type: "listFiles", command: "ls" } satisfies CommandAction;
+// @ts-expect-error search query is required nullable, not optional.
+export const rejectSearchWithoutQuery = { type: "search", command: "rg", path: null } satisfies CommandAction;
+// @ts-expect-error search path is required nullable, not optional.
+export const rejectSearchWithoutPath = { type: "search", command: "rg", query: null } satisfies CommandAction;
+// @ts-expect-error command-action variants cannot cross fields.
+export const rejectCrossedAction = { type: "unknown", command: "run", path: null } satisfies CommandAction;
+// @ts-expect-error command-action discriminators are closed.
+export const rejectUnknownType = { type: "execute", command: "run" } satisfies CommandAction;


### PR DESCRIPTION
## Summary

- export the exact four-variant public `CommandAction` union through Gollem schema and generated TypeScript
- reuse `AbsolutePathBuf` validation and normalization for `read.path` while preserving unrestricted nullable list/search paths
- require public nullable list/search fields and reject missing, null-required, crossed, unknown, malformed, and non-absolute read forms
- keep live command parsing, legacy command items, `CommandExecutionSource`, full `ThreadItem`, and lifecycle binding unchanged

## Validation

- deliberate red compile before `CommandAction` existed
- focused schema/codec/TypeScript positive and negative contracts
- 100% focused coverage for CommandAction marshal, unmarshal, validation, and nullable decoding
- `go test ./appserver/...`
- `go test ./...`
- `go vet ./appserver/...`
- pre-push `golangci-lint`, full race suite, vet, and tidy checks
- deterministic generation and `git diff --cached --check`

## Generated hashes

- schema: `a4298d575089344b065f6a17817de1382e0a20361db01e99e2c356adb4a3fa51`
- TypeScript: `93f30d5c9d5f4b018443894f8c7348713874292eea101f4d9a1803f1b8d9945d`
- strict TypeScript fixture: `9c6fa9f6181fdf92e3ec984980452cb5d5f8c34657ff025c6ed5fa3cabf89774`