### PR TITLE
feat(protocol): add collab subagent prerequisites

### DIFF
--- a/appserver/protocol/README.md
+++ b/appserver/protocol/README.md
@@ -287,6 +287,16 @@ contract. It does not alias the distinct snake-case
 `ResponsesApiWebSearchAction`, add a search provider, bind a public thread item,
 or change current runtime events.
 
+The schema also exports the exact standalone collab/subagent prerequisite
+values: unrestricted logical `AgentPath`, non-empty open `ReasoningEffort`,
+closed collab status/tool/tool-call-status and subagent activity enums, and
+`CollabAgentState` with required status plus required nullable message. The
+state follows the generated v2 TypeScript required-nullable shape rather than
+the looser `Option`-derived public JSON Schema required list. These definitions
+do not alias current internal agent state, add multi-agent methods, bind collab
+or subagent items, alter provider reasoning settings, or claim full public item
+parity.
+
 ## Generation
 
 Run:

--- a/appserver/protocol/collab_subagent_prerequisites_contract_test.go
+++ b/appserver/protocol/collab_subagent_prerequisites_contract_test.go
@@ -1,0 +1,240 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"testing"
+)
+
+func TestCollabSubagentPrerequisiteSchemasAreExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	if !reflect.DeepEqual(defs["AgentPath"], Schema{"type": "string"}) {
+		t.Fatalf("AgentPath schema = %#v", defs["AgentPath"])
+	}
+	if !reflect.DeepEqual(defs["ReasoningEffort"], Schema{"type": "string", "minLength": 1}) {
+		t.Fatalf("ReasoningEffort schema = %#v", defs["ReasoningEffort"])
+	}
+	assertStringEnumSchema(t, defs, "CollabAgentStatus", []string{
+		"pendingInit", "running", "interrupted", "completed", "errored", "shutdown", "notFound",
+	})
+	assertStringEnumSchema(t, defs, "CollabAgentTool", []string{
+		"spawnAgent", "sendInput", "resumeAgent", "wait", "closeAgent",
+	})
+	assertStringEnumSchema(t, defs, "CollabAgentToolCallStatus", []string{
+		"inProgress", "completed", "failed",
+	})
+	assertStringEnumSchema(t, defs, "SubAgentActivityKind", []string{
+		"started", "interacted", "interrupted",
+	})
+
+	state, ok := defs["CollabAgentState"].(Schema)
+	if !ok {
+		t.Fatal("$defs missing CollabAgentState")
+	}
+	if state["additionalProperties"] != false {
+		t.Fatalf("CollabAgentState allows extra fields: %#v", state)
+	}
+	if !slices.Equal(schemaRequiredNames(state), []string{"status", "message"}) {
+		t.Fatalf("CollabAgentState required = %v", schemaRequiredNames(state))
+	}
+	properties := state["properties"].(Schema)
+	if properties["status"].(Schema)["$ref"] != "#/$defs/CollabAgentStatus" {
+		t.Fatalf("CollabAgentState status = %#v", properties["status"])
+	}
+	assertNullableStringSchema(t, properties["message"])
+}
+
+func TestCollabSubagentEnumsRejectUnknownValues(t *testing.T) {
+	tests := []struct {
+		name    string
+		values  []string
+		decode  func([]byte) error
+		marshal func(string) error
+	}{
+		{
+			name:   "collab status",
+			values: []string{"pendingInit", "running", "interrupted", "completed", "errored", "shutdown", "notFound"},
+			decode: func(data []byte) error {
+				var value CollabAgentStatus
+				return json.Unmarshal(data, &value)
+			},
+			marshal: func(value string) error {
+				_, err := json.Marshal(CollabAgentStatus(value))
+				return err
+			},
+		},
+		{
+			name:   "collab tool",
+			values: []string{"spawnAgent", "sendInput", "resumeAgent", "wait", "closeAgent"},
+			decode: func(data []byte) error {
+				var value CollabAgentTool
+				return json.Unmarshal(data, &value)
+			},
+			marshal: func(value string) error {
+				_, err := json.Marshal(CollabAgentTool(value))
+				return err
+			},
+		},
+		{
+			name:   "collab tool-call status",
+			values: []string{"inProgress", "completed", "failed"},
+			decode: func(data []byte) error {
+				var value CollabAgentToolCallStatus
+				return json.Unmarshal(data, &value)
+			},
+			marshal: func(value string) error {
+				_, err := json.Marshal(CollabAgentToolCallStatus(value))
+				return err
+			},
+		},
+		{
+			name:   "subagent activity",
+			values: []string{"started", "interacted", "interrupted"},
+			decode: func(data []byte) error {
+				var value SubAgentActivityKind
+				return json.Unmarshal(data, &value)
+			},
+			marshal: func(value string) error {
+				_, err := json.Marshal(SubAgentActivityKind(value))
+				return err
+			},
+		},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			for _, value := range testCase.values {
+				if err := testCase.decode([]byte(`"` + value + `"`)); err != nil {
+					t.Errorf("decode %q: %v", value, err)
+				}
+				if err := testCase.marshal(value); err != nil {
+					t.Errorf("marshal %q: %v", value, err)
+				}
+			}
+			for _, data := range [][]byte{[]byte(`null`), []byte(`"unknown"`), []byte(`1`), []byte(`{}`)} {
+				if err := testCase.decode(data); err == nil {
+					t.Errorf("decode %s succeeded", data)
+				}
+			}
+			for _, value := range []string{"", "unknown"} {
+				if err := testCase.marshal(value); err == nil {
+					t.Errorf("marshal %q succeeded", value)
+				}
+			}
+		})
+	}
+
+	var nilStatus *CollabAgentStatus
+	if err := nilStatus.UnmarshalJSON([]byte(`"running"`)); err == nil {
+		t.Fatal("nil CollabAgentStatus receiver succeeded")
+	}
+}
+
+func TestAgentPathAndReasoningEffortWireValidation(t *testing.T) {
+	for _, value := range []string{"", "agent/1", "not/a/filesystem/path"} {
+		var path AgentPath
+		if err := json.Unmarshal([]byte(`"`+value+`"`), &path); err != nil {
+			t.Errorf("decode AgentPath %q: %v", value, err)
+		}
+		encoded, err := json.Marshal(path)
+		if err != nil || string(encoded) != `"`+value+`"` {
+			t.Errorf("marshal AgentPath %q = %s, %v", value, encoded, err)
+		}
+	}
+	for _, data := range []string{`null`, `1`, `{}`} {
+		var path AgentPath
+		if err := json.Unmarshal([]byte(data), &path); err == nil {
+			t.Errorf("decode AgentPath %s succeeded", data)
+		}
+	}
+	var nilPath *AgentPath
+	if err := nilPath.UnmarshalJSON([]byte(`"agent/1"`)); err == nil {
+		t.Fatal("nil AgentPath receiver succeeded")
+	}
+
+	for _, value := range []string{"low", "custom", " "} {
+		var effort ReasoningEffort
+		if err := json.Unmarshal([]byte(`"`+value+`"`), &effort); err != nil {
+			t.Errorf("decode ReasoningEffort %q: %v", value, err)
+		}
+		encoded, err := json.Marshal(effort)
+		if err != nil || string(encoded) != `"`+value+`"` {
+			t.Errorf("marshal ReasoningEffort %q = %s, %v", value, encoded, err)
+		}
+	}
+	for _, data := range []string{`null`, `""`, `1`, `{}`} {
+		var effort ReasoningEffort
+		if err := json.Unmarshal([]byte(data), &effort); err == nil {
+			t.Errorf("decode ReasoningEffort %s succeeded", data)
+		}
+	}
+	if _, err := json.Marshal(ReasoningEffort("")); err == nil {
+		t.Fatal("marshal empty ReasoningEffort succeeded")
+	}
+	var nilEffort *ReasoningEffort
+	if err := nilEffort.UnmarshalJSON([]byte(`"low"`)); err == nil {
+		t.Fatal("nil ReasoningEffort receiver succeeded")
+	}
+}
+
+func TestCollabAgentStateWireValidation(t *testing.T) {
+	valid := []struct {
+		input string
+		want  string
+	}{
+		{input: `{"status":"pendingInit","message":null}`, want: `{"status":"pendingInit","message":null}`},
+		{input: `{"status":"running","message":"working"}`, want: `{"status":"running","message":"working"}`},
+		{input: `{"status":"completed","message":""}`, want: `{"status":"completed","message":""}`},
+	}
+	for _, testCase := range valid {
+		var state CollabAgentState
+		if err := json.Unmarshal([]byte(testCase.input), &state); err != nil {
+			t.Errorf("Unmarshal(%s): %v", testCase.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(state)
+		if err != nil || string(encoded) != testCase.want {
+			t.Errorf("round trip %s = %s, %v", testCase.input, encoded, err)
+		}
+	}
+	for _, input := range []string{
+		`null`, `[]`, `{}`,
+		`{"status":"running"}`,
+		`{"message":null}`,
+		`{"status":null,"message":null}`,
+		`{"status":"unknown","message":null}`,
+		`{"status":"running","message":1}`,
+		`{"status":"running","message":null,"extra":true}`,
+	} {
+		var state CollabAgentState
+		if err := json.Unmarshal([]byte(input), &state); err == nil {
+			t.Errorf("Unmarshal(%s) succeeded", input)
+		}
+	}
+	if _, err := json.Marshal(CollabAgentState{Message: nil}); err == nil {
+		t.Fatal("marshal CollabAgentState with empty status succeeded")
+	}
+	var nilState *CollabAgentState
+	if err := nilState.UnmarshalJSON([]byte(`{"status":"running","message":null}`)); err == nil {
+		t.Fatal("nil CollabAgentState receiver succeeded")
+	}
+}
+
+func assertStringEnumSchema(t *testing.T, defs Schema, name string, want []string) {
+	t.Helper()
+	schema, ok := defs[name].(Schema)
+	if !ok {
+		t.Fatalf("$defs missing %s", name)
+	}
+	values, ok := schema["enum"].([]any)
+	if !ok {
+		t.Fatalf("%s enum = %#v", name, schema["enum"])
+	}
+	got := make([]string, len(values))
+	for index, value := range values {
+		got[index] = value.(string)
+	}
+	if schema["type"] != "string" || !slices.Equal(got, want) {
+		t.Fatalf("%s schema = %#v, want %v", name, schema, want)
+	}
+}

--- a/appserver/protocol/collab_subagent_prerequisites_types.go
+++ b/appserver/protocol/collab_subagent_prerequisites_types.go
@@ -1,0 +1,228 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// AgentPath is the public logical agent identifier path. It is not a local
+// filesystem path and intentionally has no normalization or non-empty rule.
+type AgentPath string
+
+func (p AgentPath) MarshalJSON() ([]byte, error) {
+	return json.Marshal(string(p))
+}
+
+func (p *AgentPath) UnmarshalJSON(data []byte) error {
+	if p == nil {
+		return errors.New("decode agent path into nil receiver")
+	}
+	value, err := decodeRequiredCollabString(data, "agent path")
+	if err != nil {
+		return err
+	}
+	*p = AgentPath(value)
+	return nil
+}
+
+// ReasoningEffort is a non-empty provider-advertised reasoning effort value.
+// The public TypeScript contract remains string because the value is open.
+type ReasoningEffort string
+
+func (e ReasoningEffort) MarshalJSON() ([]byte, error) {
+	if e == "" {
+		return nil, errors.New("reasoning effort cannot be empty")
+	}
+	return json.Marshal(string(e))
+}
+
+func (e *ReasoningEffort) UnmarshalJSON(data []byte) error {
+	if e == nil {
+		return errors.New("decode reasoning effort into nil receiver")
+	}
+	value, err := decodeRequiredCollabString(data, "reasoning effort")
+	if err != nil {
+		return err
+	}
+	if value == "" {
+		return errors.New("reasoning effort cannot be empty")
+	}
+	*e = ReasoningEffort(value)
+	return nil
+}
+
+type CollabAgentStatus string
+
+const (
+	CollabAgentStatusPendingInit CollabAgentStatus = "pendingInit"
+	CollabAgentStatusRunning     CollabAgentStatus = "running"
+	CollabAgentStatusInterrupted CollabAgentStatus = "interrupted"
+	CollabAgentStatusCompleted   CollabAgentStatus = "completed"
+	CollabAgentStatusErrored     CollabAgentStatus = "errored"
+	CollabAgentStatusShutdown    CollabAgentStatus = "shutdown"
+	CollabAgentStatusNotFound    CollabAgentStatus = "notFound"
+)
+
+func (s CollabAgentStatus) MarshalJSON() ([]byte, error) {
+	return marshalClosedCollabValue("collab agent status", s, collabAgentStatuses...)
+}
+
+func (s *CollabAgentStatus) UnmarshalJSON(data []byte) error {
+	return unmarshalClosedCollabValue(data, "collab agent status", s, collabAgentStatuses...)
+}
+
+var collabAgentStatuses = []CollabAgentStatus{
+	CollabAgentStatusPendingInit,
+	CollabAgentStatusRunning,
+	CollabAgentStatusInterrupted,
+	CollabAgentStatusCompleted,
+	CollabAgentStatusErrored,
+	CollabAgentStatusShutdown,
+	CollabAgentStatusNotFound,
+}
+
+type CollabAgentTool string
+
+const (
+	CollabAgentToolSpawnAgent  CollabAgentTool = "spawnAgent"
+	CollabAgentToolSendInput   CollabAgentTool = "sendInput"
+	CollabAgentToolResumeAgent CollabAgentTool = "resumeAgent"
+	CollabAgentToolWait        CollabAgentTool = "wait"
+	CollabAgentToolCloseAgent  CollabAgentTool = "closeAgent"
+)
+
+func (t CollabAgentTool) MarshalJSON() ([]byte, error) {
+	return marshalClosedCollabValue("collab agent tool", t, collabAgentTools...)
+}
+
+func (t *CollabAgentTool) UnmarshalJSON(data []byte) error {
+	return unmarshalClosedCollabValue(data, "collab agent tool", t, collabAgentTools...)
+}
+
+var collabAgentTools = []CollabAgentTool{
+	CollabAgentToolSpawnAgent,
+	CollabAgentToolSendInput,
+	CollabAgentToolResumeAgent,
+	CollabAgentToolWait,
+	CollabAgentToolCloseAgent,
+}
+
+type CollabAgentToolCallStatus string
+
+const (
+	CollabAgentToolCallStatusInProgress CollabAgentToolCallStatus = "inProgress"
+	CollabAgentToolCallStatusCompleted  CollabAgentToolCallStatus = "completed"
+	CollabAgentToolCallStatusFailed     CollabAgentToolCallStatus = "failed"
+)
+
+func (s CollabAgentToolCallStatus) MarshalJSON() ([]byte, error) {
+	return marshalClosedCollabValue("collab agent tool-call status", s, collabAgentToolCallStatuses...)
+}
+
+func (s *CollabAgentToolCallStatus) UnmarshalJSON(data []byte) error {
+	return unmarshalClosedCollabValue(data, "collab agent tool-call status", s, collabAgentToolCallStatuses...)
+}
+
+var collabAgentToolCallStatuses = []CollabAgentToolCallStatus{
+	CollabAgentToolCallStatusInProgress,
+	CollabAgentToolCallStatusCompleted,
+	CollabAgentToolCallStatusFailed,
+}
+
+type SubAgentActivityKind string
+
+const (
+	SubAgentActivityStarted     SubAgentActivityKind = "started"
+	SubAgentActivityInteracted  SubAgentActivityKind = "interacted"
+	SubAgentActivityInterrupted SubAgentActivityKind = "interrupted"
+)
+
+func (k SubAgentActivityKind) MarshalJSON() ([]byte, error) {
+	return marshalClosedCollabValue("subagent activity kind", k, subAgentActivityKinds...)
+}
+
+func (k *SubAgentActivityKind) UnmarshalJSON(data []byte) error {
+	return unmarshalClosedCollabValue(data, "subagent activity kind", k, subAgentActivityKinds...)
+}
+
+var subAgentActivityKinds = []SubAgentActivityKind{
+	SubAgentActivityStarted,
+	SubAgentActivityInteracted,
+	SubAgentActivityInterrupted,
+}
+
+type CollabAgentState struct {
+	Status  CollabAgentStatus `json:"status"`
+	Message *string           `json:"message"`
+}
+
+func (s CollabAgentState) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Status  CollabAgentStatus `json:"status"`
+		Message *string           `json:"message"`
+	}{Status: s.Status, Message: s.Message})
+}
+
+func (s *CollabAgentState) UnmarshalJSON(data []byte) error {
+	if s == nil {
+		return errors.New("decode collab agent state into nil receiver")
+	}
+	payload, err := decodeExactThreadItemObject(data, "collab agent state", "status", "message")
+	if err != nil {
+		return err
+	}
+	status, err := decodeRequiredThreadItemValue[CollabAgentStatus](payload, "collab agent state", "status")
+	if err != nil {
+		return err
+	}
+	message, err := decodeRequiredNullableThreadItemString(payload, "collab agent state", "message")
+	if err != nil {
+		return err
+	}
+	*s = CollabAgentState{Status: status, Message: message}
+	return nil
+}
+
+func decodeRequiredCollabString(data []byte, name string) (string, error) {
+	if isJSONNull(data) {
+		return "", fmt.Errorf("%s cannot be null", name)
+	}
+	var value string
+	if err := json.Unmarshal(data, &value); err != nil {
+		return "", fmt.Errorf("decode %s: %w", name, err)
+	}
+	return value, nil
+}
+
+func marshalClosedCollabValue[T ~string](name string, value T, allowed ...T) ([]byte, error) {
+	if !isAllowedCollabValue(value, allowed) {
+		return nil, fmt.Errorf("unknown %s %q", name, value)
+	}
+	return json.Marshal(string(value))
+}
+
+func unmarshalClosedCollabValue[T ~string](data []byte, name string, target *T, allowed ...T) error {
+	if target == nil {
+		return fmt.Errorf("decode %s into nil receiver", name)
+	}
+	value, err := decodeRequiredCollabString(data, name)
+	if err != nil {
+		return err
+	}
+	parsed := T(value)
+	if !isAllowedCollabValue(parsed, allowed) {
+		return fmt.Errorf("unknown %s %q", name, value)
+	}
+	*target = parsed
+	return nil
+}
+
+func isAllowedCollabValue[T comparable](value T, allowed []T) bool {
+	for _, candidate := range allowed {
+		if value == candidate {
+			return true
+		}
+	}
+	return false
+}

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -83,6 +83,7 @@ func wireSchemaDefinitions() Schema {
 	definitions := []wireSchemaDefinition{
 		{Name: "AbsolutePathBuf", Type: reflect.TypeFor[AbsolutePathBuf]()},
 		{Name: "ActivePermissionProfile", Type: reflect.TypeFor[ActivePermissionProfile]()},
+		{Name: "AgentPath", Type: reflect.TypeFor[AgentPath]()},
 		{Name: "AdditionalFileSystemPermissions", Type: reflect.TypeFor[AdditionalFileSystemPermissions]()},
 		{Name: "AdditionalNetworkPermissions", Type: reflect.TypeFor[AdditionalNetworkPermissions]()},
 		{Name: "AdditionalPermissionProfile", Type: reflect.TypeFor[AdditionalPermissionProfile]()},
@@ -91,6 +92,10 @@ func wireSchemaDefinitions() Schema {
 		{Name: "ApprovalRespondResult", Type: reflect.TypeFor[ApprovalRespondResult]()},
 		{Name: "ByteRange", Type: reflect.TypeFor[ByteRange]()},
 		{Name: "ClientInfo", Type: reflect.TypeFor[ClientInfo]()},
+		{Name: "CollabAgentState", Type: reflect.TypeFor[CollabAgentState]()},
+		{Name: "CollabAgentStatus", Type: reflect.TypeFor[CollabAgentStatus]()},
+		{Name: "CollabAgentTool", Type: reflect.TypeFor[CollabAgentTool]()},
+		{Name: "CollabAgentToolCallStatus", Type: reflect.TypeFor[CollabAgentToolCallStatus]()},
 		{Name: "CommandAction", Type: reflect.TypeFor[CommandAction]()},
 		{Name: "CommandExecOutputDeltaNotification", Type: reflect.TypeFor[CommandExecOutputDeltaNotification]()},
 		{Name: "CommandExecOutputStream", Type: reflect.TypeFor[CommandExecOutputStream]()},
@@ -215,10 +220,12 @@ func wireSchemaDefinitions() Schema {
 		{Name: "PermissionsRequestApprovalParams", Type: reflect.TypeFor[PermissionsRequestApprovalParams]()},
 		{Name: "PermissionsRequestApprovalResponse", Type: reflect.TypeFor[PermissionsRequestApprovalResponse]()},
 		{Name: "RequestPermissionProfile", Type: reflect.TypeFor[RequestPermissionProfile]()},
+		{Name: "ReasoningEffort", Type: reflect.TypeFor[ReasoningEffort]()},
 		{Name: "ServerRequestResolvedNotificationParams", Type: reflect.TypeFor[ServerRequestResolvedNotificationParams]()},
 		{Name: "ServerCapabilities", Type: reflect.TypeFor[ServerCapabilities]()},
 		{Name: "Surface", Type: reflect.TypeFor[Surface]()},
 		{Name: "SortDirection", Type: reflect.TypeFor[SortDirection]()},
+		{Name: "SubAgentActivityKind", Type: reflect.TypeFor[SubAgentActivityKind]()},
 		{Name: "ThreadArchiveParams", Type: reflect.TypeFor[ThreadArchiveParams]()},
 		{Name: "ThreadArchiveResponse", Type: reflect.TypeFor[ThreadArchiveResponse]()},
 		{Name: "ThreadArchivedNotification", Type: reflect.TypeFor[ThreadArchivedNotification]()},
@@ -320,6 +327,28 @@ func wireSchemaDefinitions() Schema {
 		string(SurfaceGollemExtension),
 	)
 	schemas["SortDirection"] = stringEnumSchema(string(SortDirectionAsc), string(SortDirectionDesc))
+	schemas["AgentPath"] = Schema{"type": "string"}
+	schemas["ReasoningEffort"] = Schema{"type": "string", "minLength": 1}
+	schemas["CollabAgentStatus"] = stringEnumSchema(
+		string(CollabAgentStatusPendingInit), string(CollabAgentStatusRunning),
+		string(CollabAgentStatusInterrupted), string(CollabAgentStatusCompleted),
+		string(CollabAgentStatusErrored), string(CollabAgentStatusShutdown),
+		string(CollabAgentStatusNotFound),
+	)
+	schemas["CollabAgentTool"] = stringEnumSchema(
+		string(CollabAgentToolSpawnAgent), string(CollabAgentToolSendInput),
+		string(CollabAgentToolResumeAgent), string(CollabAgentToolWait),
+		string(CollabAgentToolCloseAgent),
+	)
+	schemas["CollabAgentToolCallStatus"] = stringEnumSchema(
+		string(CollabAgentToolCallStatusInProgress), string(CollabAgentToolCallStatusCompleted),
+		string(CollabAgentToolCallStatusFailed),
+	)
+	schemas["SubAgentActivityKind"] = stringEnumSchema(
+		string(SubAgentActivityStarted), string(SubAgentActivityInteracted),
+		string(SubAgentActivityInterrupted),
+	)
+	schemas["CollabAgentState"] = collabAgentStateSchema()
 	setSchemaIntegerMinimum(schemas["ByteRange"].(Schema), 0, "start", "end")
 	schemas["ImageDetail"] = stringEnumSchema(
 		string(ImageDetailAuto), string(ImageDetailLow), string(ImageDetailHigh), string(ImageDetailOriginal),
@@ -518,6 +547,18 @@ func commandActionSchema() Schema {
 			"command": Schema{"type": "string"},
 		}),
 	}}
+}
+
+func collabAgentStateSchema() Schema {
+	return Schema{
+		"type": "object",
+		"properties": Schema{
+			"status":  Schema{"$ref": "#/$defs/CollabAgentStatus"},
+			"message": nullableStringSchema(),
+		},
+		"required":             []string{"status", "message"},
+		"additionalProperties": false,
+	}
 }
 
 func commandActionVariantSchema(actionType string, requiredFields []string, fields Schema) Schema {

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -124,6 +124,9 @@
       ],
       "type": "object"
     },
+    "AgentPath": {
+      "type": "string"
+    },
     "ApprovalRequestBase": {
       "additionalProperties": false,
       "properties": {
@@ -236,6 +239,59 @@
         "version"
       ],
       "type": "object"
+    },
+    "CollabAgentState": {
+      "additionalProperties": false,
+      "properties": {
+        "message": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "status": {
+          "$ref": "#/$defs/CollabAgentStatus"
+        }
+      },
+      "required": [
+        "status",
+        "message"
+      ],
+      "type": "object"
+    },
+    "CollabAgentStatus": {
+      "enum": [
+        "pendingInit",
+        "running",
+        "interrupted",
+        "completed",
+        "errored",
+        "shutdown",
+        "notFound"
+      ],
+      "type": "string"
+    },
+    "CollabAgentTool": {
+      "enum": [
+        "spawnAgent",
+        "sendInput",
+        "resumeAgent",
+        "wait",
+        "closeAgent"
+      ],
+      "type": "string"
+    },
+    "CollabAgentToolCallStatus": {
+      "enum": [
+        "inProgress",
+        "completed",
+        "failed"
+      ],
+      "type": "string"
     },
     "CommandAction": {
       "oneOf": [
@@ -4033,6 +4089,10 @@
       ],
       "type": "object"
     },
+    "ReasoningEffort": {
+      "minLength": 1,
+      "type": "string"
+    },
     "Request": {
       "additionalProperties": false,
       "properties": {
@@ -4305,6 +4365,14 @@
       "enum": [
         "asc",
         "desc"
+      ],
+      "type": "string"
+    },
+    "SubAgentActivityKind": {
+      "enum": [
+        "started",
+        "interacted",
+        "interrupted"
       ],
       "type": "string"
     },

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -515,6 +515,8 @@ export type AdditionalPermissionProfile = {
   "network": AdditionalNetworkPermissions | null;
 };
 
+export type AgentPath = string;
+
 export type ApprovalRequestBase = {
   "itemId": string;
   "reason"?: string;
@@ -546,6 +548,17 @@ export type ClientInfo = {
   "title"?: string | null;
   "version": string;
 };
+
+export type CollabAgentState = {
+  "message": string | null;
+  "status": CollabAgentStatus;
+};
+
+export type CollabAgentStatus = "pendingInit" | "running" | "interrupted" | "completed" | "errored" | "shutdown" | "notFound";
+
+export type CollabAgentTool = "spawnAgent" | "sendInput" | "resumeAgent" | "wait" | "closeAgent";
+
+export type CollabAgentToolCallStatus = "inProgress" | "completed" | "failed";
 
 export type CommandAction = {
   "command": string;
@@ -1450,6 +1463,8 @@ export type PermissionsRequestApprovalResponse = {
   "strictAutoReview"?: boolean;
 };
 
+export type ReasoningEffort = string;
+
 export type Request = {
   "id": RequestID;
   "method": "account/login/cancel" | "account/login/start" | "account/logout" | "account/rateLimitResetCredit/consume" | "account/rateLimits/read" | "account/read" | "account/sendAddCreditsNudgeEmail" | "account/usage/read" | "account/workspaceMessages/read" | "app/list" | "collaborationMode/list" | "command/exec" | "command/exec/resize" | "command/exec/terminate" | "command/exec/write" | "config/batchWrite" | "config/mcpServer/reload" | "config/read" | "config/value/write" | "configRequirements/read" | "environment/add" | "environment/info" | "experimentalFeature/enablement/set" | "experimentalFeature/list" | "externalAgentConfig/detect" | "externalAgentConfig/import" | "externalAgentConfig/import/readHistories" | "feedback/upload" | "fs/copy" | "fs/createDirectory" | "fs/getMetadata" | "fs/readDirectory" | "fs/readFile" | "fs/remove" | "fs/unwatch" | "fs/watch" | "fs/writeFile" | "fuzzyFileSearch" | "fuzzyFileSearch/sessionStart" | "fuzzyFileSearch/sessionStop" | "fuzzyFileSearch/sessionUpdate" | "getAuthStatus" | "getConversationSummary" | "gitDiffToRemote" | "hooks/list" | "initialize" | "marketplace/add" | "marketplace/remove" | "marketplace/upgrade" | "mcpServer/oauth/login" | "mcpServer/resource/read" | "mcpServer/tool/call" | "mcpServerStatus/list" | "memory/reset" | "mock/experimentalMethod" | "model/list" | "modelProvider/capabilities/read" | "permissionProfile/list" | "plugin/install" | "plugin/installed" | "plugin/list" | "plugin/read" | "plugin/share/checkout" | "plugin/share/delete" | "plugin/share/list" | "plugin/share/save" | "plugin/share/updateTargets" | "plugin/skill/read" | "plugin/uninstall" | "process/kill" | "process/resizePty" | "process/spawn" | "process/writeStdin" | "remoteControl/client/list" | "remoteControl/client/revoke" | "remoteControl/disable" | "remoteControl/enable" | "remoteControl/pairing/start" | "remoteControl/pairing/status" | "remoteControl/status/read" | "review/start" | "skills/config/write" | "skills/extraRoots/set" | "skills/list" | "thread/approveGuardianDeniedAction" | "thread/archive" | "thread/backgroundTerminals/clean" | "thread/backgroundTerminals/list" | "thread/backgroundTerminals/terminate" | "thread/compact/start" | "thread/decrement_elicitation" | "thread/delete" | "thread/fork" | "thread/goal/clear" | "thread/goal/get" | "thread/goal/set" | "thread/increment_elicitation" | "thread/inject_items" | "thread/items/list" | "thread/list" | "thread/loaded/list" | "thread/memoryMode/set" | "thread/metadata/update" | "thread/name/set" | "thread/read" | "thread/realtime/appendAudio" | "thread/realtime/appendSpeech" | "thread/realtime/appendText" | "thread/realtime/listVoices" | "thread/realtime/start" | "thread/realtime/stop" | "thread/resume" | "thread/rollback" | "thread/search" | "thread/settings/update" | "thread/shellCommand" | "thread/start" | "thread/turns/list" | "thread/unarchive" | "thread/unsubscribe" | "turn/interrupt" | "turn/start" | "turn/steer" | "windowsSandbox/readiness" | "windowsSandbox/setupStart" | "approval/respond" | "cache/benchmark" | "cache/stats" | "daemon/restart" | "daemon/start" | "daemon/status" | "daemon/stop" | "daemon/version" | "git/commit" | "git/diff" | "git/status" | "git/worktree/create" | "git/worktree/list" | "provider/capabilities/read" | "provider/list" | "tool/list" | "turn/retry";
@@ -1485,6 +1500,8 @@ export type ServerRequestResolvedNotification = {
 export type ServerRequestResolvedNotificationParams = ServerRequestResolvedNotification;
 
 export type SortDirection = "asc" | "desc";
+
+export type SubAgentActivityKind = "started" | "interacted" | "interrupted";
 
 export type Surface = "client-request" | "server-notification" | "server-request" | "client-notification" | "gollem-extension";
 

--- a/appserver/protocol/typescript/testdata/collab_subagent_prerequisites_contract.ts
+++ b/appserver/protocol/typescript/testdata/collab_subagent_prerequisites_contract.ts
@@ -1,0 +1,55 @@
+import type {
+  AgentPath,
+  CollabAgentState,
+  CollabAgentStatus,
+  CollabAgentTool,
+  CollabAgentToolCallStatus,
+  ReasoningEffort,
+  SubAgentActivityKind,
+} from "../gollem_appserver_protocol";
+
+export const agentPath = "agent/1" satisfies AgentPath;
+export const reasoningEffort = "custom" satisfies ReasoningEffort;
+export const collabStatuses = [
+  "pendingInit",
+  "running",
+  "interrupted",
+  "completed",
+  "errored",
+  "shutdown",
+  "notFound",
+] satisfies CollabAgentStatus[];
+export const collabTools = [
+  "spawnAgent",
+  "sendInput",
+  "resumeAgent",
+  "wait",
+  "closeAgent",
+] satisfies CollabAgentTool[];
+export const toolCallStatuses = [
+  "inProgress",
+  "completed",
+  "failed",
+] satisfies CollabAgentToolCallStatus[];
+export const activityKinds = [
+  "started",
+  "interacted",
+  "interrupted",
+] satisfies SubAgentActivityKind[];
+export const states = [
+  { status: "pendingInit", message: null },
+  { status: "running", message: "working" },
+] satisfies CollabAgentState[];
+
+// @ts-expect-error CollabAgentState message is required nullable.
+export const rejectMissingMessage = { status: "running" } satisfies CollabAgentState;
+// @ts-expect-error CollabAgentState status is closed.
+export const rejectUnknownStatus = { status: "unknown", message: null } satisfies CollabAgentState;
+// @ts-expect-error CollabAgentStatus is closed and camelCase.
+export const rejectSnakeCaseStatus = "pending_init" satisfies CollabAgentStatus;
+// @ts-expect-error CollabAgentTool is closed and camelCase.
+export const rejectUnknownTool = "spawn_agent" satisfies CollabAgentTool;
+// @ts-expect-error CollabAgentToolCallStatus is closed.
+export const rejectUnknownToolStatus = "pending" satisfies CollabAgentToolCallStatus;
+// @ts-expect-error SubAgentActivityKind is closed.
+export const rejectUnknownActivity = "completed" satisfies SubAgentActivityKind;


### PR DESCRIPTION
## Summary
- export exact `AgentPath`, `ReasoningEffort`, collab status/tool/tool-call-status, state, and subagent activity contracts
- enforce closed enums, non-empty reasoning effort, and required nullable collab-state messages
- generate deterministic JSON Schema and framework-neutral TypeScript with strict Go/TS contracts

## Scope
These are standalone dependency values only. This does not alias internal multi-agent state, add agent methods, synthesize collab/subagent items, alter provider reasoning settings, or bind lifecycle behavior.

## Verification
- deliberate red Go and TypeScript compiles before implementation/generation
- all new codecs/helpers at 100% focused coverage
- `go test -count=1 ./appserver/...`
- `go test -count=1 ./...`
- `go vet ./...`
- deterministic `go generate ./appserver/protocol`
- complete pre-push lint/race/vet/tidy gate
- `git diff --check`