### PR TITLE
Export exact model list envelopes

### DIFF
--- a/appserver/protocol/README.md
+++ b/appserver/protocol/README.md
@@ -530,6 +530,15 @@ models remain distinct until an explicit list adapter can preserve those live
 features without claiming that the extended response is the exact public
 contract.
 
+Exact standalone `ModelListParams` and `ModelListResponse` complete the public
+list-envelope value layer without binding `model/list`. Params accept optional
+nullable cursor, uint32 limit, and hidden-model selection while canonical
+output emits all three fields. Responses require a non-null exact `Model`
+array and canonical nullable next cursor while accepting omitted Rust `Option`
+cursor input. The live request and response remain provider-extended, so an
+explicit projection is still required before generated method inference can
+replace `unknown`.
+
 ## Generation
 
 Run:

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 315 {
-		t.Fatalf("definition count = %d, want 315", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 317 {
+		t.Fatalf("definition count = %d, want 317", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 315 {
-		t.Fatalf("definition count = %d, want 315", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 317 {
+		t.Fatalf("definition count = %d, want 317", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 315 {
-		t.Fatalf("definition count = %d, want 315", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 317 {
+		t.Fatalf("definition count = %d, want 317", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 315 {
-		t.Fatalf("definition count = %d, want 315", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 317 {
+		t.Fatalf("definition count = %d, want 317", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 315 {
-		t.Fatalf("definition count = %d, want 315", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 317 {
+		t.Fatalf("definition count = %d, want 317", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -1,0 +1,228 @@
+package protocol
+
+import (
+	"encoding/json"
+	"math"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+const (
+	modelListMinimalModelWire = `{"id":"id","model":"model","displayName":"name","description":"","hidden":false,` +
+		`"supportedReasoningEfforts":[],"defaultReasoningEffort":"low","isDefault":false}`
+	modelListCanonicalModelWire = `{"id":"id","model":"model","upgrade":null,"upgradeInfo":null,"availabilityNux":null,` +
+		`"displayName":"name","description":"","hidden":false,"supportedReasoningEfforts":[],` +
+		`"defaultReasoningEffort":"low","inputModalities":["text","image"],"supportsPersonality":false,` +
+		`"additionalSpeedTiers":[],"serviceTiers":[],"defaultServiceTier":null,"isDefault":false}`
+)
+
+func TestModelListSchemasAreExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	params, ok := defs["ModelListParams"].(Schema)
+	if !ok {
+		t.Fatal("$defs missing ModelListParams")
+	}
+	if params["type"] != "object" || params["additionalProperties"] != false {
+		t.Fatalf("ModelListParams is not a closed object: %#v", params)
+	}
+	if got := schemaRequiredNames(params); len(got) != 0 {
+		t.Fatalf("ModelListParams required = %v, want none", got)
+	}
+	wantParamsProperties := Schema{
+		"cursor": Schema{
+			"description": "Opaque pagination cursor returned by a previous call.",
+			"anyOf":       []any{Schema{"type": "string"}, Schema{"type": "null"}},
+		},
+		"limit": Schema{
+			"description": "Optional page size; defaults to a reasonable server-side value.",
+			"anyOf":       []any{Schema{"type": "integer", "minimum": 0}, Schema{"type": "null"}},
+		},
+		"includeHidden": Schema{
+			"description": "When true, include models that are hidden from the default picker list.",
+			"anyOf":       []any{Schema{"type": "boolean"}, Schema{"type": "null"}},
+		},
+	}
+	if got := params["properties"].(Schema); !reflect.DeepEqual(got, wantParamsProperties) {
+		t.Fatalf("ModelListParams properties = %#v, want %#v", got, wantParamsProperties)
+	}
+
+	response, ok := defs["ModelListResponse"].(Schema)
+	if !ok {
+		t.Fatal("$defs missing ModelListResponse")
+	}
+	if response["type"] != "object" || response["additionalProperties"] != false {
+		t.Fatalf("ModelListResponse is not a closed object: %#v", response)
+	}
+	if got := schemaRequiredNames(response); !slices.Equal(got, []string{"data", "nextCursor"}) {
+		t.Fatalf("ModelListResponse required = %v", got)
+	}
+	wantResponseProperties := Schema{
+		"data": Schema{"type": "array", "items": Schema{"$ref": "#/$defs/Model"}},
+		"nextCursor": Schema{
+			"description": "Opaque cursor to pass to the next call to continue after the last item. If None, there are no more items to return.",
+			"anyOf":       []any{Schema{"type": "string"}, Schema{"type": "null"}},
+		},
+	}
+	if got := response["properties"].(Schema); !reflect.DeepEqual(got, wantResponseProperties) {
+		t.Fatalf("ModelListResponse properties = %#v, want %#v", got, wantResponseProperties)
+	}
+}
+
+func TestModelListParamsAcceptExactWireFormsAndCanonicalizeOptions(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{input: `{}`, want: `{"cursor":null,"limit":null,"includeHidden":null}`},
+		{
+			input: `{"cursor":null,"limit":null,"includeHidden":null}`,
+			want:  `{"cursor":null,"limit":null,"includeHidden":null}`,
+		},
+		{
+			input: `{"cursor":"","limit":0,"includeHidden":false}`,
+			want:  `{"cursor":"","limit":0,"includeHidden":false}`,
+		},
+		{
+			input: `{"cursor":"next","limit":4294967295,"includeHidden":true}`,
+			want:  `{"cursor":"next","limit":4294967295,"includeHidden":true}`,
+		},
+	}
+	for _, tc := range cases {
+		var params ModelListParams
+		if err := json.Unmarshal([]byte(tc.input), &params); err != nil {
+			t.Errorf("Unmarshal(%s): %v", tc.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(params)
+		if err != nil || string(encoded) != tc.want {
+			t.Errorf("canonical = %s, %v; want %s", encoded, err, tc.want)
+		}
+	}
+
+	cursor := "next"
+	limit := uint32(math.MaxUint32)
+	includeHidden := false
+	encoded, err := json.Marshal(ModelListParams{
+		Cursor: &cursor, Limit: &limit, IncludeHidden: &includeHidden,
+	})
+	if err != nil || string(encoded) != `{"cursor":"next","limit":4294967295,"includeHidden":false}` {
+		t.Fatalf("marshal populated params = %s, %v", encoded, err)
+	}
+}
+
+func TestModelListParamsRejectMalformedWireForms(t *testing.T) {
+	invalid := []string{
+		`null`, `[]`, `"value"`, `1`,
+		`{"cursor":1}`, `{"cursor":false}`,
+		`{"limit":-1}`, `{"limit":1.5}`, `{"limit":4294967296}`, `{"limit":"1"}`,
+		`{"includeHidden":0}`, `{"includeHidden":"false"}`,
+		`{"providerId":"openai"}`, `{"limit":1,"pageSize":1}`,
+		`{"limit":1} {}`,
+	}
+	for _, input := range invalid {
+		var params ModelListParams
+		if err := json.Unmarshal([]byte(input), &params); err == nil {
+			t.Errorf("Unmarshal(%s) succeeded", input)
+		}
+	}
+	var params *ModelListParams
+	if err := params.UnmarshalJSON([]byte(`{}`)); err == nil {
+		t.Fatal("nil ModelListParams receiver succeeded")
+	}
+}
+
+func TestModelListResponseAcceptsExactWireFormsAndCanonicalizesCursor(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{input: `{"data":[]}`, want: `{"data":[],"nextCursor":null}`},
+		{input: `{"data":[],"nextCursor":null}`, want: `{"data":[],"nextCursor":null}`},
+		{
+			input: `{"data":[` + modelListMinimalModelWire + `],"nextCursor":""}`,
+			want:  `{"data":[` + modelListCanonicalModelWire + `],"nextCursor":""}`,
+		},
+		{
+			input: `{"data":[` + modelListMinimalModelWire + `,` + modelListMinimalModelWire + `],"nextCursor":"next"}`,
+			want:  `{"data":[` + modelListCanonicalModelWire + `,` + modelListCanonicalModelWire + `],"nextCursor":"next"}`,
+		},
+	}
+	for _, tc := range cases {
+		var response ModelListResponse
+		if err := json.Unmarshal([]byte(tc.input), &response); err != nil {
+			t.Errorf("Unmarshal(%s): %v", tc.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(response)
+		if err != nil || string(encoded) != tc.want {
+			t.Errorf("canonical = %s, %v; want %s", encoded, err, tc.want)
+		}
+	}
+}
+
+func TestModelListResponseRejectsMalformedWireForms(t *testing.T) {
+	invalid := []string{
+		`null`, `[]`, `"value"`, `1`, `{}`,
+		`{"data":null}`, `{"data":{}}`, `{"data":[null]}`, `{"data":[{}]}`,
+		`{"data":[],"nextCursor":1}`, `{"data":[],"nextCursor":false}`,
+		`{"data":[],"cursor":"next"}`, `{"data":[],"providerId":"openai"}`,
+		`{"data":[]} {}`,
+	}
+	for _, input := range invalid {
+		var response ModelListResponse
+		if err := json.Unmarshal([]byte(input), &response); err == nil {
+			t.Errorf("Unmarshal(%s) succeeded", input)
+		}
+	}
+
+	if _, err := json.Marshal(ModelListResponse{}); err == nil {
+		t.Fatal("nil model data marshaled")
+	}
+	if _, err := json.Marshal(ModelListResponse{Data: []Model{{}}}); err == nil {
+		t.Fatal("invalid nested model marshaled")
+	}
+	var response *ModelListResponse
+	if err := response.UnmarshalJSON([]byte(`{"data":[]}`)); err == nil {
+		t.Fatal("nil ModelListResponse receiver succeeded")
+	}
+}
+
+func TestModelListContractsRemainStandalone(t *testing.T) {
+	for _, binding := range WireTypeBindings() {
+		if slices.Contains(binding.Params, "ModelListParams") ||
+			slices.Contains(binding.Result, "ModelListParams") ||
+			slices.Contains(binding.Params, "ModelListResponse") ||
+			slices.Contains(binding.Result, "ModelListResponse") {
+			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 317 {
+		t.Fatalf("definition count = %d, want 317", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestModelListTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	source := string(generated)
+	for _, want := range []string{
+		`export type ModelListParams = {`,
+		`"cursor"?: string | null;`,
+		`"includeHidden"?: boolean | null;`,
+		`"limit"?: number | null;`,
+		`export type ModelListResponse = {`,
+		`"data": Array<Model>;`,
+		`"nextCursor": string | null;`,
+	} {
+		if !strings.Contains(source, want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}

--- a/appserver/protocol/model_list_types.go
+++ b/appserver/protocol/model_list_types.go
@@ -1,0 +1,120 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// ModelListParams is the exact public model-catalog page selector. It remains
+// separate from the provider-filtered live request until an adapter is defined.
+type ModelListParams struct {
+	Cursor        *string `json:"cursor,omitempty"`
+	Limit         *uint32 `json:"limit,omitempty"`
+	IncludeHidden *bool   `json:"includeHidden,omitempty"`
+}
+
+func (p ModelListParams) MarshalJSON() ([]byte, error) {
+	type wire struct {
+		Cursor        *string `json:"cursor"`
+		Limit         *uint32 `json:"limit"`
+		IncludeHidden *bool   `json:"includeHidden"`
+	}
+	return json.Marshal(wire(p))
+}
+
+func (p *ModelListParams) UnmarshalJSON(data []byte) error {
+	if p == nil {
+		return errors.New("decode model-list params into nil receiver")
+	}
+	payload, err := decodeExactThreadItemObject(
+		data,
+		"model-list params",
+		"cursor",
+		"limit",
+		"includeHidden",
+	)
+	if err != nil {
+		return err
+	}
+	cursor, err := decodeOptionalNullableModelListValue[string](payload, "cursor")
+	if err != nil {
+		return err
+	}
+	limit, err := decodeOptionalNullableModelListValue[uint32](payload, "limit")
+	if err != nil {
+		return err
+	}
+	includeHidden, err := decodeOptionalNullableModelListValue[bool](payload, "includeHidden")
+	if err != nil {
+		return err
+	}
+	*p = ModelListParams{Cursor: cursor, Limit: limit, IncludeHidden: includeHidden}
+	return nil
+}
+
+// ModelListResponse is the exact public page of strict Model values. It stays
+// outside the live method binding until provider extensions can be projected.
+type ModelListResponse struct {
+	Data       []Model `json:"data" jsonschema:"nonnullable=true"`
+	NextCursor *string `json:"nextCursor"`
+}
+
+func (r ModelListResponse) MarshalJSON() ([]byte, error) {
+	if r.Data == nil {
+		return nil, errors.New("model-list response data cannot be null")
+	}
+	type wire ModelListResponse
+	encoded, err := json.Marshal(wire(r))
+	if err != nil {
+		return nil, fmt.Errorf("encode model-list response: %w", err)
+	}
+	return encoded, nil
+}
+
+func (r *ModelListResponse) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("decode model-list response into nil receiver")
+	}
+	payload, err := decodeExactThreadItemObject(
+		data,
+		"model-list response",
+		"data",
+		"nextCursor",
+	)
+	if err != nil {
+		return err
+	}
+	models, err := decodeRequiredThreadItemArray[Model](payload, "model-list response", "data")
+	if err != nil {
+		return err
+	}
+	nextCursor, err := decodeOptionalNullableModelListValue[string](payload, "nextCursor")
+	if err != nil {
+		return err
+	}
+	*r = ModelListResponse{Data: models, NextCursor: nextCursor}
+	return nil
+}
+
+func decodeOptionalNullableModelListValue[T any](
+	payload map[string]json.RawMessage,
+	fieldName string,
+) (*T, error) {
+	raw, ok := payload[fieldName]
+	if !ok || isJSONNull(raw) {
+		return nil, nil
+	}
+	var value T
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return nil, fmt.Errorf("decode model-list %s: %w", fieldName, err)
+	}
+	return &value, nil
+}
+
+var (
+	_ json.Marshaler   = ModelListParams{}
+	_ json.Unmarshaler = (*ModelListParams)(nil)
+	_ json.Marshaler   = ModelListResponse{}
+	_ json.Unmarshaler = (*ModelListResponse)(nil)
+)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 315 {
-		t.Fatalf("definition count = %d, want 315", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 317 {
+		t.Fatalf("definition count = %d, want 317", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 315 {
-		t.Fatalf("definition count = %d, want 315", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 317 {
+		t.Fatalf("definition count = %d, want 317", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 315 {
-		t.Fatalf("definition count = %d, want 315", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 317 {
+		t.Fatalf("definition count = %d, want 317", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 315 {
-		t.Fatalf("definition count = %d, want 315", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 317 {
+		t.Fatalf("definition count = %d, want 317", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 315 {
-		t.Fatalf("definition count = %d, want 315", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 317 {
+		t.Fatalf("definition count = %d, want 317", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 315 {
-		t.Fatalf("definition count = %d, want 315", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 317 {
+		t.Fatalf("definition count = %d, want 317", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -208,6 +208,8 @@ func wireSchemaDefinitions() Schema {
 		{Name: "MessagePhase", Type: reflect.TypeFor[MessagePhase]()},
 		{Name: "Model", Type: reflect.TypeFor[Model]()},
 		{Name: "ModelAvailabilityNux", Type: reflect.TypeFor[ModelAvailabilityNux]()},
+		{Name: "ModelListParams", Type: reflect.TypeFor[ModelListParams]()},
+		{Name: "ModelListResponse", Type: reflect.TypeFor[ModelListResponse]()},
 		{Name: "ModelRerouteReason", Type: reflect.TypeFor[ModelRerouteReason]()},
 		{Name: "ModelReroutedNotification", Type: reflect.TypeFor[ModelReroutedNotification]()},
 		{Name: "ModelSafetyBufferingUpdatedNotification", Type: reflect.TypeFor[ModelSafetyBufferingUpdatedNotification]()},
@@ -420,9 +422,12 @@ func wireSchemaDefinitions() Schema {
 	schemas["InputModality"] = stringEnumSchema(string(InputModalityText), string(InputModalityImage))
 	schemas["AgentPath"] = Schema{"type": "string"}
 	schemas["ReasoningEffort"] = Schema{"type": "string", "minLength": 1}
+	schemas["ModelListParams"] = modelListParamsSchema()
 	modelProperties := schemas["Model"].(Schema)["properties"].(Schema)
 	modelProperties["additionalSpeedTiers"].(Schema)["description"] = "Deprecated: use `serviceTiers` instead."
 	modelProperties["defaultServiceTier"].(Schema)["description"] = "Catalog default service tier id for this model, when one is configured."
+	modelListResponseProperties := schemas["ModelListResponse"].(Schema)["properties"].(Schema)
+	modelListResponseProperties["nextCursor"].(Schema)["description"] = "Opaque cursor to pass to the next call to continue after the last item. If None, there are no more items to return."
 	schemas["ReasoningSummary"] = stringEnumSchema(
 		string(ReasoningSummaryAuto), string(ReasoningSummaryConcise),
 		string(ReasoningSummaryDetailed), string(ReasoningSummaryNone),
@@ -1430,6 +1435,23 @@ func threadResumeInitialTurnsPageParamsSchema() Schema {
 			Schema{"$ref": "#/$defs/SortDirection"},
 		),
 		"itemsView": nullableThreadSessionParamSchema(Schema{"$ref": "#/$defs/TurnItemsView"}),
+	}, nil)
+}
+
+func modelListParamsSchema() Schema {
+	return closedThreadSessionParamSchema(Schema{
+		"cursor": Schema{
+			"description": "Opaque pagination cursor returned by a previous call.",
+			"anyOf":       []any{Schema{"type": "string"}, Schema{"type": "null"}},
+		},
+		"limit": Schema{
+			"description": "Optional page size; defaults to a reasonable server-side value.",
+			"anyOf":       []any{Schema{"type": "integer", "minimum": 0}, Schema{"type": "null"}},
+		},
+		"includeHidden": Schema{
+			"description": "When true, include models that are hidden from the default picker list.",
+			"anyOf":       []any{Schema{"type": "boolean"}, Schema{"type": "null"}},
+		},
 	}, nil)
 }
 

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -4639,6 +4639,73 @@
       ],
       "type": "object"
     },
+    "ModelListParams": {
+      "additionalProperties": false,
+      "properties": {
+        "cursor": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Opaque pagination cursor returned by a previous call."
+        },
+        "includeHidden": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "When true, include models that are hidden from the default picker list."
+        },
+        "limit": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional page size; defaults to a reasonable server-side value."
+        }
+      },
+      "type": "object"
+    },
+    "ModelListResponse": {
+      "additionalProperties": false,
+      "properties": {
+        "data": {
+          "items": {
+            "$ref": "#/$defs/Model"
+          },
+          "type": "array"
+        },
+        "nextCursor": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Opaque cursor to pass to the next call to continue after the last item. If None, there are no more items to return."
+        }
+      },
+      "required": [
+        "data",
+        "nextCursor"
+      ],
+      "type": "object"
+    },
     "ModelRerouteReason": {
       "enum": [
         "highRiskCyberActivity"

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 315 {
-		t.Fatalf("definition count = %d, want 315", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 317 {
+		t.Fatalf("definition count = %d, want 317", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 315 {
-		t.Fatalf("definition count = %d, want 315", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 317 {
+		t.Fatalf("definition count = %d, want 317", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 315 {
-		t.Fatalf("definition count = %d, want 315", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 317 {
+		t.Fatalf("definition count = %d, want 317", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 315 {
-		t.Fatalf("definition count = %d, want 315", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 317 {
+		t.Fatalf("definition count = %d, want 317", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 315 {
-		t.Fatalf("definition count = %d, want 315", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 317 {
+		t.Fatalf("definition count = %d, want 317", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 315 {
-		t.Fatalf("definition count = %d, want 315", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 317 {
+		t.Fatalf("definition count = %d, want 317", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 315 {
-		t.Fatalf("definition count = %d, want 315", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 317 {
+		t.Fatalf("definition count = %d, want 317", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 315 {
-		t.Fatalf("definition count = %d, want 315", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 317 {
+		t.Fatalf("definition count = %d, want 317", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 315 {
-		t.Fatalf("definition count = %d, want 315", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 317 {
+		t.Fatalf("definition count = %d, want 317", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 315 {
-		t.Fatalf("definition count = %d, want 315", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 317 {
+		t.Fatalf("definition count = %d, want 317", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 315 {
-		t.Fatalf("definition count = %d, want 315", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 317 {
+		t.Fatalf("definition count = %d, want 317", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 315 {
-		t.Fatalf("definition count = %d, want 315", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 317 {
+		t.Fatalf("definition count = %d, want 317", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -1572,6 +1572,17 @@ export type ModelAvailabilityNux = {
   "message": string;
 };
 
+export type ModelListParams = {
+  "cursor"?: string | null;
+  "includeHidden"?: boolean | null;
+  "limit"?: number | null;
+};
+
+export type ModelListResponse = {
+  "data": Array<Model>;
+  "nextCursor": string | null;
+};
+
 export type ModelRerouteReason = "highRiskCyberActivity";
 
 export type ModelReroutedNotification = {

--- a/appserver/protocol/typescript/testdata/model_list_contract.ts
+++ b/appserver/protocol/typescript/testdata/model_list_contract.ts
@@ -1,0 +1,73 @@
+import type {
+  Model,
+  ModelListParams,
+  ModelListResponse,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+
+type ParamsExpected = {
+  cursor?: string | null;
+  limit?: number | null;
+  includeHidden?: boolean | null;
+};
+type ResponseExpected = {
+  data: Model[];
+  nextCursor: string | null;
+};
+type Contracts = [
+  Expect<Equal<ModelListParams, ParamsExpected>>,
+  Expect<Equal<ModelListResponse, ResponseExpected>>,
+];
+
+export const emptyParams = {} satisfies ModelListParams;
+export const nullParams = {
+  cursor: null,
+  limit: null,
+  includeHidden: null,
+} satisfies ModelListParams;
+export const populatedParams = {
+  cursor: "",
+  limit: 0,
+  includeHidden: false,
+} satisfies ModelListParams;
+
+declare const model: Model;
+export const emptyResponse = {
+  data: [],
+  nextCursor: null,
+} satisfies ModelListResponse;
+export const populatedResponse = {
+  data: [model, model],
+  nextCursor: "",
+} satisfies ModelListResponse;
+
+// @ts-expect-error cursors are nullable strings only.
+export const rejectNumericParamCursor = { cursor: 1 } satisfies ModelListParams;
+// @ts-expect-error limits are nullable numbers only.
+export const rejectStringLimit = { limit: "1" } satisfies ModelListParams;
+// @ts-expect-error hidden selection is nullable boolean only.
+export const rejectStringHidden = { includeHidden: "false" } satisfies ModelListParams;
+// @ts-expect-error exact params exclude provider filters.
+export const rejectProviderParam = { providerId: "openai" } satisfies ModelListParams;
+// @ts-expect-error data is required.
+export const rejectMissingData = { nextCursor: null } satisfies ModelListResponse;
+// @ts-expect-error data is non-null.
+export const rejectNullData = { data: null, nextCursor: null } satisfies ModelListResponse;
+// @ts-expect-error data members are non-null exact models.
+export const rejectNullModel = { data: [null], nextCursor: null } satisfies ModelListResponse;
+// @ts-expect-error canonical TypeScript requires nextCursor.
+export const rejectMissingNext = { data: [] } satisfies ModelListResponse;
+// @ts-expect-error response cursors are nullable strings only.
+export const rejectNumericNext = { data: [], nextCursor: 1 } satisfies ModelListResponse;
+// @ts-expect-error nested models remain strict.
+export const rejectMalformedModel = { data: [{}], nextCursor: null } satisfies ModelListResponse;
+// @ts-expect-error exact responses exclude provider metadata.
+export const rejectProviderResponse = { data: [], nextCursor: null, providerId: "openai" } satisfies ModelListResponse;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 315 {
-		t.Fatalf("definition count = %d, want 315", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 317 {
+		t.Fatalf("definition count = %d, want 317", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary

- export exact standalone public `ModelListParams` and `ModelListResponse`
- enforce strict optional-nullable params, uint32 limits, non-null exact `Model` arrays, and canonical next-cursor output
- keep the provider-extended live `model/list` request/response and generated method inference unchanged pending an explicit adapter
- regenerate deterministic schema and TypeScript artifacts at 317 definitions with unchanged 59 method and five item bindings

## Verification

- deliberate red Go and strict TypeScript compilation
- focused tests repeated 30 times
- focused race and 100% statement coverage for all five new codec/helper functions
- `go test -count=1 ./...`
- `go test -race -count=1 ./...` including Monty in 293.127s
- protocol coverage 95.7%; Monty coverage 88.3%
- `golangci-lint run`
- `go vet ./...`
- deterministic `go generate ./appserver/protocol`
- byte-stable `go mod tidy`
- all five Slang stdio/Unix-socket/WebSocket workflows against the feature binary
- direct provider-filtered live `model/list` output byte-identical to merged main
- complete pre-push hook manually and at push time
- `git diff --check`