### PR TITLE
Export exact model provider capability contracts

### DIFF
--- a/appserver/protocol/README.md
+++ b/appserver/protocol/README.md
@@ -539,6 +539,13 @@ cursor input. The live request and response remain provider-extended, so an
 explicit projection is still required before generated method inference can
 replace `unknown`.
 
+Exact standalone `ModelProviderCapabilitiesReadParams` and
+`ModelProviderCapabilitiesReadResponse` expose the fixed empty request and
+required namespace-tools, image-generation, and web-search booleans without
+binding the live capability endpoint. Gollem's handler accepts provider
+selectors and returns a broader provider capability record, so generated
+method inference remains `unknown` pending an explicit compatibility adapter.
+
 ## Generation
 
 Run:

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 317 {
-		t.Fatalf("definition count = %d, want 317", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 319 {
+		t.Fatalf("definition count = %d, want 319", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 317 {
-		t.Fatalf("definition count = %d, want 317", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 319 {
+		t.Fatalf("definition count = %d, want 319", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 317 {
-		t.Fatalf("definition count = %d, want 317", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 319 {
+		t.Fatalf("definition count = %d, want 319", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 317 {
-		t.Fatalf("definition count = %d, want 317", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 319 {
+		t.Fatalf("definition count = %d, want 319", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 317 {
-		t.Fatalf("definition count = %d, want 317", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 319 {
+		t.Fatalf("definition count = %d, want 319", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 317 {
-		t.Fatalf("definition count = %d, want 317", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 319 {
+		t.Fatalf("definition count = %d, want 319", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -1,0 +1,171 @@
+package protocol
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestModelProviderCapabilitiesSchemasAreExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	params, ok := defs["ModelProviderCapabilitiesReadParams"].(Schema)
+	if !ok {
+		t.Fatal("$defs missing ModelProviderCapabilitiesReadParams")
+	}
+	wantParams := Schema{
+		"type":                 "object",
+		"additionalProperties": false,
+	}
+	if !reflect.DeepEqual(params, wantParams) {
+		t.Fatalf("ModelProviderCapabilitiesReadParams = %#v, want %#v", params, wantParams)
+	}
+
+	response, ok := defs["ModelProviderCapabilitiesReadResponse"].(Schema)
+	if !ok {
+		t.Fatal("$defs missing ModelProviderCapabilitiesReadResponse")
+	}
+	wantResponse := Schema{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties": Schema{
+			"namespaceTools":  Schema{"type": "boolean"},
+			"imageGeneration": Schema{"type": "boolean"},
+			"webSearch":       Schema{"type": "boolean"},
+		},
+		"required": []string{"namespaceTools", "imageGeneration", "webSearch"},
+	}
+	if !reflect.DeepEqual(response, wantResponse) {
+		t.Fatalf("ModelProviderCapabilitiesReadResponse = %#v, want %#v", response, wantResponse)
+	}
+}
+
+func TestModelProviderCapabilitiesParamsWireContract(t *testing.T) {
+	var params ModelProviderCapabilitiesReadParams
+	if err := json.Unmarshal([]byte(`{}`), &params); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	encoded, err := json.Marshal(params)
+	if err != nil || string(encoded) != `{}` {
+		t.Fatalf("Marshal = %s, %v; want {}", encoded, err)
+	}
+
+	for _, input := range []string{
+		`null`, `[]`, `"value"`, `1`, `true`,
+		`{"providerId":"openai"}`,
+		`{"provider":"openai"}`,
+		`{"modelProvider":"openai"}`,
+		`{"extra":false}`,
+		`{} {}`,
+	} {
+		var value ModelProviderCapabilitiesReadParams
+		if err := json.Unmarshal([]byte(input), &value); err == nil {
+			t.Errorf("Unmarshal(%s) succeeded", input)
+		}
+	}
+	var nilParams *ModelProviderCapabilitiesReadParams
+	if err := nilParams.UnmarshalJSON([]byte(`{}`)); err == nil {
+		t.Fatal("nil ModelProviderCapabilitiesReadParams receiver succeeded")
+	}
+}
+
+func TestModelProviderCapabilitiesResponseAcceptsEveryBooleanCombination(t *testing.T) {
+	values := []bool{false, true}
+	for _, namespaceTools := range values {
+		for _, imageGeneration := range values {
+			for _, webSearch := range values {
+				want := fmt.Sprintf(
+					`{"namespaceTools":%t,"imageGeneration":%t,"webSearch":%t}`,
+					namespaceTools,
+					imageGeneration,
+					webSearch,
+				)
+				var response ModelProviderCapabilitiesReadResponse
+				if err := json.Unmarshal([]byte(want), &response); err != nil {
+					t.Errorf("Unmarshal(%s): %v", want, err)
+					continue
+				}
+				encoded, err := json.Marshal(response)
+				if err != nil || string(encoded) != want {
+					t.Errorf("round trip = %s, %v; want %s", encoded, err, want)
+				}
+			}
+		}
+	}
+}
+
+func TestModelProviderCapabilitiesResponseRejectsMalformedWireForms(t *testing.T) {
+	valid := `{"namespaceTools":false,"imageGeneration":false,"webSearch":false}`
+	invalid := []string{
+		`null`, `[]`, `"value"`, `1`, `true`, `{}`,
+		`{"imageGeneration":false,"webSearch":false}`,
+		`{"namespaceTools":false,"webSearch":false}`,
+		`{"namespaceTools":false,"imageGeneration":false}`,
+		`{"namespaceTools":null,"imageGeneration":false,"webSearch":false}`,
+		`{"namespaceTools":false,"imageGeneration":null,"webSearch":false}`,
+		`{"namespaceTools":false,"imageGeneration":false,"webSearch":null}`,
+		`{"namespaceTools":0,"imageGeneration":false,"webSearch":false}`,
+		`{"namespaceTools":false,"imageGeneration":"false","webSearch":false}`,
+		`{"namespaceTools":false,"imageGeneration":false,"webSearch":[]}`,
+		`{"namespaceTools":false,"imageGeneration":false,"webSearch":false,"configured":false}`,
+		`{"namespaceTools":false,"imageGeneration":false,"webSearch":false,"providerId":"openai"}`,
+		valid + ` {}`,
+	}
+	for _, input := range invalid {
+		var response ModelProviderCapabilitiesReadResponse
+		if err := json.Unmarshal([]byte(input), &response); err == nil {
+			t.Errorf("Unmarshal(%s) succeeded", input)
+		}
+	}
+	var nilResponse *ModelProviderCapabilitiesReadResponse
+	if err := nilResponse.UnmarshalJSON([]byte(valid)); err == nil {
+		t.Fatal("nil ModelProviderCapabilitiesReadResponse receiver succeeded")
+	}
+}
+
+func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
+	for _, binding := range WireTypeBindings() {
+		for _, name := range []string{
+			"ModelProviderCapabilitiesReadParams",
+			"ModelProviderCapabilitiesReadResponse",
+		} {
+			if slices.Contains(binding.Params, name) || slices.Contains(binding.Result, name) {
+				t.Fatalf("model-provider capability type unexpectedly bound: %#v", binding)
+			}
+		}
+	}
+	info, ok := LookupMethod("modelProvider/capabilities/read")
+	if !ok || info.State != MethodImplemented {
+		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 319 {
+		t.Fatalf("definition count = %d, want 319", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestModelProviderCapabilitiesTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	source := string(generated)
+	for _, want := range []string{
+		`export type ModelProviderCapabilitiesReadParams = Record<string, never>;`,
+		`export type ModelProviderCapabilitiesReadResponse = {`,
+		`"imageGeneration": boolean;`,
+		`"namespaceTools": boolean;`,
+		`"webSearch": boolean;`,
+	} {
+		if !strings.Contains(source, want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}

--- a/appserver/protocol/model_provider_capabilities_types.go
+++ b/appserver/protocol/model_provider_capabilities_types.go
@@ -1,0 +1,69 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// ModelProviderCapabilitiesReadParams is the exact empty public capability
+// request. It stays separate from Gollem's provider-selector live extension.
+type ModelProviderCapabilitiesReadParams struct{}
+
+func (p *ModelProviderCapabilitiesReadParams) UnmarshalJSON(data []byte) error {
+	if p == nil {
+		return errors.New("decode model-provider capabilities params into nil receiver")
+	}
+	if _, err := decodeExactThreadItemObject(data, "model-provider capabilities params"); err != nil {
+		return err
+	}
+	*p = ModelProviderCapabilitiesReadParams{}
+	return nil
+}
+
+// ModelProviderCapabilitiesReadResponse is the exact public capability
+// projection. Gollem's broader live response remains unbound.
+type ModelProviderCapabilitiesReadResponse struct {
+	NamespaceTools  bool `json:"namespaceTools"`
+	ImageGeneration bool `json:"imageGeneration"`
+	WebSearch       bool `json:"webSearch"`
+}
+
+func (r *ModelProviderCapabilitiesReadResponse) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("decode model-provider capabilities response into nil receiver")
+	}
+	const objectName = "model-provider capabilities response"
+	payload, err := decodeExactThreadItemObject(
+		data,
+		objectName,
+		"namespaceTools",
+		"imageGeneration",
+		"webSearch",
+	)
+	if err != nil {
+		return err
+	}
+	namespaceTools, err := decodeRequiredThreadItemValue[bool](payload, objectName, "namespaceTools")
+	if err != nil {
+		return err
+	}
+	imageGeneration, err := decodeRequiredThreadItemValue[bool](payload, objectName, "imageGeneration")
+	if err != nil {
+		return err
+	}
+	webSearch, err := decodeRequiredThreadItemValue[bool](payload, objectName, "webSearch")
+	if err != nil {
+		return err
+	}
+	*r = ModelProviderCapabilitiesReadResponse{
+		NamespaceTools:  namespaceTools,
+		ImageGeneration: imageGeneration,
+		WebSearch:       webSearch,
+	}
+	return nil
+}
+
+var (
+	_ json.Unmarshaler = (*ModelProviderCapabilitiesReadParams)(nil)
+	_ json.Unmarshaler = (*ModelProviderCapabilitiesReadResponse)(nil)
+)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 317 {
-		t.Fatalf("definition count = %d, want 317", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 319 {
+		t.Fatalf("definition count = %d, want 319", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 317 {
-		t.Fatalf("definition count = %d, want 317", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 319 {
+		t.Fatalf("definition count = %d, want 319", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 317 {
-		t.Fatalf("definition count = %d, want 317", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 319 {
+		t.Fatalf("definition count = %d, want 319", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 317 {
-		t.Fatalf("definition count = %d, want 317", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 319 {
+		t.Fatalf("definition count = %d, want 319", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 317 {
-		t.Fatalf("definition count = %d, want 317", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 319 {
+		t.Fatalf("definition count = %d, want 319", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 317 {
-		t.Fatalf("definition count = %d, want 317", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 319 {
+		t.Fatalf("definition count = %d, want 319", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -210,6 +210,8 @@ func wireSchemaDefinitions() Schema {
 		{Name: "ModelAvailabilityNux", Type: reflect.TypeFor[ModelAvailabilityNux]()},
 		{Name: "ModelListParams", Type: reflect.TypeFor[ModelListParams]()},
 		{Name: "ModelListResponse", Type: reflect.TypeFor[ModelListResponse]()},
+		{Name: "ModelProviderCapabilitiesReadParams", Type: reflect.TypeFor[ModelProviderCapabilitiesReadParams]()},
+		{Name: "ModelProviderCapabilitiesReadResponse", Type: reflect.TypeFor[ModelProviderCapabilitiesReadResponse]()},
 		{Name: "ModelRerouteReason", Type: reflect.TypeFor[ModelRerouteReason]()},
 		{Name: "ModelReroutedNotification", Type: reflect.TypeFor[ModelReroutedNotification]()},
 		{Name: "ModelSafetyBufferingUpdatedNotification", Type: reflect.TypeFor[ModelSafetyBufferingUpdatedNotification]()},

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -4707,6 +4707,30 @@
       ],
       "type": "object"
     },
+    "ModelProviderCapabilitiesReadParams": {
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ModelProviderCapabilitiesReadResponse": {
+      "additionalProperties": false,
+      "properties": {
+        "imageGeneration": {
+          "type": "boolean"
+        },
+        "namespaceTools": {
+          "type": "boolean"
+        },
+        "webSearch": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "namespaceTools",
+        "imageGeneration",
+        "webSearch"
+      ],
+      "type": "object"
+    },
     "ModelRerouteReason": {
       "enum": [
         "highRiskCyberActivity"

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 317 {
-		t.Fatalf("definition count = %d, want 317", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 319 {
+		t.Fatalf("definition count = %d, want 319", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 317 {
-		t.Fatalf("definition count = %d, want 317", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 319 {
+		t.Fatalf("definition count = %d, want 319", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 317 {
-		t.Fatalf("definition count = %d, want 317", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 319 {
+		t.Fatalf("definition count = %d, want 319", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 317 {
-		t.Fatalf("definition count = %d, want 317", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 319 {
+		t.Fatalf("definition count = %d, want 319", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 317 {
-		t.Fatalf("definition count = %d, want 317", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 319 {
+		t.Fatalf("definition count = %d, want 319", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 317 {
-		t.Fatalf("definition count = %d, want 317", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 319 {
+		t.Fatalf("definition count = %d, want 319", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 317 {
-		t.Fatalf("definition count = %d, want 317", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 319 {
+		t.Fatalf("definition count = %d, want 319", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 317 {
-		t.Fatalf("definition count = %d, want 317", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 319 {
+		t.Fatalf("definition count = %d, want 319", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 317 {
-		t.Fatalf("definition count = %d, want 317", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 319 {
+		t.Fatalf("definition count = %d, want 319", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 317 {
-		t.Fatalf("definition count = %d, want 317", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 319 {
+		t.Fatalf("definition count = %d, want 319", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 317 {
-		t.Fatalf("definition count = %d, want 317", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 319 {
+		t.Fatalf("definition count = %d, want 319", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 317 {
-		t.Fatalf("definition count = %d, want 317", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 319 {
+		t.Fatalf("definition count = %d, want 319", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -1583,6 +1583,14 @@ export type ModelListResponse = {
   "nextCursor": string | null;
 };
 
+export type ModelProviderCapabilitiesReadParams = Record<string, never>;
+
+export type ModelProviderCapabilitiesReadResponse = {
+  "imageGeneration": boolean;
+  "namespaceTools": boolean;
+  "webSearch": boolean;
+};
+
 export type ModelRerouteReason = "highRiskCyberActivity";
 
 export type ModelReroutedNotification = {

--- a/appserver/protocol/typescript/testdata/model_provider_capabilities_contract.ts
+++ b/appserver/protocol/typescript/testdata/model_provider_capabilities_contract.ts
@@ -1,0 +1,54 @@
+import type {
+  ModelProviderCapabilitiesReadParams,
+  ModelProviderCapabilitiesReadResponse,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+
+type Contracts = [
+  Expect<Equal<ModelProviderCapabilitiesReadParams, Record<string, never>>>,
+  Expect<Equal<ModelProviderCapabilitiesReadResponse, {
+    namespaceTools: boolean;
+    imageGeneration: boolean;
+    webSearch: boolean;
+  }>>,
+];
+
+export const emptyParams = {} satisfies ModelProviderCapabilitiesReadParams;
+export const allFalse = {
+  namespaceTools: false,
+  imageGeneration: false,
+  webSearch: false,
+} satisfies ModelProviderCapabilitiesReadResponse;
+export const allTrue = {
+  namespaceTools: true,
+  imageGeneration: true,
+  webSearch: true,
+} satisfies ModelProviderCapabilitiesReadResponse;
+export const mixed = {
+  namespaceTools: true,
+  imageGeneration: false,
+  webSearch: true,
+} satisfies ModelProviderCapabilitiesReadResponse;
+
+// @ts-expect-error exact params exclude provider selectors.
+export const rejectProviderParam = { providerId: "openai" } satisfies ModelProviderCapabilitiesReadParams;
+// @ts-expect-error namespaceTools is required.
+export const rejectMissingNamespace = { imageGeneration: false, webSearch: false } satisfies ModelProviderCapabilitiesReadResponse;
+// @ts-expect-error imageGeneration is required.
+export const rejectMissingImage = { namespaceTools: false, webSearch: false } satisfies ModelProviderCapabilitiesReadResponse;
+// @ts-expect-error webSearch is required.
+export const rejectMissingWeb = { namespaceTools: false, imageGeneration: false } satisfies ModelProviderCapabilitiesReadResponse;
+// @ts-expect-error capability values are non-null booleans.
+export const rejectNullNamespace = { namespaceTools: null, imageGeneration: false, webSearch: false } satisfies ModelProviderCapabilitiesReadResponse;
+// @ts-expect-error capability values are booleans only.
+export const rejectStringImage = { namespaceTools: false, imageGeneration: "false", webSearch: false } satisfies ModelProviderCapabilitiesReadResponse;
+// @ts-expect-error exact responses exclude broader Gollem capability metadata.
+export const rejectConfigured = { namespaceTools: false, imageGeneration: false, webSearch: false, configured: false } satisfies ModelProviderCapabilitiesReadResponse;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 317 {
-		t.Fatalf("definition count = %d, want 317", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 319 {
+		t.Fatalf("definition count = %d, want 319", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/server_test.go
+++ b/appserver/server_test.go
@@ -1209,6 +1209,17 @@ func TestServerCatalogHandlers(t *testing.T) {
 		t.Fatalf("codex capabilities = %#v", codexCaps)
 	}
 
+	aggregateCapsResp := server.HandleRequest(ctx, request("modelProvider/capabilities/read", map[string]any{}))
+	if aggregateCapsResp.Error != nil {
+		t.Fatalf("aggregate modelProvider/capabilities/read error: %v", aggregateCapsResp.Error)
+	}
+	var aggregateCaps catalog.ProviderCapabilities
+	decodeResult(t, aggregateCapsResp, &aggregateCaps)
+	if aggregateCaps.ProviderID != "" || !aggregateCaps.NamespaceTools ||
+		!aggregateCaps.ToolCalls || !aggregateCaps.Configured || len(aggregateCaps.ReasoningEfforts) == 0 {
+		t.Fatalf("aggregate capabilities = %#v", aggregateCaps)
+	}
+
 	aliasResp := server.HandleRequest(ctx, request("provider/capabilities/read", map[string]any{
 		"provider": catalog.ProviderAnthropic,
 	}))


### PR DESCRIPTION
## Summary
- export strict standalone `ModelProviderCapabilitiesReadParams` and `ModelProviderCapabilitiesReadResponse`
- require the exact empty params object and all three non-null capability booleans while rejecting selector/metadata extensions
- preserve the broader live provider-specific and aggregate capability endpoint, alias, method state, and 59/5 binding maps

## Verification
- deliberate red: six absent Go references; TypeScript had two missing exports, two false identities, and seven unused negative directives
- focused tests 30x, focused race, and both new unmarshallers at 100% statement coverage
- serialized uncached `go test -p 1 -count=1 ./...` passed; full `go test -race ./...` passed including Monty in 301.573s
- lint 0 issues, vet, tidy, deterministic generation, strict TypeScript, and complete pre-push twice
- all five Slang stdio/Unix-socket/WebSocket workflows passed against the feature binary
- aggregate/OpenAI/Anthropic capability responses match merged `main` byte-for-byte after sorting concurrent responses by JSON-RPC id

Generated SHA-256:
- schema: `3e4f79129d752476b0f9781027f2e24d3fdb7064e7105d0d7d5d6ccd5f4d4fc8`
- TypeScript: `23a284576e3690699e009193e944c5260e40ed44d28a4378010fcaceddbd6c25`
- strict TypeScript fixture: `c648a1c0a1586bd1728c5286c39d142b6bf17898407c2a1b92935f88df226fce`

## Known flake
The first parallel uncached full run hit the pre-existing `TestServerRuntimeInterruptKillsOwnedCommand` completion timeout. The changed protocol/catalog packages passed in that run; the isolated test then passed 10/10, the serialized uncached full suite passed, and both full/pre-push race gates passed.