### PR TITLE
Add exact warning and error notification contracts

### DIFF
--- a/appserver/protocol/README.md
+++ b/appserver/protocol/README.md
@@ -484,6 +484,15 @@ reasoning-text producers remain unbound because they omit required `itemId` and
 emit incompatible `index`/`at` extensions. Plan and reasoning-summary methods
 remain blocked until exact producers exist.
 
+Exact standalone warning, guardian-warning, and error notification records
+establish the fixed public warning/error value layer. Canonical warning output
+requires explicit nullable thread id, while decoding also accepts omission to
+match the pinned Rust `Option` input. Guardian warnings require thread id and
+message; errors require strict `TurnError`, retry state, thread id, and turn id.
+The current live error producer remains unbound because it emits a string
+error, optional ids, and an `at` timestamp without retry state. Warning and
+guardian-warning methods remain blocked until exact producers exist.
+
 ## Generation
 
 Run:

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 297 {
-		t.Fatalf("definition count = %d, want 297", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 300 {
+		t.Fatalf("definition count = %d, want 300", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 297 {
-		t.Fatalf("definition count = %d, want 297", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 300 {
+		t.Fatalf("definition count = %d, want 300", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 297 {
-		t.Fatalf("definition count = %d, want 297", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 300 {
+		t.Fatalf("definition count = %d, want 300", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 297 {
-		t.Fatalf("definition count = %d, want 297", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 300 {
+		t.Fatalf("definition count = %d, want 300", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 297 {
-		t.Fatalf("definition count = %d, want 297", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 300 {
+		t.Fatalf("definition count = %d, want 300", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 297 {
-		t.Fatalf("definition count = %d, want 297", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 300 {
+		t.Fatalf("definition count = %d, want 300", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 297 {
-		t.Fatalf("definition count = %d, want 297", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 300 {
+		t.Fatalf("definition count = %d, want 300", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -136,6 +136,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "DynamicToolCallItem", Type: reflect.TypeFor[DynamicToolCallItem]()},
 		{Name: "DynamicToolCallItemCompletedNotificationParams", Type: reflect.TypeFor[DynamicToolCallItemCompletedNotificationParams]()},
 		{Name: "DynamicToolCallItemStartedNotificationParams", Type: reflect.TypeFor[DynamicToolCallItemStartedNotificationParams]()},
+		{Name: "ErrorNotification", Type: reflect.TypeFor[ErrorNotification]()},
 		{Name: "ExecPolicyAmendment", Type: reflect.TypeFor[ExecPolicyAmendment]()},
 		{Name: "FileChangeApprovalRequestParams", Type: reflect.TypeFor[FileChangeApprovalRequestParams]()},
 		{Name: "FileChangeApprovalDecision", Type: reflect.TypeFor[FileChangeApprovalDecision]()},
@@ -175,6 +176,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "FunctionCallOutputContentItem", Type: reflect.TypeFor[FunctionCallOutputContentItem]()},
 		{Name: "GitInfo", Type: reflect.TypeFor[GitInfo]()},
 		{Name: "GrantedPermissionProfile", Type: reflect.TypeFor[GrantedPermissionProfile]()},
+		{Name: "GuardianWarningNotification", Type: reflect.TypeFor[GuardianWarningNotification]()},
 		{Name: "HookPromptFragment", Type: reflect.TypeFor[HookPromptFragment]()},
 		{Name: "ImageDetail", Type: reflect.TypeFor[ImageDetail]()},
 		{Name: "ImageGenerationItem", Type: reflect.TypeFor[ImageGenerationItem]()},
@@ -360,6 +362,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "UserInput", Type: reflect.TypeFor[UserInput]()},
 		{Name: "WebSearchAction", Type: reflect.TypeFor[WebSearchAction]()},
 		{Name: "WebSearchItem", Type: reflect.TypeFor[WebSearchItem]()},
+		{Name: "WarningNotification", Type: reflect.TypeFor[WarningNotification]()},
 		// Register exact public names after their aliases so nested schemas refer
 		// to the public names. JSON and TypeScript output remain key-sorted.
 		{Name: "ContextCompactedNotification", Type: reflect.TypeFor[ContextCompactedNotification]()},

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -1948,6 +1948,30 @@
       ],
       "type": "object"
     },
+    "ErrorNotification": {
+      "additionalProperties": false,
+      "properties": {
+        "error": {
+          "$ref": "#/$defs/TurnError"
+        },
+        "threadId": {
+          "type": "string"
+        },
+        "turnId": {
+          "type": "string"
+        },
+        "willRetry": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "error",
+        "willRetry",
+        "threadId",
+        "turnId"
+      ],
+      "type": "object"
+    },
     "ExecPolicyAmendment": {
       "items": {
         "type": "string"
@@ -2943,6 +2967,22 @@
           "$ref": "#/$defs/AdditionalNetworkPermissions"
         }
       },
+      "type": "object"
+    },
+    "GuardianWarningNotification": {
+      "additionalProperties": false,
+      "properties": {
+        "message": {
+          "type": "string"
+        },
+        "threadId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "threadId",
+        "message"
+      ],
       "type": "object"
     },
     "HookPromptFragment": {
@@ -10333,6 +10373,29 @@
           "type": "object"
         }
       ]
+    },
+    "WarningNotification": {
+      "additionalProperties": false,
+      "properties": {
+        "message": {
+          "type": "string"
+        },
+        "threadId": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "threadId",
+        "message"
+      ],
+      "type": "object"
     },
     "WebSearchAction": {
       "oneOf": [

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 297 {
-		t.Fatalf("definition count = %d, want 297", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 300 {
+		t.Fatalf("definition count = %d, want 300", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 297 {
-		t.Fatalf("definition count = %d, want 297", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 300 {
+		t.Fatalf("definition count = %d, want 300", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 297 {
-		t.Fatalf("definition count = %d, want 297", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 300 {
+		t.Fatalf("definition count = %d, want 300", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 297 {
-		t.Fatalf("definition count = %d, want 297", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 300 {
+		t.Fatalf("definition count = %d, want 300", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 297 {
-		t.Fatalf("definition count = %d, want 297", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 300 {
+		t.Fatalf("definition count = %d, want 300", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 297 {
-		t.Fatalf("definition count = %d, want 297", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 300 {
+		t.Fatalf("definition count = %d, want 300", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 297 {
-		t.Fatalf("definition count = %d, want 297", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 300 {
+		t.Fatalf("definition count = %d, want 300", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 297 {
-		t.Fatalf("definition count = %d, want 297", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 300 {
+		t.Fatalf("definition count = %d, want 300", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 297 {
-		t.Fatalf("definition count = %d, want 297", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 300 {
+		t.Fatalf("definition count = %d, want 300", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 297 {
-		t.Fatalf("definition count = %d, want 297", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 300 {
+		t.Fatalf("definition count = %d, want 300", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 297 {
-		t.Fatalf("definition count = %d, want 297", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 300 {
+		t.Fatalf("definition count = %d, want 300", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 297 {
-		t.Fatalf("definition count = %d, want 297", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 300 {
+		t.Fatalf("definition count = %d, want 300", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -926,6 +926,13 @@ export type Error = ({
   "message": string;
 } & Record<string, unknown>);
 
+export type ErrorNotification = {
+  "error": TurnError;
+  "threadId": string;
+  "turnId": string;
+  "willRetry": boolean;
+};
+
 export type ExecPolicyAmendment = Array<string>;
 
 export type FileChangeApprovalDecision = "accept" | "acceptForSession" | "decline" | "cancel";
@@ -1178,6 +1185,11 @@ export type GitInfo = {
 export type GrantedPermissionProfile = {
   "fileSystem"?: AdditionalFileSystemPermissions;
   "network"?: AdditionalNetworkPermissions;
+};
+
+export type GuardianWarningNotification = {
+  "message": string;
+  "threadId": string;
 };
 
 export type HookPromptFragment = {
@@ -2646,6 +2658,11 @@ export type UserInput = {
   "name": string;
   "path": string;
   "type": "mention";
+};
+
+export type WarningNotification = {
+  "message": string;
+  "threadId": string | null;
 };
 
 export type WebSearchAction = {

--- a/appserver/protocol/typescript/testdata/warning_error_notification_contract.ts
+++ b/appserver/protocol/typescript/testdata/warning_error_notification_contract.ts
@@ -1,0 +1,65 @@
+import type {
+  ErrorNotification,
+  GuardianWarningNotification,
+  TurnError,
+  WarningNotification,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+
+type Contracts = [
+  Expect<Equal<WarningNotification, {
+    threadId: string | null;
+    message: string;
+  }>>,
+  Expect<Equal<GuardianWarningNotification, {
+    threadId: string;
+    message: string;
+  }>>,
+  Expect<Equal<ErrorNotification, {
+    error: TurnError;
+    willRetry: boolean;
+    threadId: string;
+    turnId: string;
+  }>>,
+];
+
+export const warning = { threadId: null, message: "" } satisfies WarningNotification;
+export const targetedWarning = { threadId: "thread", message: "warn" } satisfies WarningNotification;
+export const guardian = { threadId: "thread", message: "guardian" } satisfies GuardianWarningNotification;
+export const error = {
+  error: { message: "boom", codexErrorInfo: null, additionalDetails: null },
+  willRetry: false,
+  threadId: "thread",
+  turnId: "turn",
+} satisfies ErrorNotification;
+
+// @ts-expect-error canonical warnings require explicit nullable threadId.
+export const rejectMissingWarningThread = { message: "warn" } satisfies WarningNotification;
+// @ts-expect-error warning thread ids are nullable strings only.
+export const rejectNumericWarningThread = { threadId: 1, message: "warn" } satisfies WarningNotification;
+// @ts-expect-error warning message is required.
+export const rejectMissingWarningMessage = { threadId: null } satisfies WarningNotification;
+// @ts-expect-error public warnings exclude detail extensions.
+export const rejectWarningExtension = { threadId: null, message: "warn", details: null } satisfies WarningNotification;
+// @ts-expect-error guardian thread id is required.
+export const rejectMissingGuardianThread = { message: "warn" } satisfies GuardianWarningNotification;
+// @ts-expect-error guardian thread id is non-null.
+export const rejectNullGuardianThread = { threadId: null, message: "warn" } satisfies GuardianWarningNotification;
+// @ts-expect-error error is required.
+export const rejectMissingError = { willRetry: false, threadId: "thread", turnId: "turn" } satisfies ErrorNotification;
+// @ts-expect-error retry state is required.
+export const rejectMissingRetry = { error: { message: "boom", codexErrorInfo: null, additionalDetails: null }, threadId: "thread", turnId: "turn" } satisfies ErrorNotification;
+// @ts-expect-error nested TurnError remains strict.
+export const rejectMalformedError = { error: { message: "boom" }, willRetry: false, threadId: "thread", turnId: "turn" } satisfies ErrorNotification;
+// @ts-expect-error error ids are non-null strings.
+export const rejectNullErrorThread = { error: { message: "boom", codexErrorInfo: null, additionalDetails: null }, willRetry: false, threadId: null, turnId: "turn" } satisfies ErrorNotification;
+// @ts-expect-error live timestamps are not part of the exact error record.
+export const rejectErrorExtension = { error: { message: "boom", codexErrorInfo: null, additionalDetails: null }, willRetry: false, threadId: "thread", turnId: "turn", at: "now" } satisfies ErrorNotification;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -1,0 +1,194 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestWarningErrorNotificationSchemasAreExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	warning := defs["WarningNotification"].(Schema)
+	assertClosedObjectSchema(t, warning, "threadId", "message")
+	warningProperties := warning["properties"].(Schema)
+	assertNullableStringSchema(t, warningProperties["threadId"])
+	if !reflect.DeepEqual(warningProperties["message"], Schema{"type": "string"}) {
+		t.Fatalf("WarningNotification.message = %#v", warningProperties["message"])
+	}
+
+	guardian := defs["GuardianWarningNotification"].(Schema)
+	assertClosedObjectSchema(t, guardian, "threadId", "message")
+	guardianProperties := guardian["properties"].(Schema)
+	for _, field := range []string{"threadId", "message"} {
+		if !reflect.DeepEqual(guardianProperties[field], Schema{"type": "string"}) {
+			t.Errorf("GuardianWarningNotification.%s = %#v", field, guardianProperties[field])
+		}
+	}
+
+	errorNotification := defs["ErrorNotification"].(Schema)
+	assertClosedObjectSchema(t, errorNotification, "error", "willRetry", "threadId", "turnId")
+	errorProperties := errorNotification["properties"].(Schema)
+	if !reflect.DeepEqual(errorProperties["error"], Schema{"$ref": "#/$defs/TurnError"}) {
+		t.Fatalf("ErrorNotification.error = %#v", errorProperties["error"])
+	}
+	if !reflect.DeepEqual(errorProperties["willRetry"], Schema{"type": "boolean"}) {
+		t.Fatalf("ErrorNotification.willRetry = %#v", errorProperties["willRetry"])
+	}
+	for _, field := range []string{"threadId", "turnId"} {
+		if !reflect.DeepEqual(errorProperties[field], Schema{"type": "string"}) {
+			t.Errorf("ErrorNotification.%s = %#v", field, errorProperties[field])
+		}
+	}
+}
+
+func TestWarningErrorNotificationsAcceptExactWireValues(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+		value func() any
+	}{
+		{"warning omitted thread", `{"message":"warn"}`, `{"threadId":null,"message":"warn"}`, func() any { return new(WarningNotification) }},
+		{"warning null thread", `{"threadId":null,"message":""}`, `{"threadId":null,"message":""}`, func() any { return new(WarningNotification) }},
+		{"warning thread", `{"threadId":"thread","message":"warn"}`, `{"threadId":"thread","message":"warn"}`, func() any { return new(WarningNotification) }},
+		{"guardian", `{"threadId":"","message":""}`, `{"threadId":"","message":""}`, func() any { return new(GuardianWarningNotification) }},
+		{"error", `{"error":{"message":"boom","codexErrorInfo":null,"additionalDetails":null},"willRetry":false,"threadId":"thread","turnId":"turn"}`, `{"error":{"message":"boom","codexErrorInfo":null,"additionalDetails":null},"willRetry":false,"threadId":"thread","turnId":"turn"}`, func() any { return new(ErrorNotification) }},
+		{"retrying error", `{"error":{"message":"","codexErrorInfo":"serverOverloaded","additionalDetails":"retrying"},"willRetry":true,"threadId":"","turnId":""}`, `{"error":{"message":"","codexErrorInfo":"serverOverloaded","additionalDetails":"retrying"},"willRetry":true,"threadId":"","turnId":""}`, func() any { return new(ErrorNotification) }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			value := tc.value()
+			if err := json.Unmarshal([]byte(tc.input), value); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			encoded, err := json.Marshal(value)
+			if err != nil || string(encoded) != tc.want {
+				t.Fatalf("round trip = %s, %v; want %s", encoded, err, tc.want)
+			}
+		})
+	}
+}
+
+func TestWarningErrorNotificationsRejectMalformedWireValues(t *testing.T) {
+	warningInvalid := []string{
+		`null`, `[]`, `"warning"`, `{}`,
+		`{"threadId":null}`, `{"threadId":null,"message":null}`,
+		`{"threadId":1,"message":"warn"}`, `{"threadId":null,"message":false}`,
+		`{"threadId":null,"message":"warn","details":null}`,
+		`{"threadId":null,"message":"warn"} {}`,
+	}
+	for _, input := range warningInvalid {
+		var value WarningNotification
+		if err := json.Unmarshal([]byte(input), &value); err == nil {
+			t.Errorf("WarningNotification accepted %s", input)
+		}
+	}
+
+	guardianInvalid := []string{
+		`null`, `{}`, `{"message":"warn"}`, `{"threadId":"thread"}`,
+		`{"threadId":null,"message":"warn"}`, `{"threadId":"thread","message":null}`,
+		`{"threadId":"thread","message":"warn","willRetry":false}`,
+		`{"threadId":"thread","message":"warn"} {}`,
+	}
+	for _, input := range guardianInvalid {
+		var value GuardianWarningNotification
+		if err := json.Unmarshal([]byte(input), &value); err == nil {
+			t.Errorf("GuardianWarningNotification accepted %s", input)
+		}
+	}
+
+	errorInvalid := []string{
+		`null`, `{}`,
+		`{"willRetry":false,"threadId":"thread","turnId":"turn"}`,
+		`{"error":{"message":"boom","codexErrorInfo":null,"additionalDetails":null},"threadId":"thread","turnId":"turn"}`,
+		`{"error":{"message":"boom","codexErrorInfo":null,"additionalDetails":null},"willRetry":false,"turnId":"turn"}`,
+		`{"error":{"message":"boom","codexErrorInfo":null,"additionalDetails":null},"willRetry":false,"threadId":"thread"}`,
+		`{"error":null,"willRetry":false,"threadId":"thread","turnId":"turn"}`,
+		`{"error":{"message":"boom"},"willRetry":false,"threadId":"thread","turnId":"turn"}`,
+		`{"error":{"message":"boom","codexErrorInfo":null,"additionalDetails":null},"willRetry":"false","threadId":"thread","turnId":"turn"}`,
+		`{"error":{"message":"boom","codexErrorInfo":null,"additionalDetails":null},"willRetry":false,"threadId":null,"turnId":"turn"}`,
+		`{"error":{"message":"boom","codexErrorInfo":null,"additionalDetails":null},"willRetry":false,"threadId":"thread","turnId":1}`,
+		`{"error":{"message":"boom","codexErrorInfo":null,"additionalDetails":null},"willRetry":false,"threadId":"thread","turnId":"turn","at":"now"}`,
+		`{"error":{"message":"boom","codexErrorInfo":null,"additionalDetails":null},"willRetry":false,"threadId":"thread","turnId":"turn"} {}`,
+	}
+	for _, input := range errorInvalid {
+		var value ErrorNotification
+		if err := json.Unmarshal([]byte(input), &value); err == nil {
+			t.Errorf("ErrorNotification accepted %s", input)
+		}
+	}
+}
+
+func TestWarningErrorNotificationNilReceiversAndDistinctTypes(t *testing.T) {
+	var warning *WarningNotification
+	var guardian *GuardianWarningNotification
+	var errorNotification *ErrorNotification
+	for name, decode := range map[string]func() error{
+		"warning":  func() error { return warning.UnmarshalJSON([]byte(`{}`)) },
+		"guardian": func() error { return guardian.UnmarshalJSON([]byte(`{}`)) },
+		"error":    func() error { return errorNotification.UnmarshalJSON([]byte(`{}`)) },
+	} {
+		if err := decode(); err == nil {
+			t.Errorf("nil %s receiver succeeded", name)
+		}
+	}
+	types := []reflect.Type{
+		reflect.TypeFor[WarningNotification](),
+		reflect.TypeFor[GuardianWarningNotification](),
+		reflect.TypeFor[ErrorNotification](),
+	}
+	for i := range types {
+		for j := i + 1; j < len(types); j++ {
+			if types[i] == types[j] {
+				t.Fatalf("types %d and %d unexpectedly alias", i, j)
+			}
+		}
+	}
+}
+
+func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
+	names := []string{"WarningNotification", "GuardianWarningNotification", "ErrorNotification"}
+	for _, binding := range WireTypeBindings() {
+		for _, name := range names {
+			if slices.Contains(binding.Params, name) || slices.Contains(binding.Result, name) {
+				t.Fatalf("%s unexpectedly bound to %s", name, binding.Method)
+			}
+		}
+	}
+	for _, method := range []string{"warning", "guardianWarning", "error"} {
+		info, ok := LookupMethod(method)
+		if !ok || info.State != MethodBlocked {
+			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 300 {
+		t.Fatalf("definition count = %d, want 300", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestWarningErrorNotificationTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	source := string(generated)
+	for _, want := range []string{
+		`export type WarningNotification = {`,
+		`"threadId": string | null;`,
+		`"message": string;`,
+		`export type GuardianWarningNotification = {`,
+		`export type ErrorNotification = {`,
+		`"error": TurnError;`,
+		`"willRetry": boolean;`,
+		`"turnId": string;`,
+	} {
+		if !strings.Contains(source, want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}

--- a/appserver/protocol/warning_error_notification_types.go
+++ b/appserver/protocol/warning_error_notification_types.go
@@ -1,0 +1,126 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// WarningNotification is the exact fixed public warning value. It remains
+// standalone until Gollem has an exact live producer.
+type WarningNotification struct {
+	ThreadID *string `json:"threadId"`
+	Message  string  `json:"message"`
+}
+
+func (n *WarningNotification) UnmarshalJSON(data []byte) error {
+	if n == nil {
+		return errors.New("decode warning notification into nil receiver")
+	}
+	payload, err := decodeExactThreadItemObject(data, "warning notification", "threadId", "message")
+	if err != nil {
+		return err
+	}
+	threadID, err := decodeOptionalNullableWarningThreadID(payload)
+	if err != nil {
+		return err
+	}
+	message, err := decodeRequiredThreadItemValue[string](payload, "warning notification", "message")
+	if err != nil {
+		return err
+	}
+	*n = WarningNotification{ThreadID: threadID, Message: message}
+	return nil
+}
+
+func decodeOptionalNullableWarningThreadID(payload map[string]json.RawMessage) (*string, error) {
+	raw, ok := payload["threadId"]
+	if !ok || isJSONNull(raw) {
+		return nil, nil
+	}
+	var threadID string
+	if err := json.Unmarshal(raw, &threadID); err != nil {
+		return nil, fmt.Errorf("decode warning notification threadId: %w", err)
+	}
+	return &threadID, nil
+}
+
+// GuardianWarningNotification is the exact fixed public guardian warning
+// value. It remains standalone until Gollem has an exact live producer.
+type GuardianWarningNotification struct {
+	ThreadID string `json:"threadId"`
+	Message  string `json:"message"`
+}
+
+func (n *GuardianWarningNotification) UnmarshalJSON(data []byte) error {
+	if n == nil {
+		return errors.New("decode guardian warning notification into nil receiver")
+	}
+	payload, err := decodeExactThreadItemObject(data, "guardian warning notification", "threadId", "message")
+	if err != nil {
+		return err
+	}
+	threadID, err := decodeRequiredThreadItemValue[string](payload, "guardian warning notification", "threadId")
+	if err != nil {
+		return err
+	}
+	message, err := decodeRequiredThreadItemValue[string](payload, "guardian warning notification", "message")
+	if err != nil {
+		return err
+	}
+	*n = GuardianWarningNotification{ThreadID: threadID, Message: message}
+	return nil
+}
+
+// ErrorNotification is the exact fixed public turn-error notification. It
+// remains standalone while Gollem's live runtime error envelope is
+// wire-incompatible.
+type ErrorNotification struct {
+	Error     TurnError `json:"error"`
+	WillRetry bool      `json:"willRetry"`
+	ThreadID  string    `json:"threadId"`
+	TurnID    string    `json:"turnId"`
+}
+
+func (n *ErrorNotification) UnmarshalJSON(data []byte) error {
+	if n == nil {
+		return errors.New("decode error notification into nil receiver")
+	}
+	payload, err := decodeExactThreadItemObject(
+		data,
+		"error notification",
+		"error",
+		"willRetry",
+		"threadId",
+		"turnId",
+	)
+	if err != nil {
+		return err
+	}
+	turnError, err := decodeRequiredThreadItemValue[TurnError](payload, "error notification", "error")
+	if err != nil {
+		return err
+	}
+	willRetry, err := decodeRequiredThreadItemValue[bool](payload, "error notification", "willRetry")
+	if err != nil {
+		return err
+	}
+	threadID, err := decodeRequiredThreadItemValue[string](payload, "error notification", "threadId")
+	if err != nil {
+		return err
+	}
+	turnID, err := decodeRequiredThreadItemValue[string](payload, "error notification", "turnId")
+	if err != nil {
+		return err
+	}
+	*n = ErrorNotification{
+		Error: turnError, WillRetry: willRetry, ThreadID: threadID, TurnID: turnID,
+	}
+	return nil
+}
+
+var (
+	_ json.Unmarshaler = (*WarningNotification)(nil)
+	_ json.Unmarshaler = (*GuardianWarningNotification)(nil)
+	_ json.Unmarshaler = (*ErrorNotification)(nil)
+)

--- a/appserver/runtime_error_notification_contract_test.go
+++ b/appserver/runtime_error_notification_contract_test.go
@@ -1,0 +1,79 @@
+package appserver
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"testing"
+
+	"github.com/fugue-labs/gollem/appserver/protocol"
+	"github.com/fugue-labs/gollem/appserver/store"
+)
+
+type runtimeErrorCaptureNotifier struct {
+	method string
+	params any
+}
+
+func (n *runtimeErrorCaptureNotifier) PublishNotification(method string, params any) {
+	n.method = method
+	n.params = params
+}
+
+func TestPublishRuntimeErrorRetainsLiveExtensionShape(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		turn     *store.Turn
+		wantKeys []string
+	}{
+		{"thread turn", &store.Turn{ID: "turn", ThreadID: "thread"}, []string{"at", "error", "threadId", "turnId"}},
+		{"global", nil, []string{"at", "error"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			notifier := &runtimeErrorCaptureNotifier{}
+			publishRuntimeError(notifier, tc.turn, "boom")
+			if notifier.method != "error" {
+				t.Fatalf("method = %q", notifier.method)
+			}
+			params, ok := notifier.params.(runtimeErrorNotificationParams)
+			if !ok || params.Error != "boom" || params.At.IsZero() {
+				t.Fatalf("params = %#v (%T)", notifier.params, notifier.params)
+			}
+			if tc.turn != nil && (params.ThreadID != "thread" || params.TurnID != "turn") {
+				t.Fatalf("correlated ids = %q/%q", params.ThreadID, params.TurnID)
+			}
+			if tc.turn == nil && (params.ThreadID != "" || params.TurnID != "") {
+				t.Fatalf("global ids = %q/%q", params.ThreadID, params.TurnID)
+			}
+			encoded, err := json.Marshal(params)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var payload map[string]json.RawMessage
+			if err := json.Unmarshal(encoded, &payload); err != nil {
+				t.Fatal(err)
+			}
+			keys := make([]string, 0, len(payload))
+			for key := range payload {
+				keys = append(keys, key)
+			}
+			slices.Sort(keys)
+			if !reflect.DeepEqual(keys, tc.wantKeys) {
+				t.Fatalf("keys = %v, want %v", keys, tc.wantKeys)
+			}
+			var exact protocol.ErrorNotification
+			if err := json.Unmarshal(encoded, &exact); err == nil {
+				t.Fatal("incompatible live extension decoded as exact public error")
+			}
+		})
+	}
+}
+
+func TestPublishRuntimeErrorNoopGuards(t *testing.T) {
+	publishRuntimeError(nil, &store.Turn{ID: "turn", ThreadID: "thread"}, "boom")
+	notifier := &runtimeErrorCaptureNotifier{}
+	publishRuntimeError(notifier, &store.Turn{ID: "turn", ThreadID: "thread"}, "")
+	if notifier.method != "" || notifier.params != nil {
+		t.Fatalf("unexpected notification %q %#v", notifier.method, notifier.params)
+	}
+}


### PR DESCRIPTION
## Summary
- add exact standalone `WarningNotification`, `GuardianWarningNotification`, and `ErrorNotification` values
- preserve omitted-to-null warning decode compatibility and reuse strict `TurnError`
- keep warning/error methods and all generated method/item bindings unchanged because current producers are absent or wire-incompatible
- add regression coverage proving the live runtime error envelope remains unchanged and cannot decode as the exact public value

## Verification
- deliberate red Go and strict TypeScript gates
- all five new decoder/runtime functions at 100% focused coverage
- 30 focused repetitions and focused race
- serial full suite and full repository race including Monty (254.2s)
- protocol coverage 95.4%; Monty coverage 88.3%
- lint, vet, tidy/module verification, deterministic generation, strict TypeScript
- all five Slang real-process workflows
- full pre-push twice, including a cache-cleared run, plus push-time hook

Generated output: 300 definitions, 59 method bindings, 5 item bindings.