### PR TITLE
Export exact model requirements contracts

### DIFF
--- a/appserver/protocol/README.md
+++ b/appserver/protocol/README.md
@@ -546,6 +546,13 @@ binding the live capability endpoint. Gollem's handler accepts provider
 selectors and returns a broader provider capability record, so generated
 method inference remains `unknown` pending an explicit compatibility adapter.
 
+Exact standalone `NewThreadModelDefaults` and `ModelsRequirements` expose the
+fixed nullable new-thread model, reasoning-effort, and service-tier defaults.
+They remain separate from Gollem's provider/environment requirement rows and
+the incomplete public configuration-requirement graph, so
+`configRequirements/read` inference remains `unknown` pending an explicit
+projection adapter.
+
 ## Generation
 
 Run:

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 319 {
-		t.Fatalf("definition count = %d, want 319", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 321 {
+		t.Fatalf("definition count = %d, want 321", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 319 {
-		t.Fatalf("definition count = %d, want 319", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 321 {
+		t.Fatalf("definition count = %d, want 321", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 319 {
-		t.Fatalf("definition count = %d, want 319", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 321 {
+		t.Fatalf("definition count = %d, want 321", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 319 {
-		t.Fatalf("definition count = %d, want 319", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 321 {
+		t.Fatalf("definition count = %d, want 321", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 319 {
-		t.Fatalf("definition count = %d, want 319", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 321 {
+		t.Fatalf("definition count = %d, want 321", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 319 {
-		t.Fatalf("definition count = %d, want 319", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 321 {
+		t.Fatalf("definition count = %d, want 321", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 319 {
-		t.Fatalf("definition count = %d, want 319", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 321 {
+		t.Fatalf("definition count = %d, want 321", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -1,0 +1,191 @@
+package protocol
+
+import (
+	"encoding/json"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestModelRequirementsSchemasAreExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	defaults, ok := defs["NewThreadModelDefaults"].(Schema)
+	if !ok {
+		t.Fatal("$defs missing NewThreadModelDefaults")
+	}
+	assertClosedObjectSchema(t, defaults, "model", "modelReasoningEffort", "serviceTier")
+	defaultProperties := defaults["properties"].(Schema)
+	assertNullableStringSchema(t, defaultProperties["model"])
+	assertNullableSchemaRef(t, defaultProperties["modelReasoningEffort"], "#/$defs/ReasoningEffort")
+	assertNullableStringSchema(t, defaultProperties["serviceTier"])
+
+	requirements, ok := defs["ModelsRequirements"].(Schema)
+	if !ok {
+		t.Fatal("$defs missing ModelsRequirements")
+	}
+	assertClosedObjectSchema(t, requirements, "newThread")
+	assertNullableSchemaRef(t, requirements["properties"].(Schema)["newThread"], "#/$defs/NewThreadModelDefaults")
+}
+
+func TestModelRequirementsAcceptExactWireForms(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+		value func() any
+	}{
+		{
+			"omitted defaults",
+			`{}`,
+			`{"model":null,"modelReasoningEffort":null,"serviceTier":null}`,
+			func() any { return new(NewThreadModelDefaults) },
+		},
+		{
+			"null defaults",
+			`{"model":null,"modelReasoningEffort":null,"serviceTier":null}`,
+			`{"model":null,"modelReasoningEffort":null,"serviceTier":null}`,
+			func() any { return new(NewThreadModelDefaults) },
+		},
+		{
+			"full defaults",
+			`{"model":"","modelReasoningEffort":"provider-effort","serviceTier":""}`,
+			`{"model":"","modelReasoningEffort":"provider-effort","serviceTier":""}`,
+			func() any { return new(NewThreadModelDefaults) },
+		},
+		{
+			"partial defaults",
+			`{"model":"model"}`,
+			`{"model":"model","modelReasoningEffort":null,"serviceTier":null}`,
+			func() any { return new(NewThreadModelDefaults) },
+		},
+		{
+			"omitted requirements",
+			`{}`,
+			`{"newThread":null}`,
+			func() any { return new(ModelsRequirements) },
+		},
+		{
+			"null requirements",
+			`{"newThread":null}`,
+			`{"newThread":null}`,
+			func() any { return new(ModelsRequirements) },
+		},
+		{
+			"nested omitted defaults",
+			`{"newThread":{}}`,
+			`{"newThread":{"model":null,"modelReasoningEffort":null,"serviceTier":null}}`,
+			func() any { return new(ModelsRequirements) },
+		},
+		{
+			"full nested defaults",
+			`{"newThread":{"model":"model","modelReasoningEffort":"high","serviceTier":"fast"}}`,
+			`{"newThread":{"model":"model","modelReasoningEffort":"high","serviceTier":"fast"}}`,
+			func() any { return new(ModelsRequirements) },
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			value := tc.value()
+			if err := json.Unmarshal([]byte(tc.input), value); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			encoded, err := json.Marshal(value)
+			if err != nil || string(encoded) != tc.want {
+				t.Fatalf("round trip = %s, %v; want %s", encoded, err, tc.want)
+			}
+		})
+	}
+}
+
+func TestModelRequirementsRejectMalformedWireForms(t *testing.T) {
+	defaultsInvalid := []string{
+		`null`, `[]`, `"value"`, `1`, `true`,
+		`{"model":1}`,
+		`{"modelReasoningEffort":0}`,
+		`{"modelReasoningEffort":""}`,
+		`{"serviceTier":false}`,
+		`{"model":null,"modelReasoningEffort":null,"serviceTier":null,"extra":true}`,
+		`{"model":null,"modelReasoningEffort":null,"serviceTier":null} {}`,
+	}
+	for _, input := range defaultsInvalid {
+		var value NewThreadModelDefaults
+		if err := json.Unmarshal([]byte(input), &value); err == nil {
+			t.Errorf("NewThreadModelDefaults accepted %s", input)
+		}
+	}
+
+	requirementsInvalid := []string{
+		`null`, `[]`, `"value"`, `1`, `true`,
+		`{"newThread":false}`,
+		`{"newThread":{"modelReasoningEffort":""}}`,
+		`{"newThread":{"extra":true}}`,
+		`{"newThread":null,"extra":true}`,
+		`{"newThread":null} {}`,
+	}
+	for _, input := range requirementsInvalid {
+		var value ModelsRequirements
+		if err := json.Unmarshal([]byte(input), &value); err == nil {
+			t.Errorf("ModelsRequirements accepted %s", input)
+		}
+	}
+}
+
+func TestModelRequirementsNilReceiversAndInvalidMarshal(t *testing.T) {
+	var defaults *NewThreadModelDefaults
+	if err := defaults.UnmarshalJSON([]byte(`{}`)); err == nil {
+		t.Fatal("nil NewThreadModelDefaults receiver succeeded")
+	}
+	var requirements *ModelsRequirements
+	if err := requirements.UnmarshalJSON([]byte(`{}`)); err == nil {
+		t.Fatal("nil ModelsRequirements receiver succeeded")
+	}
+
+	emptyEffort := ReasoningEffort("")
+	if _, err := json.Marshal(NewThreadModelDefaults{ModelReasoningEffort: &emptyEffort}); err == nil {
+		t.Fatal("empty reasoning effort marshal succeeded")
+	}
+}
+
+func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
+	names := []string{"NewThreadModelDefaults", "ModelsRequirements"}
+	for _, binding := range WireTypeBindings() {
+		for _, name := range names {
+			if slices.Contains(binding.Params, name) || slices.Contains(binding.Result, name) {
+				t.Fatalf("%s unexpectedly bound to %s", name, binding.Method)
+			}
+		}
+	}
+	info, ok := LookupMethod("configRequirements/read")
+	if !ok || info.State != MethodImplemented {
+		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 321 {
+		t.Fatalf("definition count = %d, want 321", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestModelRequirementsTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	source := string(generated)
+	for _, want := range []string{
+		`export type ModelsRequirements = {`,
+		`"newThread": NewThreadModelDefaults | null;`,
+		`export type NewThreadModelDefaults = {`,
+		`"model": string | null;`,
+		`"modelReasoningEffort": ReasoningEffort | null;`,
+		`"serviceTier": string | null;`,
+	} {
+		if !strings.Contains(source, want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}

--- a/appserver/protocol/model_requirements_types.go
+++ b/appserver/protocol/model_requirements_types.go
@@ -1,0 +1,96 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// NewThreadModelDefaults is the exact public model-default configuration for
+// new threads. Nullable fields stay explicit in canonical output.
+type NewThreadModelDefaults struct {
+	Model                *string          `json:"model"`
+	ModelReasoningEffort *ReasoningEffort `json:"modelReasoningEffort"`
+	ServiceTier          *string          `json:"serviceTier"`
+}
+
+func (d *NewThreadModelDefaults) UnmarshalJSON(data []byte) error {
+	if d == nil {
+		return errors.New("decode new-thread model defaults into nil receiver")
+	}
+	const objectName = "new-thread model defaults"
+	payload, err := decodeExactThreadItemObject(data, objectName, "model", "modelReasoningEffort", "serviceTier")
+	if err != nil {
+		return err
+	}
+	model, err := decodeOptionalNullableModelRequirementValue[string](payload, objectName, "model")
+	if err != nil {
+		return err
+	}
+	modelReasoningEffort, err := decodeOptionalNullableModelRequirementValue[ReasoningEffort](
+		payload,
+		objectName,
+		"modelReasoningEffort",
+	)
+	if err != nil {
+		return err
+	}
+	serviceTier, err := decodeOptionalNullableModelRequirementValue[string](payload, objectName, "serviceTier")
+	if err != nil {
+		return err
+	}
+	*d = NewThreadModelDefaults{
+		Model:                model,
+		ModelReasoningEffort: modelReasoningEffort,
+		ServiceTier:          serviceTier,
+	}
+	return nil
+}
+
+// ModelsRequirements is the exact public model-requirements configuration.
+// The live Gollem configuration-requirements response remains separate.
+type ModelsRequirements struct {
+	NewThread *NewThreadModelDefaults `json:"newThread"`
+}
+
+func (r *ModelsRequirements) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("decode models requirements into nil receiver")
+	}
+	const objectName = "models requirements"
+	payload, err := decodeExactThreadItemObject(data, objectName, "newThread")
+	if err != nil {
+		return err
+	}
+	newThread, err := decodeOptionalNullableModelRequirementValue[NewThreadModelDefaults](
+		payload,
+		objectName,
+		"newThread",
+	)
+	if err != nil {
+		return err
+	}
+	*r = ModelsRequirements{NewThread: newThread}
+	return nil
+}
+
+func decodeOptionalNullableModelRequirementValue[T any](
+	payload map[string]json.RawMessage,
+	objectName string,
+	fieldName string,
+) (*T, error) {
+	raw, ok := payload[fieldName]
+	if !ok || isJSONNull(raw) {
+		return nil, nil
+	}
+	var value T
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return nil, fmt.Errorf("decode %s %s: %w", objectName, fieldName, err)
+	}
+	return &value, nil
+}
+
+var (
+	_ json.Unmarshaler = (*NewThreadModelDefaults)(nil)
+	_ json.Unmarshaler = (*ModelsRequirements)(nil)
+)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 319 {
-		t.Fatalf("definition count = %d, want 319", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 321 {
+		t.Fatalf("definition count = %d, want 321", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 319 {
-		t.Fatalf("definition count = %d, want 319", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 321 {
+		t.Fatalf("definition count = %d, want 321", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 319 {
-		t.Fatalf("definition count = %d, want 319", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 321 {
+		t.Fatalf("definition count = %d, want 321", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 319 {
-		t.Fatalf("definition count = %d, want 319", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 321 {
+		t.Fatalf("definition count = %d, want 321", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 319 {
-		t.Fatalf("definition count = %d, want 319", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 321 {
+		t.Fatalf("definition count = %d, want 321", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 319 {
-		t.Fatalf("definition count = %d, want 319", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 321 {
+		t.Fatalf("definition count = %d, want 321", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -219,6 +219,8 @@ func wireSchemaDefinitions() Schema {
 		{Name: "ModelUpgradeInfo", Type: reflect.TypeFor[ModelUpgradeInfo]()},
 		{Name: "ModelVerification", Type: reflect.TypeFor[ModelVerification]()},
 		{Name: "ModelVerificationNotification", Type: reflect.TypeFor[ModelVerificationNotification]()},
+		{Name: "ModelsRequirements", Type: reflect.TypeFor[ModelsRequirements]()},
+		{Name: "NewThreadModelDefaults", Type: reflect.TypeFor[NewThreadModelDefaults]()},
 		{Name: "NonSteerableTurnKind", Type: reflect.TypeFor[NonSteerableTurnKind]()},
 		{Name: "McpElicitationArrayType", Type: reflect.TypeFor[McpElicitationArrayType]()},
 		{Name: "McpElicitationBooleanSchema", Type: reflect.TypeFor[McpElicitationBooleanSchema]()},

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -4908,6 +4908,25 @@
       ],
       "type": "object"
     },
+    "ModelsRequirements": {
+      "additionalProperties": false,
+      "properties": {
+        "newThread": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NewThreadModelDefaults"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "newThread"
+      ],
+      "type": "object"
+    },
     "NetworkAccess": {
       "enum": [
         "restricted",
@@ -4937,6 +4956,47 @@
         "deny"
       ],
       "type": "string"
+    },
+    "NewThreadModelDefaults": {
+      "additionalProperties": false,
+      "properties": {
+        "model": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "modelReasoningEffort": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ReasoningEffort"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "serviceTier": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "model",
+        "modelReasoningEffort",
+        "serviceTier"
+      ],
+      "type": "object"
     },
     "NonSteerableTurnKind": {
       "enum": [

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 319 {
-		t.Fatalf("definition count = %d, want 319", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 321 {
+		t.Fatalf("definition count = %d, want 321", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 319 {
-		t.Fatalf("definition count = %d, want 319", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 321 {
+		t.Fatalf("definition count = %d, want 321", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 319 {
-		t.Fatalf("definition count = %d, want 319", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 321 {
+		t.Fatalf("definition count = %d, want 321", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 319 {
-		t.Fatalf("definition count = %d, want 319", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 321 {
+		t.Fatalf("definition count = %d, want 321", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 319 {
-		t.Fatalf("definition count = %d, want 319", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 321 {
+		t.Fatalf("definition count = %d, want 321", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 319 {
-		t.Fatalf("definition count = %d, want 319", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 321 {
+		t.Fatalf("definition count = %d, want 321", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 319 {
-		t.Fatalf("definition count = %d, want 319", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 321 {
+		t.Fatalf("definition count = %d, want 321", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 319 {
-		t.Fatalf("definition count = %d, want 319", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 321 {
+		t.Fatalf("definition count = %d, want 321", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 319 {
-		t.Fatalf("definition count = %d, want 319", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 321 {
+		t.Fatalf("definition count = %d, want 321", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 319 {
-		t.Fatalf("definition count = %d, want 319", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 321 {
+		t.Fatalf("definition count = %d, want 321", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 319 {
-		t.Fatalf("definition count = %d, want 319", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 321 {
+		t.Fatalf("definition count = %d, want 321", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 319 {
-		t.Fatalf("definition count = %d, want 319", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 321 {
+		t.Fatalf("definition count = %d, want 321", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -1632,6 +1632,10 @@ export type ModelVerificationNotification = {
   "verifications": Array<ModelVerification>;
 };
 
+export type ModelsRequirements = {
+  "newThread": NewThreadModelDefaults | null;
+};
+
 export type NetworkAccess = "restricted" | "enabled";
 
 export type NetworkPolicyAmendment = {
@@ -1640,6 +1644,12 @@ export type NetworkPolicyAmendment = {
 };
 
 export type NetworkPolicyRuleAction = "allow" | "deny";
+
+export type NewThreadModelDefaults = {
+  "model": string | null;
+  "modelReasoningEffort": ReasoningEffort | null;
+  "serviceTier": string | null;
+};
 
 export type NonSteerableTurnKind = "review" | "compact";
 

--- a/appserver/protocol/typescript/testdata/model_requirements_contract.ts
+++ b/appserver/protocol/typescript/testdata/model_requirements_contract.ts
@@ -1,0 +1,61 @@
+import type {
+  ModelsRequirements,
+  NewThreadModelDefaults,
+  ReasoningEffort,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+
+type Contracts = [
+  Expect<Equal<NewThreadModelDefaults, {
+    model: string | null;
+    modelReasoningEffort: ReasoningEffort | null;
+    serviceTier: string | null;
+  }>>,
+  Expect<Equal<ModelsRequirements, {
+    newThread: NewThreadModelDefaults | null;
+  }>>,
+];
+
+export const nullDefaults = {
+  model: null,
+  modelReasoningEffort: null,
+  serviceTier: null,
+} satisfies NewThreadModelDefaults;
+export const fullDefaults = {
+  model: "",
+  modelReasoningEffort: "provider-effort",
+  serviceTier: "",
+} satisfies NewThreadModelDefaults;
+export const nullRequirements = {
+  newThread: null,
+} satisfies ModelsRequirements;
+export const fullRequirements = {
+  newThread: fullDefaults,
+} satisfies ModelsRequirements;
+
+// @ts-expect-error model is required.
+export const rejectMissingModel = { modelReasoningEffort: null, serviceTier: null } satisfies NewThreadModelDefaults;
+// @ts-expect-error modelReasoningEffort is required.
+export const rejectMissingEffort = { model: null, serviceTier: null } satisfies NewThreadModelDefaults;
+// @ts-expect-error serviceTier is required.
+export const rejectMissingTier = { model: null, modelReasoningEffort: null } satisfies NewThreadModelDefaults;
+// @ts-expect-error model is nullable string only.
+export const rejectNumericModel = { model: 1, modelReasoningEffort: null, serviceTier: null } satisfies NewThreadModelDefaults;
+// @ts-expect-error reasoning effort is nullable string only.
+export const rejectNumericEffort = { model: null, modelReasoningEffort: 1, serviceTier: null } satisfies NewThreadModelDefaults;
+// @ts-expect-error exact defaults exclude extensions.
+export const rejectDefaultsExtension = { model: null, modelReasoningEffort: null, serviceTier: null, extra: true } satisfies NewThreadModelDefaults;
+// @ts-expect-error newThread is required.
+export const rejectMissingNewThread = {} satisfies ModelsRequirements;
+// @ts-expect-error newThread is nullable exact defaults only.
+export const rejectWrongNewThread = { newThread: false } satisfies ModelsRequirements;
+// @ts-expect-error exact requirements exclude extensions.
+export const rejectRequirementsExtension = { newThread: null, extra: true } satisfies ModelsRequirements;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 319 {
-		t.Fatalf("definition count = %d, want 319", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 321 {
+		t.Fatalf("definition count = %d, want 321", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- export strict standalone `NewThreadModelDefaults` and `ModelsRequirements`
- require canonical nullable model, reasoning-effort, service-tier, and new-thread fields while accepting Rust-style omission on Go decode
- preserve the broader live `configRequirements/read` response, method state, and 59/5 binding maps

## Verification
- deliberate red: Go failed only on absent type references; TypeScript had two missing exports, two false identities, and nine unused negative directives
- focused tests 30x, focused race, and all three new codec functions at 100% statement coverage
- fresh repository-wide non-Monty normal suite passed; configured pre-push passed every non-Monty package under race
- `ext/monty` is explicitly skipped from local gates per user direction; `hooks.skipMontyRace=true` was honored
- protocol coverage 95.8%, lint 0 issues, vet, tidy, deterministic generation, and strict TypeScript
- all five Slang stdio/Unix-socket/WebSocket workflows passed against the feature binary
- parsed `configRequirements/read` results match merged `main` exactly with SHA-256 `b52199eba1a8d047d481a617d3e4a0fd277c4f6029ba65e41600d4ef215c4a65`

Generated SHA-256:
- schema: `1d83ee0293ff8e9141a0429a1542b80985d473805c056ddfbcafaf9efa62ef2f`
- TypeScript: `c7cefe6fcf970e5cc0a642ae747382c3aaf4d30baf65a9fcd82d2e9db216837a`
- strict TypeScript fixture: `8279dc1cf822eee4582b01b6e2c25ee5c2901200710b3b9024aaa05d3570b50a`