### PR TITLE
Cap model list limit schema

### DIFF
--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -37,7 +37,10 @@ func TestModelListSchemasAreExact(t *testing.T) {
 		},
 		"limit": Schema{
 			"description": "Optional page size; defaults to a reasonable server-side value.",
-			"anyOf":       []any{Schema{"type": "integer", "minimum": 0}, Schema{"type": "null"}},
+			"anyOf": []any{
+				Schema{"type": "integer", "minimum": 0, "maximum": 4294967295},
+				Schema{"type": "null"},
+			},
 		},
 		"includeHidden": Schema{
 			"description": "When true, include models that are hidden from the default picker list.",

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -1446,7 +1446,10 @@ func modelListParamsSchema() Schema {
 		},
 		"limit": Schema{
 			"description": "Optional page size; defaults to a reasonable server-side value.",
-			"anyOf":       []any{Schema{"type": "integer", "minimum": 0}, Schema{"type": "null"}},
+			"anyOf": []any{
+				Schema{"type": "integer", "minimum": 0, "maximum": 4294967295},
+				Schema{"type": "null"},
+			},
 		},
 		"includeHidden": Schema{
 			"description": "When true, include models that are hidden from the default picker list.",

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -4667,6 +4667,7 @@
         "limit": {
           "anyOf": [
             {
+              "maximum": 4294967295,
               "minimum": 0,
               "type": "integer"
             },


### PR DESCRIPTION
## Summary

- address the late PR #144 review by capping `ModelListParams.limit` at the `uint32` maximum
- align schema-driven validation with the existing strict codec rejection above `4294967295`
- regenerate the schema; TypeScript, codecs, bindings, methods, catalog, and runtime remain unchanged

## Verification

- deliberate red exact-schema test before implementation
- focused model-list tests repeated 30 times
- focused race
- full protocol tests and strict TypeScript
- `go test -count=1 ./...`
- `golangci-lint run`
- `go vet ./...`
- deterministic `go generate ./appserver/protocol`
- complete pre-push hook manually and at push time
- `git diff --check`

Follow-up to PR #144 review thread: https://github.com/fugue-labs/gollem/pull/144#discussion_r3575638591