### PR TITLE
Export exact public Turn contract

### DIFF
--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 257 {
-		t.Fatalf("definition count = %d, want 257", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 258 {
+		t.Fatalf("definition count = %d, want 258", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -1,0 +1,165 @@
+package protocol
+
+import (
+	"encoding/json"
+	"math"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestPublicTurnSchemaIsExact(t *testing.T) {
+	definition, ok := JSONSchema()["$defs"].(Schema)["Turn"].(Schema)
+	if !ok {
+		t.Fatal("$defs missing Turn")
+	}
+	if definition["type"] != "object" || definition["additionalProperties"] != false {
+		t.Fatalf("Turn schema is not a closed object: %#v", definition)
+	}
+	wantRequired := []string{
+		"id", "items", "itemsView", "status", "error", "startedAt", "completedAt", "durationMs",
+	}
+	if got := schemaRequiredNames(definition); !slices.Equal(got, wantRequired) {
+		t.Fatalf("Turn required = %v, want %v", got, wantRequired)
+	}
+	properties := definition["properties"].(Schema)
+	wantProperties := Schema{
+		"id":          Schema{"type": "string"},
+		"items":       Schema{"type": "array", "items": Schema{"$ref": "#/$defs/ThreadItem"}},
+		"itemsView":   Schema{"$ref": "#/$defs/TurnItemsView"},
+		"status":      Schema{"$ref": "#/$defs/TurnStatus"},
+		"error":       nullableSchemaRef("TurnError"),
+		"startedAt":   nullableIntegerSchema(),
+		"completedAt": nullableIntegerSchema(),
+		"durationMs":  nullableIntegerSchema(),
+	}
+	if !reflect.DeepEqual(properties, wantProperties) {
+		t.Fatalf("Turn properties = %#v, want %#v", properties, wantProperties)
+	}
+}
+
+func TestPublicTurnWireValidation(t *testing.T) {
+	valid := []string{
+		`{"id":"","items":[],"itemsView":"notLoaded","status":"completed","error":null,"startedAt":null,"completedAt":null,"durationMs":null}`,
+		`{"id":"not-a-uuid","items":[{"type":"contextCompaction","id":"item-1"}],"itemsView":"summary","status":"inProgress","error":null,"startedAt":-1,"completedAt":0,"durationMs":-2}`,
+		`{"id":"turn-1","items":[],"itemsView":"full","status":"failed","error":{"message":"failed","codexErrorInfo":"sandboxError","additionalDetails":"details"},"startedAt":-9223372036854775808,"completedAt":9223372036854775807,"durationMs":0}`,
+		`{"id":"turn-2","items":[],"itemsView":"full","status":"interrupted","error":{"message":"","codexErrorInfo":null,"additionalDetails":null},"startedAt":null,"completedAt":null,"durationMs":null}`,
+	}
+	for _, input := range valid {
+		var turn Turn
+		if err := json.Unmarshal([]byte(input), &turn); err != nil {
+			t.Errorf("Unmarshal(%s): %v", input, err)
+			continue
+		}
+		encoded, err := json.Marshal(turn)
+		if err != nil || string(encoded) != input {
+			t.Errorf("round trip %s = %s, %v", input, encoded, err)
+		}
+	}
+}
+
+func TestPublicTurnRejectsMalformedWireValues(t *testing.T) {
+	invalid := []string{
+		`null`,
+		`[]`,
+		`{}`,
+		`{"items":[],"itemsView":"full","status":"completed","error":null,"startedAt":null,"completedAt":null,"durationMs":null}`,
+		`{"id":"turn","itemsView":"full","status":"completed","error":null,"startedAt":null,"completedAt":null,"durationMs":null}`,
+		`{"id":"turn","items":[],"status":"completed","error":null,"startedAt":null,"completedAt":null,"durationMs":null}`,
+		`{"id":"turn","items":[],"itemsView":"full","error":null,"startedAt":null,"completedAt":null,"durationMs":null}`,
+		`{"id":"turn","items":[],"itemsView":"full","status":"completed","startedAt":null,"completedAt":null,"durationMs":null}`,
+		`{"id":"turn","items":[],"itemsView":"full","status":"completed","error":null,"completedAt":null,"durationMs":null}`,
+		`{"id":"turn","items":[],"itemsView":"full","status":"completed","error":null,"startedAt":null,"durationMs":null}`,
+		`{"id":"turn","items":[],"itemsView":"full","status":"completed","error":null,"startedAt":null,"completedAt":null}`,
+		`{"id":null,"items":[],"itemsView":"full","status":"completed","error":null,"startedAt":null,"completedAt":null,"durationMs":null}`,
+		`{"id":"turn","items":null,"itemsView":"full","status":"completed","error":null,"startedAt":null,"completedAt":null,"durationMs":null}`,
+		`{"id":"turn","items":{},"itemsView":"full","status":"completed","error":null,"startedAt":null,"completedAt":null,"durationMs":null}`,
+		`{"id":"turn","items":[null],"itemsView":"full","status":"completed","error":null,"startedAt":null,"completedAt":null,"durationMs":null}`,
+		`{"id":"turn","items":[{"type":"contextCompaction"}],"itemsView":"full","status":"completed","error":null,"startedAt":null,"completedAt":null,"durationMs":null}`,
+		`{"id":"turn","items":[],"itemsView":null,"status":"completed","error":null,"startedAt":null,"completedAt":null,"durationMs":null}`,
+		`{"id":"turn","items":[],"itemsView":"other","status":"completed","error":null,"startedAt":null,"completedAt":null,"durationMs":null}`,
+		`{"id":"turn","items":[],"itemsView":"full","status":null,"error":null,"startedAt":null,"completedAt":null,"durationMs":null}`,
+		`{"id":"turn","items":[],"itemsView":"full","status":"running","error":null,"startedAt":null,"completedAt":null,"durationMs":null}`,
+		`{"id":"turn","items":[],"itemsView":"full","status":"failed","error":{},"startedAt":null,"completedAt":null,"durationMs":null}`,
+		`{"id":"turn","items":[],"itemsView":"full","status":"completed","error":null,"startedAt":1.5,"completedAt":null,"durationMs":null}`,
+		`{"id":"turn","items":[],"itemsView":"full","status":"completed","error":null,"startedAt":9223372036854775808,"completedAt":null,"durationMs":null}`,
+		`{"id":"turn","items":[],"itemsView":"full","status":"completed","error":null,"startedAt":null,"completedAt":-9223372036854775809,"durationMs":null}`,
+		`{"id":"turn","items":[],"itemsView":"full","status":"completed","error":null,"startedAt":null,"completedAt":null,"durationMs":1.5}`,
+		`{"id":"turn","items":[],"itemsView":"full","status":"completed","error":null,"startedAt":null,"completedAt":null,"durationMs":null,"threadId":"crossed"}`,
+		`{"id":"turn","items":[],"itemsView":"full","status":"completed","error":null,"startedAt":null,"completedAt":null,"durationMs":null,"createdAt":"crossed"}`,
+	}
+	assertRawJSONRejects[Turn](t, invalid)
+}
+
+func TestPublicTurnMarshalValidationAndStandaloneIdentity(t *testing.T) {
+	var item ThreadItem
+	if err := json.Unmarshal([]byte(`{"type":"contextCompaction","id":"item-1"}`), &item); err != nil {
+		t.Fatal(err)
+	}
+	minimum := int64(math.MinInt64)
+	valid := Turn{
+		ID: "", Items: []ThreadItem{item}, ItemsView: TurnItemsViewFull,
+		Status: TurnStatusCompleted, StartedAt: &minimum,
+	}
+	if _, err := json.Marshal(valid); err != nil {
+		t.Fatalf("marshal valid Turn: %v", err)
+	}
+
+	invalid := []Turn{
+		{},
+		{ID: "turn", Items: nil, ItemsView: TurnItemsViewFull, Status: TurnStatusCompleted},
+		{ID: "turn", Items: []ThreadItem{}, ItemsView: TurnItemsView("other"), Status: TurnStatusCompleted},
+		{ID: "turn", Items: []ThreadItem{}, ItemsView: TurnItemsViewFull, Status: TurnStatus("running")},
+		{ID: "turn", Items: []ThreadItem{{}}, ItemsView: TurnItemsViewFull, Status: TurnStatusCompleted},
+		{ID: "turn", Items: []ThreadItem{}, ItemsView: TurnItemsViewFull, Status: TurnStatusFailed, Error: &TurnError{CodexErrorInfo: &CodexErrorInfo{}}},
+	}
+	for index, turn := range invalid {
+		if _, err := json.Marshal(turn); err == nil {
+			t.Errorf("invalid Turn %d marshaled", index)
+		}
+	}
+	var turn *Turn
+	if err := turn.UnmarshalJSON([]byte(`{"id":"turn","items":[],"itemsView":"full","status":"completed","error":null,"startedAt":null,"completedAt":null,"durationMs":null}`)); err == nil {
+		t.Fatal("nil Turn receiver succeeded")
+	}
+	if reflect.TypeFor[Turn]() == reflect.TypeFor[TurnRecord]() {
+		t.Fatal("public Turn aliases durable TurnRecord")
+	}
+}
+
+func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	want := `export type Turn = {
+  "completedAt": number | null;
+  "durationMs": number | null;
+  "error": TurnError | null;
+  "id": string;
+  "items": Array<ThreadItem>;
+  "itemsView": TurnItemsView;
+  "startedAt": number | null;
+  "status": TurnStatus;
+};`
+	if !strings.Contains(string(generated), want) {
+		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
+	}
+	if len(JSONSchema()["$defs"].(Schema)) != 258 {
+		t.Fatalf("definition count = %d, want 258", len(JSONSchema()["$defs"].(Schema)))
+	}
+	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
+	}
+	for _, binding := range WireTypeBindings() {
+		if slices.Contains(binding.Params, "Turn") || slices.Contains(binding.Result, "Turn") {
+			t.Fatalf("Turn unexpectedly bound to %s", binding.Method)
+		}
+	}
+	for _, binding := range ItemPayloadBindings() {
+		if binding.Type == "Turn" {
+			t.Fatalf("Turn unexpectedly bound to durable item %s", binding.Kind)
+		}
+	}
+}

--- a/appserver/protocol/public_turn_types.go
+++ b/appserver/protocol/public_turn_types.go
@@ -1,0 +1,97 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// Turn is the exact public v2 turn projection. It remains separate from
+// Gollem's durable TurnRecord and is not bound to methods until its public
+// parent contracts are exported.
+type Turn struct {
+	ID          string        `json:"id"`
+	Items       []ThreadItem  `json:"items" jsonschema:"nonnullable=true"`
+	ItemsView   TurnItemsView `json:"itemsView"`
+	Status      TurnStatus    `json:"status"`
+	Error       *TurnError    `json:"error"`
+	StartedAt   *int64        `json:"startedAt"`
+	CompletedAt *int64        `json:"completedAt"`
+	DurationMS  *int64        `json:"durationMs"`
+}
+
+func (t Turn) MarshalJSON() ([]byte, error) {
+	if t.Items == nil {
+		return nil, errors.New("turn items cannot be null")
+	}
+	type wire Turn
+	encoded, err := json.Marshal(wire(t))
+	if err != nil {
+		return nil, fmt.Errorf("encode turn: %w", err)
+	}
+	return encoded, nil
+}
+
+func (t *Turn) UnmarshalJSON(data []byte) error {
+	if t == nil {
+		return errors.New("decode turn into nil receiver")
+	}
+	payload, err := decodeExactThreadItemObject(
+		data,
+		"turn",
+		"id",
+		"items",
+		"itemsView",
+		"status",
+		"error",
+		"startedAt",
+		"completedAt",
+		"durationMs",
+	)
+	if err != nil {
+		return err
+	}
+	id, err := decodeRequiredThreadItemValue[string](payload, "turn", "id")
+	if err != nil {
+		return err
+	}
+	items, err := decodeRequiredThreadItemArray[ThreadItem](payload, "turn", "items")
+	if err != nil {
+		return err
+	}
+	itemsView, err := decodeRequiredThreadItemValue[TurnItemsView](payload, "turn", "itemsView")
+	if err != nil {
+		return err
+	}
+	status, err := decodeRequiredThreadItemValue[TurnStatus](payload, "turn", "status")
+	if err != nil {
+		return err
+	}
+	turnError, err := decodeRequiredNullableThreadItemValue[TurnError](payload, "turn", "error")
+	if err != nil {
+		return err
+	}
+	startedAt, err := decodeRequiredNullableThreadItemValue[int64](payload, "turn", "startedAt")
+	if err != nil {
+		return err
+	}
+	completedAt, err := decodeRequiredNullableThreadItemValue[int64](payload, "turn", "completedAt")
+	if err != nil {
+		return err
+	}
+	durationMS, err := decodeRequiredNullableThreadItemValue[int64](payload, "turn", "durationMs")
+	if err != nil {
+		return err
+	}
+	*t = Turn{
+		ID:          id,
+		Items:       items,
+		ItemsView:   itemsView,
+		Status:      status,
+		Error:       turnError,
+		StartedAt:   startedAt,
+		CompletedAt: completedAt,
+		DurationMS:  durationMS,
+	}
+	return nil
+}

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 257 {
-		t.Fatalf("definition count = %d, want 257", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 258 {
+		t.Fatalf("definition count = %d, want 258", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -311,6 +311,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "ToolRequestUserInputParams", Type: reflect.TypeFor[ToolRequestUserInputParams]()},
 		{Name: "ToolRequestUserInputQuestion", Type: reflect.TypeFor[ToolRequestUserInputQuestion]()},
 		{Name: "ToolRequestUserInputResponse", Type: reflect.TypeFor[ToolRequestUserInputResponse]()},
+		{Name: "Turn", Type: reflect.TypeFor[Turn]()},
 		{Name: "TurnDiffUpdatedNotificationParams", Type: reflect.TypeFor[TurnDiffUpdatedNotificationParams]()},
 		{Name: "TurnError", Type: reflect.TypeFor[TurnError]()},
 		{Name: "TurnItemsView", Type: reflect.TypeFor[TurnItemsView]()},

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -8414,6 +8414,77 @@
       ],
       "type": "object"
     },
+    "Turn": {
+      "additionalProperties": false,
+      "properties": {
+        "completedAt": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "durationMs": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "error": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TurnError"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "id": {
+          "type": "string"
+        },
+        "items": {
+          "items": {
+            "$ref": "#/$defs/ThreadItem"
+          },
+          "type": "array"
+        },
+        "itemsView": {
+          "$ref": "#/$defs/TurnItemsView"
+        },
+        "startedAt": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "status": {
+          "$ref": "#/$defs/TurnStatus"
+        }
+      },
+      "required": [
+        "id",
+        "items",
+        "itemsView",
+        "status",
+        "error",
+        "startedAt",
+        "completedAt",
+        "durationMs"
+      ],
+      "type": "object"
+    },
     "TurnDiffUpdatedNotification": {
       "additionalProperties": false,
       "properties": {

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 257 {
-		t.Fatalf("definition count = %d, want 257", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 258 {
+		t.Fatalf("definition count = %d, want 258", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 257 {
-		t.Fatalf("definition count = %d, want 257", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 258 {
+		t.Fatalf("definition count = %d, want 258", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 257 {
-		t.Fatalf("definition count = %d, want 257", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 258 {
+		t.Fatalf("definition count = %d, want 258", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -2290,6 +2290,17 @@ export type ToolRequestUserInputResponse = {
   "answers": Record<string, ToolRequestUserInputAnswer>;
 };
 
+export type Turn = {
+  "completedAt": number | null;
+  "durationMs": number | null;
+  "error": TurnError | null;
+  "id": string;
+  "items": Array<ThreadItem>;
+  "itemsView": TurnItemsView;
+  "startedAt": number | null;
+  "status": TurnStatus;
+};
+
 export type TurnDiffUpdatedNotification = {
   "diff": string;
   "threadId": string;

--- a/appserver/protocol/typescript/testdata/public_turn_contract.ts
+++ b/appserver/protocol/typescript/testdata/public_turn_contract.ts
@@ -1,0 +1,73 @@
+import type {
+  ThreadItem,
+  Turn,
+  TurnError,
+  TurnItemsView,
+  TurnStatus,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+
+type TurnIsExact = Expect<
+  Equal<
+    Turn,
+    {
+      id: string;
+      items: ThreadItem[];
+      itemsView: TurnItemsView;
+      status: TurnStatus;
+      error: TurnError | null;
+      startedAt: number | null;
+      completedAt: number | null;
+      durationMs: number | null;
+    }
+  >
+>;
+
+export const turns = [
+  {
+    id: "",
+    items: [],
+    itemsView: "notLoaded",
+    status: "completed",
+    error: null,
+    startedAt: null,
+    completedAt: null,
+    durationMs: null,
+  },
+  {
+    id: "turn-1",
+    items: [{ type: "contextCompaction", id: "item-1" }],
+    itemsView: "full",
+    status: "failed",
+    error: { message: "failed", codexErrorInfo: "sandboxError", additionalDetails: null },
+    startedAt: -1,
+    completedAt: 0,
+    durationMs: -2,
+  },
+] satisfies Turn[];
+
+// @ts-expect-error every nullable field remains required
+export const missingError: Turn = {
+  id: "turn",
+  items: [],
+  itemsView: "full",
+  status: "completed",
+  startedAt: null,
+  completedAt: null,
+  durationMs: null,
+};
+
+export const malformedTurns = [
+  // @ts-expect-error items cannot be null
+  { id: "turn", items: null, itemsView: "full", status: "completed", error: null, startedAt: null, completedAt: null, durationMs: null },
+  // @ts-expect-error itemsView is closed
+  { id: "turn", items: [], itemsView: "other", status: "completed", error: null, startedAt: null, completedAt: null, durationMs: null },
+  // @ts-expect-error status is closed
+  { id: "turn", items: [], itemsView: "full", status: "running", error: null, startedAt: null, completedAt: null, durationMs: null },
+] satisfies Turn[];


### PR DESCRIPTION
## Summary

- export the exact standalone public v2 `Turn` record
- enforce all eight required fields, strict nested `ThreadItem`/status/error validation, and signed-int64 timestamp boundaries
- generate the schema and TypeScript contract without binding `Turn` to durable records or methods

## Validation

- `go test ./...`
- full `go test -race -coverprofile=... ./...` (94.3% protocol, 88.3% Monty)
- focused codec coverage: 100%
- `golangci-lint run ./...`
- `go vet ./...`
- `go mod tidy` with no diff
- deterministic `go generate ./appserver/protocol`
- strict TypeScript fixture (`tsc`)
- `.githooks/pre-push`