### PR TITLE
Export exact public Thread contract

### DIFF
--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 258 {
-		t.Fatalf("definition count = %d, want 258", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 259 {
+		t.Fatalf("definition count = %d, want 259", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -1,0 +1,249 @@
+package protocol
+
+import (
+	"encoding/json"
+	"math"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+const publicThreadWire = `{"id":"","sessionId":"","forkedFromId":null,"parentThreadId":null,"preview":"","ephemeral":false,"modelProvider":"","createdAt":-9223372036854775808,"updatedAt":9223372036854775807,"recencyAt":null,"status":{"type":"idle"},"path":null,"cwd":"/workspace","cliVersion":"","source":"cli","threadSource":null,"agentNickname":null,"agentRole":null,"gitInfo":null,"name":null,"turns":[]}`
+
+func TestPublicThreadSchemaIsExact(t *testing.T) {
+	definition, ok := JSONSchema()["$defs"].(Schema)["Thread"].(Schema)
+	if !ok {
+		t.Fatal("$defs missing Thread")
+	}
+	if definition["type"] != "object" || definition["additionalProperties"] != false {
+		t.Fatalf("Thread schema is not a closed object: %#v", definition)
+	}
+	wantRequired := []string{
+		"id", "sessionId", "forkedFromId", "parentThreadId", "preview", "ephemeral",
+		"modelProvider", "createdAt", "updatedAt", "recencyAt", "status", "path", "cwd",
+		"cliVersion", "source", "threadSource", "agentNickname", "agentRole", "gitInfo", "name", "turns",
+	}
+	if got := schemaRequiredNames(definition); !slices.Equal(got, wantRequired) {
+		t.Fatalf("Thread required = %v, want %v", got, wantRequired)
+	}
+	properties := definition["properties"].(Schema)
+	wantProperties := Schema{
+		"id":             Schema{"type": "string"},
+		"sessionId":      Schema{"type": "string"},
+		"forkedFromId":   nullableStringSchema(),
+		"parentThreadId": nullableStringSchema(),
+		"preview":        Schema{"type": "string"},
+		"ephemeral":      Schema{"type": "boolean"},
+		"modelProvider":  Schema{"type": "string"},
+		"createdAt":      Schema{"type": "integer"},
+		"updatedAt":      Schema{"type": "integer"},
+		"recencyAt":      nullableIntegerSchema(),
+		"status":         Schema{"$ref": "#/$defs/ThreadStatus"},
+		"path":           nullableStringSchema(),
+		"cwd":            Schema{"$ref": "#/$defs/AbsolutePathBuf"},
+		"cliVersion":     Schema{"type": "string"},
+		"source":         Schema{"$ref": "#/$defs/SessionSource"},
+		"threadSource":   nullableSchemaRef("ThreadSource"),
+		"agentNickname":  nullableStringSchema(),
+		"agentRole":      nullableStringSchema(),
+		"gitInfo":        nullableSchemaRef("GitInfo"),
+		"name":           nullableStringSchema(),
+		"turns":          Schema{"type": "array", "items": Schema{"$ref": "#/$defs/Turn"}},
+	}
+	if !reflect.DeepEqual(properties, wantProperties) {
+		t.Fatalf("Thread properties = %#v, want %#v", properties, wantProperties)
+	}
+}
+
+func TestPublicThreadWireValidation(t *testing.T) {
+	valid := []string{
+		publicThreadWire,
+		`{"id":"not-a-uuid","sessionId":"session/tree","forkedFromId":"fork","parentThreadId":"parent","preview":"hello","ephemeral":true,"modelProvider":"openai","createdAt":-1,"updatedAt":0,"recencyAt":-2,"status":{"type":"active","activeFlags":["waitingOnApproval"]},"path":"relative/thread.jsonl","cwd":"/workspace/project","cliVersion":"1.2.3","source":{"subAgent":{"thread_spawn":{"parent_thread_id":"parent","depth":1,"agent_path":null,"agent_nickname":"nick","agent_role":"role"}}},"threadSource":"","agentNickname":"nick","agentRole":"role","gitInfo":{"sha":"abc","branch":"main","originUrl":"origin"},"name":"title","turns":[{"id":"turn-1","items":[],"itemsView":"full","status":"completed","error":null,"startedAt":null,"completedAt":null,"durationMs":null}]}`,
+	}
+	for _, input := range valid {
+		var thread Thread
+		if err := json.Unmarshal([]byte(input), &thread); err != nil {
+			t.Errorf("Unmarshal(%s): %v", input, err)
+			continue
+		}
+		encoded, err := json.Marshal(thread)
+		if err != nil || string(encoded) != input {
+			t.Errorf("round trip %s = %s, %v", input, encoded, err)
+		}
+	}
+}
+
+func TestPublicThreadRequiresEveryGeneratedTypeScriptField(t *testing.T) {
+	var base map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(publicThreadWire), &base); err != nil {
+		t.Fatal(err)
+	}
+	for name := range base {
+		copy := make(map[string]json.RawMessage, len(base)-1)
+		for key, value := range base {
+			if key != name {
+				copy[key] = value
+			}
+		}
+		encoded, err := json.Marshal(copy)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var thread Thread
+		if err := json.Unmarshal(encoded, &thread); err == nil {
+			t.Errorf("Thread without %s succeeded", name)
+		}
+	}
+}
+
+func TestPublicThreadRejectsMalformedWireValues(t *testing.T) {
+	invalid := []string{
+		`null`,
+		`[]`,
+		`{}`,
+		publicThreadWithReplacement(`"id":""`, `"id":null`),
+		publicThreadWithReplacement(`"sessionId":""`, `"sessionId":1`),
+		publicThreadWithReplacement(`"preview":""`, `"preview":null`),
+		publicThreadWithReplacement(`"ephemeral":false`, `"ephemeral":"false"`),
+		publicThreadWithReplacement(`"modelProvider":""`, `"modelProvider":null`),
+		publicThreadWithReplacement(`"createdAt":-9223372036854775808`, `"createdAt":1.5`),
+		publicThreadWithReplacement(`"createdAt":-9223372036854775808`, `"createdAt":-9223372036854775809`),
+		publicThreadWithReplacement(`"updatedAt":9223372036854775807`, `"updatedAt":9223372036854775808`),
+		publicThreadWithReplacement(`"recencyAt":null`, `"recencyAt":1.5`),
+		publicThreadWithReplacement(`"status":{"type":"idle"}`, `"status":null`),
+		publicThreadWithReplacement(`"status":{"type":"idle"}`, `"status":{"type":"active"}`),
+		publicThreadWithReplacement(`"path":null`, `"path":1`),
+		publicThreadWithReplacement(`"cwd":"/workspace"`, `"cwd":null`),
+		publicThreadWithReplacement(`"cwd":"/workspace"`, `"cwd":"relative"`),
+		publicThreadWithReplacement(`"cliVersion":""`, `"cliVersion":null`),
+		publicThreadWithReplacement(`"source":"cli"`, `"source":null`),
+		publicThreadWithReplacement(`"source":"cli"`, `"source":"mcp"`),
+		publicThreadWithReplacement(`"threadSource":null`, `"threadSource":1`),
+		publicThreadWithReplacement(`"agentNickname":null`, `"agentNickname":1`),
+		publicThreadWithReplacement(`"agentRole":null`, `"agentRole":false`),
+		publicThreadWithReplacement(`"gitInfo":null`, `"gitInfo":{}`),
+		publicThreadWithReplacement(`"name":null`, `"name":[]`),
+		publicThreadWithReplacement(`"turns":[]`, `"turns":null`),
+		publicThreadWithReplacement(`"turns":[]`, `"turns":{}`),
+		publicThreadWithReplacement(`"turns":[]`, `"turns":[null]`),
+		publicThreadWithReplacement(`"turns":[]`, `"turns":[{"id":"turn"}]`),
+		publicThreadWithExtra(`"extra":null`),
+		publicThreadWithExtra(`"historyMode":"full"`),
+		publicThreadWithExtra(`"workspace":"crossed"`),
+		publicThreadWithExtra(`"metadata":{}`),
+		publicThreadWithExtra(`"createdAtRFC3339":"crossed"`),
+		publicThreadWithExtra(`"items":[]`),
+	}
+	assertRawJSONRejects[Thread](t, invalid)
+}
+
+func TestPublicThreadMarshalValidationAndStandaloneIdentity(t *testing.T) {
+	minimum := int64(math.MinInt64)
+	maximum := int64(math.MaxInt64)
+	valid := Thread{
+		ID: "", SessionID: "", Preview: "", Ephemeral: false, ModelProvider: "",
+		CreatedAt: minimum, UpdatedAt: maximum, Status: mustThreadStatus(t, `{"type":"idle"}`),
+		CWD: AbsolutePathBuf("/workspace"), CLIVersion: "", Source: mustSessionSource(t, `"cli"`),
+		Turns: []Turn{},
+	}
+	if _, err := json.Marshal(valid); err != nil {
+		t.Fatalf("marshal valid Thread: %v", err)
+	}
+
+	invalid := []Thread{
+		{},
+		{CWD: AbsolutePathBuf("/workspace"), Status: mustThreadStatus(t, `{"type":"idle"}`), Source: mustSessionSource(t, `"cli"`), Turns: nil},
+		{CWD: AbsolutePathBuf("relative"), Status: mustThreadStatus(t, `{"type":"idle"}`), Source: mustSessionSource(t, `"cli"`), Turns: []Turn{}},
+		{CWD: AbsolutePathBuf("/workspace"), Status: ThreadStatus{}, Source: mustSessionSource(t, `"cli"`), Turns: []Turn{}},
+		{CWD: AbsolutePathBuf("/workspace"), Status: mustThreadStatus(t, `{"type":"idle"}`), Source: SessionSource{}, Turns: []Turn{}},
+		{CWD: AbsolutePathBuf("/workspace"), Status: mustThreadStatus(t, `{"type":"idle"}`), Source: mustSessionSource(t, `"cli"`), Turns: []Turn{{}}},
+	}
+	for index, thread := range invalid {
+		if _, err := json.Marshal(thread); err == nil {
+			t.Errorf("invalid Thread %d marshaled", index)
+		}
+	}
+	var thread *Thread
+	if err := thread.UnmarshalJSON([]byte(publicThreadWire)); err == nil {
+		t.Fatal("nil Thread receiver succeeded")
+	}
+	if reflect.TypeFor[Thread]() == reflect.TypeFor[ThreadRecord]() {
+		t.Fatal("public Thread aliases durable ThreadRecord")
+	}
+}
+
+func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	want := `export type Thread = {
+  "agentNickname": string | null;
+  "agentRole": string | null;
+  "cliVersion": string;
+  "createdAt": number;
+  "cwd": AbsolutePathBuf;
+  "ephemeral": boolean;
+  "forkedFromId": string | null;
+  "gitInfo": GitInfo | null;
+  "id": string;
+  "modelProvider": string;
+  "name": string | null;
+  "parentThreadId": string | null;
+  "path": string | null;
+  "preview": string;
+  "recencyAt": number | null;
+  "sessionId": string;
+  "source": SessionSource;
+  "status": ThreadStatus;
+  "threadSource": ThreadSource | null;
+  "turns": Array<Turn>;
+  "updatedAt": number;
+};`
+	if !strings.Contains(string(generated), want) {
+		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
+	}
+	if len(JSONSchema()["$defs"].(Schema)) != 259 {
+		t.Fatalf("definition count = %d, want 259", len(JSONSchema()["$defs"].(Schema)))
+	}
+	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
+	}
+	for _, binding := range WireTypeBindings() {
+		if slices.Contains(binding.Params, "Thread") || slices.Contains(binding.Result, "Thread") {
+			t.Fatalf("Thread unexpectedly bound to %s", binding.Method)
+		}
+	}
+	for _, binding := range ItemPayloadBindings() {
+		if binding.Type == "Thread" {
+			t.Fatalf("Thread unexpectedly bound to durable item %s", binding.Kind)
+		}
+	}
+}
+
+func publicThreadWithReplacement(old, replacement string) string {
+	return strings.Replace(publicThreadWire, old, replacement, 1)
+}
+
+func publicThreadWithExtra(field string) string {
+	return strings.TrimSuffix(publicThreadWire, "}") + "," + field + "}"
+}
+
+func mustThreadStatus(t *testing.T, input string) ThreadStatus {
+	t.Helper()
+	var value ThreadStatus
+	if err := json.Unmarshal([]byte(input), &value); err != nil {
+		t.Fatal(err)
+	}
+	return value
+}
+
+func mustSessionSource(t *testing.T, input string) SessionSource {
+	t.Helper()
+	var value SessionSource
+	if err := json.Unmarshal([]byte(input), &value); err != nil {
+		t.Fatal(err)
+	}
+	return value
+}

--- a/appserver/protocol/public_thread_types.go
+++ b/appserver/protocol/public_thread_types.go
@@ -1,0 +1,187 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// Thread is the exact public v2 thread projection. It remains separate from
+// Gollem's durable ThreadRecord and is not yet bound to thread methods.
+type Thread struct {
+	ID             string          `json:"id"`
+	SessionID      string          `json:"sessionId"`
+	ForkedFromID   *string         `json:"forkedFromId"`
+	ParentThreadID *string         `json:"parentThreadId"`
+	Preview        string          `json:"preview"`
+	Ephemeral      bool            `json:"ephemeral"`
+	ModelProvider  string          `json:"modelProvider"`
+	CreatedAt      int64           `json:"createdAt"`
+	UpdatedAt      int64           `json:"updatedAt"`
+	RecencyAt      *int64          `json:"recencyAt"`
+	Status         ThreadStatus    `json:"status"`
+	Path           *string         `json:"path"`
+	CWD            AbsolutePathBuf `json:"cwd"`
+	CLIVersion     string          `json:"cliVersion"`
+	Source         SessionSource   `json:"source"`
+	ThreadSource   *ThreadSource   `json:"threadSource"`
+	AgentNickname  *string         `json:"agentNickname"`
+	AgentRole      *string         `json:"agentRole"`
+	GitInfo        *GitInfo        `json:"gitInfo"`
+	Name           *string         `json:"name"`
+	Turns          []Turn          `json:"turns" jsonschema:"nonnullable=true"`
+}
+
+func (t Thread) MarshalJSON() ([]byte, error) {
+	if t.Turns == nil {
+		return nil, errors.New("thread turns cannot be null")
+	}
+	type wire Thread
+	encoded, err := json.Marshal(wire(t))
+	if err != nil {
+		return nil, fmt.Errorf("encode thread: %w", err)
+	}
+	return encoded, nil
+}
+
+func (t *Thread) UnmarshalJSON(data []byte) error {
+	if t == nil {
+		return errors.New("decode thread into nil receiver")
+	}
+	payload, err := decodeExactThreadItemObject(
+		data,
+		"thread",
+		"id",
+		"sessionId",
+		"forkedFromId",
+		"parentThreadId",
+		"preview",
+		"ephemeral",
+		"modelProvider",
+		"createdAt",
+		"updatedAt",
+		"recencyAt",
+		"status",
+		"path",
+		"cwd",
+		"cliVersion",
+		"source",
+		"threadSource",
+		"agentNickname",
+		"agentRole",
+		"gitInfo",
+		"name",
+		"turns",
+	)
+	if err != nil {
+		return err
+	}
+	id, err := decodeRequiredThreadItemValue[string](payload, "thread", "id")
+	if err != nil {
+		return err
+	}
+	sessionID, err := decodeRequiredThreadItemValue[string](payload, "thread", "sessionId")
+	if err != nil {
+		return err
+	}
+	forkedFromID, err := decodeRequiredNullableThreadItemValue[string](payload, "thread", "forkedFromId")
+	if err != nil {
+		return err
+	}
+	parentThreadID, err := decodeRequiredNullableThreadItemValue[string](payload, "thread", "parentThreadId")
+	if err != nil {
+		return err
+	}
+	preview, err := decodeRequiredThreadItemValue[string](payload, "thread", "preview")
+	if err != nil {
+		return err
+	}
+	ephemeral, err := decodeRequiredThreadItemValue[bool](payload, "thread", "ephemeral")
+	if err != nil {
+		return err
+	}
+	modelProvider, err := decodeRequiredThreadItemValue[string](payload, "thread", "modelProvider")
+	if err != nil {
+		return err
+	}
+	createdAt, err := decodeRequiredThreadItemValue[int64](payload, "thread", "createdAt")
+	if err != nil {
+		return err
+	}
+	updatedAt, err := decodeRequiredThreadItemValue[int64](payload, "thread", "updatedAt")
+	if err != nil {
+		return err
+	}
+	recencyAt, err := decodeRequiredNullableThreadItemValue[int64](payload, "thread", "recencyAt")
+	if err != nil {
+		return err
+	}
+	status, err := decodeRequiredThreadItemValue[ThreadStatus](payload, "thread", "status")
+	if err != nil {
+		return err
+	}
+	path, err := decodeRequiredNullableThreadItemValue[string](payload, "thread", "path")
+	if err != nil {
+		return err
+	}
+	cwd, err := decodeRequiredThreadItemValue[AbsolutePathBuf](payload, "thread", "cwd")
+	if err != nil {
+		return err
+	}
+	cliVersion, err := decodeRequiredThreadItemValue[string](payload, "thread", "cliVersion")
+	if err != nil {
+		return err
+	}
+	source, err := decodeRequiredThreadItemValue[SessionSource](payload, "thread", "source")
+	if err != nil {
+		return err
+	}
+	threadSource, err := decodeRequiredNullableThreadItemValue[ThreadSource](payload, "thread", "threadSource")
+	if err != nil {
+		return err
+	}
+	agentNickname, err := decodeRequiredNullableThreadItemValue[string](payload, "thread", "agentNickname")
+	if err != nil {
+		return err
+	}
+	agentRole, err := decodeRequiredNullableThreadItemValue[string](payload, "thread", "agentRole")
+	if err != nil {
+		return err
+	}
+	gitInfo, err := decodeRequiredNullableThreadItemValue[GitInfo](payload, "thread", "gitInfo")
+	if err != nil {
+		return err
+	}
+	name, err := decodeRequiredNullableThreadItemValue[string](payload, "thread", "name")
+	if err != nil {
+		return err
+	}
+	turns, err := decodeRequiredThreadItemArray[Turn](payload, "thread", "turns")
+	if err != nil {
+		return err
+	}
+	*t = Thread{
+		ID:             id,
+		SessionID:      sessionID,
+		ForkedFromID:   forkedFromID,
+		ParentThreadID: parentThreadID,
+		Preview:        preview,
+		Ephemeral:      ephemeral,
+		ModelProvider:  modelProvider,
+		CreatedAt:      createdAt,
+		UpdatedAt:      updatedAt,
+		RecencyAt:      recencyAt,
+		Status:         status,
+		Path:           path,
+		CWD:            cwd,
+		CLIVersion:     cliVersion,
+		Source:         source,
+		ThreadSource:   threadSource,
+		AgentNickname:  agentNickname,
+		AgentRole:      agentRole,
+		GitInfo:        gitInfo,
+		Name:           name,
+		Turns:          turns,
+	}
+	return nil
+}

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 258 {
-		t.Fatalf("definition count = %d, want 258", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 259 {
+		t.Fatalf("definition count = %d, want 259", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 258 {
-		t.Fatalf("definition count = %d, want 258", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 259 {
+		t.Fatalf("definition count = %d, want 259", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -249,6 +249,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "SortDirection", Type: reflect.TypeFor[SortDirection]()},
 		{Name: "SubAgentActivityKind", Type: reflect.TypeFor[SubAgentActivityKind]()},
 		{Name: "SubAgentSource", Type: reflect.TypeFor[SubAgentSource]()},
+		{Name: "Thread", Type: reflect.TypeFor[Thread]()},
 		{Name: "ThreadActiveFlag", Type: reflect.TypeFor[ThreadActiveFlag]()},
 		{Name: "ThreadArchiveParams", Type: reflect.TypeFor[ThreadArchiveParams]()},
 		{Name: "ThreadArchiveResponse", Type: reflect.TypeFor[ThreadArchiveResponse]()},

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -5858,6 +5858,164 @@
       ],
       "type": "object"
     },
+    "Thread": {
+      "additionalProperties": false,
+      "properties": {
+        "agentNickname": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "agentRole": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "cliVersion": {
+          "type": "string"
+        },
+        "createdAt": {
+          "type": "integer"
+        },
+        "cwd": {
+          "$ref": "#/$defs/AbsolutePathBuf"
+        },
+        "ephemeral": {
+          "type": "boolean"
+        },
+        "forkedFromId": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "gitInfo": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GitInfo"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "id": {
+          "type": "string"
+        },
+        "modelProvider": {
+          "type": "string"
+        },
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "parentThreadId": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "preview": {
+          "type": "string"
+        },
+        "recencyAt": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "sessionId": {
+          "type": "string"
+        },
+        "source": {
+          "$ref": "#/$defs/SessionSource"
+        },
+        "status": {
+          "$ref": "#/$defs/ThreadStatus"
+        },
+        "threadSource": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ThreadSource"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "turns": {
+          "items": {
+            "$ref": "#/$defs/Turn"
+          },
+          "type": "array"
+        },
+        "updatedAt": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "id",
+        "sessionId",
+        "forkedFromId",
+        "parentThreadId",
+        "preview",
+        "ephemeral",
+        "modelProvider",
+        "createdAt",
+        "updatedAt",
+        "recencyAt",
+        "status",
+        "path",
+        "cwd",
+        "cliVersion",
+        "source",
+        "threadSource",
+        "agentNickname",
+        "agentRole",
+        "gitInfo",
+        "name",
+        "turns"
+      ],
+      "type": "object"
+    },
     "ThreadActiveFlag": {
       "enum": [
         "waitingOnApproval",

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 258 {
-		t.Fatalf("definition count = %d, want 258", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 259 {
+		t.Fatalf("definition count = %d, want 259", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 258 {
-		t.Fatalf("definition count = %d, want 258", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 259 {
+		t.Fatalf("definition count = %d, want 259", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 258 {
-		t.Fatalf("definition count = %d, want 258", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 259 {
+		t.Fatalf("definition count = %d, want 259", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -1776,6 +1776,30 @@ export type TextElement = {
   "placeholder": string | null;
 };
 
+export type Thread = {
+  "agentNickname": string | null;
+  "agentRole": string | null;
+  "cliVersion": string;
+  "createdAt": number;
+  "cwd": AbsolutePathBuf;
+  "ephemeral": boolean;
+  "forkedFromId": string | null;
+  "gitInfo": GitInfo | null;
+  "id": string;
+  "modelProvider": string;
+  "name": string | null;
+  "parentThreadId": string | null;
+  "path": string | null;
+  "preview": string;
+  "recencyAt": number | null;
+  "sessionId": string;
+  "source": SessionSource;
+  "status": ThreadStatus;
+  "threadSource": ThreadSource | null;
+  "turns": Array<Turn>;
+  "updatedAt": number;
+};
+
 export type ThreadActiveFlag = "waitingOnApproval" | "waitingOnUserInput";
 
 export type ThreadArchiveParams = {

--- a/appserver/protocol/typescript/testdata/public_thread_contract.ts
+++ b/appserver/protocol/typescript/testdata/public_thread_contract.ts
@@ -1,0 +1,106 @@
+import type {
+  AbsolutePathBuf,
+  GitInfo,
+  SessionSource,
+  Thread,
+  ThreadSource,
+  ThreadStatus,
+  Turn,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+
+type ThreadIsExact = Expect<
+  Equal<
+    Thread,
+    {
+      id: string;
+      sessionId: string;
+      forkedFromId: string | null;
+      parentThreadId: string | null;
+      preview: string;
+      ephemeral: boolean;
+      modelProvider: string;
+      createdAt: number;
+      updatedAt: number;
+      recencyAt: number | null;
+      status: ThreadStatus;
+      path: string | null;
+      cwd: AbsolutePathBuf;
+      cliVersion: string;
+      source: SessionSource;
+      threadSource: ThreadSource | null;
+      agentNickname: string | null;
+      agentRole: string | null;
+      gitInfo: GitInfo | null;
+      name: string | null;
+      turns: Turn[];
+    }
+  >
+>;
+
+export const threads = [
+  {
+    id: "",
+    sessionId: "",
+    forkedFromId: null,
+    parentThreadId: null,
+    preview: "",
+    ephemeral: false,
+    modelProvider: "",
+    createdAt: -1,
+    updatedAt: 0,
+    recencyAt: null,
+    status: { type: "idle" },
+    path: null,
+    cwd: "/workspace",
+    cliVersion: "",
+    source: "cli",
+    threadSource: null,
+    agentNickname: null,
+    agentRole: null,
+    gitInfo: null,
+    name: null,
+    turns: [],
+  },
+] satisfies Thread[];
+
+// @ts-expect-error nullable fields remain required
+export const missingName: Thread = {
+  id: "thread",
+  sessionId: "session",
+  forkedFromId: null,
+  parentThreadId: null,
+  preview: "",
+  ephemeral: false,
+  modelProvider: "openai",
+  createdAt: 0,
+  updatedAt: 0,
+  recencyAt: null,
+  status: { type: "idle" },
+  path: null,
+  cwd: "/workspace",
+  cliVersion: "1",
+  source: "cli",
+  threadSource: null,
+  agentNickname: null,
+  agentRole: null,
+  gitInfo: null,
+  turns: [],
+};
+
+export const malformedThreads = [
+  // @ts-expect-error turns cannot be null
+  { ...threads[0], turns: null },
+  // @ts-expect-error statuses remain strict
+  { ...threads[0], status: { type: "active" } },
+  // @ts-expect-error sources remain strict
+  { ...threads[0], source: "mcp" },
+  // @ts-expect-error experimental fields are excluded
+  { ...threads[0], historyMode: "full" },
+] satisfies Thread[];


### PR DESCRIPTION
## Summary

- export the exact standalone public v2 `Thread` record
- enforce all 21 generated-TypeScript fields, strict nested status/source/Git/Turn values, signed-int64 bounds, and absolute `cwd` validation
- exclude experimental and durable-only fields while leaving method/store/runtime bindings unchanged

## Validation

- deliberate red Go and TypeScript contracts
- `go test ./...`
- exact non-Monty race/coverage gate (94.4% protocol) plus separate 88.3% Monty coverage
- focused codec coverage: 100%
- `golangci-lint run ./...`
- `go vet ./...`
- `go mod tidy` with no diff
- deterministic `go generate ./appserver/protocol`
- strict TypeScript fixture (`tsc`)
- `.githooks/pre-push`