### PR TITLE
Add exact MCP tool-call app context

### DIFF
--- a/appserver/protocol/README.md
+++ b/appserver/protocol/README.md
@@ -270,6 +270,13 @@ crossed and unknown fields. Exporting this parsed-command value does not parse
 live commands, change `CommandExecutionSource`, bind it into Gollem's legacy
 command item, or claim that the runtime emits public command actions.
 
+The exact public `McpToolCallAppContext` value is exported with required
+`connectorId` and required nullable `linkId`, `resourceUri`, `appName`,
+`templateId`, and `actionName` fields. All use the public camel-case spelling,
+and canonical output includes explicit nulls. This definition is not bound into
+Gollem's legacy MCP item, projected from deprecated `mcpAppResourceUri`, or
+treated as evidence that connector metadata exists on current runtime calls.
+
 ## Generation
 
 Run:

--- a/appserver/protocol/command_action_types.go
+++ b/appserver/protocol/command_action_types.go
@@ -75,7 +75,7 @@ func validateCommandActionJSON(data []byte) (json.RawMessage, error) {
 		if err := rejectThreadItemFields(payload, "listFiles command action", "type", "command", "path"); err != nil {
 			return nil, err
 		}
-		path, err := decodeRequiredNullableCommandActionString(payload, "listFiles command action", "path")
+		path, err := decodeRequiredNullableThreadItemString(payload, "listFiles command action", "path")
 		if err != nil {
 			return nil, err
 		}
@@ -88,11 +88,11 @@ func validateCommandActionJSON(data []byte) (json.RawMessage, error) {
 		if err := rejectThreadItemFields(payload, "search command action", "type", "command", "query", "path"); err != nil {
 			return nil, err
 		}
-		query, err := decodeRequiredNullableCommandActionString(payload, "search command action", "query")
+		query, err := decodeRequiredNullableThreadItemString(payload, "search command action", "query")
 		if err != nil {
 			return nil, err
 		}
-		path, err := decodeRequiredNullableCommandActionString(payload, "search command action", "path")
+		path, err := decodeRequiredNullableThreadItemString(payload, "search command action", "path")
 		if err != nil {
 			return nil, err
 		}
@@ -115,7 +115,7 @@ func validateCommandActionJSON(data []byte) (json.RawMessage, error) {
 	}
 }
 
-func decodeRequiredNullableCommandActionString(payload map[string]json.RawMessage, objectName, fieldName string) (*string, error) {
+func decodeRequiredNullableThreadItemString(payload map[string]json.RawMessage, objectName, fieldName string) (*string, error) {
 	raw, ok := payload[fieldName]
 	if !ok {
 		return nil, fmt.Errorf("%s requires %s", objectName, fieldName)

--- a/appserver/protocol/mcp_tool_call_app_context_contract_test.go
+++ b/appserver/protocol/mcp_tool_call_app_context_contract_test.go
@@ -1,0 +1,82 @@
+package protocol
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestMcpToolCallAppContextSchemaIsExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	context, ok := defs["McpToolCallAppContext"].(Schema)
+	if !ok {
+		t.Fatal("$defs missing McpToolCallAppContext")
+	}
+	assertSchemaRequiredNames(
+		t,
+		context,
+		"connectorId",
+		"linkId",
+		"resourceUri",
+		"appName",
+		"templateId",
+		"actionName",
+	)
+	properties := context["properties"].(Schema)
+	if connector := properties["connectorId"].(Schema); connector["type"] != "string" {
+		t.Fatalf("connectorId = %#v", connector)
+	}
+	for _, name := range []string{"linkId", "resourceUri", "appName", "templateId", "actionName"} {
+		assertNullableStringSchema(t, properties[name])
+	}
+	if context["additionalProperties"] != false {
+		t.Fatalf("McpToolCallAppContext allows extra fields: %#v", context)
+	}
+}
+
+func TestMcpToolCallAppContextWireValidation(t *testing.T) {
+	valid := []string{
+		`{"connectorId":"connector-1","linkId":null,"resourceUri":null,"appName":null,"templateId":null,"actionName":null}`,
+		`{"connectorId":"","linkId":"link-1","resourceUri":"app://resource","appName":"Repo","templateId":"template-1","actionName":"search"}`,
+	}
+	for _, input := range valid {
+		var context McpToolCallAppContext
+		if err := json.Unmarshal([]byte(input), &context); err != nil {
+			t.Errorf("Unmarshal(%s): %v", input, err)
+		}
+	}
+
+	invalid := []string{
+		`null`, `[]`, `{}`,
+		`{"connectorId":null,"linkId":null,"resourceUri":null,"appName":null,"templateId":null,"actionName":null}`,
+		`{"connectorId":"c","resourceUri":null,"appName":null,"templateId":null,"actionName":null}`,
+		`{"connectorId":"c","linkId":null,"appName":null,"templateId":null,"actionName":null}`,
+		`{"connectorId":"c","linkId":null,"resourceUri":null,"templateId":null,"actionName":null}`,
+		`{"connectorId":"c","linkId":null,"resourceUri":null,"appName":null,"actionName":null}`,
+		`{"connectorId":"c","linkId":null,"resourceUri":null,"appName":null,"templateId":null}`,
+		`{"connectorId":"c","linkId":1,"resourceUri":null,"appName":null,"templateId":null,"actionName":null}`,
+		`{"connector_id":"c","link_id":null,"resource_uri":null,"app_name":null,"template_id":null,"action_name":null}`,
+		`{"connectorId":"c","linkId":null,"resourceUri":null,"appName":null,"templateId":null,"actionName":null,"extra":true}`,
+	}
+	for _, input := range invalid {
+		var context McpToolCallAppContext
+		if err := json.Unmarshal([]byte(input), &context); err == nil {
+			t.Errorf("Unmarshal(%s) succeeded", input)
+		}
+	}
+}
+
+func TestMcpToolCallAppContextMarshalEmitsExplicitNulls(t *testing.T) {
+	encoded, err := json.Marshal(McpToolCallAppContext{ConnectorID: "connector-1"})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := `{"connectorId":"connector-1","linkId":null,"resourceUri":null,"appName":null,"templateId":null,"actionName":null}`
+	if string(encoded) != want {
+		t.Fatalf("Marshal = %s, want %s", encoded, want)
+	}
+
+	var context *McpToolCallAppContext
+	if err := context.UnmarshalJSON(encoded); err == nil {
+		t.Fatal("nil McpToolCallAppContext receiver succeeded")
+	}
+}

--- a/appserver/protocol/mcp_tool_call_app_context_types.go
+++ b/appserver/protocol/mcp_tool_call_app_context_types.go
@@ -1,0 +1,66 @@
+package protocol
+
+import (
+	"errors"
+)
+
+type McpToolCallAppContext struct {
+	ConnectorID string  `json:"connectorId"`
+	LinkID      *string `json:"linkId"`
+	ResourceURI *string `json:"resourceUri"`
+	AppName     *string `json:"appName"`
+	TemplateID  *string `json:"templateId"`
+	ActionName  *string `json:"actionName"`
+}
+
+func (c *McpToolCallAppContext) UnmarshalJSON(data []byte) error {
+	if c == nil {
+		return errors.New("decode MCP tool-call app context into nil receiver")
+	}
+	payload, err := decodeExactThreadItemObject(
+		data,
+		"MCP tool-call app context",
+		"connectorId",
+		"linkId",
+		"resourceUri",
+		"appName",
+		"templateId",
+		"actionName",
+	)
+	if err != nil {
+		return err
+	}
+	connectorID, err := decodeRequiredThreadItemValue[string](payload, "MCP tool-call app context", "connectorId")
+	if err != nil {
+		return err
+	}
+	linkID, err := decodeRequiredNullableThreadItemString(payload, "MCP tool-call app context", "linkId")
+	if err != nil {
+		return err
+	}
+	resourceURI, err := decodeRequiredNullableThreadItemString(payload, "MCP tool-call app context", "resourceUri")
+	if err != nil {
+		return err
+	}
+	appName, err := decodeRequiredNullableThreadItemString(payload, "MCP tool-call app context", "appName")
+	if err != nil {
+		return err
+	}
+	templateID, err := decodeRequiredNullableThreadItemString(payload, "MCP tool-call app context", "templateId")
+	if err != nil {
+		return err
+	}
+	actionName, err := decodeRequiredNullableThreadItemString(payload, "MCP tool-call app context", "actionName")
+	if err != nil {
+		return err
+	}
+	*c = McpToolCallAppContext{
+		ConnectorID: connectorID,
+		LinkID:      linkID,
+		ResourceURI: resourceURI,
+		AppName:     appName,
+		TemplateID:  templateID,
+		ActionName:  actionName,
+	}
+	return nil
+}

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -175,6 +175,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "MCPToolCallItemStartedNotificationParams", Type: reflect.TypeFor[MCPToolCallItemStartedNotificationParams]()},
 		{Name: "MCPToolCallProgressNotificationParams", Type: reflect.TypeFor[MCPToolCallProgressNotificationParams]()},
 		{Name: "MCPToolCallResult", Type: reflect.TypeFor[MCPToolCallResult]()},
+		{Name: "McpToolCallAppContext", Type: reflect.TypeFor[McpToolCallAppContext]()},
 		{Name: "MemoryCitation", Type: reflect.TypeFor[MemoryCitation]()},
 		{Name: "MemoryCitationEntry", Type: reflect.TypeFor[MemoryCitationEntry]()},
 		{Name: "MessagePhase", Type: reflect.TypeFor[MessagePhase]()},

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -3458,6 +3458,73 @@
       ],
       "type": "object"
     },
+    "McpToolCallAppContext": {
+      "additionalProperties": false,
+      "properties": {
+        "actionName": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "appName": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "connectorId": {
+          "type": "string"
+        },
+        "linkId": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "resourceUri": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "templateId": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "connectorId",
+        "linkId",
+        "resourceUri",
+        "appName",
+        "templateId",
+        "actionName"
+      ],
+      "type": "object"
+    },
     "McpToolCallError": {
       "additionalProperties": false,
       "properties": {

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -1342,6 +1342,15 @@ export type McpServerElicitationRequestResponse = {
   "content": unknown;
 };
 
+export type McpToolCallAppContext = {
+  "actionName": string | null;
+  "appName": string | null;
+  "connectorId": string;
+  "linkId": string | null;
+  "resourceUri": string | null;
+  "templateId": string | null;
+};
+
 export type McpToolCallError = {
   "message": string;
 };

--- a/appserver/protocol/typescript/testdata/mcp_tool_call_app_context_contract.ts
+++ b/appserver/protocol/typescript/testdata/mcp_tool_call_app_context_contract.ts
@@ -1,0 +1,26 @@
+import type { McpToolCallAppContext } from "../gollem_appserver_protocol";
+
+export const nullContext = {
+  connectorId: "connector-1",
+  linkId: null,
+  resourceUri: null,
+  appName: null,
+  templateId: null,
+  actionName: null,
+} satisfies McpToolCallAppContext;
+
+export const populatedContext = {
+  connectorId: "connector-1",
+  linkId: "link-1",
+  resourceUri: "app://resource",
+  appName: "Repo",
+  templateId: "template-1",
+  actionName: "search",
+} satisfies McpToolCallAppContext;
+
+// @ts-expect-error connectorId is required non-null.
+export const rejectNullConnector = { ...nullContext, connectorId: null } satisfies McpToolCallAppContext;
+// @ts-expect-error nullable fields are required, not optional.
+export const rejectMissingLink = { connectorId: "connector-1", resourceUri: null, appName: null, templateId: null, actionName: null } satisfies McpToolCallAppContext;
+// @ts-expect-error public fields use camelCase.
+export const rejectSnakeCase = { connector_id: "connector-1", link_id: null, resource_uri: null, app_name: null, template_id: null, action_name: null } satisfies McpToolCallAppContext;


### PR DESCRIPTION
## Summary

- export exact public `McpToolCallAppContext` with required camel-case fields
- require non-null `connectorId` and explicit nullable link/resource/app/template/action values
- reject omissions, null connector ids, snake_case aliases, unknown fields, and malformed values while emitting canonical explicit nulls
- keep Gollem legacy MCP items, deprecated resource URI fields, runtime events, and full public MCP item parity unchanged

## Validation

- deliberate red compile before the type existed
- focused schema/codec/TypeScript positive and negative contracts
- 100% focused coverage for the new decoder and shared required-nullable helper
- prior CommandAction regression remains 100% covered
- `go test ./appserver/...`
- `go test ./...`
- `go vet ./appserver/...`
- pre-push `golangci-lint`, full race suite, vet, and tidy checks
- deterministic generation and `git diff --cached --check`

## Generated hashes

- schema: `40a0cd38e03d88fc5f98a66cd8226355dcb2775f48758fd89a69dc90a9c32973`
- TypeScript: `dc522c2b6be1ba947f4286752dd2759d515bc148974ba69b618facabe4e215c8`
- strict TypeScript fixture: `ada9d7389d30e12f30d85e4f2a50833f651cd155898aa65dc73e995211bc4cff`