### PR TITLE
feat(protocol): add thread item JSON prerequisites

### DIFF
--- a/appserver/protocol/README.md
+++ b/appserver/protocol/README.md
@@ -324,6 +324,12 @@ app-server `WebSearchAction` contract and does not bind provider payloads,
 durable timeline items, live shell execution, lifecycle methods, or
 raw-response notifications.
 
+The next standalone `ThreadItem` dependencies are also exported without live
+item adoption: recursive precision-preserving `JsonValue`, strict image
+generation records, and exact JSON-valued `McpToolCallResult`. The existing
+all-caps MCP runtime result remains distinct because it still carries legacy
+`MCPContent[]` rather than general JSON values.
+
 ## Generation
 
 Run:

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -171,11 +171,13 @@ func wireSchemaDefinitions() Schema {
 		{Name: "GrantedPermissionProfile", Type: reflect.TypeFor[GrantedPermissionProfile]()},
 		{Name: "HookPromptFragment", Type: reflect.TypeFor[HookPromptFragment]()},
 		{Name: "ImageDetail", Type: reflect.TypeFor[ImageDetail]()},
+		{Name: "ImageGenerationItem", Type: reflect.TypeFor[ImageGenerationItem]()},
 		{Name: "ImplementationInfo", Type: reflect.TypeFor[ImplementationInfo]()},
 		{Name: "InitializeCapabilities", Type: reflect.TypeFor[InitializeCapabilities]()},
 		{Name: "InitializeParams", Type: reflect.TypeFor[InitializeParams]()},
 		{Name: "InitializeResponse", Type: reflect.TypeFor[InitializeResponse]()},
 		{Name: "InternalChatMessageMetadataPassthrough", Type: reflect.TypeFor[InternalChatMessageMetadataPassthrough]()},
+		{Name: "JsonValue", Type: reflect.TypeFor[JsonValue]()},
 		{Name: "ItemLifecycleNotificationParams", Type: reflect.TypeFor[ItemLifecycleNotificationParams]()},
 		{Name: "LegacyAppPathString", Type: reflect.TypeFor[LegacyAppPathString]()},
 		{Name: "LocalShellAction", Type: reflect.TypeFor[LocalShellAction]()},
@@ -188,6 +190,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "MCPToolCallProgressNotificationParams", Type: reflect.TypeFor[MCPToolCallProgressNotificationParams]()},
 		{Name: "MCPToolCallResult", Type: reflect.TypeFor[MCPToolCallResult]()},
 		{Name: "McpToolCallAppContext", Type: reflect.TypeFor[McpToolCallAppContext]()},
+		{Name: "McpToolCallResult", Type: reflect.TypeFor[McpToolCallResult]()},
 		{Name: "MemoryCitation", Type: reflect.TypeFor[MemoryCitation]()},
 		{Name: "MemoryCitationEntry", Type: reflect.TypeFor[MemoryCitationEntry]()},
 		{Name: "MessagePhase", Type: reflect.TypeFor[MessagePhase]()},
@@ -373,6 +376,7 @@ func wireSchemaDefinitions() Schema {
 	)
 	schemas["LocalShellAction"] = localShellActionSchema()
 	schemas["ResponseItem"] = responseItemSchema()
+	schemas["JsonValue"] = jsonValueSchema()
 	setSchemaIntegerMinimum(schemas["ByteRange"].(Schema), 0, "start", "end")
 	schemas["ImageDetail"] = stringEnumSchema(
 		string(ImageDetailAuto), string(ImageDetailLow), string(ImageDetailHigh), string(ImageDetailOriginal),
@@ -697,6 +701,20 @@ func localShellActionSchema() Schema {
 
 func nullableUnsignedIntegerSchema() Schema {
 	return Schema{"anyOf": []any{Schema{"type": "integer", "minimum": 0}, Schema{"type": "null"}}}
+}
+
+func jsonValueSchema() Schema {
+	return Schema{"anyOf": []any{
+		Schema{"type": "number"},
+		Schema{"type": "string"},
+		Schema{"type": "boolean"},
+		Schema{"type": "array", "items": Schema{"$ref": "#/$defs/JsonValue"}},
+		Schema{
+			"type": "object", "additionalProperties": Schema{"$ref": "#/$defs/JsonValue"},
+			"x-gollem-typescript-recursive-map": true,
+		},
+		Schema{"type": "null"},
+	}}
 }
 
 func responseItemSchema() Schema {

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -2668,6 +2668,40 @@
       ],
       "type": "string"
     },
+    "ImageGenerationItem": {
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "result": {
+          "type": "string"
+        },
+        "revisedPrompt": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "savedPath": {
+          "$ref": "#/$defs/AbsolutePathBuf"
+        },
+        "status": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "status",
+        "revisedPrompt",
+        "result"
+      ],
+      "type": "object"
+    },
     "ImplementationInfo": {
       "additionalProperties": false,
       "properties": {
@@ -2836,6 +2870,35 @@
         "at"
       ],
       "type": "object"
+    },
+    "JsonValue": {
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/JsonValue"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/JsonValue"
+          },
+          "type": "object",
+          "x-gollem-typescript-recursive-map": true
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "LegacyAppPathString": {
       "type": "string"
@@ -3888,6 +3951,43 @@
         "turnId",
         "itemId",
         "message"
+      ],
+      "type": "object"
+    },
+    "McpToolCallResult": {
+      "additionalProperties": false,
+      "properties": {
+        "_meta": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/JsonValue"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "content": {
+          "items": {
+            "$ref": "#/$defs/JsonValue"
+          },
+          "type": "array"
+        },
+        "structuredContent": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/JsonValue"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "content",
+        "structuredContent",
+        "_meta"
       ],
       "type": "object"
     },

--- a/appserver/protocol/thread_item_json_image_mcp_contract_test.go
+++ b/appserver/protocol/thread_item_json_image_mcp_contract_test.go
@@ -1,0 +1,204 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"testing"
+)
+
+func TestThreadItemJSONImageMCPPrerequisiteSchemasAreExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+
+	jsonValue := defs["JsonValue"].(Schema)
+	variants := jsonValue["anyOf"].([]any)
+	if len(variants) != 6 {
+		t.Fatalf("JsonValue variants = %#v", variants)
+	}
+	for index, want := range []Schema{
+		{"type": "number"},
+		{"type": "string"},
+		{"type": "boolean"},
+		{"type": "array", "items": Schema{"$ref": "#/$defs/JsonValue"}},
+		{
+			"type": "object", "additionalProperties": Schema{"$ref": "#/$defs/JsonValue"},
+			"x-gollem-typescript-recursive-map": true,
+		},
+		{"type": "null"},
+	} {
+		if !reflect.DeepEqual(variants[index], want) {
+			t.Fatalf("JsonValue variant %d = %#v, want %#v", index, variants[index], want)
+		}
+	}
+
+	image := defs["ImageGenerationItem"].(Schema)
+	if !slices.Equal(schemaRequiredNames(image), []string{"id", "status", "revisedPrompt", "result"}) {
+		t.Fatalf("ImageGenerationItem required = %v", schemaRequiredNames(image))
+	}
+	imageProperties := image["properties"].(Schema)
+	assertNullableStringSchema(t, imageProperties["revisedPrompt"])
+	if !reflect.DeepEqual(imageProperties["savedPath"], Schema{"$ref": "#/$defs/AbsolutePathBuf"}) {
+		t.Fatalf("ImageGenerationItem.savedPath = %#v", imageProperties["savedPath"])
+	}
+
+	result := defs["McpToolCallResult"].(Schema)
+	if !slices.Equal(schemaRequiredNames(result), []string{"content", "structuredContent", "_meta"}) {
+		t.Fatalf("McpToolCallResult required = %v", schemaRequiredNames(result))
+	}
+	resultProperties := result["properties"].(Schema)
+	if !reflect.DeepEqual(resultProperties["content"], Schema{
+		"type": "array", "items": Schema{"$ref": "#/$defs/JsonValue"},
+	}) {
+		t.Fatalf("McpToolCallResult.content = %#v", resultProperties["content"])
+	}
+	for _, name := range []string{"structuredContent", "_meta"} {
+		want := Schema{"anyOf": []any{
+			Schema{"$ref": "#/$defs/JsonValue"},
+			Schema{"type": "null"},
+		}}
+		if !reflect.DeepEqual(resultProperties[name], want) {
+			t.Fatalf("McpToolCallResult.%s = %#v", name, resultProperties[name])
+		}
+	}
+}
+
+func TestJsonValueWireValidationAndPrecision(t *testing.T) {
+	valid := []struct {
+		input string
+		want  string
+	}{
+		{input: `null`, want: `null`},
+		{input: `true`, want: `true`},
+		{input: `"text"`, want: `"text"`},
+		{input: `18446744073709551616`, want: `18446744073709551616`},
+		{input: `[null,false,1,"x",{"z":1,"a":2}]`, want: `[null,false,1,"x",{"a":2,"z":1}]`},
+		{input: ` { "nested": [1e100, {"ok": true}] } `, want: `{"nested":[1e100,{"ok":true}]}`},
+	}
+	for _, testCase := range valid {
+		var value JsonValue
+		if err := json.Unmarshal([]byte(testCase.input), &value); err != nil {
+			t.Fatalf("Unmarshal(%s): %v", testCase.input, err)
+		}
+		encoded, err := json.Marshal(value)
+		if err != nil || string(encoded) != testCase.want {
+			t.Fatalf("round trip %s = %s, %v; want %s", testCase.input, encoded, err, testCase.want)
+		}
+	}
+	for _, input := range []string{"", `undefined`, `1 2`, `{"broken":}`} {
+		var value JsonValue
+		if err := value.UnmarshalJSON([]byte(input)); err == nil {
+			t.Errorf("UnmarshalJSON(%q) succeeded", input)
+		}
+	}
+	if _, err := json.Marshal(JsonValue{}); err == nil {
+		t.Fatal("Marshal empty JsonValue succeeded")
+	}
+	var nilValue *JsonValue
+	if err := nilValue.UnmarshalJSON([]byte(`null`)); err == nil {
+		t.Fatal("nil JsonValue receiver succeeded")
+	}
+}
+
+func TestImageGenerationItemWireValidation(t *testing.T) {
+	valid := []struct {
+		input string
+		want  string
+	}{
+		{
+			input: `{"id":"image-1","status":"completed","revisedPrompt":null,"result":"base64"}`,
+			want:  `{"id":"image-1","status":"completed","revisedPrompt":null,"result":"base64"}`,
+		},
+		{
+			input: `{"id":"","status":"","revisedPrompt":"draw","result":"","savedPath":"/workspace/../workspace/image.png"}`,
+			want:  `{"id":"","status":"","revisedPrompt":"draw","result":"","savedPath":"/workspace/image.png"}`,
+		},
+	}
+	for _, testCase := range valid {
+		var item ImageGenerationItem
+		if err := json.Unmarshal([]byte(testCase.input), &item); err != nil {
+			t.Fatalf("Unmarshal(%s): %v", testCase.input, err)
+		}
+		encoded, err := json.Marshal(item)
+		if err != nil || string(encoded) != testCase.want {
+			t.Fatalf("round trip %s = %s, %v; want %s", testCase.input, encoded, err, testCase.want)
+		}
+	}
+	invalid := []string{
+		`null`, `{}`,
+		`{"status":"completed","revisedPrompt":null,"result":"x"}`,
+		`{"id":"i","revisedPrompt":null,"result":"x"}`,
+		`{"id":"i","status":"completed","result":"x"}`,
+		`{"id":"i","status":"completed","revisedPrompt":null}`,
+		`{"id":null,"status":"completed","revisedPrompt":null,"result":"x"}`,
+		`{"id":"i","status":null,"revisedPrompt":null,"result":"x"}`,
+		`{"id":"i","status":"completed","revisedPrompt":1,"result":"x"}`,
+		`{"id":"i","status":"completed","revisedPrompt":null,"result":null}`,
+		`{"id":"i","status":"completed","revisedPrompt":null,"result":"x","savedPath":null}`,
+		`{"id":"i","status":"completed","revisedPrompt":null,"result":"x","savedPath":"relative.png"}`,
+		`{"id":"i","status":"completed","revisedPrompt":null,"result":"x","extra":true}`,
+	}
+	for _, input := range invalid {
+		var item ImageGenerationItem
+		if err := json.Unmarshal([]byte(input), &item); err == nil {
+			t.Errorf("Unmarshal(%s) succeeded", input)
+		}
+	}
+	var nilItem *ImageGenerationItem
+	if err := nilItem.UnmarshalJSON([]byte(valid[0].input)); err == nil {
+		t.Fatal("nil ImageGenerationItem receiver succeeded")
+	}
+	invalidPath := AbsolutePathBuf("relative.png")
+	if _, err := json.Marshal(ImageGenerationItem{
+		ID: "image-1", Status: "completed", Result: "base64", SavedPath: &invalidPath,
+	}); err == nil {
+		t.Fatal("Marshal image item with relative savedPath succeeded")
+	}
+}
+
+func TestMcpToolCallResultWireValidation(t *testing.T) {
+	valid := []struct {
+		input string
+		want  string
+	}{
+		{input: `{"content":[],"structuredContent":null,"_meta":null}`, want: `{"content":[],"structuredContent":null,"_meta":null}`},
+		{
+			input: `{"content":[null,"text",18446744073709551616,{"z":1,"a":2}],"structuredContent":{"ok":true},"_meta":[1,false]}`,
+			want:  `{"content":[null,"text",18446744073709551616,{"a":2,"z":1}],"structuredContent":{"ok":true},"_meta":[1,false]}`,
+		},
+	}
+	for _, testCase := range valid {
+		var result McpToolCallResult
+		if err := json.Unmarshal([]byte(testCase.input), &result); err != nil {
+			t.Fatalf("Unmarshal(%s): %v", testCase.input, err)
+		}
+		encoded, err := json.Marshal(result)
+		if err != nil || string(encoded) != testCase.want {
+			t.Fatalf("round trip %s = %s, %v; want %s", testCase.input, encoded, err, testCase.want)
+		}
+	}
+	for _, input := range []string{
+		`null`, `{}`,
+		`{"structuredContent":null,"_meta":null}`,
+		`{"content":null,"structuredContent":null,"_meta":null}`,
+		`{"content":{},"structuredContent":null,"_meta":null}`,
+		`{"content":[] ,"_meta":null}`,
+		`{"content":[],"structuredContent":null}`,
+		`{"content":[],"structuredContent":null,"_meta":null,"extra":true}`,
+	} {
+		var result McpToolCallResult
+		if err := json.Unmarshal([]byte(input), &result); err == nil {
+			t.Errorf("Unmarshal(%s) succeeded", input)
+		}
+	}
+	encoded, err := json.Marshal(McpToolCallResult{})
+	if err != nil || string(encoded) != `{"content":[],"structuredContent":null,"_meta":null}` {
+		t.Fatalf("Marshal zero result = %s, %v", encoded, err)
+	}
+	var nilResult *McpToolCallResult
+	if err := nilResult.UnmarshalJSON([]byte(valid[0].input)); err == nil {
+		t.Fatal("nil McpToolCallResult receiver succeeded")
+	}
+	if _, err := json.Marshal(McpToolCallResult{Content: []JsonValue{{}}}); err == nil {
+		t.Fatal("Marshal MCP result with empty JsonValue succeeded")
+	}
+}

--- a/appserver/protocol/thread_item_json_image_mcp_types.go
+++ b/appserver/protocol/thread_item_json_image_mcp_types.go
@@ -1,0 +1,115 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// JsonValue retains one precision-preserving JSON value.
+type JsonValue struct {
+	raw json.RawMessage
+}
+
+func (v JsonValue) MarshalJSON() ([]byte, error) {
+	if len(v.raw) == 0 {
+		return nil, errors.New("JSON value has no value")
+	}
+	return canonicalizeResponseItemJSONValue(v.raw)
+}
+
+func (v *JsonValue) UnmarshalJSON(data []byte) error {
+	if v == nil {
+		return errors.New("decode JSON value into nil receiver")
+	}
+	canonical, err := canonicalizeResponseItemJSONValue(data)
+	if err != nil {
+		return fmt.Errorf("decode JSON value: %w", err)
+	}
+	v.raw = canonical
+	return nil
+}
+
+type ImageGenerationItem struct {
+	ID            string           `json:"id"`
+	Status        string           `json:"status"`
+	RevisedPrompt *string          `json:"revisedPrompt"`
+	Result        string           `json:"result"`
+	SavedPath     *AbsolutePathBuf `json:"savedPath,omitempty" jsonschema:"nonnullable=true"`
+}
+
+func (i *ImageGenerationItem) UnmarshalJSON(data []byte) error {
+	if i == nil {
+		return errors.New("decode image-generation item into nil receiver")
+	}
+	payload, err := decodeExactThreadItemObject(data, "image-generation item", "id", "status", "revisedPrompt", "result", "savedPath")
+	if err != nil {
+		return err
+	}
+	id, err := decodeRequiredThreadItemValue[string](payload, "image-generation item", "id")
+	if err != nil {
+		return err
+	}
+	status, err := decodeRequiredThreadItemValue[string](payload, "image-generation item", "status")
+	if err != nil {
+		return err
+	}
+	revisedPrompt, err := decodeRequiredNullableThreadItemValue[string](payload, "image-generation item", "revisedPrompt")
+	if err != nil {
+		return err
+	}
+	result, err := decodeRequiredThreadItemValue[string](payload, "image-generation item", "result")
+	if err != nil {
+		return err
+	}
+	savedPath, err := decodeOptionalResponseItemValue[AbsolutePathBuf](payload, "image-generation item", "savedPath")
+	if err != nil {
+		return err
+	}
+	*i = ImageGenerationItem{ID: id, Status: status, RevisedPrompt: revisedPrompt, Result: result, SavedPath: savedPath}
+	return nil
+}
+
+// McpToolCallResult is the exact public JSON-valued result. Gollem's live
+// MCPToolCallResult remains a separate legacy MCPContent-backed value.
+type McpToolCallResult struct {
+	Content           []JsonValue `json:"content" jsonschema:"nonnullable=true"`
+	StructuredContent *JsonValue  `json:"structuredContent"`
+	Meta              *JsonValue  `json:"_meta"`
+}
+
+func (r McpToolCallResult) MarshalJSON() ([]byte, error) {
+	content := r.Content
+	if content == nil {
+		content = []JsonValue{}
+	}
+	return json.Marshal(struct {
+		Content           []JsonValue `json:"content"`
+		StructuredContent *JsonValue  `json:"structuredContent"`
+		Meta              *JsonValue  `json:"_meta"`
+	}{Content: content, StructuredContent: r.StructuredContent, Meta: r.Meta})
+}
+
+func (r *McpToolCallResult) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("decode MCP tool-call result into nil receiver")
+	}
+	payload, err := decodeExactThreadItemObject(data, "MCP tool-call result", "content", "structuredContent", "_meta")
+	if err != nil {
+		return err
+	}
+	content, err := decodeRequiredThreadItemValue[[]JsonValue](payload, "MCP tool-call result", "content")
+	if err != nil {
+		return err
+	}
+	structuredContent, err := decodeRequiredNullableThreadItemValue[JsonValue](payload, "MCP tool-call result", "structuredContent")
+	if err != nil {
+		return err
+	}
+	meta, err := decodeRequiredNullableThreadItemValue[JsonValue](payload, "MCP tool-call result", "_meta")
+	if err != nil {
+		return err
+	}
+	*r = McpToolCallResult{Content: content, StructuredContent: structuredContent, Meta: meta}
+	return nil
+}

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -277,6 +277,9 @@ func typeScriptObjectType(schema Schema, indent int) (string, error) {
 			if err != nil {
 				return "", err
 			}
+			if recursive, _ := schema["x-gollem-typescript-recursive-map"].(bool); recursive {
+				return "{ [key: string]: " + valueType + " }", nil
+			}
 			return "Record<string, " + valueType + ">", nil
 		}
 		if !additionalAllowed {

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -1138,6 +1138,14 @@ export type HookPromptFragment = {
 
 export type ImageDetail = "auto" | "low" | "high" | "original";
 
+export type ImageGenerationItem = {
+  "id": string;
+  "result": string;
+  "revisedPrompt": string | null;
+  "savedPath"?: AbsolutePathBuf;
+  "status": string;
+};
+
 export type ImplementationInfo = {
   "name": string;
   "version"?: string;
@@ -1178,6 +1186,8 @@ export type ItemLifecycleNotificationParams = {
   "threadId": string;
   "turnId"?: string;
 };
+
+export type JsonValue = number | string | boolean | Array<JsonValue> | { [key: string]: JsonValue } | null;
 
 export type LegacyAppPathString = string;
 
@@ -1422,6 +1432,12 @@ export type McpToolCallProgressNotification = {
   "message": string;
   "threadId": string;
   "turnId": string;
+};
+
+export type McpToolCallResult = {
+  "_meta": JsonValue | null;
+  "content": Array<JsonValue>;
+  "structuredContent": JsonValue | null;
 };
 
 export type McpToolCallStatus = "inProgress" | "completed" | "failed";

--- a/appserver/protocol/typescript/testdata/thread_item_json_image_mcp_contract.ts
+++ b/appserver/protocol/typescript/testdata/thread_item_json_image_mcp_contract.ts
@@ -1,0 +1,49 @@
+import type {
+  ImageGenerationItem,
+  JsonValue,
+  McpToolCallResult,
+} from "../gollem_appserver_protocol";
+
+export const jsonValues = [
+  null,
+  true,
+  1,
+  "text",
+  [null, { nested: [1, false] }],
+  { value: "ok" },
+] satisfies JsonValue[];
+
+export const imageItems = [
+  { id: "image-1", status: "completed", revisedPrompt: null, result: "base64" },
+  {
+    id: "image-2",
+    status: "completed",
+    revisedPrompt: "draw",
+    result: "base64",
+    savedPath: "/workspace/image.png",
+  },
+] satisfies ImageGenerationItem[];
+
+export const mcpResults = [
+  { content: [], structuredContent: null, _meta: null },
+  {
+    content: [null, "text", 1, { ok: true }],
+    structuredContent: { result: [1, 2] },
+    _meta: ["source"],
+  },
+] satisfies McpToolCallResult[];
+
+// @ts-expect-error undefined is not JSON.
+undefined satisfies JsonValue;
+// @ts-expect-error functions are not JSON.
+(() => true) satisfies JsonValue;
+// @ts-expect-error revisedPrompt is required nullable.
+({ id: "image-1", status: "completed", result: "base64" }) satisfies ImageGenerationItem;
+// @ts-expect-error optional savedPath is non-null when present.
+({ id: "image-1", status: "completed", revisedPrompt: null, result: "base64", savedPath: null }) satisfies ImageGenerationItem;
+// @ts-expect-error MCP content is required and non-null.
+({ content: null, structuredContent: null, _meta: null }) satisfies McpToolCallResult;
+// @ts-expect-error structuredContent is required nullable.
+({ content: [], _meta: null }) satisfies McpToolCallResult;
+// @ts-expect-error _meta is required nullable.
+({ content: [], structuredContent: null }) satisfies McpToolCallResult;


### PR DESCRIPTION
## Summary\n\n- export precision-preserving recursive JsonValue, strict ImageGenerationItem, and exact camel-case McpToolCallResult as standalone ThreadItem prerequisites\n- keep the existing all-caps MCPToolCallResult/MCPContent runtime contract distinct and leave all live item/provider/lifecycle bindings unchanged\n- add a narrowly schema-marked recursive TypeScript map renderer so JsonValue compiles as an inline index signature without changing unrelated Record types\n\n## Contract decisions\n\n- JsonValue accepts only valid JSON values, including nested nulls and arbitrarily large JSON numbers, and canonicalizes object ordering without float64 coercion\n- ImageGenerationItem requires id/status/revisedPrompt/result, keeps revisedPrompt explicitly nullable, and permits only optional non-null AbsolutePathBuf savedPath\n- McpToolCallResult requires a non-null JsonValue[] content array and required nullable structuredContent/_meta\n- WebSearchItem action reconciliation, CommandExecutionSource broadening, full ThreadItem, durable/runtime aliases, and lifecycle binding remain separate\n\n## Generated artifacts\n\n- definitions/type bindings/item bindings: 239 / 59 / 5\n- schema SHA-256: c7747a9467f6657f588f5baaddd369caed26950e8bdcb400a67be77f56c11a93\n- TypeScript SHA-256: 31240562048ffc8a12fb549219d8e7d18c10cd63eb6f30f89281a48144092a2c\n- strict TypeScript fixture SHA-256: 4c8218e65d131b90f06779b034b1dde28485429a8f053ff0cc8042884cbba29f\n\n## Verification\n\n- focused schema/wire/precision/path/nullability tests: pass; every new codec function executes at 100%\n- go test ./...: pass\n- exact CI package set under go test -race: pass; Monty normal suite passes\n- golangci-lint run ./...: 0 issues\n- go vet ./...: pass\n- go mod tidy: no diff\n- deterministic go generate rerun: byte-identical\n- strict generated TypeScript fixture: pass\n- Slang real integration: 5/5 stdio, direct file approval, direct command approval, Unix socket, and WebSocket workflows against trimpath branch binary SHA-256 cf12ad3dbea8840218c65f55498dcbc586052768dbc0b9f89fea2ffc6dadcee7