### PR TITLE
feat(protocol): add raw response content prerequisites

### DIFF
--- a/appserver/protocol/README.md
+++ b/appserver/protocol/README.md
@@ -297,6 +297,14 @@ do not alias current internal agent state, add multi-agent methods, bind collab
 or subagent items, alter provider reasoning settings, or claim full public item
 parity.
 
+The exact standalone raw-response content prerequisites are exported as strict
+validated unions: snake-case input-text/encrypted-content agent message input,
+reasoning-text/text reasoning content, and summary-text reasoning summary.
+Required content stays non-null, crossed and unknown fields fail closed, and
+canonical output preserves public snake-case names. These definitions do not
+export full `ResponseItem`, bind raw-response notifications, map provider
+payloads, or change live agent/reasoning deltas.
+
 ## Generation
 
 Run:

--- a/appserver/protocol/raw_response_content_prerequisites_contract_test.go
+++ b/appserver/protocol/raw_response_content_prerequisites_contract_test.go
@@ -1,0 +1,164 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"testing"
+)
+
+func TestRawResponseContentPrerequisiteSchemasAreExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	assertRawResponseContentSchema(t, defs, "AgentMessageInputContent", []rawResponseContentVariantExpectation{
+		{contentType: "input_text", field: "text"},
+		{contentType: "encrypted_content", field: "encrypted_content"},
+	})
+	assertRawResponseContentSchema(t, defs, "ReasoningItemContent", []rawResponseContentVariantExpectation{
+		{contentType: "reasoning_text", field: "text"},
+		{contentType: "text", field: "text"},
+	})
+	assertRawResponseContentSchema(t, defs, "ReasoningItemReasoningSummary", []rawResponseContentVariantExpectation{
+		{contentType: "summary_text", field: "text"},
+	})
+}
+
+func TestRawResponseContentPrerequisiteWireValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		valid   []string
+		invalid []string
+		decode  func([]byte) (json.Marshaler, error)
+		empty   json.Marshaler
+		nilCall func() error
+	}{
+		{
+			name:  "agent message input content",
+			valid: []string{`{"type":"input_text","text":"hello"}`, `{"type":"input_text","text":""}`, `{"type":"encrypted_content","encrypted_content":"cipher"}`},
+			invalid: []string{
+				`null`, `[]`, `{}`,
+				`{"type":"input_text"}`,
+				`{"type":"input_text","text":null}`,
+				`{"type":"input_text","text":"hello","encrypted_content":"cipher"}`,
+				`{"type":"encrypted_content"}`,
+				`{"type":"encrypted_content","encrypted_content":null}`,
+				`{"type":"encrypted_content","encryptedContent":"cipher"}`,
+				`{"type":"text","text":"hello"}`,
+				`{"type":1,"text":"hello"}`,
+				`{"type":"input_text","text":"hello","extra":true}`,
+			},
+			decode: func(data []byte) (json.Marshaler, error) {
+				var value AgentMessageInputContent
+				err := json.Unmarshal(data, &value)
+				return value, err
+			},
+			empty: AgentMessageInputContent{},
+			nilCall: func() error {
+				var value *AgentMessageInputContent
+				return value.UnmarshalJSON([]byte(`{"type":"input_text","text":"hello"}`))
+			},
+		},
+		{
+			name:  "reasoning item content",
+			valid: []string{`{"type":"reasoning_text","text":"thinking"}`, `{"type":"text","text":"visible"}`, `{"type":"text","text":""}`},
+			invalid: []string{
+				`null`, `[]`, `{}`,
+				`{"type":"reasoning_text"}`,
+				`{"type":"reasoning_text","text":null}`,
+				`{"type":"reasoningText","text":"thinking"}`,
+				`{"type":"text","encrypted_content":"cipher"}`,
+				`{"type":"text","text":"visible","extra":true}`,
+			},
+			decode: func(data []byte) (json.Marshaler, error) {
+				var value ReasoningItemContent
+				err := json.Unmarshal(data, &value)
+				return value, err
+			},
+			empty: ReasoningItemContent{},
+			nilCall: func() error {
+				var value *ReasoningItemContent
+				return value.UnmarshalJSON([]byte(`{"type":"text","text":"visible"}`))
+			},
+		},
+		{
+			name:  "reasoning summary content",
+			valid: []string{`{"type":"summary_text","text":"summary"}`, `{"type":"summary_text","text":""}`},
+			invalid: []string{
+				`null`, `[]`, `{}`,
+				`{"type":"summary_text"}`,
+				`{"type":"summary_text","text":null}`,
+				`{"type":"summaryText","text":"summary"}`,
+				`{"type":"text","text":"summary"}`,
+				`{"type":"summary_text","text":"summary","extra":true}`,
+			},
+			decode: func(data []byte) (json.Marshaler, error) {
+				var value ReasoningItemReasoningSummary
+				err := json.Unmarshal(data, &value)
+				return value, err
+			},
+			empty: ReasoningItemReasoningSummary{},
+			nilCall: func() error {
+				var value *ReasoningItemReasoningSummary
+				return value.UnmarshalJSON([]byte(`{"type":"summary_text","text":"summary"}`))
+			},
+		},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			for _, input := range testCase.valid {
+				value, err := testCase.decode([]byte(input))
+				if err != nil {
+					t.Errorf("Unmarshal(%s): %v", input, err)
+					continue
+				}
+				encoded, err := json.Marshal(value)
+				if err != nil || string(encoded) != input {
+					t.Errorf("round trip %s = %s, %v", input, encoded, err)
+				}
+			}
+			for _, input := range testCase.invalid {
+				if _, err := testCase.decode([]byte(input)); err == nil {
+					t.Errorf("Unmarshal(%s) succeeded", input)
+				}
+			}
+			if _, err := json.Marshal(testCase.empty); err == nil {
+				t.Fatal("Marshal empty value succeeded")
+			}
+			if err := testCase.nilCall(); err == nil {
+				t.Fatal("nil receiver succeeded")
+			}
+		})
+	}
+}
+
+type rawResponseContentVariantExpectation struct {
+	contentType string
+	field       string
+}
+
+func assertRawResponseContentSchema(t *testing.T, defs Schema, name string, want []rawResponseContentVariantExpectation) {
+	t.Helper()
+	schema, ok := defs[name].(Schema)
+	if !ok {
+		t.Fatalf("$defs missing %s", name)
+	}
+	variants, ok := schema["oneOf"].([]any)
+	if !ok || len(variants) != len(want) {
+		t.Fatalf("%s variants = %#v", name, schema["oneOf"])
+	}
+	for index, expected := range want {
+		variant := variants[index].(Schema)
+		if variant["additionalProperties"] != false {
+			t.Fatalf("%s %s allows extra fields", name, expected.contentType)
+		}
+		properties := variant["properties"].(Schema)
+		if !reflect.DeepEqual(properties["type"].(Schema)["enum"], []any{expected.contentType}) {
+			t.Fatalf("%s variant %d type = %#v", name, index, properties["type"])
+		}
+		if !slices.Equal(schemaRequiredNames(variant), []string{"type", expected.field}) {
+			t.Fatalf("%s %s required = %v", name, expected.contentType, schemaRequiredNames(variant))
+		}
+		if !reflect.DeepEqual(properties[expected.field], Schema{"type": "string"}) {
+			t.Fatalf("%s %s field = %#v", name, expected.contentType, properties[expected.field])
+		}
+	}
+}

--- a/appserver/protocol/raw_response_content_prerequisites_types.go
+++ b/appserver/protocol/raw_response_content_prerequisites_types.go
@@ -1,0 +1,144 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+type AgentMessageInputContent struct {
+	raw json.RawMessage
+}
+
+func (c AgentMessageInputContent) MarshalJSON() ([]byte, error) {
+	if len(c.raw) == 0 {
+		return nil, errors.New("agent message input content has no value")
+	}
+	return validateRawResponseContentJSON(c.raw, "agent message input content", agentMessageInputContentVariants)
+}
+
+func (c *AgentMessageInputContent) UnmarshalJSON(data []byte) error {
+	if c == nil {
+		return errors.New("decode agent message input content into nil receiver")
+	}
+	canonical, err := validateRawResponseContentJSON(data, "agent message input content", agentMessageInputContentVariants)
+	if err != nil {
+		return err
+	}
+	c.raw = canonical
+	return nil
+}
+
+var agentMessageInputContentVariants = []rawResponseContentVariant{
+	{contentType: "input_text", field: "text"},
+	{contentType: "encrypted_content", field: "encrypted_content"},
+}
+
+type ReasoningItemContent struct {
+	raw json.RawMessage
+}
+
+func (c ReasoningItemContent) MarshalJSON() ([]byte, error) {
+	if len(c.raw) == 0 {
+		return nil, errors.New("reasoning item content has no value")
+	}
+	return validateRawResponseContentJSON(c.raw, "reasoning item content", reasoningItemContentVariants)
+}
+
+func (c *ReasoningItemContent) UnmarshalJSON(data []byte) error {
+	if c == nil {
+		return errors.New("decode reasoning item content into nil receiver")
+	}
+	canonical, err := validateRawResponseContentJSON(data, "reasoning item content", reasoningItemContentVariants)
+	if err != nil {
+		return err
+	}
+	c.raw = canonical
+	return nil
+}
+
+var reasoningItemContentVariants = []rawResponseContentVariant{
+	{contentType: "reasoning_text", field: "text"},
+	{contentType: "text", field: "text"},
+}
+
+type ReasoningItemReasoningSummary struct {
+	raw json.RawMessage
+}
+
+func (s ReasoningItemReasoningSummary) MarshalJSON() ([]byte, error) {
+	if len(s.raw) == 0 {
+		return nil, errors.New("reasoning item summary has no value")
+	}
+	return validateRawResponseContentJSON(s.raw, "reasoning item summary", reasoningItemSummaryVariants)
+}
+
+func (s *ReasoningItemReasoningSummary) UnmarshalJSON(data []byte) error {
+	if s == nil {
+		return errors.New("decode reasoning item summary into nil receiver")
+	}
+	canonical, err := validateRawResponseContentJSON(data, "reasoning item summary", reasoningItemSummaryVariants)
+	if err != nil {
+		return err
+	}
+	s.raw = canonical
+	return nil
+}
+
+var reasoningItemSummaryVariants = []rawResponseContentVariant{
+	{contentType: "summary_text", field: "text"},
+}
+
+type rawResponseContentVariant struct {
+	contentType string
+	field       string
+}
+
+func validateRawResponseContentJSON(data []byte, objectName string, variants []rawResponseContentVariant) (json.RawMessage, error) {
+	allowedFields := []string{"type"}
+	for _, variant := range variants {
+		if !containsRawResponseField(allowedFields, variant.field) {
+			allowedFields = append(allowedFields, variant.field)
+		}
+	}
+	payload, err := decodeExactThreadItemObject(data, objectName, allowedFields...)
+	if err != nil {
+		return nil, err
+	}
+	contentType, err := decodeRequiredThreadItemValue[string](payload, objectName, "type")
+	if err != nil {
+		return nil, err
+	}
+	for _, variant := range variants {
+		if contentType != variant.contentType {
+			continue
+		}
+		if err := rejectThreadItemFields(payload, objectName+" "+contentType, "type", variant.field); err != nil {
+			return nil, err
+		}
+		value, err := decodeRequiredThreadItemValue[string](payload, objectName+" "+contentType, variant.field)
+		if err != nil {
+			return nil, err
+		}
+		if variant.field == "encrypted_content" {
+			return json.Marshal(struct {
+				Type             string `json:"type"`
+				EncryptedContent string `json:"encrypted_content"`
+			}{Type: contentType, EncryptedContent: value})
+		}
+		return json.Marshal(struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		}{Type: contentType, Text: value})
+	}
+	return nil, fmt.Errorf("unknown %s type %q", objectName, contentType)
+}
+
+func containsRawResponseField(fields []string, candidate string) bool {
+	for _, field := range fields {
+		if field == candidate {
+			return true
+		}
+	}
+	return false
+}

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -83,6 +83,7 @@ func wireSchemaDefinitions() Schema {
 	definitions := []wireSchemaDefinition{
 		{Name: "AbsolutePathBuf", Type: reflect.TypeFor[AbsolutePathBuf]()},
 		{Name: "ActivePermissionProfile", Type: reflect.TypeFor[ActivePermissionProfile]()},
+		{Name: "AgentMessageInputContent", Type: reflect.TypeFor[AgentMessageInputContent]()},
 		{Name: "AgentPath", Type: reflect.TypeFor[AgentPath]()},
 		{Name: "AdditionalFileSystemPermissions", Type: reflect.TypeFor[AdditionalFileSystemPermissions]()},
 		{Name: "AdditionalNetworkPermissions", Type: reflect.TypeFor[AdditionalNetworkPermissions]()},
@@ -221,6 +222,8 @@ func wireSchemaDefinitions() Schema {
 		{Name: "PermissionsRequestApprovalResponse", Type: reflect.TypeFor[PermissionsRequestApprovalResponse]()},
 		{Name: "RequestPermissionProfile", Type: reflect.TypeFor[RequestPermissionProfile]()},
 		{Name: "ReasoningEffort", Type: reflect.TypeFor[ReasoningEffort]()},
+		{Name: "ReasoningItemContent", Type: reflect.TypeFor[ReasoningItemContent]()},
+		{Name: "ReasoningItemReasoningSummary", Type: reflect.TypeFor[ReasoningItemReasoningSummary]()},
 		{Name: "ServerRequestResolvedNotificationParams", Type: reflect.TypeFor[ServerRequestResolvedNotificationParams]()},
 		{Name: "ServerCapabilities", Type: reflect.TypeFor[ServerCapabilities]()},
 		{Name: "Surface", Type: reflect.TypeFor[Surface]()},
@@ -349,6 +352,9 @@ func wireSchemaDefinitions() Schema {
 		string(SubAgentActivityInterrupted),
 	)
 	schemas["CollabAgentState"] = collabAgentStateSchema()
+	schemas["AgentMessageInputContent"] = rawResponseContentSchema(agentMessageInputContentVariants)
+	schemas["ReasoningItemContent"] = rawResponseContentSchema(reasoningItemContentVariants)
+	schemas["ReasoningItemReasoningSummary"] = rawResponseContentSchema(reasoningItemSummaryVariants)
 	setSchemaIntegerMinimum(schemas["ByteRange"].(Schema), 0, "start", "end")
 	schemas["ImageDetail"] = stringEnumSchema(
 		string(ImageDetailAuto), string(ImageDetailLow), string(ImageDetailHigh), string(ImageDetailOriginal),
@@ -557,6 +563,26 @@ func collabAgentStateSchema() Schema {
 			"message": nullableStringSchema(),
 		},
 		"required":             []string{"status", "message"},
+		"additionalProperties": false,
+	}
+}
+
+func rawResponseContentSchema(variants []rawResponseContentVariant) Schema {
+	oneOf := make([]any, 0, len(variants))
+	for _, variant := range variants {
+		oneOf = append(oneOf, rawResponseContentVariantSchema(variant))
+	}
+	return Schema{"oneOf": oneOf}
+}
+
+func rawResponseContentVariantSchema(variant rawResponseContentVariant) Schema {
+	return Schema{
+		"type": "object",
+		"properties": Schema{
+			"type":        Schema{"type": "string", "enum": []any{variant.contentType}},
+			variant.field: Schema{"type": "string"},
+		},
+		"required":             []string{"type", variant.field},
 		"additionalProperties": false,
 	}
 }

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -124,6 +124,48 @@
       ],
       "type": "object"
     },
+    "AgentMessageInputContent": {
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "text": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "input_text"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "text"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "encrypted_content": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "encrypted_content"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "encrypted_content"
+          ],
+          "type": "object"
+        }
+      ]
+    },
     "AgentPath": {
       "type": "string"
     },
@@ -4092,6 +4134,71 @@
     "ReasoningEffort": {
       "minLength": 1,
       "type": "string"
+    },
+    "ReasoningItemContent": {
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "text": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "reasoning_text"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "text"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "text": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "text"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "text"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "ReasoningItemReasoningSummary": {
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "text": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "summary_text"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "text"
+          ],
+          "type": "object"
+        }
+      ]
     },
     "Request": {
       "additionalProperties": false,

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -515,6 +515,14 @@ export type AdditionalPermissionProfile = {
   "network": AdditionalNetworkPermissions | null;
 };
 
+export type AgentMessageInputContent = {
+  "text": string;
+  "type": "input_text";
+} | {
+  "encrypted_content": string;
+  "type": "encrypted_content";
+};
+
 export type AgentPath = string;
 
 export type ApprovalRequestBase = {
@@ -1464,6 +1472,19 @@ export type PermissionsRequestApprovalResponse = {
 };
 
 export type ReasoningEffort = string;
+
+export type ReasoningItemContent = {
+  "text": string;
+  "type": "reasoning_text";
+} | {
+  "text": string;
+  "type": "text";
+};
+
+export type ReasoningItemReasoningSummary = {
+  "text": string;
+  "type": "summary_text";
+};
 
 export type Request = {
   "id": RequestID;

--- a/appserver/protocol/typescript/testdata/raw_response_content_prerequisites_contract.ts
+++ b/appserver/protocol/typescript/testdata/raw_response_content_prerequisites_contract.ts
@@ -1,0 +1,31 @@
+import type {
+  AgentMessageInputContent,
+  ReasoningItemContent,
+  ReasoningItemReasoningSummary,
+} from "../gollem_appserver_protocol";
+
+export const agentMessageContent = [
+  { type: "input_text", text: "hello" },
+  { type: "encrypted_content", encrypted_content: "cipher" },
+] satisfies AgentMessageInputContent[];
+export const reasoningContent = [
+  { type: "reasoning_text", text: "thinking" },
+  { type: "text", text: "visible" },
+] satisfies ReasoningItemContent[];
+export const reasoningSummary = {
+  type: "summary_text",
+  text: "summary",
+} satisfies ReasoningItemReasoningSummary;
+
+// @ts-expect-error input_text requires text.
+export const rejectMissingInputText = { type: "input_text" } satisfies AgentMessageInputContent;
+// @ts-expect-error encrypted content uses snake_case.
+export const rejectCamelEncryptedContent = { type: "encrypted_content", encryptedContent: "cipher" } satisfies AgentMessageInputContent;
+// @ts-expect-error agent-message variants cannot cross fields.
+export const rejectCrossedAgentContent = { type: "input_text", text: "hello", encrypted_content: "cipher" } satisfies AgentMessageInputContent;
+// @ts-expect-error reasoning content discriminators are snake_case.
+export const rejectCamelReasoningType = { type: "reasoningText", text: "thinking" } satisfies ReasoningItemContent;
+// @ts-expect-error reasoning content requires text.
+export const rejectMissingReasoningText = { type: "text" } satisfies ReasoningItemContent;
+// @ts-expect-error reasoning summary discriminator is snake_case.
+export const rejectCamelSummaryType = { type: "summaryText", text: "summary" } satisfies ReasoningItemReasoningSummary;


### PR DESCRIPTION
## Summary
- export exact agent-message input, reasoning-content, and reasoning-summary unions
- enforce strict snake_case discriminators/fields and reject crossed, unknown, null, and malformed values
- generate deterministic JSON Schema and framework-neutral TypeScript with strict Go/TS contracts

## Scope
These are standalone dependency values only. This does not export full `ResponseItem`, bind raw-response notifications, map provider payloads, or alter live agent/reasoning events.

## Verification
- deliberate red Go and TypeScript compiles before implementation/generation
- all new/shared codecs at 100% focused coverage
- `go test -count=1 ./appserver/...`
- `go test -count=1 ./...`
- `go vet ./...`
- deterministic `go generate ./appserver/protocol`
- complete pre-push lint/race/vet/tidy gate
- `git diff --check`