### PR TITLE
feat(protocol): add exact web search action

### DIFF
--- a/appserver/protocol/README.md
+++ b/appserver/protocol/README.md
@@ -277,6 +277,16 @@ and canonical output includes explicit nulls. This definition is not bound into
 Gollem's legacy MCP item, projected from deprecated `mcpAppResourceUri`, or
 treated as evidence that connector metadata exists on current runtime calls.
 
+The exact public `WebSearchAction` union is exported independently with strict
+`search`, `openPage`, `findInPage`, and `other` variants. The search query and
+query-list, open-page URL, and find-in-page URL/pattern follow the generated v2
+TypeScript contract: each variant field is required nullable and canonical
+output includes explicit nulls. This deliberately resolves the public JSON
+Schema's looser `Option`-derived required list in favor of the generated client
+contract. It does not alias the distinct snake-case
+`ResponsesApiWebSearchAction`, add a search provider, bind a public thread item,
+or change current runtime events.
+
 ## Generation
 
 Run:

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -280,6 +280,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "TurnLifecycleStatus", Type: reflect.TypeFor[TurnLifecycleStatus]()},
 		{Name: "TurnRecord", Type: reflect.TypeFor[TurnRecord]()},
 		{Name: "UserInput", Type: reflect.TypeFor[UserInput]()},
+		{Name: "WebSearchAction", Type: reflect.TypeFor[WebSearchAction]()},
 		// Register exact public names after their aliases so nested schemas refer
 		// to the public names. JSON and TypeScript output remain key-sorted.
 		{Name: "ContextCompactedNotification", Type: reflect.TypeFor[ContextCompactedNotification]()},
@@ -343,6 +344,7 @@ func wireSchemaDefinitions() Schema {
 	)
 	schemas["CommandExecutionApprovalDecision"] = commandExecutionApprovalDecisionSchema()
 	schemas["CommandAction"] = commandActionSchema()
+	schemas["WebSearchAction"] = webSearchActionSchema()
 	schemas["AbsolutePathBuf"] = Schema{
 		"type":        "string",
 		"description": "An absolute, lexically normalized local path.",
@@ -519,6 +521,43 @@ func commandActionSchema() Schema {
 }
 
 func commandActionVariantSchema(actionType string, requiredFields []string, fields Schema) Schema {
+	properties := Schema{
+		"type": Schema{"type": "string", "enum": []any{actionType}},
+	}
+	for name, schema := range fields {
+		properties[name] = schema
+	}
+	required := []string{"type"}
+	required = append(required, requiredFields...)
+	return Schema{
+		"type":                 "object",
+		"properties":           properties,
+		"required":             required,
+		"additionalProperties": false,
+	}
+}
+
+func webSearchActionSchema() Schema {
+	return Schema{"oneOf": []any{
+		webSearchActionVariantSchema("search", []string{"query", "queries"}, Schema{
+			"query": nullableStringSchema(),
+			"queries": Schema{"oneOf": []any{
+				Schema{"type": "array", "items": Schema{"type": "string"}},
+				Schema{"type": "null"},
+			}},
+		}),
+		webSearchActionVariantSchema("openPage", []string{"url"}, Schema{
+			"url": nullableStringSchema(),
+		}),
+		webSearchActionVariantSchema("findInPage", []string{"url", "pattern"}, Schema{
+			"url":     nullableStringSchema(),
+			"pattern": nullableStringSchema(),
+		}),
+		webSearchActionVariantSchema("other", nil, nil),
+	}}
+}
+
+func webSearchActionVariantSchema(actionType string, requiredFields []string, fields Schema) Schema {
 	properties := Schema{
 		"type": Schema{"type": "string", "enum": []any{actionType}},
 	}

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -6284,6 +6284,128 @@
           "type": "object"
         }
       ]
+    },
+    "WebSearchAction": {
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "queries": {
+              "oneOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "query": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "type": {
+              "enum": [
+                "search"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "query",
+            "queries"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "enum": [
+                "openPage"
+              ],
+              "type": "string"
+            },
+            "url": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "type",
+            "url"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "pattern": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "type": {
+              "enum": [
+                "findInPage"
+              ],
+              "type": "string"
+            },
+            "url": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "type",
+            "url",
+            "pattern"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "enum": [
+                "other"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        }
+      ]
     }
   },
   "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -1924,6 +1924,21 @@ export type UserInput = {
   "type": "mention";
 };
 
+export type WebSearchAction = {
+  "queries": Array<string> | null;
+  "query": string | null;
+  "type": "search";
+} | {
+  "type": "openPage";
+  "url": string | null;
+} | {
+  "pattern": string | null;
+  "type": "findInPage";
+  "url": string | null;
+} | {
+  "type": "other";
+};
+
 export type WireTypeBinding = {
   "method": KnownMethod;
   "surface": ProtocolSurface;

--- a/appserver/protocol/typescript/testdata/web_search_action_contract.ts
+++ b/appserver/protocol/typescript/testdata/web_search_action_contract.ts
@@ -1,0 +1,26 @@
+import type { WebSearchAction } from "../gollem_appserver_protocol";
+
+export const actions = [
+  { type: "search", query: null, queries: null },
+  { type: "search", query: "gollem", queries: ["gollem", "slang"] },
+  { type: "openPage", url: null },
+  { type: "openPage", url: "https://example.com" },
+  { type: "findInPage", url: null, pattern: null },
+  { type: "findInPage", url: "https://example.com", pattern: "needle" },
+  { type: "other" },
+] satisfies WebSearchAction[];
+
+// @ts-expect-error search query is required nullable, not optional.
+export const rejectSearchWithoutQuery = { type: "search", queries: null } satisfies WebSearchAction;
+// @ts-expect-error search queries are required nullable, not optional.
+export const rejectSearchWithoutQueries = { type: "search", query: null } satisfies WebSearchAction;
+// @ts-expect-error query arrays contain only strings.
+export const rejectNullQueryElement = { type: "search", query: null, queries: [null] } satisfies WebSearchAction;
+// @ts-expect-error openPage URL is required nullable, not optional.
+export const rejectOpenPageWithoutURL = { type: "openPage" } satisfies WebSearchAction;
+// @ts-expect-error findInPage pattern is required nullable, not optional.
+export const rejectFindWithoutPattern = { type: "findInPage", url: null } satisfies WebSearchAction;
+// @ts-expect-error variants cannot cross fields.
+export const rejectCrossedAction = { type: "other", url: null } satisfies WebSearchAction;
+// @ts-expect-error discriminators are closed and camelCase.
+export const rejectSnakeCaseType = { type: "open_page", url: null } satisfies WebSearchAction;

--- a/appserver/protocol/web_search_action_contract_test.go
+++ b/appserver/protocol/web_search_action_contract_test.go
@@ -1,0 +1,132 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"testing"
+)
+
+func TestWebSearchActionSchemaIsExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	action, ok := defs["WebSearchAction"].(Schema)
+	if !ok {
+		t.Fatal("$defs missing WebSearchAction")
+	}
+	variants, ok := action["oneOf"].([]any)
+	if !ok || len(variants) != 4 {
+		t.Fatalf("WebSearchAction variants = %#v", action["oneOf"])
+	}
+	want := []struct {
+		actionType string
+		required   []string
+	}{
+		{actionType: "search", required: []string{"type", "query", "queries"}},
+		{actionType: "openPage", required: []string{"type", "url"}},
+		{actionType: "findInPage", required: []string{"type", "url", "pattern"}},
+		{actionType: "other", required: []string{"type"}},
+	}
+	for index, expected := range want {
+		variant := variants[index].(Schema)
+		if variant["additionalProperties"] != false {
+			t.Fatalf("WebSearchAction %s allows extra fields", expected.actionType)
+		}
+		properties := variant["properties"].(Schema)
+		if !reflect.DeepEqual(properties["type"].(Schema)["enum"], []any{expected.actionType}) {
+			t.Fatalf("WebSearchAction variant %d type = %#v", index, properties["type"])
+		}
+		if !slices.Equal(schemaRequiredNames(variant), expected.required) {
+			t.Fatalf("WebSearchAction %s required = %v, want %v", expected.actionType, schemaRequiredNames(variant), expected.required)
+		}
+	}
+
+	searchProperties := variants[0].(Schema)["properties"].(Schema)
+	assertNullableStringSchema(t, searchProperties["query"])
+	assertNullableStringArraySchema(t, searchProperties["queries"])
+	openProperties := variants[1].(Schema)["properties"].(Schema)
+	assertNullableStringSchema(t, openProperties["url"])
+	findProperties := variants[2].(Schema)["properties"].(Schema)
+	assertNullableStringSchema(t, findProperties["url"])
+	assertNullableStringSchema(t, findProperties["pattern"])
+}
+
+func TestWebSearchActionWireValidationAndCanonicalization(t *testing.T) {
+	valid := []struct {
+		input string
+		want  string
+	}{
+		{input: `{"type":"search","query":null,"queries":null}`, want: `{"type":"search","query":null,"queries":null}`},
+		{input: `{"type":"search","query":"gollem","queries":["gollem","slang"]}`, want: `{"type":"search","query":"gollem","queries":["gollem","slang"]}`},
+		{input: `{"type":"search","query":"","queries":[]}`, want: `{"type":"search","query":"","queries":[]}`},
+		{input: `{"type":"openPage","url":null}`, want: `{"type":"openPage","url":null}`},
+		{input: `{"type":"openPage","url":"https://example.com"}`, want: `{"type":"openPage","url":"https://example.com"}`},
+		{input: `{"type":"findInPage","url":null,"pattern":null}`, want: `{"type":"findInPage","url":null,"pattern":null}`},
+		{input: `{"type":"findInPage","url":"https://example.com","pattern":"needle"}`, want: `{"type":"findInPage","url":"https://example.com","pattern":"needle"}`},
+		{input: `{"type":"other"}`, want: `{"type":"other"}`},
+	}
+	for _, testCase := range valid {
+		var action WebSearchAction
+		if err := json.Unmarshal([]byte(testCase.input), &action); err != nil {
+			t.Errorf("Unmarshal(%s): %v", testCase.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(action)
+		if err != nil {
+			t.Errorf("Marshal(%s): %v", testCase.input, err)
+			continue
+		}
+		if string(encoded) != testCase.want {
+			t.Errorf("round trip %s = %s, want %s", testCase.input, encoded, testCase.want)
+		}
+	}
+
+	invalid := []string{
+		`null`, `[]`, `{}`,
+		`{"type":"search","queries":null}`,
+		`{"type":"search","query":null}`,
+		`{"type":"search","query":1,"queries":null}`,
+		`{"type":"search","query":null,"queries":"gollem"}`,
+		`{"type":"search","query":null,"queries":["gollem",null]}`,
+		`{"type":"search","query":null,"queries":[1]}`,
+		`{"type":"search","query":null,"queries":null,"url":null}`,
+		`{"type":"openPage"}`,
+		`{"type":"openPage","url":1}`,
+		`{"type":"openPage","url":null,"query":null}`,
+		`{"type":"findInPage","pattern":null}`,
+		`{"type":"findInPage","url":null}`,
+		`{"type":"findInPage","url":false,"pattern":null}`,
+		`{"type":"findInPage","url":null,"pattern":[]}`,
+		`{"type":"findInPage","url":null,"pattern":null,"query":null}`,
+		`{"type":"other","url":null}`,
+		`{"type":"search_web","query":null,"queries":null}`,
+		`{"type":1,"query":null,"queries":null}`,
+		`{"type":"other","extra":true}`,
+	}
+	for _, input := range invalid {
+		var action WebSearchAction
+		if err := json.Unmarshal([]byte(input), &action); err == nil {
+			t.Errorf("Unmarshal(%s) succeeded", input)
+		}
+	}
+}
+
+func TestWebSearchActionEmptyAndNilReceiversFailClosed(t *testing.T) {
+	if _, err := json.Marshal(WebSearchAction{}); err == nil {
+		t.Fatal("Marshal empty WebSearchAction succeeded")
+	}
+	var action *WebSearchAction
+	if err := action.UnmarshalJSON([]byte(`{"type":"other"}`)); err == nil {
+		t.Fatal("nil WebSearchAction receiver succeeded")
+	}
+}
+
+func assertNullableStringArraySchema(t *testing.T, value any) {
+	t.Helper()
+	want := Schema{"oneOf": []any{
+		Schema{"type": "array", "items": Schema{"type": "string"}},
+		Schema{"type": "null"},
+	}}
+	if !reflect.DeepEqual(value, want) {
+		t.Fatalf("nullable string array schema = %#v, want %#v", value, want)
+	}
+}

--- a/appserver/protocol/web_search_action_types.go
+++ b/appserver/protocol/web_search_action_types.go
@@ -1,0 +1,132 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// WebSearchAction retains one validated public web-search action without
+// binding it to Gollem runtime items or provider-specific search payloads.
+type WebSearchAction struct {
+	raw json.RawMessage
+}
+
+func (a WebSearchAction) MarshalJSON() ([]byte, error) {
+	if len(a.raw) == 0 {
+		return nil, errors.New("web-search action has no value")
+	}
+	return validateWebSearchActionJSON(a.raw)
+}
+
+func (a *WebSearchAction) UnmarshalJSON(data []byte) error {
+	if a == nil {
+		return errors.New("decode web-search action into nil receiver")
+	}
+	canonical, err := validateWebSearchActionJSON(data)
+	if err != nil {
+		return err
+	}
+	a.raw = canonical
+	return nil
+}
+
+func validateWebSearchActionJSON(data []byte) (json.RawMessage, error) {
+	payload, err := decodeExactThreadItemObject(
+		data,
+		"web-search action",
+		"type",
+		"query",
+		"queries",
+		"url",
+		"pattern",
+	)
+	if err != nil {
+		return nil, err
+	}
+	actionType, err := decodeRequiredThreadItemValue[string](payload, "web-search action", "type")
+	if err != nil {
+		return nil, err
+	}
+	switch actionType {
+	case "search":
+		if err := rejectThreadItemFields(payload, "search web-search action", "type", "query", "queries"); err != nil {
+			return nil, err
+		}
+		query, err := decodeRequiredNullableThreadItemString(payload, "search web-search action", "query")
+		if err != nil {
+			return nil, err
+		}
+		queries, err := decodeRequiredNullableWebSearchQueries(payload, "search web-search action", "queries")
+		if err != nil {
+			return nil, err
+		}
+		return json.Marshal(struct {
+			Type    string    `json:"type"`
+			Query   *string   `json:"query"`
+			Queries *[]string `json:"queries"`
+		}{Type: actionType, Query: query, Queries: queries})
+	case "openPage":
+		if err := rejectThreadItemFields(payload, "openPage web-search action", "type", "url"); err != nil {
+			return nil, err
+		}
+		url, err := decodeRequiredNullableThreadItemString(payload, "openPage web-search action", "url")
+		if err != nil {
+			return nil, err
+		}
+		return json.Marshal(struct {
+			Type string  `json:"type"`
+			URL  *string `json:"url"`
+		}{Type: actionType, URL: url})
+	case "findInPage":
+		if err := rejectThreadItemFields(payload, "findInPage web-search action", "type", "url", "pattern"); err != nil {
+			return nil, err
+		}
+		url, err := decodeRequiredNullableThreadItemString(payload, "findInPage web-search action", "url")
+		if err != nil {
+			return nil, err
+		}
+		pattern, err := decodeRequiredNullableThreadItemString(payload, "findInPage web-search action", "pattern")
+		if err != nil {
+			return nil, err
+		}
+		return json.Marshal(struct {
+			Type    string  `json:"type"`
+			URL     *string `json:"url"`
+			Pattern *string `json:"pattern"`
+		}{Type: actionType, URL: url, Pattern: pattern})
+	case "other":
+		if err := rejectThreadItemFields(payload, "other web-search action", "type"); err != nil {
+			return nil, err
+		}
+		return json.Marshal(struct {
+			Type string `json:"type"`
+		}{Type: actionType})
+	default:
+		return nil, fmt.Errorf("unknown web-search action type %q", actionType)
+	}
+}
+
+func decodeRequiredNullableWebSearchQueries(payload map[string]json.RawMessage, objectName, fieldName string) (*[]string, error) {
+	raw, ok := payload[fieldName]
+	if !ok {
+		return nil, fmt.Errorf("%s requires %s", objectName, fieldName)
+	}
+	if isJSONNull(raw) {
+		return nil, nil
+	}
+	var elements []json.RawMessage
+	if err := json.Unmarshal(raw, &elements); err != nil {
+		return nil, fmt.Errorf("decode %s %s: %w", objectName, fieldName, err)
+	}
+	values := make([]string, len(elements))
+	for index, element := range elements {
+		if isJSONNull(element) {
+			return nil, fmt.Errorf("decode %s %s[%d]: expected string", objectName, fieldName, index)
+		}
+		if err := json.Unmarshal(element, &values[index]); err != nil {
+			return nil, fmt.Errorf("decode %s %s[%d]: %w", objectName, fieldName, index, err)
+		}
+	}
+	return &values, nil
+}


### PR DESCRIPTION
## Summary
- export the exact public camelCase `WebSearchAction` four-variant union
- require explicit nullable search/open/find fields and reject crossed, unknown, and malformed values
- generate deterministic JSON Schema and framework-neutral TypeScript with strict Go/TS contracts

## Scope
This is a standalone ThreadItem prerequisite. It does not alias the distinct snake_case `ResponsesApiWebSearchAction`, add a search provider, bind a public `ThreadItem`, or change runtime events.

## Verification
- deliberate red Go and TypeScript compiles before implementation/generation
- focused codec helpers at 100% coverage
- `go test -count=1 ./appserver/...`
- `go test -count=1 ./...`
- `go vet ./...`
- deterministic `go generate ./appserver/protocol`
- complete pre-push lint/race/vet/tidy gate
- `git diff --check`