### PR TITLE
feat(protocol): add response item prerequisites

### DIFF
--- a/appserver/protocol/README.md
+++ b/appserver/protocol/README.md
@@ -313,6 +313,15 @@ canonically when absent, following generated TypeScript rather than the looser
 app-server action, add a provider/tool, export full `ResponseItem`, or bind live
 web-search events.
 
+The remaining standalone `ResponseItem` dependency values are exported without
+exporting the full response-item union: strict input/output content items,
+function-call output bodies, internal chat-message metadata, and local-shell
+actions/status. Optional image detail and metadata fields are non-null when
+present; local-shell execution keeps all generated TypeScript nullable fields
+required and validates unsigned JSON timeouts. These values are not bound to
+provider payloads, durable timeline items, live shell execution, or raw-response
+notifications.
+
 ## Generation
 
 Run:

--- a/appserver/protocol/response_item_prerequisites_contract_test.go
+++ b/appserver/protocol/response_item_prerequisites_contract_test.go
@@ -1,0 +1,321 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"testing"
+)
+
+func TestResponseItemPrerequisiteSchemasAreExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	assertContentItemSchema(t, defs, "ContentItem", []contentItemSchemaExpectation{
+		{itemType: "input_text", field: "text"},
+		{itemType: "input_image", field: "image_url", optionalDetail: true},
+		{itemType: "output_text", field: "text"},
+	})
+	assertContentItemSchema(t, defs, "FunctionCallOutputContentItem", []contentItemSchemaExpectation{
+		{itemType: "input_text", field: "text"},
+		{itemType: "input_image", field: "image_url", optionalDetail: true},
+		{itemType: "encrypted_content", field: "encrypted_content"},
+	})
+
+	body := defs["FunctionCallOutputBody"].(Schema)
+	bodyVariants, ok := body["anyOf"].([]any)
+	if !ok || len(bodyVariants) != 2 {
+		t.Fatalf("FunctionCallOutputBody variants = %#v", body)
+	}
+	if !reflect.DeepEqual(bodyVariants[0], Schema{"type": "string"}) {
+		t.Fatalf("FunctionCallOutputBody string = %#v", bodyVariants[0])
+	}
+	if !reflect.DeepEqual(bodyVariants[1], Schema{
+		"type": "array", "items": Schema{"$ref": "#/$defs/FunctionCallOutputContentItem"},
+	}) {
+		t.Fatalf("FunctionCallOutputBody array = %#v", bodyVariants[1])
+	}
+
+	metadata := defs["InternalChatMessageMetadataPassthrough"].(Schema)
+	if metadata["type"] != "object" || metadata["additionalProperties"] != false {
+		t.Fatalf("InternalChatMessageMetadataPassthrough = %#v", metadata)
+	}
+	if required := schemaRequiredNames(metadata); len(required) != 0 {
+		t.Fatalf("InternalChatMessageMetadataPassthrough required = %v", required)
+	}
+	if !reflect.DeepEqual(metadata["properties"].(Schema)["turn_id"], Schema{"type": "string"}) {
+		t.Fatalf("InternalChatMessageMetadataPassthrough.turn_id = %#v", metadata["properties"])
+	}
+
+	assertStringEnum(t, defs["LocalShellStatus"], "completed", "in_progress", "incomplete")
+	action := defs["LocalShellAction"].(Schema)
+	actionVariants, ok := action["oneOf"].([]any)
+	if !ok || len(actionVariants) != 1 {
+		t.Fatalf("LocalShellAction variants = %#v", action)
+	}
+	execAction := actionVariants[0].(Schema)
+	if execAction["additionalProperties"] != false {
+		t.Fatalf("LocalShellAction allows extra fields")
+	}
+	wantRequired := []string{"type", "command", "timeout_ms", "working_directory", "env", "user"}
+	if !slices.Equal(schemaRequiredNames(execAction), wantRequired) {
+		t.Fatalf("LocalShellAction required = %v, want %v", schemaRequiredNames(execAction), wantRequired)
+	}
+	properties := execAction["properties"].(Schema)
+	if !reflect.DeepEqual(properties["type"].(Schema)["enum"], []any{"exec"}) {
+		t.Fatalf("LocalShellAction.type = %#v", properties["type"])
+	}
+	if !reflect.DeepEqual(properties["command"], Schema{"type": "array", "items": Schema{"type": "string"}}) {
+		t.Fatalf("LocalShellAction.command = %#v", properties["command"])
+	}
+	assertNullableUnsignedIntegerSchema(t, properties["timeout_ms"])
+	assertNullableStringSchema(t, properties["working_directory"])
+	assertNullableStringSchema(t, properties["user"])
+	assertNullableStringMapSchema(t, properties["env"])
+}
+
+func TestResponseItemContentPrerequisiteWireValidation(t *testing.T) {
+	t.Run("ContentItem", func(t *testing.T) {
+		valid := []string{
+			`{"type":"input_text","text":""}`,
+			`{"type":"input_text","text":"hello"}`,
+			`{"type":"input_image","image_url":"https://example.test/image.png"}`,
+			`{"type":"input_image","image_url":"data:image/png;base64,AA==","detail":"original"}`,
+			`{"type":"output_text","text":"done"}`,
+		}
+		invalid := []string{
+			`null`, `[]`, `{}`,
+			`{"type":"input_text"}`,
+			`{"type":"input_text","text":null}`,
+			`{"type":"input_text","text":"hello","image_url":"crossed"}`,
+			`{"type":"input_image"}`,
+			`{"type":"input_image","image_url":null}`,
+			`{"type":"input_image","image_url":"x","detail":null}`,
+			`{"type":"input_image","image_url":"x","detail":"medium"}`,
+			`{"type":"inputImage","image_url":"x"}`,
+			`{"type":"output_text","text":"done","extra":true}`,
+		}
+		assertRawJSONRoundTrips[ContentItem](t, valid)
+		assertRawJSONRejects[ContentItem](t, invalid)
+		assertEmptyRawJSONMarshalRejects(t, ContentItem{})
+		var value *ContentItem
+		if err := value.UnmarshalJSON([]byte(valid[0])); err == nil {
+			t.Fatal("nil ContentItem receiver succeeded")
+		}
+	})
+
+	t.Run("FunctionCallOutputContentItem", func(t *testing.T) {
+		valid := []string{
+			`{"type":"input_text","text":"tool output"}`,
+			`{"type":"input_image","image_url":"https://example.test/image.png"}`,
+			`{"type":"input_image","image_url":"image.png","detail":"low"}`,
+			`{"type":"encrypted_content","encrypted_content":"cipher"}`,
+		}
+		invalid := []string{
+			`null`, `[]`, `{}`,
+			`{"type":"input_text","text":null}`,
+			`{"type":"input_image","image_url":"x","detail":null}`,
+			`{"type":"input_image","image_url":"x","text":"crossed"}`,
+			`{"type":"encrypted_content"}`,
+			`{"type":"encrypted_content","encrypted_content":null}`,
+			`{"type":"encrypted_content","encryptedContent":"cipher"}`,
+			`{"type":"output_text","text":"unsupported"}`,
+			`{"type":"input_text","text":"tool output","extra":true}`,
+		}
+		assertRawJSONRoundTrips[FunctionCallOutputContentItem](t, valid)
+		assertRawJSONRejects[FunctionCallOutputContentItem](t, invalid)
+		assertEmptyRawJSONMarshalRejects(t, FunctionCallOutputContentItem{})
+		var value *FunctionCallOutputContentItem
+		if err := value.UnmarshalJSON([]byte(valid[0])); err == nil {
+			t.Fatal("nil FunctionCallOutputContentItem receiver succeeded")
+		}
+	})
+}
+
+func TestFunctionCallOutputBodyWireValidation(t *testing.T) {
+	valid := []string{
+		`"plain"`, `""`, `[]`,
+		`[{"type":"input_text","text":"tool output"}]`,
+		`[{"type":"input_image","image_url":"image.png","detail":"high"},{"type":"encrypted_content","encrypted_content":"cipher"}]`,
+	}
+	invalid := []string{
+		`null`, `{}`, `1`, `true`,
+		`[null]`, `["plain"]`,
+		`[{"type":"input_image","image_url":"image.png","detail":null}]`,
+		`[{"type":"output_text","text":"unsupported"}]`,
+	}
+	assertRawJSONRoundTrips[FunctionCallOutputBody](t, valid)
+	assertRawJSONRejects[FunctionCallOutputBody](t, invalid)
+	assertEmptyRawJSONMarshalRejects(t, FunctionCallOutputBody{})
+	var value *FunctionCallOutputBody
+	if err := value.UnmarshalJSON([]byte(`"plain"`)); err == nil {
+		t.Fatal("nil FunctionCallOutputBody receiver succeeded")
+	}
+	for _, input := range []string{"", `"unterminated`, `[{"type":`} {
+		if _, err := validateFunctionCallOutputBodyJSON([]byte(input)); err == nil {
+			t.Errorf("validateFunctionCallOutputBodyJSON(%q) succeeded", input)
+		}
+	}
+}
+
+func TestInternalChatMessageMetadataPassthroughWireValidation(t *testing.T) {
+	valid := []string{`{}`, `{"turn_id":"turn-1"}`, `{"turn_id":""}`}
+	for _, input := range valid {
+		var value InternalChatMessageMetadataPassthrough
+		if err := json.Unmarshal([]byte(input), &value); err != nil {
+			t.Errorf("Unmarshal(%s): %v", input, err)
+			continue
+		}
+		encoded, err := json.Marshal(value)
+		if err != nil || string(encoded) != input {
+			t.Errorf("round trip %s = %s, %v", input, encoded, err)
+		}
+	}
+	for _, input := range []string{`null`, `[]`, `{"turn_id":null}`, `{"turnId":"turn-1"}`, `{"turn_id":1}`, `{"extra":true}`} {
+		assertJSONRejects[InternalChatMessageMetadataPassthrough](t, input)
+	}
+	var value *InternalChatMessageMetadataPassthrough
+	if err := value.UnmarshalJSON([]byte(`{}`)); err == nil {
+		t.Fatal("nil InternalChatMessageMetadataPassthrough receiver succeeded")
+	}
+}
+
+func TestLocalShellPrerequisiteWireValidation(t *testing.T) {
+	for _, input := range []string{`"completed"`, `"in_progress"`, `"incomplete"`} {
+		assertJSONAccepts[LocalShellStatus](t, input)
+	}
+	for _, input := range []string{`null`, `"inProgress"`, `"failed"`, `1`} {
+		assertJSONRejects[LocalShellStatus](t, input)
+	}
+	for _, status := range []LocalShellStatus{LocalShellStatusCompleted, LocalShellStatusInProgress, LocalShellStatusIncomplete} {
+		if _, err := json.Marshal(status); err != nil {
+			t.Errorf("Marshal(%q): %v", status, err)
+		}
+	}
+	if _, err := json.Marshal(LocalShellStatus("failed")); err == nil {
+		t.Fatal("Marshal invalid LocalShellStatus succeeded")
+	}
+
+	valid := []string{
+		`{"type":"exec","command":[],"timeout_ms":null,"working_directory":null,"env":null,"user":null}`,
+		`{"type":"exec","command":["printf","ok"],"timeout_ms":0,"working_directory":"","env":{},"user":""}`,
+		`{"type":"exec","command":["go","test","./..."],"timeout_ms":60000,"working_directory":"/workspace","env":{"A":"1","EMPTY":""},"user":"runner"}`,
+	}
+	invalid := []string{
+		`null`, `[]`, `{}`,
+		`{"type":"exec","command":[],"timeout_ms":null,"working_directory":null,"env":null}`,
+		`{"type":"exec","command":null,"timeout_ms":null,"working_directory":null,"env":null,"user":null}`,
+		`{"type":"exec","command":"go","timeout_ms":null,"working_directory":null,"env":null,"user":null}`,
+		`{"type":"exec","command":["go",null],"timeout_ms":null,"working_directory":null,"env":null,"user":null}`,
+		`{"type":"exec","command":["go",1],"timeout_ms":null,"working_directory":null,"env":null,"user":null}`,
+		`{"type":"exec","command":[],"timeout_ms":-1,"working_directory":null,"env":null,"user":null}`,
+		`{"type":"exec","command":[],"timeout_ms":1.5,"working_directory":null,"env":null,"user":null}`,
+		`{"type":"exec","command":[],"timeout_ms":null,"working_directory":1,"env":null,"user":null}`,
+		`{"type":"exec","command":[],"timeout_ms":null,"working_directory":null,"user":null}`,
+		`{"type":"exec","command":[],"timeout_ms":null,"working_directory":null,"env":[],"user":null}`,
+		`{"type":"exec","command":[],"timeout_ms":null,"working_directory":null,"env":{"A":1},"user":null}`,
+		`{"type":"exec","command":[],"timeout_ms":null,"working_directory":null,"env":{"A":null},"user":null}`,
+		`{"type":"exec","command":[],"timeout_ms":null,"working_directory":null,"env":null,"user":1}`,
+		`{"type":"exec","command":[],"timeout_ms":null,"working_directory":null,"env":null,"user":null,"extra":true}`,
+		`{"type":"shell","command":[],"timeout_ms":null,"working_directory":null,"env":null,"user":null}`,
+	}
+	assertRawJSONRoundTrips[LocalShellAction](t, valid)
+	assertRawJSONRejects[LocalShellAction](t, invalid)
+	assertEmptyRawJSONMarshalRejects(t, LocalShellAction{})
+	var action *LocalShellAction
+	if err := action.UnmarshalJSON([]byte(valid[0])); err == nil {
+		t.Fatal("nil LocalShellAction receiver succeeded")
+	}
+	var status *LocalShellStatus
+	if err := status.UnmarshalJSON([]byte(`"completed"`)); err == nil {
+		t.Fatal("nil LocalShellStatus receiver succeeded")
+	}
+}
+
+type contentItemSchemaExpectation struct {
+	itemType       string
+	field          string
+	optionalDetail bool
+}
+
+func assertContentItemSchema(t *testing.T, defs Schema, name string, want []contentItemSchemaExpectation) {
+	t.Helper()
+	schema, ok := defs[name].(Schema)
+	if !ok {
+		t.Fatalf("$defs missing %s", name)
+	}
+	variants, ok := schema["oneOf"].([]any)
+	if !ok || len(variants) != len(want) {
+		t.Fatalf("%s variants = %#v", name, schema)
+	}
+	for index, expected := range want {
+		variant := variants[index].(Schema)
+		if variant["additionalProperties"] != false {
+			t.Fatalf("%s %s allows extra fields", name, expected.itemType)
+		}
+		properties := variant["properties"].(Schema)
+		if !reflect.DeepEqual(properties["type"].(Schema)["enum"], []any{expected.itemType}) {
+			t.Fatalf("%s %s type = %#v", name, expected.itemType, properties["type"])
+		}
+		if !slices.Equal(schemaRequiredNames(variant), []string{"type", expected.field}) {
+			t.Fatalf("%s %s required = %v", name, expected.itemType, schemaRequiredNames(variant))
+		}
+		if !reflect.DeepEqual(properties[expected.field], Schema{"type": "string"}) {
+			t.Fatalf("%s %s field = %#v", name, expected.itemType, properties[expected.field])
+		}
+		if expected.optionalDetail {
+			if !reflect.DeepEqual(properties["detail"], Schema{"$ref": "#/$defs/ImageDetail"}) {
+				t.Fatalf("%s input_image detail = %#v", name, properties["detail"])
+			}
+		}
+	}
+}
+
+func assertNullableUnsignedIntegerSchema(t *testing.T, raw any) {
+	t.Helper()
+	want := Schema{"anyOf": []any{Schema{"type": "integer", "minimum": 0}, Schema{"type": "null"}}}
+	if !reflect.DeepEqual(raw, want) {
+		t.Fatalf("nullable unsigned integer = %#v", raw)
+	}
+}
+
+func assertNullableStringMapSchema(t *testing.T, raw any) {
+	t.Helper()
+	want := Schema{"anyOf": []any{
+		Schema{"type": "object", "additionalProperties": Schema{"type": "string"}},
+		Schema{"type": "null"},
+	}}
+	if !reflect.DeepEqual(raw, want) {
+		t.Fatalf("nullable string map = %#v", raw)
+	}
+}
+
+func assertRawJSONRoundTrips[T json.Marshaler](t *testing.T, inputs []string) {
+	t.Helper()
+	for _, input := range inputs {
+		var value T
+		if err := json.Unmarshal([]byte(input), &value); err != nil {
+			t.Errorf("Unmarshal(%s): %v", input, err)
+			continue
+		}
+		encoded, err := json.Marshal(value)
+		if err != nil || string(encoded) != input {
+			t.Errorf("round trip %s = %s, %v", input, encoded, err)
+		}
+	}
+}
+
+func assertRawJSONRejects[T any](t *testing.T, inputs []string) {
+	t.Helper()
+	for _, input := range inputs {
+		var value T
+		if err := json.Unmarshal([]byte(input), &value); err == nil {
+			t.Errorf("Unmarshal(%s) succeeded", input)
+		}
+	}
+}
+
+func assertEmptyRawJSONMarshalRejects(t *testing.T, value any) {
+	t.Helper()
+	if _, err := json.Marshal(value); err == nil {
+		t.Fatalf("Marshal(%T zero value) succeeded", value)
+	}
+}

--- a/appserver/protocol/response_item_prerequisites_types.go
+++ b/appserver/protocol/response_item_prerequisites_types.go
@@ -1,0 +1,404 @@
+package protocol
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+type ContentItem struct {
+	raw json.RawMessage
+}
+
+func (c ContentItem) MarshalJSON() ([]byte, error) {
+	if len(c.raw) == 0 {
+		return nil, errors.New("content item has no value")
+	}
+	return validateContentItemJSON(c.raw, "content item", contentItemVariants)
+}
+
+func (c *ContentItem) UnmarshalJSON(data []byte) error {
+	if c == nil {
+		return errors.New("decode content item into nil receiver")
+	}
+	canonical, err := validateContentItemJSON(data, "content item", contentItemVariants)
+	if err != nil {
+		return err
+	}
+	c.raw = canonical
+	return nil
+}
+
+var contentItemVariants = []contentItemVariant{
+	{itemType: "input_text", field: "text"},
+	{itemType: "input_image", field: "image_url", optionalDetail: true},
+	{itemType: "output_text", field: "text"},
+}
+
+type FunctionCallOutputContentItem struct {
+	raw json.RawMessage
+}
+
+func (c FunctionCallOutputContentItem) MarshalJSON() ([]byte, error) {
+	if len(c.raw) == 0 {
+		return nil, errors.New("function-call output content item has no value")
+	}
+	return validateContentItemJSON(c.raw, "function-call output content item", functionCallOutputContentItemVariants)
+}
+
+func (c *FunctionCallOutputContentItem) UnmarshalJSON(data []byte) error {
+	if c == nil {
+		return errors.New("decode function-call output content item into nil receiver")
+	}
+	canonical, err := validateContentItemJSON(data, "function-call output content item", functionCallOutputContentItemVariants)
+	if err != nil {
+		return err
+	}
+	c.raw = canonical
+	return nil
+}
+
+var functionCallOutputContentItemVariants = []contentItemVariant{
+	{itemType: "input_text", field: "text"},
+	{itemType: "input_image", field: "image_url", optionalDetail: true},
+	{itemType: "encrypted_content", field: "encrypted_content"},
+}
+
+type contentItemVariant struct {
+	itemType       string
+	field          string
+	optionalDetail bool
+}
+
+func validateContentItemJSON(data []byte, objectName string, variants []contentItemVariant) (json.RawMessage, error) {
+	allowedFields := []string{"type"}
+	for _, variant := range variants {
+		if !containsRawResponseField(allowedFields, variant.field) {
+			allowedFields = append(allowedFields, variant.field)
+		}
+		if variant.optionalDetail && !containsRawResponseField(allowedFields, "detail") {
+			allowedFields = append(allowedFields, "detail")
+		}
+	}
+	payload, err := decodeExactThreadItemObject(data, objectName, allowedFields...)
+	if err != nil {
+		return nil, err
+	}
+	itemType, err := decodeRequiredThreadItemValue[string](payload, objectName, "type")
+	if err != nil {
+		return nil, err
+	}
+	for _, variant := range variants {
+		if itemType != variant.itemType {
+			continue
+		}
+		allowed := []string{"type", variant.field}
+		if variant.optionalDetail {
+			allowed = append(allowed, "detail")
+		}
+		if err := rejectThreadItemFields(payload, objectName+" "+itemType, allowed...); err != nil {
+			return nil, err
+		}
+		value, err := decodeRequiredThreadItemValue[string](payload, objectName+" "+itemType, variant.field)
+		if err != nil {
+			return nil, err
+		}
+		switch variant.field {
+		case "image_url":
+			detail, err := decodeOptionalImageDetail(payload, objectName+" "+itemType)
+			if err != nil {
+				return nil, err
+			}
+			return json.Marshal(struct {
+				Type     string       `json:"type"`
+				ImageURL string       `json:"image_url"`
+				Detail   *ImageDetail `json:"detail,omitempty"`
+			}{Type: itemType, ImageURL: value, Detail: detail})
+		case "encrypted_content":
+			return json.Marshal(struct {
+				Type             string `json:"type"`
+				EncryptedContent string `json:"encrypted_content"`
+			}{Type: itemType, EncryptedContent: value})
+		default:
+			return json.Marshal(struct {
+				Type string `json:"type"`
+				Text string `json:"text"`
+			}{Type: itemType, Text: value})
+		}
+	}
+	return nil, fmt.Errorf("unknown %s type %q", objectName, itemType)
+}
+
+type FunctionCallOutputBody struct {
+	raw json.RawMessage
+}
+
+func (b FunctionCallOutputBody) MarshalJSON() ([]byte, error) {
+	if len(b.raw) == 0 {
+		return nil, errors.New("function-call output body has no value")
+	}
+	return validateFunctionCallOutputBodyJSON(b.raw)
+}
+
+func (b *FunctionCallOutputBody) UnmarshalJSON(data []byte) error {
+	if b == nil {
+		return errors.New("decode function-call output body into nil receiver")
+	}
+	canonical, err := validateFunctionCallOutputBodyJSON(data)
+	if err != nil {
+		return err
+	}
+	b.raw = canonical
+	return nil
+}
+
+func validateFunctionCallOutputBodyJSON(data []byte) (json.RawMessage, error) {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 {
+		return nil, errors.New("function-call output body is empty")
+	}
+	switch trimmed[0] {
+	case '"':
+		var value string
+		if err := json.Unmarshal(trimmed, &value); err != nil {
+			return nil, fmt.Errorf("decode function-call output body string: %w", err)
+		}
+		return json.Marshal(value)
+	case '[':
+		var items []FunctionCallOutputContentItem
+		if err := json.Unmarshal(trimmed, &items); err != nil {
+			return nil, fmt.Errorf("decode function-call output body items: %w", err)
+		}
+		return json.Marshal(items)
+	default:
+		return nil, errors.New("function-call output body must be a string or content-item array")
+	}
+}
+
+type InternalChatMessageMetadataPassthrough struct {
+	TurnID *string `json:"turn_id,omitempty"`
+}
+
+func (m InternalChatMessageMetadataPassthrough) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		TurnID *string `json:"turn_id,omitempty"`
+	}{TurnID: m.TurnID})
+}
+
+func (m *InternalChatMessageMetadataPassthrough) UnmarshalJSON(data []byte) error {
+	if m == nil {
+		return errors.New("decode internal chat-message metadata into nil receiver")
+	}
+	payload, err := decodeExactThreadItemObject(data, "internal chat-message metadata", "turn_id")
+	if err != nil {
+		return err
+	}
+	turnID, err := decodeOptionalNonNullMetadataString(payload, "turn_id")
+	if err != nil {
+		return err
+	}
+	m.TurnID = turnID
+	return nil
+}
+
+func decodeOptionalNonNullMetadataString(payload map[string]json.RawMessage, fieldName string) (*string, error) {
+	raw, ok := payload[fieldName]
+	if !ok {
+		return nil, nil
+	}
+	if isJSONNull(raw) {
+		return nil, fmt.Errorf("internal chat-message metadata %s cannot be null", fieldName)
+	}
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return nil, fmt.Errorf("decode internal chat-message metadata %s: %w", fieldName, err)
+	}
+	return &value, nil
+}
+
+type LocalShellStatus string
+
+const (
+	LocalShellStatusCompleted  LocalShellStatus = "completed"
+	LocalShellStatusInProgress LocalShellStatus = "in_progress"
+	LocalShellStatusIncomplete LocalShellStatus = "incomplete"
+)
+
+func (s LocalShellStatus) MarshalJSON() ([]byte, error) {
+	if !s.valid() {
+		return nil, fmt.Errorf("invalid local-shell status %q", s)
+	}
+	return json.Marshal(string(s))
+}
+
+func (s *LocalShellStatus) UnmarshalJSON(data []byte) error {
+	if s == nil {
+		return errors.New("decode local-shell status into nil receiver")
+	}
+	if isJSONNull(data) {
+		return errors.New("local-shell status cannot be null")
+	}
+	var value string
+	if err := json.Unmarshal(data, &value); err != nil {
+		return fmt.Errorf("decode local-shell status: %w", err)
+	}
+	status := LocalShellStatus(value)
+	if !status.valid() {
+		return fmt.Errorf("invalid local-shell status %q", value)
+	}
+	*s = status
+	return nil
+}
+
+func (s LocalShellStatus) valid() bool {
+	switch s {
+	case LocalShellStatusCompleted, LocalShellStatusInProgress, LocalShellStatusIncomplete:
+		return true
+	default:
+		return false
+	}
+}
+
+type LocalShellAction struct {
+	raw json.RawMessage
+}
+
+func (a LocalShellAction) MarshalJSON() ([]byte, error) {
+	if len(a.raw) == 0 {
+		return nil, errors.New("local-shell action has no value")
+	}
+	return validateLocalShellActionJSON(a.raw)
+}
+
+func (a *LocalShellAction) UnmarshalJSON(data []byte) error {
+	if a == nil {
+		return errors.New("decode local-shell action into nil receiver")
+	}
+	canonical, err := validateLocalShellActionJSON(data)
+	if err != nil {
+		return err
+	}
+	a.raw = canonical
+	return nil
+}
+
+func validateLocalShellActionJSON(data []byte) (json.RawMessage, error) {
+	payload, err := decodeExactThreadItemObject(
+		data,
+		"local-shell action",
+		"type",
+		"command",
+		"timeout_ms",
+		"working_directory",
+		"env",
+		"user",
+	)
+	if err != nil {
+		return nil, err
+	}
+	actionType, err := decodeRequiredThreadItemValue[string](payload, "local-shell action", "type")
+	if err != nil {
+		return nil, err
+	}
+	if actionType != "exec" {
+		return nil, fmt.Errorf("unknown local-shell action type %q", actionType)
+	}
+	command, err := decodeRequiredNonNullStringArray(payload, "local-shell exec action", "command")
+	if err != nil {
+		return nil, err
+	}
+	timeoutMS, err := decodeRequiredNullableThreadItemValue[uint64](payload, "local-shell exec action", "timeout_ms")
+	if err != nil {
+		return nil, err
+	}
+	workingDirectory, err := decodeRequiredNullableThreadItemValue[string](payload, "local-shell exec action", "working_directory")
+	if err != nil {
+		return nil, err
+	}
+	env, err := decodeRequiredNullableStringMap(payload, "local-shell exec action", "env")
+	if err != nil {
+		return nil, err
+	}
+	user, err := decodeRequiredNullableThreadItemValue[string](payload, "local-shell exec action", "user")
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(struct {
+		Type             string             `json:"type"`
+		Command          []string           `json:"command"`
+		TimeoutMS        *uint64            `json:"timeout_ms"`
+		WorkingDirectory *string            `json:"working_directory"`
+		Env              *map[string]string `json:"env"`
+		User             *string            `json:"user"`
+	}{
+		Type:             actionType,
+		Command:          command,
+		TimeoutMS:        timeoutMS,
+		WorkingDirectory: workingDirectory,
+		Env:              env,
+		User:             user,
+	})
+}
+
+func decodeRequiredNullableThreadItemValue[T any](payload map[string]json.RawMessage, objectName, fieldName string) (*T, error) {
+	raw, ok := payload[fieldName]
+	if !ok {
+		return nil, fmt.Errorf("%s requires %s", objectName, fieldName)
+	}
+	if isJSONNull(raw) {
+		return nil, nil
+	}
+	var value T
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return nil, fmt.Errorf("decode %s %s: %w", objectName, fieldName, err)
+	}
+	return &value, nil
+}
+
+func decodeRequiredNonNullStringArray(payload map[string]json.RawMessage, objectName, fieldName string) ([]string, error) {
+	raw, ok := payload[fieldName]
+	if !ok || isJSONNull(raw) {
+		return nil, fmt.Errorf("%s requires %s", objectName, fieldName)
+	}
+	var elements []json.RawMessage
+	if err := json.Unmarshal(raw, &elements); err != nil {
+		return nil, fmt.Errorf("decode %s %s: %w", objectName, fieldName, err)
+	}
+	values := make([]string, len(elements))
+	for index, element := range elements {
+		if isJSONNull(element) {
+			return nil, fmt.Errorf("decode %s %s[%d]: expected string", objectName, fieldName, index)
+		}
+		if err := json.Unmarshal(element, &values[index]); err != nil {
+			return nil, fmt.Errorf("decode %s %s[%d]: %w", objectName, fieldName, index, err)
+		}
+	}
+	return values, nil
+}
+
+func decodeRequiredNullableStringMap(payload map[string]json.RawMessage, objectName, fieldName string) (*map[string]string, error) {
+	raw, ok := payload[fieldName]
+	if !ok {
+		return nil, fmt.Errorf("%s requires %s", objectName, fieldName)
+	}
+	if isJSONNull(raw) {
+		return nil, nil
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return nil, fmt.Errorf("decode %s %s: %w", objectName, fieldName, err)
+	}
+	values := make(map[string]string, len(fields))
+	for name, value := range fields {
+		if isJSONNull(value) {
+			return nil, fmt.Errorf("decode %s %s[%q]: expected string", objectName, fieldName, name)
+		}
+		var decoded string
+		if err := json.Unmarshal(value, &decoded); err != nil {
+			return nil, fmt.Errorf("decode %s %s[%q]: %w", objectName, fieldName, name, err)
+		}
+		values[name] = decoded
+	}
+	return &values, nil
+}

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -115,6 +115,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "CommandExecutionItemCompletedNotificationParams", Type: reflect.TypeFor[CommandExecutionItemCompletedNotificationParams]()},
 		{Name: "CommandExecutionItemStartedNotificationParams", Type: reflect.TypeFor[CommandExecutionItemStartedNotificationParams]()},
 		{Name: "CommandExecutionOutputDeltaNotificationParams", Type: reflect.TypeFor[CommandExecutionOutputDeltaNotificationParams]()},
+		{Name: "ContentItem", Type: reflect.TypeFor[ContentItem]()},
 		{Name: "ContextCompactionItem", Type: reflect.TypeFor[ContextCompactionItem]()},
 		{Name: "DaemonShutdownParams", Type: reflect.TypeFor[DaemonShutdownParams]()},
 		{Name: "DaemonShutdownState", Type: reflect.TypeFor[DaemonShutdownState]()},
@@ -165,6 +166,8 @@ func wireSchemaDefinitions() Schema {
 		{Name: "FsWatchResponse", Type: reflect.TypeFor[FsWatchResponse]()},
 		{Name: "FsWriteFileParams", Type: reflect.TypeFor[FsWriteFileParams]()},
 		{Name: "FsWriteFileResponse", Type: reflect.TypeFor[FsWriteFileResponse]()},
+		{Name: "FunctionCallOutputBody", Type: reflect.TypeFor[FunctionCallOutputBody]()},
+		{Name: "FunctionCallOutputContentItem", Type: reflect.TypeFor[FunctionCallOutputContentItem]()},
 		{Name: "GrantedPermissionProfile", Type: reflect.TypeFor[GrantedPermissionProfile]()},
 		{Name: "HookPromptFragment", Type: reflect.TypeFor[HookPromptFragment]()},
 		{Name: "ImageDetail", Type: reflect.TypeFor[ImageDetail]()},
@@ -172,8 +175,11 @@ func wireSchemaDefinitions() Schema {
 		{Name: "InitializeCapabilities", Type: reflect.TypeFor[InitializeCapabilities]()},
 		{Name: "InitializeParams", Type: reflect.TypeFor[InitializeParams]()},
 		{Name: "InitializeResponse", Type: reflect.TypeFor[InitializeResponse]()},
+		{Name: "InternalChatMessageMetadataPassthrough", Type: reflect.TypeFor[InternalChatMessageMetadataPassthrough]()},
 		{Name: "ItemLifecycleNotificationParams", Type: reflect.TypeFor[ItemLifecycleNotificationParams]()},
 		{Name: "LegacyAppPathString", Type: reflect.TypeFor[LegacyAppPathString]()},
+		{Name: "LocalShellAction", Type: reflect.TypeFor[LocalShellAction]()},
+		{Name: "LocalShellStatus", Type: reflect.TypeFor[LocalShellStatus]()},
 		{Name: "MCPContent", Type: reflect.TypeFor[MCPContent]()},
 		{Name: "MCPToolCallError", Type: reflect.TypeFor[MCPToolCallError]()},
 		{Name: "MCPToolCallItem", Type: reflect.TypeFor[MCPToolCallItem]()},
@@ -357,6 +363,14 @@ func wireSchemaDefinitions() Schema {
 	schemas["ReasoningItemContent"] = rawResponseContentSchema(reasoningItemContentVariants)
 	schemas["ReasoningItemReasoningSummary"] = rawResponseContentSchema(reasoningItemSummaryVariants)
 	schemas["ResponsesApiWebSearchAction"] = responsesAPIWebSearchActionSchema()
+	schemas["ContentItem"] = contentItemSchema(contentItemVariants)
+	schemas["FunctionCallOutputContentItem"] = contentItemSchema(functionCallOutputContentItemVariants)
+	schemas["FunctionCallOutputBody"] = functionCallOutputBodySchema()
+	schemas["InternalChatMessageMetadataPassthrough"] = internalChatMessageMetadataSchema()
+	schemas["LocalShellStatus"] = stringEnumSchema(
+		string(LocalShellStatusCompleted), string(LocalShellStatusInProgress), string(LocalShellStatusIncomplete),
+	)
+	schemas["LocalShellAction"] = localShellActionSchema()
 	setSchemaIntegerMinimum(schemas["ByteRange"].(Schema), 0, "start", "end")
 	schemas["ImageDetail"] = stringEnumSchema(
 		string(ImageDetailAuto), string(ImageDetailLow), string(ImageDetailHigh), string(ImageDetailOriginal),
@@ -621,6 +635,66 @@ func responsesAPIWebSearchActionVariantSchema(actionType string, fields Schema) 
 		"required":             []string{"type"},
 		"additionalProperties": false,
 	}
+}
+
+func contentItemSchema(variants []contentItemVariant) Schema {
+	items := make([]any, 0, len(variants))
+	for _, variant := range variants {
+		properties := Schema{
+			"type":        Schema{"type": "string", "enum": []any{variant.itemType}},
+			variant.field: Schema{"type": "string"},
+		}
+		if variant.optionalDetail {
+			properties["detail"] = Schema{"$ref": "#/$defs/ImageDetail"}
+		}
+		items = append(items, Schema{
+			"type":                 "object",
+			"properties":           properties,
+			"required":             []string{"type", variant.field},
+			"additionalProperties": false,
+		})
+	}
+	return Schema{"oneOf": items}
+}
+
+func functionCallOutputBodySchema() Schema {
+	return Schema{"anyOf": []any{
+		Schema{"type": "string"},
+		Schema{"type": "array", "items": Schema{"$ref": "#/$defs/FunctionCallOutputContentItem"}},
+	}}
+}
+
+func internalChatMessageMetadataSchema() Schema {
+	return Schema{
+		"type": "object",
+		"properties": Schema{
+			"turn_id": Schema{"type": "string"},
+		},
+		"additionalProperties": false,
+	}
+}
+
+func localShellActionSchema() Schema {
+	return Schema{"oneOf": []any{Schema{
+		"type": "object",
+		"properties": Schema{
+			"type":              Schema{"type": "string", "enum": []any{"exec"}},
+			"command":           Schema{"type": "array", "items": Schema{"type": "string"}},
+			"timeout_ms":        nullableUnsignedIntegerSchema(),
+			"working_directory": nullableStringSchema(),
+			"env": Schema{"anyOf": []any{
+				Schema{"type": "object", "additionalProperties": Schema{"type": "string"}},
+				Schema{"type": "null"},
+			}},
+			"user": nullableStringSchema(),
+		},
+		"required":             []string{"type", "command", "timeout_ms", "working_directory", "env", "user"},
+		"additionalProperties": false,
+	}}}
+}
+
+func nullableUnsignedIntegerSchema() Schema {
+	return Schema{"anyOf": []any{Schema{"type": "integer", "minimum": 0}, Schema{"type": "null"}}}
 }
 
 func commandActionVariantSchema(actionType string, requiredFields []string, fields Schema) Schema {

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -1104,6 +1104,70 @@
       ],
       "type": "string"
     },
+    "ContentItem": {
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "text": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "input_text"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "text"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "detail": {
+              "$ref": "#/$defs/ImageDetail"
+            },
+            "image_url": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "input_image"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "image_url"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "text": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "output_text"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "text"
+          ],
+          "type": "object"
+        }
+      ]
+    },
     "ContextCompactedNotification": {
       "additionalProperties": false,
       "properties": {
@@ -2490,6 +2554,83 @@
       },
       "type": "object"
     },
+    "FunctionCallOutputBody": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/FunctionCallOutputContentItem"
+          },
+          "type": "array"
+        }
+      ]
+    },
+    "FunctionCallOutputContentItem": {
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "text": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "input_text"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "text"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "detail": {
+              "$ref": "#/$defs/ImageDetail"
+            },
+            "image_url": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "input_image"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "image_url"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "encrypted_content": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "encrypted_content"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "encrypted_content"
+          ],
+          "type": "object"
+        }
+      ]
+    },
     "GrantedPermissionProfile": {
       "additionalProperties": false,
       "properties": {
@@ -2654,6 +2795,15 @@
       ],
       "type": "object"
     },
+    "InternalChatMessageMetadataPassthrough": {
+      "additionalProperties": false,
+      "properties": {
+        "turn_id": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
     "ItemLifecycleNotificationParams": {
       "additionalProperties": false,
       "properties": {
@@ -2688,6 +2838,88 @@
       "type": "object"
     },
     "LegacyAppPathString": {
+      "type": "string"
+    },
+    "LocalShellAction": {
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "command": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "env": {
+              "anyOf": [
+                {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "timeout_ms": {
+              "anyOf": [
+                {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "type": {
+              "enum": [
+                "exec"
+              ],
+              "type": "string"
+            },
+            "user": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "working_directory": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "type",
+            "command",
+            "timeout_ms",
+            "working_directory",
+            "env",
+            "user"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "LocalShellStatus": {
+      "enum": [
+        "completed",
+        "in_progress",
+        "incomplete"
+      ],
       "type": "string"
     },
     "MCPContent": {

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -739,6 +739,18 @@ export type CommandExecutionRequestApprovalResponse = {
 
 export type CommandExecutionStatus = "inProgress" | "completed" | "failed" | "declined";
 
+export type ContentItem = {
+  "text": string;
+  "type": "input_text";
+} | {
+  "detail"?: ImageDetail;
+  "image_url": string;
+  "type": "input_image";
+} | {
+  "text": string;
+  "type": "output_text";
+};
+
 export type ContextCompactedNotification = {
   "threadId": string;
   "turnId": string;
@@ -1100,6 +1112,20 @@ export type FsWriteFileResponse = {
   "path"?: string;
 };
 
+export type FunctionCallOutputBody = string | Array<FunctionCallOutputContentItem>;
+
+export type FunctionCallOutputContentItem = {
+  "text": string;
+  "type": "input_text";
+} | {
+  "detail"?: ImageDetail;
+  "image_url": string;
+  "type": "input_image";
+} | {
+  "encrypted_content": string;
+  "type": "encrypted_content";
+};
+
 export type GrantedPermissionProfile = {
   "fileSystem"?: AdditionalFileSystemPermissions;
   "network"?: AdditionalNetworkPermissions;
@@ -1141,6 +1167,10 @@ export type InitializeResponse = {
   "userAgent": string;
 };
 
+export type InternalChatMessageMetadataPassthrough = {
+  "turn_id"?: string;
+};
+
 export type ItemLifecycleNotificationParams = {
   "at": string;
   "item"?: TimelineItem | null;
@@ -1150,6 +1180,17 @@ export type ItemLifecycleNotificationParams = {
 };
 
 export type LegacyAppPathString = string;
+
+export type LocalShellAction = {
+  "command": Array<string>;
+  "env": Record<string, string> | null;
+  "timeout_ms": number | null;
+  "type": "exec";
+  "user": string | null;
+  "working_directory": string | null;
+};
+
+export type LocalShellStatus = "completed" | "in_progress" | "incomplete";
 
 export type MCPContent = {
   "text"?: string;

--- a/appserver/protocol/typescript/testdata/response_item_prerequisites_contract.ts
+++ b/appserver/protocol/typescript/testdata/response_item_prerequisites_contract.ts
@@ -1,0 +1,78 @@
+import type {
+  ContentItem,
+  FunctionCallOutputBody,
+  FunctionCallOutputContentItem,
+  InternalChatMessageMetadataPassthrough,
+  LocalShellAction,
+  LocalShellStatus,
+} from "../gollem_appserver_protocol";
+
+export const contentItems = [
+  { type: "input_text", text: "hello" },
+  { type: "input_image", image_url: "image.png" },
+  { type: "input_image", image_url: "image.png", detail: "original" },
+  { type: "output_text", text: "done" },
+] satisfies ContentItem[];
+
+export const functionOutputItems = [
+  { type: "input_text", text: "tool output" },
+  { type: "input_image", image_url: "image.png", detail: "low" },
+  { type: "encrypted_content", encrypted_content: "cipher" },
+] satisfies FunctionCallOutputContentItem[];
+
+export const functionOutputBodies = [
+  "plain",
+  [],
+  [{ type: "input_text", text: "tool output" }],
+] satisfies FunctionCallOutputBody[];
+
+export const metadata = [
+  {},
+  { turn_id: "turn-1" },
+] satisfies InternalChatMessageMetadataPassthrough[];
+
+export const shellStatuses = ["completed", "in_progress", "incomplete"] satisfies LocalShellStatus[];
+export const shellActions = [
+  {
+    type: "exec",
+    command: [],
+    timeout_ms: null,
+    working_directory: null,
+    env: null,
+    user: null,
+  },
+  {
+    type: "exec",
+    command: ["go", "test", "./..."],
+    timeout_ms: 60_000,
+    working_directory: "/workspace",
+    env: { CI: "1" },
+    user: "runner",
+  },
+] satisfies LocalShellAction[];
+
+// @ts-expect-error image detail is non-null when present.
+export const rejectNullDetail = { type: "input_image", image_url: "image.png", detail: null } satisfies ContentItem;
+// @ts-expect-error content variants cannot cross fields.
+export const rejectCrossedContent = { type: "output_text", text: "done", image_url: "image.png" } satisfies ContentItem;
+// @ts-expect-error encrypted content uses snake_case.
+export const rejectCamelEncrypted = { type: "encrypted_content", encryptedContent: "cipher" } satisfies FunctionCallOutputContentItem;
+// @ts-expect-error function output bodies contain strict content items.
+export const rejectOutputTextBody = [{ type: "output_text", text: "unsupported" }] satisfies FunctionCallOutputBody;
+// @ts-expect-error metadata uses snake_case.
+export const rejectCamelTurn = { turnId: "turn-1" } satisfies InternalChatMessageMetadataPassthrough;
+// @ts-expect-error optional metadata is non-null when present.
+export const rejectNullTurn = { turn_id: null } satisfies InternalChatMessageMetadataPassthrough;
+// @ts-expect-error LocalShellStatus is closed and snake_case.
+export const rejectShellStatus = "inProgress" satisfies LocalShellStatus;
+// @ts-expect-error local-shell nullable fields are required.
+export const rejectMissingShellFields = { type: "exec", command: [] } satisfies LocalShellAction;
+export const rejectNumericEnvironment = {
+  type: "exec",
+  command: [],
+  timeout_ms: null,
+  working_directory: null,
+  // @ts-expect-error shell environment values are strings.
+  env: { CI: 1 },
+  user: null,
+} satisfies LocalShellAction;


### PR DESCRIPTION
## Summary
- export strict standalone `ContentItem`, `FunctionCallOutputContentItem`, `FunctionCallOutputBody`, `InternalChatMessageMetadataPassthrough`, `LocalShellAction`, and `LocalShellStatus`
- follow generated TypeScript required-nullable local-shell fields and optional non-null image/metadata fields while enforcing uint64 timeout and strict string collections at the Go/schema boundary
- leave full `ResponseItem`, provider conversion, shell runtime, durable items, and raw-response notification behavior unbound

## Representation note
The wire timeout is a JSON uint64. Gollem Go/JSON Schema enforce that range; the JSON-derived TypeScript client represents it as `number`, while the upstream Rust-only ts-rs model spells uint64 as `bigint`.

## Verification
- deliberate red Go/TypeScript contracts before implementation
- every new codec/helper at 100% focused coverage
- deterministic 235-definition/59-method/5-item generation and strict TypeScript
- full app-server tests, repository race suite, lint, vet, tidy, and clean-tree generation
- all five canonical Slang transport workflows against a trimpath branch binary