### PR TITLE
Export exact configuration requirements contracts

### DIFF
--- a/appserver/protocol/README.md
+++ b/appserver/protocol/README.md
@@ -548,9 +548,12 @@ method inference remains `unknown` pending an explicit compatibility adapter.
 
 Exact standalone `NewThreadModelDefaults` and `ModelsRequirements` expose the
 fixed nullable new-thread model, reasoning-effort, and service-tier defaults.
-They remain separate from Gollem's provider/environment requirement rows and
-the incomplete public configuration-requirement graph, so
-`configRequirements/read` inference remains `unknown` pending an explicit
+`ComputerUseRequirements`, `ResidencyRequirement`, `WebSearchMode`,
+`WindowsSandboxSetupMode`, `ConfigRequirements`, and
+`ConfigRequirementsReadResponse` complete the fixed public configuration-
+requirement graph with canonical required-nullable output. These values remain
+separate from Gollem's provider/environment requirement rows and `data` alias,
+so `configRequirements/read` inference remains `unknown` pending an explicit
 projection adapter.
 
 ## Generation

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -1,0 +1,316 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestConfigRequirementsSchemasAreExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	for name, want := range map[string][]any{
+		"ResidencyRequirement":    {"us"},
+		"WebSearchMode":           {"disabled", "cached", "indexed", "live"},
+		"WindowsSandboxSetupMode": {"elevated", "unelevated"},
+	} {
+		if got := defs[name].(Schema); got["type"] != "string" || !reflect.DeepEqual(got["enum"], want) {
+			t.Errorf("%s schema = %#v, want string enum %v", name, got, want)
+		}
+	}
+
+	computerUse := defs["ComputerUseRequirements"].(Schema)
+	assertClosedObjectSchema(t, computerUse, "allowLockedComputerUse")
+	assertConfigNullableSchema(t, computerUse["properties"].(Schema)["allowLockedComputerUse"], Schema{"type": "boolean"})
+
+	requirements := defs["ConfigRequirements"].(Schema)
+	fields := []string{
+		"allowedApprovalPolicies", "allowedSandboxModes", "allowedWindowsSandboxImplementations",
+		"allowedPermissionProfiles", "defaultPermissions", "allowedWebSearchModes",
+		"allowManagedHooksOnly", "allowAppshots", "allowRemoteControl", "computerUse",
+		"featureRequirements", "enforceResidency", "models",
+	}
+	assertClosedObjectSchema(t, requirements, fields...)
+	properties := requirements["properties"].(Schema)
+	assertConfigNullableSchema(t, properties["allowedApprovalPolicies"], configRequirementsArraySchema("AskForApproval"))
+	assertConfigNullableSchema(t, properties["allowedSandboxModes"], configRequirementsArraySchema("SandboxMode"))
+	assertConfigNullableSchema(t, properties["allowedWindowsSandboxImplementations"], configRequirementsArraySchema("WindowsSandboxSetupMode"))
+	assertConfigNullableSchema(t, properties["allowedPermissionProfiles"], configRequirementsBoolMapSchema())
+	assertConfigNullableSchema(t, properties["defaultPermissions"], Schema{"type": "string"})
+	assertConfigNullableSchema(t, properties["allowedWebSearchModes"], configRequirementsArraySchema("WebSearchMode"))
+	for _, field := range []string{"allowManagedHooksOnly", "allowAppshots", "allowRemoteControl"} {
+		assertConfigNullableSchema(t, properties[field], Schema{"type": "boolean"})
+	}
+	assertConfigNullableSchema(t, properties["computerUse"], Schema{"$ref": "#/$defs/ComputerUseRequirements"})
+	assertConfigNullableSchema(t, properties["featureRequirements"], configRequirementsBoolMapSchema())
+	assertConfigNullableSchema(t, properties["enforceResidency"], Schema{"$ref": "#/$defs/ResidencyRequirement"})
+	assertConfigNullableSchema(t, properties["models"], Schema{"$ref": "#/$defs/ModelsRequirements"})
+
+	response := defs["ConfigRequirementsReadResponse"].(Schema)
+	assertClosedObjectSchema(t, response, "requirements")
+	assertConfigNullableSchema(t, response["properties"].(Schema)["requirements"], Schema{"$ref": "#/$defs/ConfigRequirements"})
+}
+
+func TestConfigRequirementLeafValuesAreExact(t *testing.T) {
+	for _, value := range []ResidencyRequirement{ResidencyRequirementUS} {
+		assertConfigRequirementEnumRoundTrip(t, value)
+	}
+	for _, value := range []WebSearchMode{
+		WebSearchModeDisabled, WebSearchModeCached, WebSearchModeIndexed, WebSearchModeLive,
+	} {
+		assertConfigRequirementEnumRoundTrip(t, value)
+	}
+	for _, value := range []WindowsSandboxSetupMode{
+		WindowsSandboxSetupModeElevated, WindowsSandboxSetupModeUnelevated,
+	} {
+		assertConfigRequirementEnumRoundTrip(t, value)
+	}
+
+	for _, input := range []string{`null`, `"eu"`, `""`, `1`, `true`, `[]`, `"us" {}`} {
+		assertJSONRejects[ResidencyRequirement](t, input)
+	}
+	for _, input := range []string{`null`, `"remote"`, `""`, `1`, `true`, `[]`, `"live" {}`} {
+		assertJSONRejects[WebSearchMode](t, input)
+	}
+	for _, input := range []string{`null`, `"admin"`, `""`, `1`, `true`, `[]`, `"elevated" {}`} {
+		assertJSONRejects[WindowsSandboxSetupMode](t, input)
+	}
+}
+
+func TestComputerUseRequirementsAcceptAndCanonicalizeRustOptions(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{`{}`, `{"allowLockedComputerUse":null}`},
+		{`{"allowLockedComputerUse":null}`, `{"allowLockedComputerUse":null}`},
+		{`{"allowLockedComputerUse":false}`, `{"allowLockedComputerUse":false}`},
+		{`{"allowLockedComputerUse":true}`, `{"allowLockedComputerUse":true}`},
+	}
+	for _, tc := range cases {
+		var value ComputerUseRequirements
+		assertConfigRequirementsRoundTrip(t, tc.input, tc.want, &value)
+	}
+	for _, input := range []string{
+		`null`, `[]`, `"value"`, `1`, `true`,
+		`{"allowLockedComputerUse":0}`,
+		`{"allowLockedComputerUse":"false"}`,
+		`{"allowLockedComputerUse":null,"extra":true}`,
+		`{"allowLockedComputerUse":null} {}`,
+	} {
+		assertJSONRejects[ComputerUseRequirements](t, input)
+	}
+}
+
+func TestConfigRequirementsAcceptExactWireForms(t *testing.T) {
+	nullCanonical := `{"allowedApprovalPolicies":null,"allowedSandboxModes":null,"allowedWindowsSandboxImplementations":null,"allowedPermissionProfiles":null,"defaultPermissions":null,"allowedWebSearchModes":null,"allowManagedHooksOnly":null,"allowAppshots":null,"allowRemoteControl":null,"computerUse":null,"featureRequirements":null,"enforceResidency":null,"models":null}`
+	var omitted ConfigRequirements
+	assertConfigRequirementsRoundTrip(t, `{}`, nullCanonical, &omitted)
+	var explicitNull ConfigRequirements
+	assertConfigRequirementsRoundTrip(t, nullCanonical, nullCanonical, &explicitNull)
+
+	full := `{"allowedApprovalPolicies":["untrusted",{"granular":{"sandbox_approval":true,"rules":false,"skill_approval":true,"request_permissions":false,"mcp_elicitations":true}}],"allowedSandboxModes":["read-only","workspace-write","danger-full-access"],"allowedWindowsSandboxImplementations":["elevated","unelevated"],"allowedPermissionProfiles":{"":false,"strict":true},"defaultPermissions":"","allowedWebSearchModes":["disabled","cached","indexed","live"],"allowManagedHooksOnly":false,"allowAppshots":true,"allowRemoteControl":false,"computerUse":{"allowLockedComputerUse":false},"featureRequirements":{"":false,"feature":true},"enforceResidency":"us","models":{"newThread":{"model":"","modelReasoningEffort":"custom","serviceTier":""}}}`
+	var fullValue ConfigRequirements
+	assertConfigRequirementsRoundTrip(t, full, full, &fullValue)
+
+	partialWant := `{"allowedApprovalPolicies":null,"allowedSandboxModes":null,"allowedWindowsSandboxImplementations":null,"allowedPermissionProfiles":null,"defaultPermissions":null,"allowedWebSearchModes":null,"allowManagedHooksOnly":null,"allowAppshots":null,"allowRemoteControl":null,"computerUse":{"allowLockedComputerUse":null},"featureRequirements":null,"enforceResidency":null,"models":{"newThread":null}}`
+	var partial ConfigRequirements
+	assertConfigRequirementsRoundTrip(t, `{"computerUse":{},"models":{}}`, partialWant, &partial)
+}
+
+func TestConfigRequirementsRejectMalformedWireForms(t *testing.T) {
+	invalid := []string{
+		`null`, `[]`, `"value"`, `1`, `true`,
+		`{"allowedApprovalPolicies":{}}`,
+		`{"allowedApprovalPolicies":[null]}`,
+		`{"allowedApprovalPolicies":["always"]}`,
+		`{"allowedSandboxModes":[null]}`,
+		`{"allowedSandboxModes":["readOnly"]}`,
+		`{"allowedWindowsSandboxImplementations":[null]}`,
+		`{"allowedWindowsSandboxImplementations":["admin"]}`,
+		`{"allowedPermissionProfiles":[]}`,
+		`{"allowedPermissionProfiles":{"profile":null}}`,
+		`{"allowedPermissionProfiles":{"profile":"true"}}`,
+		`{"defaultPermissions":false}`,
+		`{"allowedWebSearchModes":[null]}`,
+		`{"allowedWebSearchModes":["remote"]}`,
+		`{"allowManagedHooksOnly":0}`,
+		`{"allowAppshots":"true"}`,
+		`{"allowRemoteControl":[]}`,
+		`{"computerUse":false}`,
+		`{"computerUse":{"extra":true}}`,
+		`{"featureRequirements":{"feature":null}}`,
+		`{"enforceResidency":"eu"}`,
+		`{"models":{"extra":true}}`,
+		`{"extra":true}`,
+		`{} {}`,
+	}
+	for _, input := range invalid {
+		assertJSONRejects[ConfigRequirements](t, input)
+	}
+}
+
+func TestConfigRequirementsReadResponseIsExact(t *testing.T) {
+	var omitted ConfigRequirementsReadResponse
+	assertConfigRequirementsRoundTrip(t, `{}`, `{"requirements":null}`, &omitted)
+	var explicitNull ConfigRequirementsReadResponse
+	assertConfigRequirementsRoundTrip(t, `{"requirements":null}`, `{"requirements":null}`, &explicitNull)
+	var nested ConfigRequirementsReadResponse
+	assertConfigRequirementsRoundTrip(
+		t,
+		`{"requirements":{"allowRemoteControl":false}}`,
+		`{"requirements":{"allowedApprovalPolicies":null,"allowedSandboxModes":null,"allowedWindowsSandboxImplementations":null,"allowedPermissionProfiles":null,"defaultPermissions":null,"allowedWebSearchModes":null,"allowManagedHooksOnly":null,"allowAppshots":null,"allowRemoteControl":false,"computerUse":null,"featureRequirements":null,"enforceResidency":null,"models":null}}`,
+		&nested,
+	)
+	for _, input := range []string{
+		`null`, `[]`, `"value"`, `1`, `true`,
+		`{"requirements":false}`,
+		`{"requirements":{"extra":true}}`,
+		`{"requirements":null,"extra":true}`,
+		`{"requirements":null} {}`,
+	} {
+		assertJSONRejects[ConfigRequirementsReadResponse](t, input)
+	}
+}
+
+func TestConfigRequirementsNilReceiversAndInvalidMarshal(t *testing.T) {
+	var computerUse *ComputerUseRequirements
+	if err := computerUse.UnmarshalJSON([]byte(`{}`)); err == nil {
+		t.Fatal("nil ComputerUseRequirements receiver succeeded")
+	}
+	var requirements *ConfigRequirements
+	if err := requirements.UnmarshalJSON([]byte(`{}`)); err == nil {
+		t.Fatal("nil ConfigRequirements receiver succeeded")
+	}
+	var response *ConfigRequirementsReadResponse
+	if err := response.UnmarshalJSON([]byte(`{}`)); err == nil {
+		t.Fatal("nil ConfigRequirementsReadResponse receiver succeeded")
+	}
+	var residency *ResidencyRequirement
+	if err := residency.UnmarshalJSON([]byte(`"us"`)); err == nil {
+		t.Fatal("nil ResidencyRequirement receiver succeeded")
+	}
+	var webSearch *WebSearchMode
+	if err := webSearch.UnmarshalJSON([]byte(`"live"`)); err == nil {
+		t.Fatal("nil WebSearchMode receiver succeeded")
+	}
+	var windows *WindowsSandboxSetupMode
+	if err := windows.UnmarshalJSON([]byte(`"elevated"`)); err == nil {
+		t.Fatal("nil WindowsSandboxSetupMode receiver succeeded")
+	}
+
+	invalidWebSearch := []WebSearchMode{"remote"}
+	if _, err := json.Marshal(ConfigRequirements{AllowedWebSearchModes: &invalidWebSearch}); err == nil {
+		t.Fatal("invalid nested web-search mode marshal succeeded")
+	}
+	if _, err := json.Marshal(ResidencyRequirement("eu")); err == nil {
+		t.Fatal("invalid residency requirement marshal succeeded")
+	}
+	if _, err := json.Marshal(WindowsSandboxSetupMode("admin")); err == nil {
+		t.Fatal("invalid Windows sandbox setup mode marshal succeeded")
+	}
+}
+
+func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
+	names := []string{
+		"ComputerUseRequirements", "ConfigRequirements", "ConfigRequirementsReadResponse",
+		"ResidencyRequirement", "WebSearchMode", "WindowsSandboxSetupMode",
+	}
+	for _, binding := range WireTypeBindings() {
+		for _, name := range names {
+			if slices.Contains(binding.Params, name) || slices.Contains(binding.Result, name) {
+				t.Fatalf("%s unexpectedly bound to %s", name, binding.Method)
+			}
+		}
+	}
+	info, ok := LookupMethod("configRequirements/read")
+	if !ok || info.State != MethodImplemented {
+		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 327 {
+		t.Fatalf("definition count = %d, want 327", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestConfigRequirementsTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	source := string(generated)
+	for _, want := range []string{
+		`export type ComputerUseRequirements = {`,
+		`"allowLockedComputerUse": boolean | null;`,
+		`export type ResidencyRequirement = "us";`,
+		`export type WebSearchMode = "disabled" | "cached" | "indexed" | "live";`,
+		`export type WindowsSandboxSetupMode = "elevated" | "unelevated";`,
+		`export type ConfigRequirements = {`,
+		`"allowedApprovalPolicies": Array<AskForApproval> | null;`,
+		`"allowedPermissionProfiles": { [key in string]?: boolean } | null;`,
+		`"featureRequirements": { [key in string]?: boolean } | null;`,
+		`"models": ModelsRequirements | null;`,
+		`export type ConfigRequirementsReadResponse = {`,
+		`"requirements": ConfigRequirements | null;`,
+	} {
+		if !strings.Contains(source, want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}
+
+func assertConfigNullableSchema(t *testing.T, raw any, want Schema) {
+	t.Helper()
+	schema, ok := raw.(Schema)
+	if !ok {
+		t.Fatalf("nullable schema = %#v", raw)
+	}
+	variants, ok := schema["anyOf"].([]any)
+	if !ok || len(variants) != 2 || !reflect.DeepEqual(variants[0], want) ||
+		!reflect.DeepEqual(variants[1], Schema{"type": "null"}) {
+		t.Fatalf("nullable schema = %#v, want %#v/null", schema, want)
+	}
+}
+
+func configRequirementsArraySchema(item string) Schema {
+	return Schema{"type": "array", "items": Schema{"$ref": "#/$defs/" + item}}
+}
+
+func configRequirementsBoolMapSchema() Schema {
+	return Schema{
+		"type": "object", "additionalProperties": Schema{"type": "boolean"},
+		"x-gollem-typescript-optional-map": true,
+	}
+}
+
+func assertConfigRequirementEnumRoundTrip[T interface {
+	~string
+	json.Marshaler
+}](t *testing.T, value T) {
+	t.Helper()
+	encoded, err := json.Marshal(value)
+	if err != nil || string(encoded) != `"`+string(value)+`"` {
+		t.Fatalf("Marshal(%q) = %s, %v", value, encoded, err)
+	}
+	var decoded T
+	if err := json.Unmarshal(encoded, &decoded); err != nil || decoded != value {
+		t.Fatalf("Unmarshal(%s) = %q, %v", encoded, decoded, err)
+	}
+}
+
+func assertConfigRequirementsRoundTrip(t *testing.T, input, want string, target any) {
+	t.Helper()
+	if err := json.Unmarshal([]byte(input), target); err != nil {
+		t.Fatalf("Unmarshal(%s): %v", input, err)
+	}
+	encoded, err := json.Marshal(target)
+	if err != nil || string(encoded) != want {
+		t.Fatalf("round trip %s = %s, %v; want %s", input, encoded, err, want)
+	}
+}

--- a/appserver/protocol/config_requirements_types.go
+++ b/appserver/protocol/config_requirements_types.go
@@ -1,0 +1,337 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// ComputerUseRequirements is the exact public computer-use requirement.
+// Nullable Rust options remain explicit in canonical output.
+type ComputerUseRequirements struct {
+	AllowLockedComputerUse *bool `json:"allowLockedComputerUse"`
+}
+
+func (r *ComputerUseRequirements) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("decode computer-use requirements into nil receiver")
+	}
+	const objectName = "computer-use requirements"
+	payload, err := decodeExactThreadItemObject(data, objectName, "allowLockedComputerUse")
+	if err != nil {
+		return err
+	}
+	allowLockedComputerUse, err := decodeOptionalNullableConfigRequirementValue[bool](
+		payload,
+		objectName,
+		"allowLockedComputerUse",
+	)
+	if err != nil {
+		return err
+	}
+	*r = ComputerUseRequirements{AllowLockedComputerUse: allowLockedComputerUse}
+	return nil
+}
+
+// ResidencyRequirement is the exact closed public residency requirement.
+type ResidencyRequirement string
+
+const ResidencyRequirementUS ResidencyRequirement = "us"
+
+func (r ResidencyRequirement) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(r, "residency requirement", ResidencyRequirement.valid)
+}
+
+func (r *ResidencyRequirement) UnmarshalJSON(data []byte) error {
+	return unmarshalThreadTurnLeafEnum(data, r, "residency requirement", ResidencyRequirement.valid)
+}
+
+func (r ResidencyRequirement) valid() bool { return r == ResidencyRequirementUS }
+
+// WebSearchMode is the exact closed public web-search requirement mode.
+type WebSearchMode string
+
+const (
+	WebSearchModeDisabled WebSearchMode = "disabled"
+	WebSearchModeCached   WebSearchMode = "cached"
+	WebSearchModeIndexed  WebSearchMode = "indexed"
+	WebSearchModeLive     WebSearchMode = "live"
+)
+
+func (m WebSearchMode) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(m, "web-search mode", WebSearchMode.valid)
+}
+
+func (m *WebSearchMode) UnmarshalJSON(data []byte) error {
+	return unmarshalThreadTurnLeafEnum(data, m, "web-search mode", WebSearchMode.valid)
+}
+
+func (m WebSearchMode) valid() bool {
+	switch m {
+	case WebSearchModeDisabled, WebSearchModeCached, WebSearchModeIndexed, WebSearchModeLive:
+		return true
+	default:
+		return false
+	}
+}
+
+// WindowsSandboxSetupMode is the exact closed public Windows setup mode. It
+// does not add a Windows sandbox implementation to Gollem.
+type WindowsSandboxSetupMode string
+
+const (
+	WindowsSandboxSetupModeElevated   WindowsSandboxSetupMode = "elevated"
+	WindowsSandboxSetupModeUnelevated WindowsSandboxSetupMode = "unelevated"
+)
+
+func (m WindowsSandboxSetupMode) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(m, "Windows sandbox setup mode", WindowsSandboxSetupMode.valid)
+}
+
+func (m *WindowsSandboxSetupMode) UnmarshalJSON(data []byte) error {
+	return unmarshalThreadTurnLeafEnum(data, m, "Windows sandbox setup mode", WindowsSandboxSetupMode.valid)
+}
+
+func (m WindowsSandboxSetupMode) valid() bool {
+	return m == WindowsSandboxSetupModeElevated || m == WindowsSandboxSetupModeUnelevated
+}
+
+// ConfigRequirements is the exact public configuration-requirements value.
+// Gollem's broader live provider/workspace requirements remain separate.
+type ConfigRequirements struct {
+	AllowedApprovalPolicies              *[]AskForApproval          `json:"allowedApprovalPolicies"`
+	AllowedSandboxModes                  *[]SandboxMode             `json:"allowedSandboxModes"`
+	AllowedWindowsSandboxImplementations *[]WindowsSandboxSetupMode `json:"allowedWindowsSandboxImplementations"`
+	AllowedPermissionProfiles            *map[string]bool           `json:"allowedPermissionProfiles"`
+	DefaultPermissions                   *string                    `json:"defaultPermissions"`
+	AllowedWebSearchModes                *[]WebSearchMode           `json:"allowedWebSearchModes"`
+	AllowManagedHooksOnly                *bool                      `json:"allowManagedHooksOnly"`
+	AllowAppshots                        *bool                      `json:"allowAppshots"`
+	AllowRemoteControl                   *bool                      `json:"allowRemoteControl"`
+	ComputerUse                          *ComputerUseRequirements   `json:"computerUse"`
+	FeatureRequirements                  *map[string]bool           `json:"featureRequirements"`
+	EnforceResidency                     *ResidencyRequirement      `json:"enforceResidency"`
+	Models                               *ModelsRequirements        `json:"models"`
+}
+
+func (r *ConfigRequirements) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("decode config requirements into nil receiver")
+	}
+	const objectName = "config requirements"
+	payload, err := decodeExactThreadItemObject(
+		data,
+		objectName,
+		"allowedApprovalPolicies",
+		"allowedSandboxModes",
+		"allowedWindowsSandboxImplementations",
+		"allowedPermissionProfiles",
+		"defaultPermissions",
+		"allowedWebSearchModes",
+		"allowManagedHooksOnly",
+		"allowAppshots",
+		"allowRemoteControl",
+		"computerUse",
+		"featureRequirements",
+		"enforceResidency",
+		"models",
+	)
+	if err != nil {
+		return err
+	}
+	allowedApprovalPolicies, err := decodeOptionalNullableConfigRequirementArray[AskForApproval](
+		payload, objectName, "allowedApprovalPolicies",
+	)
+	if err != nil {
+		return err
+	}
+	allowedSandboxModes, err := decodeOptionalNullableConfigRequirementArray[SandboxMode](
+		payload, objectName, "allowedSandboxModes",
+	)
+	if err != nil {
+		return err
+	}
+	allowedWindowsSandboxImplementations, err := decodeOptionalNullableConfigRequirementArray[WindowsSandboxSetupMode](
+		payload, objectName, "allowedWindowsSandboxImplementations",
+	)
+	if err != nil {
+		return err
+	}
+	allowedPermissionProfiles, err := decodeOptionalNullableConfigRequirementBoolMap(
+		payload, objectName, "allowedPermissionProfiles",
+	)
+	if err != nil {
+		return err
+	}
+	defaultPermissions, err := decodeOptionalNullableConfigRequirementValue[string](
+		payload, objectName, "defaultPermissions",
+	)
+	if err != nil {
+		return err
+	}
+	allowedWebSearchModes, err := decodeOptionalNullableConfigRequirementArray[WebSearchMode](
+		payload, objectName, "allowedWebSearchModes",
+	)
+	if err != nil {
+		return err
+	}
+	allowManagedHooksOnly, err := decodeOptionalNullableConfigRequirementValue[bool](
+		payload, objectName, "allowManagedHooksOnly",
+	)
+	if err != nil {
+		return err
+	}
+	allowAppshots, err := decodeOptionalNullableConfigRequirementValue[bool](payload, objectName, "allowAppshots")
+	if err != nil {
+		return err
+	}
+	allowRemoteControl, err := decodeOptionalNullableConfigRequirementValue[bool](
+		payload, objectName, "allowRemoteControl",
+	)
+	if err != nil {
+		return err
+	}
+	computerUse, err := decodeOptionalNullableConfigRequirementValue[ComputerUseRequirements](
+		payload, objectName, "computerUse",
+	)
+	if err != nil {
+		return err
+	}
+	featureRequirements, err := decodeOptionalNullableConfigRequirementBoolMap(
+		payload, objectName, "featureRequirements",
+	)
+	if err != nil {
+		return err
+	}
+	enforceResidency, err := decodeOptionalNullableConfigRequirementValue[ResidencyRequirement](
+		payload, objectName, "enforceResidency",
+	)
+	if err != nil {
+		return err
+	}
+	models, err := decodeOptionalNullableConfigRequirementValue[ModelsRequirements](payload, objectName, "models")
+	if err != nil {
+		return err
+	}
+	*r = ConfigRequirements{
+		AllowedApprovalPolicies:              allowedApprovalPolicies,
+		AllowedSandboxModes:                  allowedSandboxModes,
+		AllowedWindowsSandboxImplementations: allowedWindowsSandboxImplementations,
+		AllowedPermissionProfiles:            allowedPermissionProfiles,
+		DefaultPermissions:                   defaultPermissions,
+		AllowedWebSearchModes:                allowedWebSearchModes,
+		AllowManagedHooksOnly:                allowManagedHooksOnly,
+		AllowAppshots:                        allowAppshots,
+		AllowRemoteControl:                   allowRemoteControl,
+		ComputerUse:                          computerUse,
+		FeatureRequirements:                  featureRequirements,
+		EnforceResidency:                     enforceResidency,
+		Models:                               models,
+	}
+	return nil
+}
+
+// ConfigRequirementsReadResponse is the exact public read response. It stays
+// standalone until the broader live handler has an explicit projection.
+type ConfigRequirementsReadResponse struct {
+	Requirements *ConfigRequirements `json:"requirements"`
+}
+
+func (r *ConfigRequirementsReadResponse) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("decode config-requirements read response into nil receiver")
+	}
+	const objectName = "config-requirements read response"
+	payload, err := decodeExactThreadItemObject(data, objectName, "requirements")
+	if err != nil {
+		return err
+	}
+	requirements, err := decodeOptionalNullableConfigRequirementValue[ConfigRequirements](
+		payload, objectName, "requirements",
+	)
+	if err != nil {
+		return err
+	}
+	*r = ConfigRequirementsReadResponse{Requirements: requirements}
+	return nil
+}
+
+func decodeOptionalNullableConfigRequirementValue[T any](
+	payload map[string]json.RawMessage,
+	objectName string,
+	fieldName string,
+) (*T, error) {
+	raw, ok := payload[fieldName]
+	if !ok || isJSONNull(raw) {
+		return nil, nil
+	}
+	var value T
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return nil, fmt.Errorf("decode %s %s: %w", objectName, fieldName, err)
+	}
+	return &value, nil
+}
+
+func decodeOptionalNullableConfigRequirementArray[T any](
+	payload map[string]json.RawMessage,
+	objectName string,
+	fieldName string,
+) (*[]T, error) {
+	raw, ok := payload[fieldName]
+	if !ok || isJSONNull(raw) {
+		return nil, nil
+	}
+	var elements []json.RawMessage
+	if err := json.Unmarshal(raw, &elements); err != nil {
+		return nil, fmt.Errorf("decode %s %s: %w", objectName, fieldName, err)
+	}
+	values := make([]T, len(elements))
+	for index, element := range elements {
+		if isJSONNull(element) {
+			return nil, fmt.Errorf("decode %s %s[%d]: value cannot be null", objectName, fieldName, index)
+		}
+		if err := json.Unmarshal(element, &values[index]); err != nil {
+			return nil, fmt.Errorf("decode %s %s[%d]: %w", objectName, fieldName, index, err)
+		}
+	}
+	return &values, nil
+}
+
+func decodeOptionalNullableConfigRequirementBoolMap(
+	payload map[string]json.RawMessage,
+	objectName string,
+	fieldName string,
+) (*map[string]bool, error) {
+	raw, ok := payload[fieldName]
+	if !ok || isJSONNull(raw) {
+		return nil, nil
+	}
+	var entries map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &entries); err != nil {
+		return nil, fmt.Errorf("decode %s %s: %w", objectName, fieldName, err)
+	}
+	values := make(map[string]bool, len(entries))
+	for name, encoded := range entries {
+		if isJSONNull(encoded) {
+			return nil, fmt.Errorf("decode %s %s[%q]: value cannot be null", objectName, fieldName, name)
+		}
+		var value bool
+		if err := json.Unmarshal(encoded, &value); err != nil {
+			return nil, fmt.Errorf("decode %s %s[%q]: %w", objectName, fieldName, name, err)
+		}
+		values[name] = value
+	}
+	return &values, nil
+}
+
+var (
+	_ json.Unmarshaler = (*ComputerUseRequirements)(nil)
+	_ json.Marshaler   = ResidencyRequirement("")
+	_ json.Unmarshaler = (*ResidencyRequirement)(nil)
+	_ json.Marshaler   = WebSearchMode("")
+	_ json.Unmarshaler = (*WebSearchMode)(nil)
+	_ json.Marshaler   = WindowsSandboxSetupMode("")
+	_ json.Unmarshaler = (*WindowsSandboxSetupMode)(nil)
+	_ json.Unmarshaler = (*ConfigRequirements)(nil)
+	_ json.Unmarshaler = (*ConfigRequirementsReadResponse)(nil)
+)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 321 {
-		t.Fatalf("definition count = %d, want 321", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 327 {
+		t.Fatalf("definition count = %d, want 327", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 321 {
-		t.Fatalf("definition count = %d, want 321", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 327 {
+		t.Fatalf("definition count = %d, want 327", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 321 {
-		t.Fatalf("definition count = %d, want 321", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 327 {
+		t.Fatalf("definition count = %d, want 327", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 321 {
-		t.Fatalf("definition count = %d, want 321", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 327 {
+		t.Fatalf("definition count = %d, want 327", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 321 {
-		t.Fatalf("definition count = %d, want 321", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 327 {
+		t.Fatalf("definition count = %d, want 327", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 321 {
-		t.Fatalf("definition count = %d, want 321", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 327 {
+		t.Fatalf("definition count = %d, want 327", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 321 {
-		t.Fatalf("definition count = %d, want 321", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 327 {
+		t.Fatalf("definition count = %d, want 327", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 321 {
-		t.Fatalf("definition count = %d, want 321", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 327 {
+		t.Fatalf("definition count = %d, want 327", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 321 {
-		t.Fatalf("definition count = %d, want 321", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 327 {
+		t.Fatalf("definition count = %d, want 327", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 321 {
-		t.Fatalf("definition count = %d, want 321", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 327 {
+		t.Fatalf("definition count = %d, want 327", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 321 {
-		t.Fatalf("definition count = %d, want 321", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 327 {
+		t.Fatalf("definition count = %d, want 327", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 321 {
-		t.Fatalf("definition count = %d, want 321", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 327 {
+		t.Fatalf("definition count = %d, want 327", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 321 {
-		t.Fatalf("definition count = %d, want 321", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 327 {
+		t.Fatalf("definition count = %d, want 327", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 321 {
-		t.Fatalf("definition count = %d, want 321", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 327 {
+		t.Fatalf("definition count = %d, want 327", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -120,6 +120,9 @@ func wireSchemaDefinitions() Schema {
 		{Name: "CommandExecutionItemStartedNotificationParams", Type: reflect.TypeFor[CommandExecutionItemStartedNotificationParams]()},
 		{Name: "CommandExecutionOutputDeltaNotificationParams", Type: reflect.TypeFor[CommandExecutionOutputDeltaNotificationParams]()},
 		{Name: "CommandExecutionSource", Type: reflect.TypeFor[CommandExecutionSource]()},
+		{Name: "ComputerUseRequirements", Type: reflect.TypeFor[ComputerUseRequirements]()},
+		{Name: "ConfigRequirements", Type: reflect.TypeFor[ConfigRequirements]()},
+		{Name: "ConfigRequirementsReadResponse", Type: reflect.TypeFor[ConfigRequirementsReadResponse]()},
 		{Name: "ConfigWarningNotification", Type: reflect.TypeFor[ConfigWarningNotification]()},
 		{Name: "ContentItem", Type: reflect.TypeFor[ContentItem]()},
 		{Name: "ContextCompactionItem", Type: reflect.TypeFor[ContextCompactionItem]()},
@@ -269,6 +272,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "ReasoningTextDeltaNotification", Type: reflect.TypeFor[ReasoningTextDeltaNotification]()},
 		{Name: "ReasoningItemContent", Type: reflect.TypeFor[ReasoningItemContent]()},
 		{Name: "ReasoningItemReasoningSummary", Type: reflect.TypeFor[ReasoningItemReasoningSummary]()},
+		{Name: "ResidencyRequirement", Type: reflect.TypeFor[ResidencyRequirement]()},
 		{Name: "RawResponseItemCompletedNotification", Type: reflect.TypeFor[RawResponseItemCompletedNotification]()},
 		{Name: "ResponseItem", Type: reflect.TypeFor[ResponseItem]()},
 		{Name: "ResponsesApiWebSearchAction", Type: reflect.TypeFor[ResponsesApiWebSearchAction]()},
@@ -383,7 +387,9 @@ func wireSchemaDefinitions() Schema {
 		{Name: "UserInput", Type: reflect.TypeFor[UserInput]()},
 		{Name: "WebSearchAction", Type: reflect.TypeFor[WebSearchAction]()},
 		{Name: "WebSearchItem", Type: reflect.TypeFor[WebSearchItem]()},
+		{Name: "WebSearchMode", Type: reflect.TypeFor[WebSearchMode]()},
 		{Name: "WarningNotification", Type: reflect.TypeFor[WarningNotification]()},
+		{Name: "WindowsSandboxSetupMode", Type: reflect.TypeFor[WindowsSandboxSetupMode]()},
 		// Register exact public names after their aliases so nested schemas refer
 		// to the public names. JSON and TypeScript output remain key-sorted.
 		{Name: "ContextCompactedNotification", Type: reflect.TypeFor[ContextCompactedNotification]()},
@@ -426,6 +432,19 @@ func wireSchemaDefinitions() Schema {
 	schemas["InputModality"] = stringEnumSchema(string(InputModalityText), string(InputModalityImage))
 	schemas["AgentPath"] = Schema{"type": "string"}
 	schemas["ReasoningEffort"] = Schema{"type": "string", "minLength": 1}
+	schemas["ResidencyRequirement"] = stringEnumSchema(string(ResidencyRequirementUS))
+	schemas["WebSearchMode"] = stringEnumSchema(
+		string(WebSearchModeDisabled), string(WebSearchModeCached),
+		string(WebSearchModeIndexed), string(WebSearchModeLive),
+	)
+	schemas["WindowsSandboxSetupMode"] = stringEnumSchema(
+		string(WindowsSandboxSetupModeElevated), string(WindowsSandboxSetupModeUnelevated),
+	)
+	configRequirementsProperties := schemas["ConfigRequirements"].(Schema)["properties"].(Schema)
+	for _, name := range []string{"allowedPermissionProfiles", "featureRequirements"} {
+		variants := configRequirementsProperties[name].(Schema)["anyOf"].([]any)
+		variants[0].(Schema)["x-gollem-typescript-optional-map"] = true
+	}
 	schemas["ModelListParams"] = modelListParamsSchema()
 	modelProperties := schemas["Model"].(Schema)["properties"].(Schema)
 	modelProperties["additionalSpeedTiers"].(Schema)["description"] = "Deprecated: use `serviceTiers` instead."

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -1365,6 +1365,215 @@
       ],
       "type": "string"
     },
+    "ComputerUseRequirements": {
+      "additionalProperties": false,
+      "properties": {
+        "allowLockedComputerUse": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "allowLockedComputerUse"
+      ],
+      "type": "object"
+    },
+    "ConfigRequirements": {
+      "additionalProperties": false,
+      "properties": {
+        "allowAppshots": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "allowManagedHooksOnly": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "allowRemoteControl": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "allowedApprovalPolicies": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/AskForApproval"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "allowedPermissionProfiles": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "type": "boolean"
+              },
+              "type": "object",
+              "x-gollem-typescript-optional-map": true
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "allowedSandboxModes": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/SandboxMode"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "allowedWebSearchModes": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/WebSearchMode"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "allowedWindowsSandboxImplementations": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/WindowsSandboxSetupMode"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "computerUse": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ComputerUseRequirements"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "defaultPermissions": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "enforceResidency": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ResidencyRequirement"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "featureRequirements": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "type": "boolean"
+              },
+              "type": "object",
+              "x-gollem-typescript-optional-map": true
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "models": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ModelsRequirements"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "allowedApprovalPolicies",
+        "allowedSandboxModes",
+        "allowedWindowsSandboxImplementations",
+        "allowedPermissionProfiles",
+        "defaultPermissions",
+        "allowedWebSearchModes",
+        "allowManagedHooksOnly",
+        "allowAppshots",
+        "allowRemoteControl",
+        "computerUse",
+        "featureRequirements",
+        "enforceResidency",
+        "models"
+      ],
+      "type": "object"
+    },
+    "ConfigRequirementsReadResponse": {
+      "additionalProperties": false,
+      "properties": {
+        "requirements": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ConfigRequirements"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "requirements"
+      ],
+      "type": "object"
+    },
     "ConfigWarningNotification": {
       "additionalProperties": false,
       "properties": {
@@ -5787,6 +5996,12 @@
         "fileSystem"
       ],
       "type": "object"
+    },
+    "ResidencyRequirement": {
+      "enum": [
+        "us"
+      ],
+      "type": "string"
     },
     "Response": {
       "additionalProperties": false,
@@ -11106,6 +11321,22 @@
         "action"
       ],
       "type": "object"
+    },
+    "WebSearchMode": {
+      "enum": [
+        "disabled",
+        "cached",
+        "indexed",
+        "live"
+      ],
+      "type": "string"
+    },
+    "WindowsSandboxSetupMode": {
+      "enum": [
+        "elevated",
+        "unelevated"
+      ],
+      "type": "string"
     }
   },
   "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 321 {
-		t.Fatalf("definition count = %d, want 321", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 327 {
+		t.Fatalf("definition count = %d, want 327", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 321 {
-		t.Fatalf("definition count = %d, want 321", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 327 {
+		t.Fatalf("definition count = %d, want 327", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 321 {
-		t.Fatalf("definition count = %d, want 321", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 327 {
+		t.Fatalf("definition count = %d, want 327", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 321 {
-		t.Fatalf("definition count = %d, want 321", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 327 {
+		t.Fatalf("definition count = %d, want 327", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 321 {
-		t.Fatalf("definition count = %d, want 321", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 327 {
+		t.Fatalf("definition count = %d, want 327", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 321 {
-		t.Fatalf("definition count = %d, want 321", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 327 {
+		t.Fatalf("definition count = %d, want 327", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 321 {
-		t.Fatalf("definition count = %d, want 321", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 327 {
+		t.Fatalf("definition count = %d, want 327", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 321 {
-		t.Fatalf("definition count = %d, want 321", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 327 {
+		t.Fatalf("definition count = %d, want 327", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 321 {
-		t.Fatalf("definition count = %d, want 321", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 327 {
+		t.Fatalf("definition count = %d, want 327", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 321 {
-		t.Fatalf("definition count = %d, want 321", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 327 {
+		t.Fatalf("definition count = %d, want 327", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 321 {
-		t.Fatalf("definition count = %d, want 321", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 327 {
+		t.Fatalf("definition count = %d, want 327", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 321 {
-		t.Fatalf("definition count = %d, want 321", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 327 {
+		t.Fatalf("definition count = %d, want 327", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -782,6 +782,30 @@ export type CommandExecutionSource = "agent" | "userShell" | "unifiedExecStartup
 
 export type CommandExecutionStatus = "inProgress" | "completed" | "failed" | "declined";
 
+export type ComputerUseRequirements = {
+  "allowLockedComputerUse": boolean | null;
+};
+
+export type ConfigRequirements = {
+  "allowAppshots": boolean | null;
+  "allowManagedHooksOnly": boolean | null;
+  "allowRemoteControl": boolean | null;
+  "allowedApprovalPolicies": Array<AskForApproval> | null;
+  "allowedPermissionProfiles": { [key in string]?: boolean } | null;
+  "allowedSandboxModes": Array<SandboxMode> | null;
+  "allowedWebSearchModes": Array<WebSearchMode> | null;
+  "allowedWindowsSandboxImplementations": Array<WindowsSandboxSetupMode> | null;
+  "computerUse": ComputerUseRequirements | null;
+  "defaultPermissions": string | null;
+  "enforceResidency": ResidencyRequirement | null;
+  "featureRequirements": { [key in string]?: boolean } | null;
+  "models": ModelsRequirements | null;
+};
+
+export type ConfigRequirementsReadResponse = {
+  "requirements": ConfigRequirements | null;
+};
+
 export type ConfigWarningNotification = {
   "details": string | null;
   "path"?: string;
@@ -1783,6 +1807,8 @@ export type RequestPermissionProfile = {
   "fileSystem": AdditionalFileSystemPermissions | null;
   "network": AdditionalNetworkPermissions | null;
 };
+
+export type ResidencyRequirement = "us";
 
 export type Response = {
   "error"?: Error;
@@ -2808,6 +2834,10 @@ export type WebSearchItem = {
   "id": string;
   "query": string;
 };
+
+export type WebSearchMode = "disabled" | "cached" | "indexed" | "live";
+
+export type WindowsSandboxSetupMode = "elevated" | "unelevated";
 
 export type WireTypeBinding = {
   "method": KnownMethod;

--- a/appserver/protocol/typescript/testdata/config_requirements_contract.ts
+++ b/appserver/protocol/typescript/testdata/config_requirements_contract.ts
@@ -1,0 +1,134 @@
+import type {
+  AskForApproval,
+  ComputerUseRequirements,
+  ConfigRequirements,
+  ConfigRequirementsReadResponse,
+  ModelsRequirements,
+  ResidencyRequirement,
+  SandboxMode,
+  WebSearchMode,
+  WindowsSandboxSetupMode,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+
+type Contracts = [
+  Expect<Equal<ComputerUseRequirements, { allowLockedComputerUse: boolean | null }>>,
+  Expect<Equal<ResidencyRequirement, "us">>,
+  Expect<Equal<WebSearchMode, "disabled" | "cached" | "indexed" | "live">>,
+  Expect<Equal<WindowsSandboxSetupMode, "elevated" | "unelevated">>,
+  Expect<Equal<ConfigRequirements, {
+    allowedApprovalPolicies: AskForApproval[] | null;
+    allowedSandboxModes: SandboxMode[] | null;
+    allowedWindowsSandboxImplementations: WindowsSandboxSetupMode[] | null;
+    allowedPermissionProfiles: { [key in string]?: boolean } | null;
+    defaultPermissions: string | null;
+    allowedWebSearchModes: WebSearchMode[] | null;
+    allowManagedHooksOnly: boolean | null;
+    allowAppshots: boolean | null;
+    allowRemoteControl: boolean | null;
+    computerUse: ComputerUseRequirements | null;
+    featureRequirements: { [key in string]?: boolean } | null;
+    enforceResidency: ResidencyRequirement | null;
+    models: ModelsRequirements | null;
+  }>>,
+  Expect<Equal<ConfigRequirementsReadResponse, { requirements: ConfigRequirements | null }>>,
+];
+
+export const nullComputerUse = {
+  allowLockedComputerUse: null,
+} satisfies ComputerUseRequirements;
+export const fullComputerUse = {
+  allowLockedComputerUse: false,
+} satisfies ComputerUseRequirements;
+
+export const nullRequirements = {
+  allowedApprovalPolicies: null,
+  allowedSandboxModes: null,
+  allowedWindowsSandboxImplementations: null,
+  allowedPermissionProfiles: null,
+  defaultPermissions: null,
+  allowedWebSearchModes: null,
+  allowManagedHooksOnly: null,
+  allowAppshots: null,
+  allowRemoteControl: null,
+  computerUse: null,
+  featureRequirements: null,
+  enforceResidency: null,
+  models: null,
+} satisfies ConfigRequirements;
+
+export const fullRequirements = {
+  allowedApprovalPolicies: ["untrusted"],
+  allowedSandboxModes: ["read-only", "workspace-write"],
+  allowedWindowsSandboxImplementations: ["elevated", "unelevated"],
+  allowedPermissionProfiles: { "": false, strict: true },
+  defaultPermissions: "",
+  allowedWebSearchModes: ["disabled", "cached", "indexed", "live"],
+  allowManagedHooksOnly: false,
+  allowAppshots: true,
+  allowRemoteControl: false,
+  computerUse: fullComputerUse,
+  featureRequirements: { "": false, feature: true },
+  enforceResidency: "us",
+  models: { newThread: null },
+} satisfies ConfigRequirements;
+
+export const nullResponse = {
+  requirements: null,
+} satisfies ConfigRequirementsReadResponse;
+export const fullResponse = {
+  requirements: fullRequirements,
+} satisfies ConfigRequirementsReadResponse;
+
+"us" satisfies ResidencyRequirement;
+"disabled" satisfies WebSearchMode;
+"cached" satisfies WebSearchMode;
+"indexed" satisfies WebSearchMode;
+"live" satisfies WebSearchMode;
+"elevated" satisfies WindowsSandboxSetupMode;
+"unelevated" satisfies WindowsSandboxSetupMode;
+
+// @ts-expect-error allowLockedComputerUse is required.
+export const rejectMissingComputerUse = {} satisfies ComputerUseRequirements;
+// @ts-expect-error computer-use values are nullable booleans only.
+export const rejectNumericComputerUse = { allowLockedComputerUse: 1 } satisfies ComputerUseRequirements;
+// @ts-expect-error exact computer-use requirements exclude extensions.
+export const rejectComputerUseExtension = { allowLockedComputerUse: null, extra: true } satisfies ComputerUseRequirements;
+// @ts-expect-error residency values are closed.
+"eu" satisfies ResidencyRequirement;
+// @ts-expect-error web-search modes are closed.
+"remote" satisfies WebSearchMode;
+// @ts-expect-error Windows sandbox modes are closed.
+"admin" satisfies WindowsSandboxSetupMode;
+// @ts-expect-error all parent fields are required.
+export const rejectMissingConfigFields = { models: null } satisfies ConfigRequirements;
+// @ts-expect-error approval arrays exclude null members.
+export const rejectNullApproval = { ...nullRequirements, allowedApprovalPolicies: [null] } satisfies ConfigRequirements;
+// @ts-expect-error sandbox modes are closed.
+export const rejectSandboxMode = { ...nullRequirements, allowedSandboxModes: ["readOnly"] } satisfies ConfigRequirements;
+// @ts-expect-error Windows setup arrays exclude null members.
+export const rejectNullWindowsMode = { ...nullRequirements, allowedWindowsSandboxImplementations: [null] } satisfies ConfigRequirements;
+// @ts-expect-error permission-profile map values are booleans.
+export const rejectPermissionMapValue = { ...nullRequirements, allowedPermissionProfiles: { strict: "true" } } satisfies ConfigRequirements;
+// @ts-expect-error web-search arrays exclude unknown values.
+export const rejectWebSearchMode = { ...nullRequirements, allowedWebSearchModes: ["remote"] } satisfies ConfigRequirements;
+// @ts-expect-error nested computer-use requirements remain exact.
+export const rejectNestedComputerUse = { ...nullRequirements, computerUse: {} } satisfies ConfigRequirements;
+// @ts-expect-error feature map values are booleans.
+export const rejectFeatureMapValue = { ...nullRequirements, featureRequirements: { feature: null } } satisfies ConfigRequirements;
+// @ts-expect-error exact config requirements exclude extensions.
+export const rejectConfigExtension = { ...nullRequirements, extra: true } satisfies ConfigRequirements;
+// @ts-expect-error requirements is required nullable.
+export const rejectMissingResponse = {} satisfies ConfigRequirementsReadResponse;
+// @ts-expect-error response requirements use the exact parent.
+export const rejectWrongResponse = { requirements: false } satisfies ConfigRequirementsReadResponse;
+// @ts-expect-error exact responses exclude live data arrays.
+export const rejectResponseExtension = { requirements: null, data: [] } satisfies ConfigRequirementsReadResponse;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/typescript_test.go
+++ b/appserver/protocol/typescript_test.go
@@ -138,7 +138,7 @@ func TestTypeScriptFixtureTypeChecksWhenCompilerIsAvailable(t *testing.T) {
 	if _, err := exec.LookPath("tsc"); err != nil {
 		t.Skip("tsc is not installed")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "tsc", "--project", filepath.Join("typescript", "tsconfig.json"))
 	output, err := cmd.CombinedOutput()

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 321 {
-		t.Fatalf("definition count = %d, want 321", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 327 {
+		t.Fatalf("definition count = %d, want 327", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary

- export exact standalone `ComputerUseRequirements`, `ResidencyRequirement`, `WebSearchMode`, `WindowsSandboxSetupMode`, `ConfigRequirements`, and `ConfigRequirementsReadResponse` contracts
- strictly decode closed objects, enum values, non-null array members, and open boolean maps while canonicalizing omitted Rust `Option` fields to explicit `null`
- register the six definitions in deterministic JSON Schema and TypeScript output without binding or changing the live `configRequirements/read` method
- add exact Go/schema/TypeScript positive and negative contract coverage
- raise the strict TypeScript fixture subprocess budget from 10 to 30 seconds after the first hosted race/coverage run killed a valid `tsc` process at 10.04 seconds

## Compatibility

The generated surface advances to 327 definitions while preserving 224 methods, 59 wire bindings, and 5 item bindings. `configRequirements/read` inference remains `unknown` until an explicit projection exists for Gollem's provider/environment requirement rows and `data` alias.

The feature binary's live response is byte-identical to the previous merged binary: 4 `requirements` rows, 4 `data` rows, SHA-256 `b52199eba1a8d047d481a617d3e4a0fd277c4f6029ba65e41600d4ef215c4a65`.

## Validation

- focused Go contract tests: 30 repetitions
- focused race detector
- 100% statement coverage for every new decoder/helper
- all non-Monty Go packages, normal and race
- repeated race-enabled TypeScript subprocess test and full protocol race suite after the timeout adjustment
- `golangci-lint run ./...`
- `go vet ./...`
- `go mod tidy` unchanged
- deterministic `go generate ./appserver/protocol`
- strict TypeScript 5.9.2
- all five real Slang stdio/socket/WebSocket workflows
- schema SHA-256: `7446b2926d2259d117b4ebf3c8fa667d2f30aaf33e6bf1348b9dde78400ba9b9`
- generated TypeScript SHA-256: `2f8fa7f70c7e70114b4a08b1b0c2dd41e57bf1f9f89757f02775c48c2b2f6ac7`
- trimpath feature binary SHA-256: `b277b3fe6a57bec6c924b78a67593c75cfc3d81d11fa426e59acc951bd0566cf`

Local Monty tests were skipped per the local execution policy; hosted CI remains responsible for the repository's Monty test job.