### PR TITLE
feat(protocol): add response item contract

### DIFF
--- a/appserver/protocol/README.md
+++ b/appserver/protocol/README.md
@@ -301,26 +301,28 @@ The exact standalone raw-response content prerequisites are exported as strict
 validated unions: snake-case input-text/encrypted-content agent message input,
 reasoning-text/text reasoning content, and summary-text reasoning summary.
 Required content stays non-null, crossed and unknown fields fail closed, and
-canonical output preserves public snake-case names. These definitions do not
-export full `ResponseItem`, bind raw-response notifications, map provider
-payloads, or change live agent/reasoning deltas.
+canonical output preserves public snake-case names. They remain independently
+validated dependencies; the parent `ResponseItem` export does not bind
+raw-response notifications, map provider payloads, or change live
+agent/reasoning deltas.
 
 The distinct `ResponsesApiWebSearchAction` union is also exported independently
 with snake-case search/open-page/find-in-page/other discriminators. Optional
 query, query-list, URL, and pattern fields are non-null when present and omit
 canonically when absent, following generated TypeScript rather than the looser
-`Option`-derived JSON Schema nullability. This does not alias the camel-case
-app-server action, add a provider/tool, export full `ResponseItem`, or bind live
-web-search events.
+`Option`-derived JSON Schema nullability. This remains distinct from the
+app-server action referenced by `ResponseItem` and does not add a provider/tool
+or bind live web-search events.
 
-The remaining standalone `ResponseItem` dependency values are exported without
-exporting the full response-item union: strict input/output content items,
-function-call output bodies, internal chat-message metadata, and local-shell
-actions/status. Optional image detail and metadata fields are non-null when
-present; local-shell execution keeps all generated TypeScript nullable fields
-required and validates unsigned JSON timeouts. These values are not bound to
-provider payloads, durable timeline items, live shell execution, or raw-response
-notifications.
+The standalone `ResponseItem` dependencies and full 16-variant response-item
+union are exported as strict validated values. Optional ids, phases, statuses,
+namespaces, prompts, actions, content, encrypted content, and metadata are
+non-null when present; fields declared nullable by generated TypeScript remain
+required and explicit. Arbitrary tool-search arguments and tool arrays retain
+all valid JSON values with number precision. The union references the existing
+app-server `WebSearchAction` contract and does not bind provider payloads,
+durable timeline items, live shell execution, lifecycle methods, or
+raw-response notifications.
 
 ## Generation
 

--- a/appserver/protocol/response_item_contract_test.go
+++ b/appserver/protocol/response_item_contract_test.go
@@ -1,0 +1,299 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"testing"
+)
+
+func TestResponseItemSchemaIsExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	response, ok := defs["ResponseItem"].(Schema)
+	if !ok {
+		t.Fatal("$defs missing ResponseItem")
+	}
+	variants, ok := response["oneOf"].([]any)
+	if !ok || len(variants) != 16 {
+		t.Fatalf("ResponseItem variants = %#v", response["oneOf"])
+	}
+	want := []struct {
+		itemType string
+		required []string
+		common   bool
+	}{
+		{itemType: "message", required: []string{"type", "role", "content"}, common: true},
+		{itemType: "agent_message", required: []string{"type", "author", "recipient", "content"}, common: true},
+		{itemType: "reasoning", required: []string{"type", "summary", "encrypted_content"}, common: true},
+		{itemType: "local_shell_call", required: []string{"type", "call_id", "status", "action"}, common: true},
+		{itemType: "function_call", required: []string{"type", "name", "arguments", "call_id"}, common: true},
+		{itemType: "tool_search_call", required: []string{"type", "call_id", "execution", "arguments"}, common: true},
+		{itemType: "function_call_output", required: []string{"type", "call_id", "output"}, common: true},
+		{itemType: "custom_tool_call", required: []string{"type", "call_id", "name", "input"}, common: true},
+		{itemType: "custom_tool_call_output", required: []string{"type", "call_id", "output"}, common: true},
+		{itemType: "tool_search_output", required: []string{"type", "call_id", "status", "execution", "tools"}, common: true},
+		{itemType: "web_search_call", required: []string{"type"}, common: true},
+		{itemType: "image_generation_call", required: []string{"type", "status", "result"}, common: true},
+		{itemType: "compaction", required: []string{"type", "encrypted_content"}, common: true},
+		{itemType: "compaction_trigger", required: []string{"type"}},
+		{itemType: "context_compaction", required: []string{"type"}, common: true},
+		{itemType: "other", required: []string{"type"}},
+	}
+	byType := make(map[string]Schema, len(variants))
+	for index, expected := range want {
+		variant := variants[index].(Schema)
+		if variant["additionalProperties"] != false {
+			t.Fatalf("ResponseItem %s allows extra fields", expected.itemType)
+		}
+		properties := variant["properties"].(Schema)
+		if !reflect.DeepEqual(properties["type"].(Schema)["enum"], []any{expected.itemType}) {
+			t.Fatalf("ResponseItem variant %d type = %#v", index, properties["type"])
+		}
+		if !slices.Equal(schemaRequiredNames(variant), expected.required) {
+			t.Fatalf("ResponseItem %s required = %v, want %v", expected.itemType, schemaRequiredNames(variant), expected.required)
+		}
+		_, hasID := properties["id"]
+		_, hasMetadata := properties[responseItemMetadataField]
+		if hasID != expected.common || hasMetadata != expected.common {
+			t.Fatalf("ResponseItem %s common fields: id=%v metadata=%v", expected.itemType, hasID, hasMetadata)
+		}
+		if expected.common {
+			if !reflect.DeepEqual(properties["id"], Schema{"type": "string"}) {
+				t.Fatalf("ResponseItem %s id = %#v", expected.itemType, properties["id"])
+			}
+			assertResponseItemRef(t, properties[responseItemMetadataField], "InternalChatMessageMetadataPassthrough")
+		}
+		byType[expected.itemType] = variant
+	}
+
+	assertResponseItemArrayRef(t, byType["message"], "content", "ContentItem")
+	assertResponseItemRef(t, responseItemProperties(byType["message"])["phase"], "MessagePhase")
+	assertResponseItemArrayRef(t, byType["agent_message"], "content", "AgentMessageInputContent")
+	assertResponseItemArrayRef(t, byType["reasoning"], "summary", "ReasoningItemReasoningSummary")
+	assertResponseItemArrayRef(t, byType["reasoning"], "content", "ReasoningItemContent")
+	assertNullableStringSchema(t, responseItemProperties(byType["reasoning"])["encrypted_content"])
+	assertNullableStringSchema(t, responseItemProperties(byType["local_shell_call"])["call_id"])
+	assertResponseItemRef(t, responseItemProperties(byType["local_shell_call"])["status"], "LocalShellStatus")
+	assertResponseItemRef(t, responseItemProperties(byType["local_shell_call"])["action"], "LocalShellAction")
+	assertNullableStringSchema(t, responseItemProperties(byType["tool_search_call"])["call_id"])
+	if !reflect.DeepEqual(responseItemProperties(byType["tool_search_call"])["arguments"], Schema{}) {
+		t.Fatalf("tool_search_call arguments = %#v", responseItemProperties(byType["tool_search_call"])["arguments"])
+	}
+	assertResponseItemRef(t, responseItemProperties(byType["function_call_output"])["output"], "FunctionCallOutputBody")
+	assertResponseItemRef(t, responseItemProperties(byType["custom_tool_call_output"])["output"], "FunctionCallOutputBody")
+	assertNullableStringSchema(t, responseItemProperties(byType["tool_search_output"])["call_id"])
+	tools := responseItemProperties(byType["tool_search_output"])["tools"].(Schema)
+	if tools["type"] != "array" || !reflect.DeepEqual(tools["items"], Schema{}) {
+		t.Fatalf("tool_search_output tools = %#v", tools)
+	}
+	assertResponseItemRef(t, responseItemProperties(byType["web_search_call"])["action"], "WebSearchAction")
+	if !reflect.DeepEqual(responseItemProperties(byType["context_compaction"])["encrypted_content"], Schema{"type": "string"}) {
+		t.Fatalf("context_compaction encrypted_content = %#v", responseItemProperties(byType["context_compaction"])["encrypted_content"])
+	}
+}
+
+func TestResponseItemWireValidationAndCanonicalization(t *testing.T) {
+	valid := []string{
+		`{"type":"message","role":"assistant","content":[]}`,
+		`{"type":"message","id":"msg-1","role":"assistant","content":[{"type":"output_text","text":"done"}],"phase":"final_answer","internal_chat_message_metadata_passthrough":{"turn_id":"turn-1"}}`,
+		`{"type":"agent_message","author":"agent-a","recipient":"agent-b","content":[]}`,
+		`{"type":"agent_message","id":"agent-1","author":"agent-a","recipient":"agent-b","content":[{"type":"input_text","text":"hello"}],"internal_chat_message_metadata_passthrough":{}}`,
+		`{"type":"reasoning","summary":[],"encrypted_content":null}`,
+		`{"type":"reasoning","id":"reason-1","summary":[{"type":"summary_text","text":"summary"}],"content":[{"type":"reasoning_text","text":"thinking"}],"encrypted_content":"cipher","internal_chat_message_metadata_passthrough":{"turn_id":"turn-1"}}`,
+		`{"type":"local_shell_call","call_id":null,"status":"in_progress","action":{"type":"exec","command":[],"timeout_ms":null,"working_directory":null,"env":null,"user":null}}`,
+		`{"type":"local_shell_call","id":"shell-1","call_id":"call-1","status":"completed","action":{"type":"exec","command":["pwd"],"timeout_ms":1000,"working_directory":"/workspace","env":{"CI":"1"},"user":"runner"},"internal_chat_message_metadata_passthrough":{}}`,
+		`{"type":"function_call","name":"run","arguments":"{}","call_id":"call-1"}`,
+		`{"type":"function_call","id":"fn-1","name":"run","namespace":"tools","arguments":"{\"x\":1}","call_id":"call-1","internal_chat_message_metadata_passthrough":{"turn_id":"turn-1"}}`,
+		`{"type":"tool_search_call","call_id":null,"execution":"search","arguments":null}`,
+		`{"type":"tool_search_call","id":"search-1","call_id":"call-1","status":"completed","execution":"search","arguments":{"limit":10,"query":"go"},"internal_chat_message_metadata_passthrough":{}}`,
+		`{"type":"function_call_output","call_id":"call-1","output":"done"}`,
+		`{"type":"function_call_output","id":"out-1","call_id":"call-1","output":[{"type":"input_text","text":"done"}],"internal_chat_message_metadata_passthrough":{}}`,
+		`{"type":"custom_tool_call","call_id":"call-1","name":"shell","input":"pwd"}`,
+		`{"type":"custom_tool_call","id":"custom-1","status":"completed","call_id":"call-1","name":"shell","namespace":"local","input":"pwd","internal_chat_message_metadata_passthrough":{}}`,
+		`{"type":"custom_tool_call_output","call_id":"call-1","output":"done"}`,
+		`{"type":"custom_tool_call_output","id":"custom-out-1","call_id":"call-1","name":"shell","output":[],"internal_chat_message_metadata_passthrough":{}}`,
+		`{"type":"tool_search_output","call_id":null,"status":"completed","execution":"search","tools":[]}`,
+		`{"type":"tool_search_output","id":"tools-1","call_id":"call-1","status":"completed","execution":"search","tools":[null,true,1,"tool",[1],{"name":"run"}],"internal_chat_message_metadata_passthrough":{}}`,
+		`{"type":"web_search_call"}`,
+		`{"type":"web_search_call","id":"web-1","status":"completed","action":{"type":"search","query":"gollem","queries":[]},"internal_chat_message_metadata_passthrough":{}}`,
+		`{"type":"image_generation_call","status":"completed","result":"base64"}`,
+		`{"type":"image_generation_call","id":"image-1","status":"completed","revised_prompt":"draw","result":"base64","internal_chat_message_metadata_passthrough":{}}`,
+		`{"type":"compaction","encrypted_content":"cipher"}`,
+		`{"type":"compaction","id":"compact-1","encrypted_content":"cipher","internal_chat_message_metadata_passthrough":{}}`,
+		`{"type":"compaction_trigger"}`,
+		`{"type":"context_compaction"}`,
+		`{"type":"context_compaction","id":"context-1","encrypted_content":"cipher","internal_chat_message_metadata_passthrough":{}}`,
+		`{"type":"other"}`,
+	}
+	assertRawJSONRoundTrips[ResponseItem](t, valid)
+
+	invalid := []string{
+		`null`, `[]`, `{}`, `{"type":null}`, `{"type":1}`, `{"type":"unknown"}`,
+		`{"type":"message","role":"assistant"}`,
+		`{"type":"message","id":null,"role":"assistant","content":[]}`,
+		`{"type":"message","role":null,"content":[]}`,
+		`{"type":"message","role":"assistant","content":null}`,
+		`{"type":"message","role":"assistant","content":[],"phase":null}`,
+		`{"type":"message","role":"assistant","content":[],"internal_chat_message_metadata_passthrough":null}`,
+		`{"type":"message","role":"assistant","content":[],"call_id":"crossed"}`,
+		`{"type":"agent_message","author":"agent-a","content":[]}`,
+		`{"type":"agent_message","recipient":"agent-b","content":[]}`,
+		`{"type":"agent_message","id":null,"author":"agent-a","recipient":"agent-b","content":[]}`,
+		`{"type":"agent_message","author":"agent-a","recipient":"agent-b","content":null}`,
+		`{"type":"agent_message","author":"agent-a","recipient":"agent-b","content":[],"role":"crossed"}`,
+		`{"type":"reasoning","summary":[]}`,
+		`{"type":"reasoning","id":null,"summary":[],"encrypted_content":null}`,
+		`{"type":"reasoning","summary":null,"encrypted_content":null}`,
+		`{"type":"reasoning","summary":[],"content":null,"encrypted_content":null}`,
+		`{"type":"reasoning","summary":[],"encrypted_content":1}`,
+		`{"type":"reasoning","summary":[],"encrypted_content":null,"role":"crossed"}`,
+		`{"type":"local_shell_call","status":"completed","action":{"type":"exec","command":[],"timeout_ms":null,"working_directory":null,"env":null,"user":null}}`,
+		`{"type":"local_shell_call","id":null,"call_id":null,"status":"completed","action":{"type":"exec","command":[],"timeout_ms":null,"working_directory":null,"env":null,"user":null}}`,
+		`{"type":"local_shell_call","call_id":1,"status":"completed","action":{"type":"exec","command":[],"timeout_ms":null,"working_directory":null,"env":null,"user":null}}`,
+		`{"type":"local_shell_call","call_id":null,"status":"failed","action":{"type":"exec","command":[],"timeout_ms":null,"working_directory":null,"env":null,"user":null}}`,
+		`{"type":"local_shell_call","call_id":null,"status":"completed","action":null}`,
+		`{"type":"local_shell_call","call_id":null,"status":"completed","action":{"type":"exec","command":[],"timeout_ms":null,"working_directory":null,"env":null,"user":null},"role":"crossed"}`,
+		`{"type":"function_call","name":"run","call_id":"call-1"}`,
+		`{"type":"function_call","arguments":"{}","call_id":"call-1"}`,
+		`{"type":"function_call","id":null,"name":"run","arguments":"{}","call_id":"call-1"}`,
+		`{"type":"function_call","name":"run","namespace":null,"arguments":"{}","call_id":"call-1"}`,
+		`{"type":"function_call","name":"run","arguments":{},"call_id":"call-1"}`,
+		`{"type":"function_call","name":"run","arguments":"{}","call_id":null}`,
+		`{"type":"function_call","name":"run","arguments":"{}","call_id":"call-1","role":"crossed"}`,
+		`{"type":"tool_search_call","execution":"search","arguments":null}`,
+		`{"type":"tool_search_call","id":null,"call_id":null,"execution":"search","arguments":null}`,
+		`{"type":"tool_search_call","call_id":null,"status":null,"execution":"search","arguments":null}`,
+		`{"type":"tool_search_call","call_id":null,"arguments":null}`,
+		`{"type":"tool_search_call","call_id":null,"execution":"search"}`,
+		`{"type":"tool_search_call","call_id":null,"execution":"search","arguments":null,"role":"crossed"}`,
+		`{"type":"function_call_output","call_id":null,"output":"done"}`,
+		`{"type":"function_call_output","id":null,"call_id":"call-1","output":"done"}`,
+		`{"type":"function_call_output","call_id":"call-1","output":null}`,
+		`{"type":"function_call_output","call_id":"call-1","output":"done","role":"crossed"}`,
+		`{"type":"custom_tool_call","call_id":"call-1","input":"pwd"}`,
+		`{"type":"custom_tool_call","name":"shell","input":"pwd"}`,
+		`{"type":"custom_tool_call","id":null,"call_id":"call-1","name":"shell","input":"pwd"}`,
+		`{"type":"custom_tool_call","status":null,"call_id":"call-1","name":"shell","input":"pwd"}`,
+		`{"type":"custom_tool_call","call_id":"call-1","name":"shell","namespace":null,"input":"pwd"}`,
+		`{"type":"custom_tool_call","call_id":"call-1","name":"shell"}`,
+		`{"type":"custom_tool_call","call_id":"call-1","name":"shell","input":"pwd","role":"crossed"}`,
+		`{"type":"custom_tool_call_output","output":"done"}`,
+		`{"type":"custom_tool_call_output","id":null,"call_id":"call-1","output":"done"}`,
+		`{"type":"custom_tool_call_output","call_id":"call-1","name":null,"output":"done"}`,
+		`{"type":"custom_tool_call_output","call_id":"call-1","output":{}}`,
+		`{"type":"custom_tool_call_output","call_id":"call-1","output":"done","role":"crossed"}`,
+		`{"type":"tool_search_output","call_id":null,"status":"completed","execution":"search"}`,
+		`{"type":"tool_search_output","id":null,"call_id":null,"status":"completed","execution":"search","tools":[]}`,
+		`{"type":"tool_search_output","call_id":1,"status":"completed","execution":"search","tools":[]}`,
+		`{"type":"tool_search_output","call_id":null,"status":"completed","execution":"search","tools":null}`,
+		`{"type":"tool_search_output","call_id":null,"status":"completed","execution":"search","tools":{}}`,
+		`{"type":"tool_search_output","call_id":null,"status":null,"execution":"search","tools":[]}`,
+		`{"type":"tool_search_output","call_id":null,"status":"completed","tools":[]}`,
+		`{"type":"tool_search_output","call_id":null,"status":"completed","execution":"search","tools":[],"role":"crossed"}`,
+		`{"type":"web_search_call","status":null}`,
+		`{"type":"web_search_call","id":null}`,
+		`{"type":"web_search_call","action":null}`,
+		`{"type":"web_search_call","action":{"type":"open_page","url":"https://example.test"}}`,
+		`{"type":"web_search_call","role":"crossed"}`,
+		`{"type":"image_generation_call","status":"completed"}`,
+		`{"type":"image_generation_call","id":null,"status":"completed","result":"base64"}`,
+		`{"type":"image_generation_call","status":null,"result":"base64"}`,
+		`{"type":"image_generation_call","status":"completed","revised_prompt":null,"result":"base64"}`,
+		`{"type":"image_generation_call","status":"completed","result":"base64","role":"crossed"}`,
+		`{"type":"compaction"}`,
+		`{"type":"compaction","id":null,"encrypted_content":"cipher"}`,
+		`{"type":"compaction","encrypted_content":null}`,
+		`{"type":"compaction","encrypted_content":"cipher","role":"crossed"}`,
+		`{"type":"compaction_trigger","id":"forbidden"}`,
+		`{"type":"context_compaction","id":null}`,
+		`{"type":"context_compaction","encrypted_content":null}`,
+		`{"type":"context_compaction","role":"crossed"}`,
+		`{"type":"other","extra":true}`,
+		`{"type":"other","callId":"camel"}`,
+	}
+	assertRawJSONRejects[ResponseItem](t, invalid)
+}
+
+func TestResponseItemUnknownJSONValuesRemainPreciseAndCanonical(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{
+			input: `{ "type": "tool_search_call", "call_id": null, "execution": "search", "arguments": { "z": 1, "a": 18446744073709551616 } }`,
+			want:  `{"type":"tool_search_call","call_id":null,"execution":"search","arguments":{"a":18446744073709551616,"z":1}}`,
+		},
+		{
+			input: `{ "type": "tool_search_output", "call_id": null, "status": "completed", "execution": "search", "tools": [ { "z": 1, "a": 2 }, null, 1e100 ] }`,
+			want:  `{"type":"tool_search_output","call_id":null,"status":"completed","execution":"search","tools":[{"a":2,"z":1},null,1e100]}`,
+		},
+	}
+	for _, testCase := range cases {
+		var item ResponseItem
+		if err := json.Unmarshal([]byte(testCase.input), &item); err != nil {
+			t.Fatalf("Unmarshal(%s): %v", testCase.input, err)
+		}
+		encoded, err := json.Marshal(item)
+		if err != nil {
+			t.Fatalf("Marshal(%s): %v", testCase.input, err)
+		}
+		if string(encoded) != testCase.want {
+			t.Fatalf("round trip %s = %s, want %s", testCase.input, encoded, testCase.want)
+		}
+	}
+
+	for _, testCase := range []struct {
+		input string
+		want  string
+	}{
+		{input: ` null `, want: `null`},
+		{input: ` {"z":1,"a":[true,false]} `, want: `{"a":[true,false],"z":1}`},
+	} {
+		got, err := canonicalizeResponseItemJSONValue([]byte(testCase.input))
+		if err != nil || string(got) != testCase.want {
+			t.Fatalf("canonicalize(%q) = %s, %v; want %s", testCase.input, got, err, testCase.want)
+		}
+	}
+	for _, input := range []string{"", "1 2", "1 trailing"} {
+		if _, err := canonicalizeResponseItemJSONValue([]byte(input)); err == nil {
+			t.Errorf("canonicalize(%q) succeeded", input)
+		}
+	}
+	if _, err := decodeRequiredResponseItemJSON(map[string]json.RawMessage{}, "test item", "arguments"); err == nil {
+		t.Fatal("missing required unknown JSON succeeded")
+	}
+	if _, err := decodeRequiredResponseItemJSON(map[string]json.RawMessage{"arguments": json.RawMessage(`invalid`)}, "test item", "arguments"); err == nil {
+		t.Fatal("malformed required unknown JSON succeeded")
+	}
+	if _, err := decodeRequiredResponseItemJSONArray(map[string]json.RawMessage{"tools": json.RawMessage(`[invalid]`)}, "test item", "tools"); err == nil {
+		t.Fatal("malformed required unknown array succeeded")
+	}
+}
+
+func TestResponseItemEmptyAndNilReceiversFailClosed(t *testing.T) {
+	assertEmptyRawJSONMarshalRejects(t, ResponseItem{})
+	var item *ResponseItem
+	if err := item.UnmarshalJSON([]byte(`{"type":"other"}`)); err == nil {
+		t.Fatal("nil ResponseItem receiver succeeded")
+	}
+}
+
+func responseItemProperties(schema Schema) Schema {
+	return schema["properties"].(Schema)
+}
+
+func assertResponseItemRef(t *testing.T, raw any, name string) {
+	t.Helper()
+	if !reflect.DeepEqual(raw, Schema{"$ref": "#/$defs/" + name}) {
+		t.Fatalf("ResponseItem ref = %#v, want %s", raw, name)
+	}
+}
+
+func assertResponseItemArrayRef(t *testing.T, variant Schema, fieldName, name string) {
+	t.Helper()
+	property := responseItemProperties(variant)[fieldName]
+	want := Schema{"type": "array", "items": Schema{"$ref": "#/$defs/" + name}}
+	if !reflect.DeepEqual(property, want) {
+		t.Fatalf("ResponseItem %s = %#v, want %#v", fieldName, property, want)
+	}
+}

--- a/appserver/protocol/response_item_types.go
+++ b/appserver/protocol/response_item_types.go
@@ -1,0 +1,641 @@
+package protocol
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// ResponseItem retains one validated public model response item. It remains
+// independent from provider payloads and Gollem's durable timeline records.
+type ResponseItem struct {
+	raw json.RawMessage
+}
+
+func (i ResponseItem) MarshalJSON() ([]byte, error) {
+	if len(i.raw) == 0 {
+		return nil, errors.New("response item has no value")
+	}
+	return validateResponseItemJSON(i.raw)
+}
+
+func (i *ResponseItem) UnmarshalJSON(data []byte) error {
+	if i == nil {
+		return errors.New("decode response item into nil receiver")
+	}
+	canonical, err := validateResponseItemJSON(data)
+	if err != nil {
+		return err
+	}
+	i.raw = canonical
+	return nil
+}
+
+var responseItemFields = []string{
+	"type",
+	"id",
+	"role",
+	"content",
+	"phase",
+	"internal_chat_message_metadata_passthrough",
+	"author",
+	"recipient",
+	"summary",
+	"encrypted_content",
+	"call_id",
+	"status",
+	"action",
+	"name",
+	"namespace",
+	"arguments",
+	"execution",
+	"output",
+	"input",
+	"tools",
+	"revised_prompt",
+	"result",
+}
+
+const responseItemMetadataField = "internal_chat_message_metadata_passthrough"
+
+func validateResponseItemJSON(data []byte) (json.RawMessage, error) {
+	payload, err := decodeExactThreadItemObject(data, "response item", responseItemFields...)
+	if err != nil {
+		return nil, err
+	}
+	itemType, err := decodeRequiredThreadItemValue[string](payload, "response item", "type")
+	if err != nil {
+		return nil, err
+	}
+
+	switch itemType {
+	case "message":
+		return validateMessageResponseItem(payload, itemType)
+	case "agent_message":
+		return validateAgentMessageResponseItem(payload, itemType)
+	case "reasoning":
+		return validateReasoningResponseItem(payload, itemType)
+	case "local_shell_call":
+		return validateLocalShellCallResponseItem(payload, itemType)
+	case "function_call":
+		return validateFunctionCallResponseItem(payload, itemType)
+	case "tool_search_call":
+		return validateToolSearchCallResponseItem(payload, itemType)
+	case "function_call_output":
+		return validateFunctionCallOutputResponseItem(payload, itemType)
+	case "custom_tool_call":
+		return validateCustomToolCallResponseItem(payload, itemType)
+	case "custom_tool_call_output":
+		return validateCustomToolCallOutputResponseItem(payload, itemType)
+	case "tool_search_output":
+		return validateToolSearchOutputResponseItem(payload, itemType)
+	case "web_search_call":
+		return validateWebSearchCallResponseItem(payload, itemType)
+	case "image_generation_call":
+		return validateImageGenerationCallResponseItem(payload, itemType)
+	case "compaction":
+		return validateCompactionResponseItem(payload, itemType)
+	case "compaction_trigger", "other":
+		if err := rejectThreadItemFields(payload, itemType+" response item", "type"); err != nil {
+			return nil, err
+		}
+		return json.Marshal(struct {
+			Type string `json:"type"`
+		}{Type: itemType})
+	case "context_compaction":
+		return validateContextCompactionResponseItem(payload, itemType)
+	default:
+		return nil, fmt.Errorf("unknown response item type %q", itemType)
+	}
+}
+
+type responseItemCommon struct {
+	ID       *string
+	Metadata *InternalChatMessageMetadataPassthrough
+}
+
+func decodeResponseItemCommon(payload map[string]json.RawMessage, objectName string) (responseItemCommon, error) {
+	id, err := decodeOptionalResponseItemValue[string](payload, objectName, "id")
+	if err != nil {
+		return responseItemCommon{}, err
+	}
+	metadata, err := decodeOptionalResponseItemValue[InternalChatMessageMetadataPassthrough](
+		payload,
+		objectName,
+		responseItemMetadataField,
+	)
+	if err != nil {
+		return responseItemCommon{}, err
+	}
+	return responseItemCommon{ID: id, Metadata: metadata}, nil
+}
+
+func validateMessageResponseItem(payload map[string]json.RawMessage, itemType string) (json.RawMessage, error) {
+	const objectName = "message response item"
+	if err := rejectThreadItemFields(payload, objectName, "type", "id", "role", "content", "phase", responseItemMetadataField); err != nil {
+		return nil, err
+	}
+	common, err := decodeResponseItemCommon(payload, objectName)
+	if err != nil {
+		return nil, err
+	}
+	role, err := decodeRequiredThreadItemValue[string](payload, objectName, "role")
+	if err != nil {
+		return nil, err
+	}
+	content, err := decodeRequiredThreadItemValue[[]ContentItem](payload, objectName, "content")
+	if err != nil {
+		return nil, err
+	}
+	phase, err := decodeOptionalResponseItemValue[MessagePhase](payload, objectName, "phase")
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(struct {
+		Type     string                                  `json:"type"`
+		ID       *string                                 `json:"id,omitempty"`
+		Role     string                                  `json:"role"`
+		Content  []ContentItem                           `json:"content"`
+		Phase    *MessagePhase                           `json:"phase,omitempty"`
+		Metadata *InternalChatMessageMetadataPassthrough `json:"internal_chat_message_metadata_passthrough,omitempty"`
+	}{Type: itemType, ID: common.ID, Role: role, Content: content, Phase: phase, Metadata: common.Metadata})
+}
+
+func validateAgentMessageResponseItem(payload map[string]json.RawMessage, itemType string) (json.RawMessage, error) {
+	const objectName = "agent-message response item"
+	if err := rejectThreadItemFields(payload, objectName, "type", "id", "author", "recipient", "content", responseItemMetadataField); err != nil {
+		return nil, err
+	}
+	common, err := decodeResponseItemCommon(payload, objectName)
+	if err != nil {
+		return nil, err
+	}
+	author, err := decodeRequiredThreadItemValue[string](payload, objectName, "author")
+	if err != nil {
+		return nil, err
+	}
+	recipient, err := decodeRequiredThreadItemValue[string](payload, objectName, "recipient")
+	if err != nil {
+		return nil, err
+	}
+	content, err := decodeRequiredThreadItemValue[[]AgentMessageInputContent](payload, objectName, "content")
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(struct {
+		Type      string                                  `json:"type"`
+		ID        *string                                 `json:"id,omitempty"`
+		Author    string                                  `json:"author"`
+		Recipient string                                  `json:"recipient"`
+		Content   []AgentMessageInputContent              `json:"content"`
+		Metadata  *InternalChatMessageMetadataPassthrough `json:"internal_chat_message_metadata_passthrough,omitempty"`
+	}{Type: itemType, ID: common.ID, Author: author, Recipient: recipient, Content: content, Metadata: common.Metadata})
+}
+
+func validateReasoningResponseItem(payload map[string]json.RawMessage, itemType string) (json.RawMessage, error) {
+	const objectName = "reasoning response item"
+	if err := rejectThreadItemFields(payload, objectName, "type", "id", "summary", "content", "encrypted_content", responseItemMetadataField); err != nil {
+		return nil, err
+	}
+	common, err := decodeResponseItemCommon(payload, objectName)
+	if err != nil {
+		return nil, err
+	}
+	summary, err := decodeRequiredThreadItemValue[[]ReasoningItemReasoningSummary](payload, objectName, "summary")
+	if err != nil {
+		return nil, err
+	}
+	content, err := decodeOptionalResponseItemValue[[]ReasoningItemContent](payload, objectName, "content")
+	if err != nil {
+		return nil, err
+	}
+	encryptedContent, err := decodeRequiredNullableThreadItemValue[string](payload, objectName, "encrypted_content")
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(struct {
+		Type             string                                  `json:"type"`
+		ID               *string                                 `json:"id,omitempty"`
+		Summary          []ReasoningItemReasoningSummary         `json:"summary"`
+		Content          *[]ReasoningItemContent                 `json:"content,omitempty"`
+		EncryptedContent *string                                 `json:"encrypted_content"`
+		Metadata         *InternalChatMessageMetadataPassthrough `json:"internal_chat_message_metadata_passthrough,omitempty"`
+	}{
+		Type: itemType, ID: common.ID, Summary: summary, Content: content,
+		EncryptedContent: encryptedContent, Metadata: common.Metadata,
+	})
+}
+
+func validateLocalShellCallResponseItem(payload map[string]json.RawMessage, itemType string) (json.RawMessage, error) {
+	const objectName = "local-shell-call response item"
+	if err := rejectThreadItemFields(payload, objectName, "type", "id", "call_id", "status", "action", responseItemMetadataField); err != nil {
+		return nil, err
+	}
+	common, err := decodeResponseItemCommon(payload, objectName)
+	if err != nil {
+		return nil, err
+	}
+	callID, err := decodeRequiredNullableThreadItemValue[string](payload, objectName, "call_id")
+	if err != nil {
+		return nil, err
+	}
+	status, err := decodeRequiredThreadItemValue[LocalShellStatus](payload, objectName, "status")
+	if err != nil {
+		return nil, err
+	}
+	action, err := decodeRequiredThreadItemValue[LocalShellAction](payload, objectName, "action")
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(struct {
+		Type     string                                  `json:"type"`
+		ID       *string                                 `json:"id,omitempty"`
+		CallID   *string                                 `json:"call_id"`
+		Status   LocalShellStatus                        `json:"status"`
+		Action   LocalShellAction                        `json:"action"`
+		Metadata *InternalChatMessageMetadataPassthrough `json:"internal_chat_message_metadata_passthrough,omitempty"`
+	}{Type: itemType, ID: common.ID, CallID: callID, Status: status, Action: action, Metadata: common.Metadata})
+}
+
+func validateFunctionCallResponseItem(payload map[string]json.RawMessage, itemType string) (json.RawMessage, error) {
+	const objectName = "function-call response item"
+	if err := rejectThreadItemFields(payload, objectName, "type", "id", "name", "namespace", "arguments", "call_id", responseItemMetadataField); err != nil {
+		return nil, err
+	}
+	common, err := decodeResponseItemCommon(payload, objectName)
+	if err != nil {
+		return nil, err
+	}
+	name, err := decodeRequiredThreadItemValue[string](payload, objectName, "name")
+	if err != nil {
+		return nil, err
+	}
+	namespace, err := decodeOptionalResponseItemValue[string](payload, objectName, "namespace")
+	if err != nil {
+		return nil, err
+	}
+	arguments, err := decodeRequiredThreadItemValue[string](payload, objectName, "arguments")
+	if err != nil {
+		return nil, err
+	}
+	callID, err := decodeRequiredThreadItemValue[string](payload, objectName, "call_id")
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(struct {
+		Type      string                                  `json:"type"`
+		ID        *string                                 `json:"id,omitempty"`
+		Name      string                                  `json:"name"`
+		Namespace *string                                 `json:"namespace,omitempty"`
+		Arguments string                                  `json:"arguments"`
+		CallID    string                                  `json:"call_id"`
+		Metadata  *InternalChatMessageMetadataPassthrough `json:"internal_chat_message_metadata_passthrough,omitempty"`
+	}{
+		Type: itemType, ID: common.ID, Name: name, Namespace: namespace,
+		Arguments: arguments, CallID: callID, Metadata: common.Metadata,
+	})
+}
+
+func validateToolSearchCallResponseItem(payload map[string]json.RawMessage, itemType string) (json.RawMessage, error) {
+	const objectName = "tool-search-call response item"
+	if err := rejectThreadItemFields(payload, objectName, "type", "id", "call_id", "status", "execution", "arguments", responseItemMetadataField); err != nil {
+		return nil, err
+	}
+	common, err := decodeResponseItemCommon(payload, objectName)
+	if err != nil {
+		return nil, err
+	}
+	callID, err := decodeRequiredNullableThreadItemValue[string](payload, objectName, "call_id")
+	if err != nil {
+		return nil, err
+	}
+	status, err := decodeOptionalResponseItemValue[string](payload, objectName, "status")
+	if err != nil {
+		return nil, err
+	}
+	execution, err := decodeRequiredThreadItemValue[string](payload, objectName, "execution")
+	if err != nil {
+		return nil, err
+	}
+	arguments, err := decodeRequiredResponseItemJSON(payload, objectName, "arguments")
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(struct {
+		Type      string                                  `json:"type"`
+		ID        *string                                 `json:"id,omitempty"`
+		CallID    *string                                 `json:"call_id"`
+		Status    *string                                 `json:"status,omitempty"`
+		Execution string                                  `json:"execution"`
+		Arguments json.RawMessage                         `json:"arguments"`
+		Metadata  *InternalChatMessageMetadataPassthrough `json:"internal_chat_message_metadata_passthrough,omitempty"`
+	}{
+		Type: itemType, ID: common.ID, CallID: callID, Status: status,
+		Execution: execution, Arguments: arguments, Metadata: common.Metadata,
+	})
+}
+
+func validateFunctionCallOutputResponseItem(payload map[string]json.RawMessage, itemType string) (json.RawMessage, error) {
+	const objectName = "function-call-output response item"
+	if err := rejectThreadItemFields(payload, objectName, "type", "id", "call_id", "output", responseItemMetadataField); err != nil {
+		return nil, err
+	}
+	common, err := decodeResponseItemCommon(payload, objectName)
+	if err != nil {
+		return nil, err
+	}
+	callID, err := decodeRequiredThreadItemValue[string](payload, objectName, "call_id")
+	if err != nil {
+		return nil, err
+	}
+	output, err := decodeRequiredThreadItemValue[FunctionCallOutputBody](payload, objectName, "output")
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(struct {
+		Type     string                                  `json:"type"`
+		ID       *string                                 `json:"id,omitempty"`
+		CallID   string                                  `json:"call_id"`
+		Output   FunctionCallOutputBody                  `json:"output"`
+		Metadata *InternalChatMessageMetadataPassthrough `json:"internal_chat_message_metadata_passthrough,omitempty"`
+	}{Type: itemType, ID: common.ID, CallID: callID, Output: output, Metadata: common.Metadata})
+}
+
+func validateCustomToolCallResponseItem(payload map[string]json.RawMessage, itemType string) (json.RawMessage, error) {
+	const objectName = "custom-tool-call response item"
+	if err := rejectThreadItemFields(payload, objectName, "type", "id", "status", "call_id", "name", "namespace", "input", responseItemMetadataField); err != nil {
+		return nil, err
+	}
+	common, err := decodeResponseItemCommon(payload, objectName)
+	if err != nil {
+		return nil, err
+	}
+	status, err := decodeOptionalResponseItemValue[string](payload, objectName, "status")
+	if err != nil {
+		return nil, err
+	}
+	callID, err := decodeRequiredThreadItemValue[string](payload, objectName, "call_id")
+	if err != nil {
+		return nil, err
+	}
+	name, err := decodeRequiredThreadItemValue[string](payload, objectName, "name")
+	if err != nil {
+		return nil, err
+	}
+	namespace, err := decodeOptionalResponseItemValue[string](payload, objectName, "namespace")
+	if err != nil {
+		return nil, err
+	}
+	input, err := decodeRequiredThreadItemValue[string](payload, objectName, "input")
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(struct {
+		Type      string                                  `json:"type"`
+		ID        *string                                 `json:"id,omitempty"`
+		Status    *string                                 `json:"status,omitempty"`
+		CallID    string                                  `json:"call_id"`
+		Name      string                                  `json:"name"`
+		Namespace *string                                 `json:"namespace,omitempty"`
+		Input     string                                  `json:"input"`
+		Metadata  *InternalChatMessageMetadataPassthrough `json:"internal_chat_message_metadata_passthrough,omitempty"`
+	}{
+		Type: itemType, ID: common.ID, Status: status, CallID: callID, Name: name,
+		Namespace: namespace, Input: input, Metadata: common.Metadata,
+	})
+}
+
+func validateCustomToolCallOutputResponseItem(payload map[string]json.RawMessage, itemType string) (json.RawMessage, error) {
+	const objectName = "custom-tool-call-output response item"
+	if err := rejectThreadItemFields(payload, objectName, "type", "id", "call_id", "name", "output", responseItemMetadataField); err != nil {
+		return nil, err
+	}
+	common, err := decodeResponseItemCommon(payload, objectName)
+	if err != nil {
+		return nil, err
+	}
+	callID, err := decodeRequiredThreadItemValue[string](payload, objectName, "call_id")
+	if err != nil {
+		return nil, err
+	}
+	name, err := decodeOptionalResponseItemValue[string](payload, objectName, "name")
+	if err != nil {
+		return nil, err
+	}
+	output, err := decodeRequiredThreadItemValue[FunctionCallOutputBody](payload, objectName, "output")
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(struct {
+		Type     string                                  `json:"type"`
+		ID       *string                                 `json:"id,omitempty"`
+		CallID   string                                  `json:"call_id"`
+		Name     *string                                 `json:"name,omitempty"`
+		Output   FunctionCallOutputBody                  `json:"output"`
+		Metadata *InternalChatMessageMetadataPassthrough `json:"internal_chat_message_metadata_passthrough,omitempty"`
+	}{Type: itemType, ID: common.ID, CallID: callID, Name: name, Output: output, Metadata: common.Metadata})
+}
+
+func validateToolSearchOutputResponseItem(payload map[string]json.RawMessage, itemType string) (json.RawMessage, error) {
+	const objectName = "tool-search-output response item"
+	if err := rejectThreadItemFields(payload, objectName, "type", "id", "call_id", "status", "execution", "tools", responseItemMetadataField); err != nil {
+		return nil, err
+	}
+	common, err := decodeResponseItemCommon(payload, objectName)
+	if err != nil {
+		return nil, err
+	}
+	callID, err := decodeRequiredNullableThreadItemValue[string](payload, objectName, "call_id")
+	if err != nil {
+		return nil, err
+	}
+	status, err := decodeRequiredThreadItemValue[string](payload, objectName, "status")
+	if err != nil {
+		return nil, err
+	}
+	execution, err := decodeRequiredThreadItemValue[string](payload, objectName, "execution")
+	if err != nil {
+		return nil, err
+	}
+	tools, err := decodeRequiredResponseItemJSONArray(payload, objectName, "tools")
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(struct {
+		Type      string                                  `json:"type"`
+		ID        *string                                 `json:"id,omitempty"`
+		CallID    *string                                 `json:"call_id"`
+		Status    string                                  `json:"status"`
+		Execution string                                  `json:"execution"`
+		Tools     []json.RawMessage                       `json:"tools"`
+		Metadata  *InternalChatMessageMetadataPassthrough `json:"internal_chat_message_metadata_passthrough,omitempty"`
+	}{
+		Type: itemType, ID: common.ID, CallID: callID, Status: status,
+		Execution: execution, Tools: tools, Metadata: common.Metadata,
+	})
+}
+
+func validateWebSearchCallResponseItem(payload map[string]json.RawMessage, itemType string) (json.RawMessage, error) {
+	const objectName = "web-search-call response item"
+	if err := rejectThreadItemFields(payload, objectName, "type", "id", "status", "action", responseItemMetadataField); err != nil {
+		return nil, err
+	}
+	common, err := decodeResponseItemCommon(payload, objectName)
+	if err != nil {
+		return nil, err
+	}
+	status, err := decodeOptionalResponseItemValue[string](payload, objectName, "status")
+	if err != nil {
+		return nil, err
+	}
+	action, err := decodeOptionalResponseItemValue[WebSearchAction](payload, objectName, "action")
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(struct {
+		Type     string                                  `json:"type"`
+		ID       *string                                 `json:"id,omitempty"`
+		Status   *string                                 `json:"status,omitempty"`
+		Action   *WebSearchAction                        `json:"action,omitempty"`
+		Metadata *InternalChatMessageMetadataPassthrough `json:"internal_chat_message_metadata_passthrough,omitempty"`
+	}{Type: itemType, ID: common.ID, Status: status, Action: action, Metadata: common.Metadata})
+}
+
+func validateImageGenerationCallResponseItem(payload map[string]json.RawMessage, itemType string) (json.RawMessage, error) {
+	const objectName = "image-generation-call response item"
+	if err := rejectThreadItemFields(payload, objectName, "type", "id", "status", "revised_prompt", "result", responseItemMetadataField); err != nil {
+		return nil, err
+	}
+	common, err := decodeResponseItemCommon(payload, objectName)
+	if err != nil {
+		return nil, err
+	}
+	status, err := decodeRequiredThreadItemValue[string](payload, objectName, "status")
+	if err != nil {
+		return nil, err
+	}
+	revisedPrompt, err := decodeOptionalResponseItemValue[string](payload, objectName, "revised_prompt")
+	if err != nil {
+		return nil, err
+	}
+	result, err := decodeRequiredThreadItemValue[string](payload, objectName, "result")
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(struct {
+		Type          string                                  `json:"type"`
+		ID            *string                                 `json:"id,omitempty"`
+		Status        string                                  `json:"status"`
+		RevisedPrompt *string                                 `json:"revised_prompt,omitempty"`
+		Result        string                                  `json:"result"`
+		Metadata      *InternalChatMessageMetadataPassthrough `json:"internal_chat_message_metadata_passthrough,omitempty"`
+	}{
+		Type: itemType, ID: common.ID, Status: status, RevisedPrompt: revisedPrompt,
+		Result: result, Metadata: common.Metadata,
+	})
+}
+
+func validateCompactionResponseItem(payload map[string]json.RawMessage, itemType string) (json.RawMessage, error) {
+	const objectName = "compaction response item"
+	if err := rejectThreadItemFields(payload, objectName, "type", "id", "encrypted_content", responseItemMetadataField); err != nil {
+		return nil, err
+	}
+	common, err := decodeResponseItemCommon(payload, objectName)
+	if err != nil {
+		return nil, err
+	}
+	encryptedContent, err := decodeRequiredThreadItemValue[string](payload, objectName, "encrypted_content")
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(struct {
+		Type             string                                  `json:"type"`
+		ID               *string                                 `json:"id,omitempty"`
+		EncryptedContent string                                  `json:"encrypted_content"`
+		Metadata         *InternalChatMessageMetadataPassthrough `json:"internal_chat_message_metadata_passthrough,omitempty"`
+	}{Type: itemType, ID: common.ID, EncryptedContent: encryptedContent, Metadata: common.Metadata})
+}
+
+func validateContextCompactionResponseItem(payload map[string]json.RawMessage, itemType string) (json.RawMessage, error) {
+	const objectName = "context-compaction response item"
+	if err := rejectThreadItemFields(payload, objectName, "type", "id", "encrypted_content", responseItemMetadataField); err != nil {
+		return nil, err
+	}
+	common, err := decodeResponseItemCommon(payload, objectName)
+	if err != nil {
+		return nil, err
+	}
+	encryptedContent, err := decodeOptionalResponseItemValue[string](payload, objectName, "encrypted_content")
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(struct {
+		Type             string                                  `json:"type"`
+		ID               *string                                 `json:"id,omitempty"`
+		EncryptedContent *string                                 `json:"encrypted_content,omitempty"`
+		Metadata         *InternalChatMessageMetadataPassthrough `json:"internal_chat_message_metadata_passthrough,omitempty"`
+	}{Type: itemType, ID: common.ID, EncryptedContent: encryptedContent, Metadata: common.Metadata})
+}
+
+func decodeOptionalResponseItemValue[T any](payload map[string]json.RawMessage, objectName, fieldName string) (*T, error) {
+	raw, ok := payload[fieldName]
+	if !ok {
+		return nil, nil
+	}
+	if isJSONNull(raw) {
+		return nil, fmt.Errorf("%s %s cannot be null", objectName, fieldName)
+	}
+	var value T
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return nil, fmt.Errorf("decode %s %s: %w", objectName, fieldName, err)
+	}
+	return &value, nil
+}
+
+func decodeRequiredResponseItemJSON(payload map[string]json.RawMessage, objectName, fieldName string) (json.RawMessage, error) {
+	raw, ok := payload[fieldName]
+	if !ok {
+		return nil, fmt.Errorf("%s requires %s", objectName, fieldName)
+	}
+	canonical, err := canonicalizeResponseItemJSONValue(raw)
+	if err != nil {
+		return nil, fmt.Errorf("decode %s %s: %w", objectName, fieldName, err)
+	}
+	return canonical, nil
+}
+
+func decodeRequiredResponseItemJSONArray(payload map[string]json.RawMessage, objectName, fieldName string) ([]json.RawMessage, error) {
+	raw, ok := payload[fieldName]
+	if !ok || isJSONNull(raw) {
+		return nil, fmt.Errorf("%s requires %s", objectName, fieldName)
+	}
+	canonical, err := canonicalizeResponseItemJSONValue(raw)
+	if err != nil {
+		return nil, fmt.Errorf("decode %s %s: %w", objectName, fieldName, err)
+	}
+	var values []json.RawMessage
+	if err := json.Unmarshal(canonical, &values); err != nil {
+		return nil, fmt.Errorf("decode %s %s: %w", objectName, fieldName, err)
+	}
+	return values, nil
+}
+
+func canonicalizeResponseItemJSONValue(data []byte) (json.RawMessage, error) {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return nil, err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return nil, errors.New("multiple JSON values")
+		}
+		return nil, fmt.Errorf("trailing JSON value: %w", err)
+	}
+	canonical, err := json.Marshal(value)
+	return canonical, err
+}

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -230,6 +230,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "ReasoningEffort", Type: reflect.TypeFor[ReasoningEffort]()},
 		{Name: "ReasoningItemContent", Type: reflect.TypeFor[ReasoningItemContent]()},
 		{Name: "ReasoningItemReasoningSummary", Type: reflect.TypeFor[ReasoningItemReasoningSummary]()},
+		{Name: "ResponseItem", Type: reflect.TypeFor[ResponseItem]()},
 		{Name: "ResponsesApiWebSearchAction", Type: reflect.TypeFor[ResponsesApiWebSearchAction]()},
 		{Name: "ServerRequestResolvedNotificationParams", Type: reflect.TypeFor[ServerRequestResolvedNotificationParams]()},
 		{Name: "ServerCapabilities", Type: reflect.TypeFor[ServerCapabilities]()},
@@ -371,6 +372,7 @@ func wireSchemaDefinitions() Schema {
 		string(LocalShellStatusCompleted), string(LocalShellStatusInProgress), string(LocalShellStatusIncomplete),
 	)
 	schemas["LocalShellAction"] = localShellActionSchema()
+	schemas["ResponseItem"] = responseItemSchema()
 	setSchemaIntegerMinimum(schemas["ByteRange"].(Schema), 0, "start", "end")
 	schemas["ImageDetail"] = stringEnumSchema(
 		string(ImageDetailAuto), string(ImageDetailLow), string(ImageDetailHigh), string(ImageDetailOriginal),
@@ -695,6 +697,103 @@ func localShellActionSchema() Schema {
 
 func nullableUnsignedIntegerSchema() Schema {
 	return Schema{"anyOf": []any{Schema{"type": "integer", "minimum": 0}, Schema{"type": "null"}}}
+}
+
+func responseItemSchema() Schema {
+	return Schema{"oneOf": []any{
+		responseItemVariantSchema("message", []string{"role", "content"}, Schema{
+			"role":    Schema{"type": "string"},
+			"content": Schema{"type": "array", "items": Schema{"$ref": "#/$defs/ContentItem"}},
+			"phase":   Schema{"$ref": "#/$defs/MessagePhase"},
+		}, true),
+		responseItemVariantSchema("agent_message", []string{"author", "recipient", "content"}, Schema{
+			"author":    Schema{"type": "string"},
+			"recipient": Schema{"type": "string"},
+			"content":   Schema{"type": "array", "items": Schema{"$ref": "#/$defs/AgentMessageInputContent"}},
+		}, true),
+		responseItemVariantSchema("reasoning", []string{"summary", "encrypted_content"}, Schema{
+			"summary":           Schema{"type": "array", "items": Schema{"$ref": "#/$defs/ReasoningItemReasoningSummary"}},
+			"content":           Schema{"type": "array", "items": Schema{"$ref": "#/$defs/ReasoningItemContent"}},
+			"encrypted_content": nullableStringSchema(),
+		}, true),
+		responseItemVariantSchema("local_shell_call", []string{"call_id", "status", "action"}, Schema{
+			"call_id": nullableStringSchema(),
+			"status":  Schema{"$ref": "#/$defs/LocalShellStatus"},
+			"action":  Schema{"$ref": "#/$defs/LocalShellAction"},
+		}, true),
+		responseItemVariantSchema("function_call", []string{"name", "arguments", "call_id"}, Schema{
+			"name":      Schema{"type": "string"},
+			"namespace": Schema{"type": "string"},
+			"arguments": Schema{"type": "string"},
+			"call_id":   Schema{"type": "string"},
+		}, true),
+		responseItemVariantSchema("tool_search_call", []string{"call_id", "execution", "arguments"}, Schema{
+			"call_id":   nullableStringSchema(),
+			"status":    Schema{"type": "string"},
+			"execution": Schema{"type": "string"},
+			"arguments": Schema{},
+		}, true),
+		responseItemVariantSchema("function_call_output", []string{"call_id", "output"}, Schema{
+			"call_id": Schema{"type": "string"},
+			"output":  Schema{"$ref": "#/$defs/FunctionCallOutputBody"},
+		}, true),
+		responseItemVariantSchema("custom_tool_call", []string{"call_id", "name", "input"}, Schema{
+			"status":    Schema{"type": "string"},
+			"call_id":   Schema{"type": "string"},
+			"name":      Schema{"type": "string"},
+			"namespace": Schema{"type": "string"},
+			"input":     Schema{"type": "string"},
+		}, true),
+		responseItemVariantSchema("custom_tool_call_output", []string{"call_id", "output"}, Schema{
+			"call_id": Schema{"type": "string"},
+			"name":    Schema{"type": "string"},
+			"output":  Schema{"$ref": "#/$defs/FunctionCallOutputBody"},
+		}, true),
+		responseItemVariantSchema("tool_search_output", []string{"call_id", "status", "execution", "tools"}, Schema{
+			"call_id":   nullableStringSchema(),
+			"status":    Schema{"type": "string"},
+			"execution": Schema{"type": "string"},
+			"tools":     Schema{"type": "array", "items": Schema{}},
+		}, true),
+		responseItemVariantSchema("web_search_call", nil, Schema{
+			"status": Schema{"type": "string"},
+			"action": Schema{"$ref": "#/$defs/WebSearchAction"},
+		}, true),
+		responseItemVariantSchema("image_generation_call", []string{"status", "result"}, Schema{
+			"status":         Schema{"type": "string"},
+			"revised_prompt": Schema{"type": "string"},
+			"result":         Schema{"type": "string"},
+		}, true),
+		responseItemVariantSchema("compaction", []string{"encrypted_content"}, Schema{
+			"encrypted_content": Schema{"type": "string"},
+		}, true),
+		responseItemVariantSchema("compaction_trigger", nil, nil, false),
+		responseItemVariantSchema("context_compaction", nil, Schema{
+			"encrypted_content": Schema{"type": "string"},
+		}, true),
+		responseItemVariantSchema("other", nil, nil, false),
+	}}
+}
+
+func responseItemVariantSchema(itemType string, requiredFields []string, fields Schema, common bool) Schema {
+	properties := Schema{
+		"type": Schema{"type": "string", "enum": []any{itemType}},
+	}
+	if common {
+		properties["id"] = Schema{"type": "string"}
+		properties[responseItemMetadataField] = Schema{"$ref": "#/$defs/InternalChatMessageMetadataPassthrough"}
+	}
+	for name, schema := range fields {
+		properties[name] = schema
+	}
+	required := []string{"type"}
+	required = append(required, requiredFields...)
+	return Schema{
+		"type":                 "object",
+		"properties":           properties,
+		"required":             required,
+		"additionalProperties": false,
+	}
 }
 
 func commandActionVariantSchema(actionType string, requiredFields []string, fields Schema) Schema {

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -4652,6 +4652,526 @@
       ],
       "type": "object"
     },
+    "ResponseItem": {
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "content": {
+              "items": {
+                "$ref": "#/$defs/ContentItem"
+              },
+              "type": "array"
+            },
+            "id": {
+              "type": "string"
+            },
+            "internal_chat_message_metadata_passthrough": {
+              "$ref": "#/$defs/InternalChatMessageMetadataPassthrough"
+            },
+            "phase": {
+              "$ref": "#/$defs/MessagePhase"
+            },
+            "role": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "message"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "role",
+            "content"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "author": {
+              "type": "string"
+            },
+            "content": {
+              "items": {
+                "$ref": "#/$defs/AgentMessageInputContent"
+              },
+              "type": "array"
+            },
+            "id": {
+              "type": "string"
+            },
+            "internal_chat_message_metadata_passthrough": {
+              "$ref": "#/$defs/InternalChatMessageMetadataPassthrough"
+            },
+            "recipient": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "agent_message"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "author",
+            "recipient",
+            "content"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "content": {
+              "items": {
+                "$ref": "#/$defs/ReasoningItemContent"
+              },
+              "type": "array"
+            },
+            "encrypted_content": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "id": {
+              "type": "string"
+            },
+            "internal_chat_message_metadata_passthrough": {
+              "$ref": "#/$defs/InternalChatMessageMetadataPassthrough"
+            },
+            "summary": {
+              "items": {
+                "$ref": "#/$defs/ReasoningItemReasoningSummary"
+              },
+              "type": "array"
+            },
+            "type": {
+              "enum": [
+                "reasoning"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "summary",
+            "encrypted_content"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "action": {
+              "$ref": "#/$defs/LocalShellAction"
+            },
+            "call_id": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "id": {
+              "type": "string"
+            },
+            "internal_chat_message_metadata_passthrough": {
+              "$ref": "#/$defs/InternalChatMessageMetadataPassthrough"
+            },
+            "status": {
+              "$ref": "#/$defs/LocalShellStatus"
+            },
+            "type": {
+              "enum": [
+                "local_shell_call"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "call_id",
+            "status",
+            "action"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "arguments": {
+              "type": "string"
+            },
+            "call_id": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "internal_chat_message_metadata_passthrough": {
+              "$ref": "#/$defs/InternalChatMessageMetadataPassthrough"
+            },
+            "name": {
+              "type": "string"
+            },
+            "namespace": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "function_call"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "name",
+            "arguments",
+            "call_id"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "arguments": {},
+            "call_id": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "execution": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "internal_chat_message_metadata_passthrough": {
+              "$ref": "#/$defs/InternalChatMessageMetadataPassthrough"
+            },
+            "status": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "tool_search_call"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "call_id",
+            "execution",
+            "arguments"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "call_id": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "internal_chat_message_metadata_passthrough": {
+              "$ref": "#/$defs/InternalChatMessageMetadataPassthrough"
+            },
+            "output": {
+              "$ref": "#/$defs/FunctionCallOutputBody"
+            },
+            "type": {
+              "enum": [
+                "function_call_output"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "call_id",
+            "output"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "call_id": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "input": {
+              "type": "string"
+            },
+            "internal_chat_message_metadata_passthrough": {
+              "$ref": "#/$defs/InternalChatMessageMetadataPassthrough"
+            },
+            "name": {
+              "type": "string"
+            },
+            "namespace": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "custom_tool_call"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "call_id",
+            "name",
+            "input"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "call_id": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "internal_chat_message_metadata_passthrough": {
+              "$ref": "#/$defs/InternalChatMessageMetadataPassthrough"
+            },
+            "name": {
+              "type": "string"
+            },
+            "output": {
+              "$ref": "#/$defs/FunctionCallOutputBody"
+            },
+            "type": {
+              "enum": [
+                "custom_tool_call_output"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "call_id",
+            "output"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "call_id": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "execution": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "internal_chat_message_metadata_passthrough": {
+              "$ref": "#/$defs/InternalChatMessageMetadataPassthrough"
+            },
+            "status": {
+              "type": "string"
+            },
+            "tools": {
+              "items": {},
+              "type": "array"
+            },
+            "type": {
+              "enum": [
+                "tool_search_output"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "call_id",
+            "status",
+            "execution",
+            "tools"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "action": {
+              "$ref": "#/$defs/WebSearchAction"
+            },
+            "id": {
+              "type": "string"
+            },
+            "internal_chat_message_metadata_passthrough": {
+              "$ref": "#/$defs/InternalChatMessageMetadataPassthrough"
+            },
+            "status": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "web_search_call"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "internal_chat_message_metadata_passthrough": {
+              "$ref": "#/$defs/InternalChatMessageMetadataPassthrough"
+            },
+            "result": {
+              "type": "string"
+            },
+            "revised_prompt": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "image_generation_call"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "status",
+            "result"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "encrypted_content": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "internal_chat_message_metadata_passthrough": {
+              "$ref": "#/$defs/InternalChatMessageMetadataPassthrough"
+            },
+            "type": {
+              "enum": [
+                "compaction"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "encrypted_content"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "enum": [
+                "compaction_trigger"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "encrypted_content": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "internal_chat_message_metadata_passthrough": {
+              "$ref": "#/$defs/InternalChatMessageMetadataPassthrough"
+            },
+            "type": {
+              "enum": [
+                "context_compaction"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "enum": [
+                "other"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        }
+      ]
+    },
     "ResponsesApiWebSearchAction": {
       "oneOf": [
         {

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -1548,6 +1548,109 @@ export type Response = {
   "result"?: unknown;
 };
 
+export type ResponseItem = {
+  "content": Array<ContentItem>;
+  "id"?: string;
+  "internal_chat_message_metadata_passthrough"?: InternalChatMessageMetadataPassthrough;
+  "phase"?: MessagePhase;
+  "role": string;
+  "type": "message";
+} | {
+  "author": string;
+  "content": Array<AgentMessageInputContent>;
+  "id"?: string;
+  "internal_chat_message_metadata_passthrough"?: InternalChatMessageMetadataPassthrough;
+  "recipient": string;
+  "type": "agent_message";
+} | {
+  "content"?: Array<ReasoningItemContent>;
+  "encrypted_content": string | null;
+  "id"?: string;
+  "internal_chat_message_metadata_passthrough"?: InternalChatMessageMetadataPassthrough;
+  "summary": Array<ReasoningItemReasoningSummary>;
+  "type": "reasoning";
+} | {
+  "action": LocalShellAction;
+  "call_id": string | null;
+  "id"?: string;
+  "internal_chat_message_metadata_passthrough"?: InternalChatMessageMetadataPassthrough;
+  "status": LocalShellStatus;
+  "type": "local_shell_call";
+} | {
+  "arguments": string;
+  "call_id": string;
+  "id"?: string;
+  "internal_chat_message_metadata_passthrough"?: InternalChatMessageMetadataPassthrough;
+  "name": string;
+  "namespace"?: string;
+  "type": "function_call";
+} | {
+  "arguments": unknown;
+  "call_id": string | null;
+  "execution": string;
+  "id"?: string;
+  "internal_chat_message_metadata_passthrough"?: InternalChatMessageMetadataPassthrough;
+  "status"?: string;
+  "type": "tool_search_call";
+} | {
+  "call_id": string;
+  "id"?: string;
+  "internal_chat_message_metadata_passthrough"?: InternalChatMessageMetadataPassthrough;
+  "output": FunctionCallOutputBody;
+  "type": "function_call_output";
+} | {
+  "call_id": string;
+  "id"?: string;
+  "input": string;
+  "internal_chat_message_metadata_passthrough"?: InternalChatMessageMetadataPassthrough;
+  "name": string;
+  "namespace"?: string;
+  "status"?: string;
+  "type": "custom_tool_call";
+} | {
+  "call_id": string;
+  "id"?: string;
+  "internal_chat_message_metadata_passthrough"?: InternalChatMessageMetadataPassthrough;
+  "name"?: string;
+  "output": FunctionCallOutputBody;
+  "type": "custom_tool_call_output";
+} | {
+  "call_id": string | null;
+  "execution": string;
+  "id"?: string;
+  "internal_chat_message_metadata_passthrough"?: InternalChatMessageMetadataPassthrough;
+  "status": string;
+  "tools": Array<unknown>;
+  "type": "tool_search_output";
+} | {
+  "action"?: WebSearchAction;
+  "id"?: string;
+  "internal_chat_message_metadata_passthrough"?: InternalChatMessageMetadataPassthrough;
+  "status"?: string;
+  "type": "web_search_call";
+} | {
+  "id"?: string;
+  "internal_chat_message_metadata_passthrough"?: InternalChatMessageMetadataPassthrough;
+  "result": string;
+  "revised_prompt"?: string;
+  "status": string;
+  "type": "image_generation_call";
+} | {
+  "encrypted_content": string;
+  "id"?: string;
+  "internal_chat_message_metadata_passthrough"?: InternalChatMessageMetadataPassthrough;
+  "type": "compaction";
+} | {
+  "type": "compaction_trigger";
+} | {
+  "encrypted_content"?: string;
+  "id"?: string;
+  "internal_chat_message_metadata_passthrough"?: InternalChatMessageMetadataPassthrough;
+  "type": "context_compaction";
+} | {
+  "type": "other";
+};
+
 export type ResponsesApiWebSearchAction = {
   "queries"?: Array<string>;
   "query"?: string;

--- a/appserver/protocol/typescript/testdata/response_item_contract.ts
+++ b/appserver/protocol/typescript/testdata/response_item_contract.ts
@@ -1,0 +1,91 @@
+import type { ResponseItem } from "../gollem_appserver_protocol";
+
+export const responseItems = [
+  { type: "message", role: "assistant", content: [] },
+  {
+    type: "message",
+    id: "msg-1",
+    role: "assistant",
+    content: [{ type: "output_text", text: "done" }],
+    phase: "final_answer",
+    internal_chat_message_metadata_passthrough: { turn_id: "turn-1" },
+  },
+  { type: "agent_message", author: "agent-a", recipient: "agent-b", content: [] },
+  {
+    type: "agent_message",
+    content: [{ type: "input_text", text: "hello" }],
+    author: "agent-a",
+    recipient: "agent-b",
+  },
+  { type: "reasoning", summary: [], encrypted_content: null },
+  {
+    type: "reasoning",
+    summary: [{ type: "summary_text", text: "summary" }],
+    content: [{ type: "reasoning_text", text: "thinking" }],
+    encrypted_content: "cipher",
+  },
+  {
+    type: "local_shell_call",
+    call_id: null,
+    status: "in_progress",
+    action: {
+      type: "exec",
+      command: [],
+      timeout_ms: null,
+      working_directory: null,
+      env: null,
+      user: null,
+    },
+  },
+  { type: "function_call", name: "run", arguments: "{}", call_id: "call-1" },
+  { type: "tool_search_call", call_id: null, execution: "search", arguments: null },
+  { type: "tool_search_call", call_id: "call-1", status: "completed", execution: "search", arguments: { query: "go" } },
+  { type: "function_call_output", call_id: "call-1", output: "done" },
+  { type: "function_call_output", call_id: "call-1", output: [{ type: "input_text", text: "done" }] },
+  { type: "custom_tool_call", call_id: "call-1", name: "shell", input: "pwd" },
+  { type: "custom_tool_call_output", call_id: "call-1", name: "shell", output: [] },
+  { type: "tool_search_output", call_id: null, status: "completed", execution: "search", tools: [null, 1, "tool", { name: "run" }] },
+  { type: "web_search_call" },
+  { type: "web_search_call", status: "completed", action: { type: "openPage", url: null } },
+  { type: "image_generation_call", status: "completed", revised_prompt: "draw", result: "base64" },
+  { type: "compaction", encrypted_content: "cipher" },
+  { type: "compaction_trigger" },
+  { type: "context_compaction" },
+  { type: "context_compaction", encrypted_content: "cipher" },
+  { type: "other" },
+] satisfies ResponseItem[];
+
+// @ts-expect-error message content is required.
+export const rejectMissingMessageContent = { type: "message", role: "assistant" } satisfies ResponseItem;
+// @ts-expect-error optional ids are non-null when present.
+export const rejectNullResponseItemId = { type: "message", id: null, role: "assistant", content: [] } satisfies ResponseItem;
+// @ts-expect-error optional metadata is non-null when present.
+export const rejectNullResponseMetadata = { type: "message", role: "assistant", content: [], internal_chat_message_metadata_passthrough: null } satisfies ResponseItem;
+// @ts-expect-error optional reasoning content is non-null when present.
+export const rejectNullReasoningContent = { type: "reasoning", summary: [], content: null, encrypted_content: null } satisfies ResponseItem;
+// @ts-expect-error reasoning encrypted content is required even when null.
+export const rejectMissingReasoningEncryptedContent = { type: "reasoning", summary: [] } satisfies ResponseItem;
+export const rejectMissingShellCallId = {
+  type: "local_shell_call",
+  status: "completed",
+  action: { type: "exec", command: [], timeout_ms: null, working_directory: null, env: null, user: null },
+// @ts-expect-error local shell call_id is required even when null.
+} satisfies ResponseItem;
+// @ts-expect-error function namespaces are non-null when present.
+export const rejectNullFunctionNamespace = { type: "function_call", name: "run", namespace: null, arguments: "{}", call_id: "call-1" } satisfies ResponseItem;
+// @ts-expect-error tool-search call_id is required even when null.
+export const rejectMissingToolSearchCallId = { type: "tool_search_call", execution: "search", arguments: {} } satisfies ResponseItem;
+// @ts-expect-error function output uses the strict output-body union.
+export const rejectObjectFunctionOutput = { type: "function_call_output", call_id: "call-1", output: {} } satisfies ResponseItem;
+// @ts-expect-error tools must be an array.
+export const rejectObjectTools = { type: "tool_search_output", call_id: null, status: "completed", execution: "search", tools: {} } satisfies ResponseItem;
+// @ts-expect-error web-search actions use the established app-server action contract.
+export const rejectSnakeCaseWebAction = { type: "web_search_call", action: { type: "open_page", url: null } } satisfies ResponseItem;
+// @ts-expect-error revised prompts are non-null when present.
+export const rejectNullRevisedPrompt = { type: "image_generation_call", status: "completed", revised_prompt: null, result: "base64" } satisfies ResponseItem;
+// @ts-expect-error compaction encrypted content is required and non-null.
+export const rejectNullCompactionContent = { type: "compaction", encrypted_content: null } satisfies ResponseItem;
+// @ts-expect-error context-compaction encrypted content is non-null when present.
+export const rejectNullContextCompactionContent = { type: "context_compaction", encrypted_content: null } satisfies ResponseItem;
+// @ts-expect-error closed variants reject crossed fields.
+export const rejectCrossedResponseItem = { type: "other", call_id: "call-1" } satisfies ResponseItem;


### PR DESCRIPTION
## Summary

- export the strict public 16-variant `ResponseItem` union without binding providers, runtime items, durable timeline records, lifecycle methods, or raw-response notifications
- enforce generated-TypeScript required/optional/nullability semantics, strict per-variant fields, canonical JSON, and precision-preserving arbitrary JSON for tool-search arguments/tools
- generate the 236-definition TypeScript/schema surface and add exhaustive Go plus strict TypeScript positive/negative contracts

## Contract decisions

- optional ids, metadata, phase/status/namespace/name/action/revised-prompt/content/encrypted-content fields reject explicit null
- reasoning encrypted content and local/tool-search call ids remain required nullable where generated TypeScript is stricter than the looser public schema
- `web_search_call.action` references Gollem's established app-server `WebSearchAction`; the separate `ResponsesApiWebSearchAction` remains distinct
- `unknown` arguments and `unknown[]` tools accept every valid JSON value, including null values/elements, while `json.Decoder.UseNumber` avoids float precision loss
- provider conversion, shell behavior, existing agent/reasoning/web-search events, `rawResponseItem/completed`, and lifecycle bindings remain unchanged

## Generated artifacts

- definitions/type bindings/item bindings: 236 / 59 / 5
- schema SHA-256: `18fc9badaba9e9c72ce943684b86eab36d9bf94db5a0c95c78272936a5624cf2`
- TypeScript SHA-256: `73ef2070e94f1c1c3b2441031c149ca2c76697acbd8e27e3ea12487f2e311ae9`
- strict TypeScript fixture SHA-256: `25b4a9fad8a02e1cd260fefe855f968f48a67a93b0d5a52198c3b574c6ee9c7a`

## Verification

- focused `ResponseItem` Go tests: pass; every statement in all 22 new codec functions/helpers covered
- `go test ./...`: pass
- exact CI package set under `go test -race`: pass; Monty passes its normal suite
- `golangci-lint run ./...`: 0 issues
- `go vet ./...`: pass
- `go mod tidy`: no diff
- `go generate ./appserver/protocol`: deterministic, byte-identical rerun
- strict generated TypeScript fixture: pass
- Slang real integration: 5/5 stdio, direct file approval, direct command approval, Unix socket, and WebSocket workflows against trimpath branch binary SHA-256 `2790ad5e06450cc2a8ccec1ec8a6d0173478d1290b467d2ffb3a28b8c30b5ce6`