### PR TITLE
feat(protocol): add responses API web search action

### DIFF
--- a/appserver/protocol/README.md
+++ b/appserver/protocol/README.md
@@ -305,6 +305,14 @@ canonical output preserves public snake-case names. These definitions do not
 export full `ResponseItem`, bind raw-response notifications, map provider
 payloads, or change live agent/reasoning deltas.
 
+The distinct `ResponsesApiWebSearchAction` union is also exported independently
+with snake-case search/open-page/find-in-page/other discriminators. Optional
+query, query-list, URL, and pattern fields are non-null when present and omit
+canonically when absent, following generated TypeScript rather than the looser
+`Option`-derived JSON Schema nullability. This does not alias the camel-case
+app-server action, add a provider/tool, export full `ResponseItem`, or bind live
+web-search events.
+
 ## Generation
 
 Run:

--- a/appserver/protocol/responses_api_web_search_action_contract_test.go
+++ b/appserver/protocol/responses_api_web_search_action_contract_test.go
@@ -1,0 +1,111 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"testing"
+)
+
+func TestResponsesAPIWebSearchActionSchemaIsExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	action, ok := defs["ResponsesApiWebSearchAction"].(Schema)
+	if !ok {
+		t.Fatal("$defs missing ResponsesApiWebSearchAction")
+	}
+	variants, ok := action["oneOf"].([]any)
+	if !ok || len(variants) != 4 {
+		t.Fatalf("ResponsesApiWebSearchAction variants = %#v", action["oneOf"])
+	}
+	want := []struct {
+		actionType string
+		fields     []string
+	}{
+		{actionType: "search", fields: []string{"query", "queries"}},
+		{actionType: "open_page", fields: []string{"url"}},
+		{actionType: "find_in_page", fields: []string{"url", "pattern"}},
+		{actionType: "other"},
+	}
+	for index, expected := range want {
+		variant := variants[index].(Schema)
+		if variant["additionalProperties"] != false {
+			t.Fatalf("ResponsesApiWebSearchAction %s allows extra fields", expected.actionType)
+		}
+		if !slices.Equal(schemaRequiredNames(variant), []string{"type"}) {
+			t.Fatalf("ResponsesApiWebSearchAction %s required = %v", expected.actionType, schemaRequiredNames(variant))
+		}
+		properties := variant["properties"].(Schema)
+		if !reflect.DeepEqual(properties["type"].(Schema)["enum"], []any{expected.actionType}) {
+			t.Fatalf("ResponsesApiWebSearchAction variant %d type = %#v", index, properties["type"])
+		}
+		for _, field := range expected.fields {
+			if field == "queries" {
+				wantSchema := Schema{"type": "array", "items": Schema{"type": "string"}}
+				if !reflect.DeepEqual(properties[field], wantSchema) {
+					t.Fatalf("ResponsesApiWebSearchAction %s %s = %#v", expected.actionType, field, properties[field])
+				}
+				continue
+			}
+			if !reflect.DeepEqual(properties[field], Schema{"type": "string"}) {
+				t.Fatalf("ResponsesApiWebSearchAction %s %s = %#v", expected.actionType, field, properties[field])
+			}
+		}
+	}
+}
+
+func TestResponsesAPIWebSearchActionWireValidation(t *testing.T) {
+	valid := []string{
+		`{"type":"search"}`,
+		`{"type":"search","query":"gollem"}`,
+		`{"type":"search","queries":[]}`,
+		`{"type":"search","query":"gollem","queries":["gollem","slang"]}`,
+		`{"type":"open_page"}`,
+		`{"type":"open_page","url":"https://example.com"}`,
+		`{"type":"find_in_page"}`,
+		`{"type":"find_in_page","url":"https://example.com","pattern":"needle"}`,
+		`{"type":"other"}`,
+	}
+	for _, input := range valid {
+		var action ResponsesApiWebSearchAction
+		if err := json.Unmarshal([]byte(input), &action); err != nil {
+			t.Errorf("Unmarshal(%s): %v", input, err)
+			continue
+		}
+		encoded, err := json.Marshal(action)
+		if err != nil || string(encoded) != input {
+			t.Errorf("round trip %s = %s, %v", input, encoded, err)
+		}
+	}
+	for _, input := range []string{
+		`null`, `[]`, `{}`,
+		`{"type":"search","query":null}`,
+		`{"type":"search","queries":null}`,
+		`{"type":"search","query":1}`,
+		`{"type":"search","queries":"gollem"}`,
+		`{"type":"search","queries":["gollem",null]}`,
+		`{"type":"search","queries":["gollem",1]}`,
+		`{"type":"search","url":"https://example.com"}`,
+		`{"type":"open_page","url":null}`,
+		`{"type":"open_page","query":"gollem"}`,
+		`{"type":"find_in_page","url":null}`,
+		`{"type":"find_in_page","pattern":null}`,
+		`{"type":"find_in_page","queries":[]}`,
+		`{"type":"other","url":"https://example.com"}`,
+		`{"type":"openPage","url":"https://example.com"}`,
+		`{"type":"unknown"}`,
+		`{"type":1}`,
+		`{"type":"other","extra":true}`,
+	} {
+		var action ResponsesApiWebSearchAction
+		if err := json.Unmarshal([]byte(input), &action); err == nil {
+			t.Errorf("Unmarshal(%s) succeeded", input)
+		}
+	}
+	if _, err := json.Marshal(ResponsesApiWebSearchAction{}); err == nil {
+		t.Fatal("Marshal empty ResponsesApiWebSearchAction succeeded")
+	}
+	var nilAction *ResponsesApiWebSearchAction
+	if err := nilAction.UnmarshalJSON([]byte(`{"type":"other"}`)); err == nil {
+		t.Fatal("nil ResponsesApiWebSearchAction receiver succeeded")
+	}
+}

--- a/appserver/protocol/responses_api_web_search_action_types.go
+++ b/appserver/protocol/responses_api_web_search_action_types.go
@@ -1,0 +1,147 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// ResponsesApiWebSearchAction is the provider-response action description. It
+// remains distinct from the camel-case app-server WebSearchAction contract.
+type ResponsesApiWebSearchAction struct {
+	raw json.RawMessage
+}
+
+func (a ResponsesApiWebSearchAction) MarshalJSON() ([]byte, error) {
+	if len(a.raw) == 0 {
+		return nil, errors.New("responses API web-search action has no value")
+	}
+	return validateResponsesAPIWebSearchActionJSON(a.raw)
+}
+
+func (a *ResponsesApiWebSearchAction) UnmarshalJSON(data []byte) error {
+	if a == nil {
+		return errors.New("decode Responses API web-search action into nil receiver")
+	}
+	canonical, err := validateResponsesAPIWebSearchActionJSON(data)
+	if err != nil {
+		return err
+	}
+	a.raw = canonical
+	return nil
+}
+
+func validateResponsesAPIWebSearchActionJSON(data []byte) (json.RawMessage, error) {
+	payload, err := decodeExactThreadItemObject(
+		data,
+		"Responses API web-search action",
+		"type",
+		"query",
+		"queries",
+		"url",
+		"pattern",
+	)
+	if err != nil {
+		return nil, err
+	}
+	actionType, err := decodeRequiredThreadItemValue[string](payload, "Responses API web-search action", "type")
+	if err != nil {
+		return nil, err
+	}
+	switch actionType {
+	case "search":
+		if err := rejectThreadItemFields(payload, "Responses API search action", "type", "query", "queries"); err != nil {
+			return nil, err
+		}
+		query, err := decodeOptionalNonNullResponsesAPIString(payload, "Responses API search action", "query")
+		if err != nil {
+			return nil, err
+		}
+		queries, err := decodeOptionalNonNullResponsesAPIQueries(payload, "Responses API search action", "queries")
+		if err != nil {
+			return nil, err
+		}
+		return json.Marshal(struct {
+			Type    string    `json:"type"`
+			Query   *string   `json:"query,omitempty"`
+			Queries *[]string `json:"queries,omitempty"`
+		}{Type: actionType, Query: query, Queries: queries})
+	case "open_page":
+		if err := rejectThreadItemFields(payload, "Responses API open-page action", "type", "url"); err != nil {
+			return nil, err
+		}
+		url, err := decodeOptionalNonNullResponsesAPIString(payload, "Responses API open-page action", "url")
+		if err != nil {
+			return nil, err
+		}
+		return json.Marshal(struct {
+			Type string  `json:"type"`
+			URL  *string `json:"url,omitempty"`
+		}{Type: actionType, URL: url})
+	case "find_in_page":
+		if err := rejectThreadItemFields(payload, "Responses API find-in-page action", "type", "url", "pattern"); err != nil {
+			return nil, err
+		}
+		url, err := decodeOptionalNonNullResponsesAPIString(payload, "Responses API find-in-page action", "url")
+		if err != nil {
+			return nil, err
+		}
+		pattern, err := decodeOptionalNonNullResponsesAPIString(payload, "Responses API find-in-page action", "pattern")
+		if err != nil {
+			return nil, err
+		}
+		return json.Marshal(struct {
+			Type    string  `json:"type"`
+			URL     *string `json:"url,omitempty"`
+			Pattern *string `json:"pattern,omitempty"`
+		}{Type: actionType, URL: url, Pattern: pattern})
+	case "other":
+		if err := rejectThreadItemFields(payload, "Responses API other web-search action", "type"); err != nil {
+			return nil, err
+		}
+		return json.Marshal(struct {
+			Type string `json:"type"`
+		}{Type: actionType})
+	default:
+		return nil, fmt.Errorf("unknown Responses API web-search action type %q", actionType)
+	}
+}
+
+func decodeOptionalNonNullResponsesAPIString(payload map[string]json.RawMessage, objectName, fieldName string) (*string, error) {
+	raw, ok := payload[fieldName]
+	if !ok {
+		return nil, nil
+	}
+	if isJSONNull(raw) {
+		return nil, fmt.Errorf("%s %s cannot be null", objectName, fieldName)
+	}
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return nil, fmt.Errorf("decode %s %s: %w", objectName, fieldName, err)
+	}
+	return &value, nil
+}
+
+func decodeOptionalNonNullResponsesAPIQueries(payload map[string]json.RawMessage, objectName, fieldName string) (*[]string, error) {
+	raw, ok := payload[fieldName]
+	if !ok {
+		return nil, nil
+	}
+	if isJSONNull(raw) {
+		return nil, fmt.Errorf("%s %s cannot be null", objectName, fieldName)
+	}
+	var elements []json.RawMessage
+	if err := json.Unmarshal(raw, &elements); err != nil {
+		return nil, fmt.Errorf("decode %s %s: %w", objectName, fieldName, err)
+	}
+	values := make([]string, len(elements))
+	for index, element := range elements {
+		if isJSONNull(element) {
+			return nil, fmt.Errorf("decode %s %s[%d]: expected string", objectName, fieldName, index)
+		}
+		if err := json.Unmarshal(element, &values[index]); err != nil {
+			return nil, fmt.Errorf("decode %s %s[%d]: %w", objectName, fieldName, index, err)
+		}
+	}
+	return &values, nil
+}

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -224,6 +224,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "ReasoningEffort", Type: reflect.TypeFor[ReasoningEffort]()},
 		{Name: "ReasoningItemContent", Type: reflect.TypeFor[ReasoningItemContent]()},
 		{Name: "ReasoningItemReasoningSummary", Type: reflect.TypeFor[ReasoningItemReasoningSummary]()},
+		{Name: "ResponsesApiWebSearchAction", Type: reflect.TypeFor[ResponsesApiWebSearchAction]()},
 		{Name: "ServerRequestResolvedNotificationParams", Type: reflect.TypeFor[ServerRequestResolvedNotificationParams]()},
 		{Name: "ServerCapabilities", Type: reflect.TypeFor[ServerCapabilities]()},
 		{Name: "Surface", Type: reflect.TypeFor[Surface]()},
@@ -355,6 +356,7 @@ func wireSchemaDefinitions() Schema {
 	schemas["AgentMessageInputContent"] = rawResponseContentSchema(agentMessageInputContentVariants)
 	schemas["ReasoningItemContent"] = rawResponseContentSchema(reasoningItemContentVariants)
 	schemas["ReasoningItemReasoningSummary"] = rawResponseContentSchema(reasoningItemSummaryVariants)
+	schemas["ResponsesApiWebSearchAction"] = responsesAPIWebSearchActionSchema()
 	setSchemaIntegerMinimum(schemas["ByteRange"].(Schema), 0, "start", "end")
 	schemas["ImageDetail"] = stringEnumSchema(
 		string(ImageDetailAuto), string(ImageDetailLow), string(ImageDetailHigh), string(ImageDetailOriginal),
@@ -583,6 +585,40 @@ func rawResponseContentVariantSchema(variant rawResponseContentVariant) Schema {
 			variant.field: Schema{"type": "string"},
 		},
 		"required":             []string{"type", variant.field},
+		"additionalProperties": false,
+	}
+}
+
+func responsesAPIWebSearchActionSchema() Schema {
+	return Schema{"oneOf": []any{
+		responsesAPIWebSearchActionVariantSchema("search", Schema{
+			"query": Schema{"type": "string"},
+			"queries": Schema{
+				"type": "array", "items": Schema{"type": "string"},
+			},
+		}),
+		responsesAPIWebSearchActionVariantSchema("open_page", Schema{
+			"url": Schema{"type": "string"},
+		}),
+		responsesAPIWebSearchActionVariantSchema("find_in_page", Schema{
+			"url":     Schema{"type": "string"},
+			"pattern": Schema{"type": "string"},
+		}),
+		responsesAPIWebSearchActionVariantSchema("other", nil),
+	}}
+}
+
+func responsesAPIWebSearchActionVariantSchema(actionType string, fields Schema) Schema {
+	properties := Schema{
+		"type": Schema{"type": "string", "enum": []any{actionType}},
+	}
+	for name, schema := range fields {
+		properties[name] = schema
+	}
+	return Schema{
+		"type":                 "object",
+		"properties":           properties,
+		"required":             []string{"type"},
 		"additionalProperties": false,
 	}
 }

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -4420,6 +4420,88 @@
       ],
       "type": "object"
     },
+    "ResponsesApiWebSearchAction": {
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "queries": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "query": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "search"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "enum": [
+                "open_page"
+              ],
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "pattern": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "find_in_page"
+              ],
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "enum": [
+                "other"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        }
+      ]
+    },
     "ServerCapabilities": {
       "additionalProperties": false,
       "properties": {

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -1507,6 +1507,21 @@ export type Response = {
   "result"?: unknown;
 };
 
+export type ResponsesApiWebSearchAction = {
+  "queries"?: Array<string>;
+  "query"?: string;
+  "type": "search";
+} | {
+  "type": "open_page";
+  "url"?: string;
+} | {
+  "pattern"?: string;
+  "type": "find_in_page";
+  "url"?: string;
+} | {
+  "type": "other";
+};
+
 export type ServerCapabilities = {
   "experimental"?: Array<string> | null;
   "protocolSchema": boolean;

--- a/appserver/protocol/typescript/testdata/responses_api_web_search_action_contract.ts
+++ b/appserver/protocol/typescript/testdata/responses_api_web_search_action_contract.ts
@@ -1,0 +1,24 @@
+import type { ResponsesApiWebSearchAction } from "../gollem_appserver_protocol";
+
+export const actions = [
+  { type: "search" },
+  { type: "search", query: "gollem" },
+  { type: "search", queries: [] },
+  { type: "search", query: "gollem", queries: ["gollem", "slang"] },
+  { type: "open_page" },
+  { type: "open_page", url: "https://example.com" },
+  { type: "find_in_page" },
+  { type: "find_in_page", url: "https://example.com", pattern: "needle" },
+  { type: "other" },
+] satisfies ResponsesApiWebSearchAction[];
+
+// @ts-expect-error optional query is non-null when present.
+export const rejectNullQuery = { type: "search", query: null } satisfies ResponsesApiWebSearchAction;
+// @ts-expect-error optional queries are non-null when present.
+export const rejectNullQueries = { type: "search", queries: null } satisfies ResponsesApiWebSearchAction;
+// @ts-expect-error query arrays contain only strings.
+export const rejectNullQueryElement = { type: "search", queries: [null] } satisfies ResponsesApiWebSearchAction;
+// @ts-expect-error variants cannot cross fields.
+export const rejectCrossedAction = { type: "other", url: "https://example.com" } satisfies ResponsesApiWebSearchAction;
+// @ts-expect-error Responses API discriminators are snake_case.
+export const rejectCamelCaseType = { type: "openPage", url: "https://example.com" } satisfies ResponsesApiWebSearchAction;


### PR DESCRIPTION
## Summary
- export strict standalone `ResponsesApiWebSearchAction` with snake-case search/open-page/find-in-page/other variants
- follow generated TypeScript optional non-null fields and canonical omission while rejecting explicit nulls and crossed/unknown forms
- keep the type distinct from camel-case `WebSearchAction` and leave provider/runtime/full `ResponseItem` behavior unbound

## Verification
- deliberate red Go contract before implementation
- focused codec helpers at 100% coverage
- deterministic 229-definition/59-method/5-item generation and strict TypeScript
- full app-server tests, repository race suite, lint, vet, tidy, and clean-tree generation
- all five canonical Slang stdio/Unix-socket/WebSocket workflows against a trimpath branch binary