### PR TITLE
Export exact managed hook requirements

### DIFF
--- a/appserver/protocol/README.md
+++ b/appserver/protocol/README.md
@@ -556,6 +556,14 @@ separate from Gollem's provider/environment requirement rows and `data` alias,
 so `configRequirements/read` inference remains `unknown` pending an explicit
 projection adapter.
 
+Exact standalone `ConfiguredHookHandler`, `ConfiguredHookMatcherGroup`, and
+`ManagedHooksRequirements` expose the strict managed-hook configuration value
+graph. Command handlers canonicalize nullable Windows-command, timeout, and
+status fields; matcher groups and all ten case-sensitive event arrays are
+non-null. These values do not register or execute hooks, bind into the live
+config endpoint, or claim managed-hook enforcement; those runtime and policy
+decisions remain separate.
+
 ## Generation
 
 Run:

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 327 {
-		t.Fatalf("definition count = %d, want 327", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 330 {
+		t.Fatalf("definition count = %d, want 330", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 327 {
-		t.Fatalf("definition count = %d, want 327", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 330 {
+		t.Fatalf("definition count = %d, want 330", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 327 {
-		t.Fatalf("definition count = %d, want 327", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 330 {
+		t.Fatalf("definition count = %d, want 330", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 327 {
-		t.Fatalf("definition count = %d, want 327", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 330 {
+		t.Fatalf("definition count = %d, want 330", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -1,0 +1,296 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestManagedHooksRequirementSchemasAreExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	handler := defs["ConfiguredHookHandler"].(Schema)
+	variants, ok := handler["oneOf"].([]any)
+	if !ok || len(variants) != 3 {
+		t.Fatalf("ConfiguredHookHandler variants = %#v", handler["oneOf"])
+	}
+	wantVariants := []struct {
+		hookType string
+		fields   []string
+	}{
+		{hookType: "command", fields: []string{"type", "command", "commandWindows", "timeoutSec", "async", "statusMessage"}},
+		{hookType: "prompt", fields: []string{"type"}},
+		{hookType: "agent", fields: []string{"type"}},
+	}
+	for index, want := range wantVariants {
+		variant := variants[index].(Schema)
+		if variant["additionalProperties"] != false {
+			t.Fatalf("%s handler allows extra fields", want.hookType)
+		}
+		properties := variant["properties"].(Schema)
+		if !reflect.DeepEqual(properties["type"].(Schema)["enum"], []any{want.hookType}) {
+			t.Fatalf("handler variant %d type = %#v", index, properties["type"])
+		}
+		if !slices.Equal(schemaRequiredNames(variant), want.fields) {
+			t.Fatalf("%s handler required = %v, want %v", want.hookType, schemaRequiredNames(variant), want.fields)
+		}
+	}
+	command := variants[0].(Schema)["properties"].(Schema)
+	if !reflect.DeepEqual(command["command"], Schema{"type": "string"}) ||
+		!reflect.DeepEqual(command["async"], Schema{"type": "boolean"}) {
+		t.Fatalf("command handler required fields = %#v", command)
+	}
+	assertConfigNullableSchema(t, command["commandWindows"], Schema{"type": "string"})
+	assertConfigNullableSchema(t, command["timeoutSec"], Schema{"type": "integer", "minimum": 0})
+	assertConfigNullableSchema(t, command["statusMessage"], Schema{"type": "string"})
+
+	group := defs["ConfiguredHookMatcherGroup"].(Schema)
+	assertClosedObjectSchema(t, group, "matcher", "hooks")
+	groupProperties := group["properties"].(Schema)
+	assertConfigNullableSchema(t, groupProperties["matcher"], Schema{"type": "string"})
+	if !reflect.DeepEqual(groupProperties["hooks"], Schema{
+		"type": "array", "items": Schema{"$ref": "#/$defs/ConfiguredHookHandler"},
+	}) {
+		t.Fatalf("matcher hooks schema = %#v", groupProperties["hooks"])
+	}
+
+	requirements := defs["ManagedHooksRequirements"].(Schema)
+	fields := []string{
+		"managedDir", "windowsManagedDir", "PreToolUse", "PermissionRequest",
+		"PostToolUse", "PreCompact", "PostCompact", "SessionStart",
+		"UserPromptSubmit", "SubagentStart", "SubagentStop", "Stop",
+	}
+	assertClosedObjectSchema(t, requirements, fields...)
+	properties := requirements["properties"].(Schema)
+	assertConfigNullableSchema(t, properties["managedDir"], Schema{"type": "string"})
+	assertConfigNullableSchema(t, properties["windowsManagedDir"], Schema{"type": "string"})
+	for _, field := range fields[2:] {
+		if !reflect.DeepEqual(properties[field], Schema{
+			"type": "array", "items": Schema{"$ref": "#/$defs/ConfiguredHookMatcherGroup"},
+		}) {
+			t.Fatalf("%s schema = %#v", field, properties[field])
+		}
+	}
+}
+
+func TestConfiguredHookHandlerAcceptsExactWireForms(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{
+			input: `{"type":"command","command":"","async":false}`,
+			want:  `{"type":"command","command":"","commandWindows":null,"timeoutSec":null,"async":false,"statusMessage":null}`,
+		},
+		{
+			input: `{"type":"command","command":"run","commandWindows":"run.exe","timeoutSec":18446744073709551615,"async":true,"statusMessage":"working"}`,
+			want:  `{"type":"command","command":"run","commandWindows":"run.exe","timeoutSec":18446744073709551615,"async":true,"statusMessage":"working"}`,
+		},
+		{input: `{"type":"prompt"}`, want: `{"type":"prompt"}`},
+		{input: `{"type":"agent"}`, want: `{"type":"agent"}`},
+	}
+	for _, tc := range cases {
+		var value ConfiguredHookHandler
+		assertManagedHooksRoundTrip(t, tc.input, tc.want, &value)
+	}
+}
+
+func TestConfiguredHookHandlerRejectsMalformedWireForms(t *testing.T) {
+	invalid := []string{
+		`null`, `[]`, `"value"`, `1`, `true`, `{}`,
+		`{"type":"command","async":false}`,
+		`{"type":"command","command":"run"}`,
+		`{"type":"command","command":null,"async":false}`,
+		`{"type":"command","command":"run","async":null}`,
+		`{"type":"command","command":"run","async":false,"commandWindows":1}`,
+		`{"type":"command","command":"run","async":false,"timeoutSec":-1}`,
+		`{"type":"command","command":"run","async":false,"timeoutSec":1.5}`,
+		`{"type":"command","command":"run","async":false,"timeoutSec":18446744073709551616}`,
+		`{"type":"command","command":"run","async":false,"statusMessage":[]}`,
+		`{"type":"command","command":"run","async":false,"extra":true}`,
+		`{"type":"prompt","command":"run"}`,
+		`{"type":"agent","async":false}`,
+		`{"type":"other"}`,
+		`{"type":1}`,
+		`{"type":"prompt"} {}`,
+	}
+	for _, input := range invalid {
+		assertJSONRejects[ConfiguredHookHandler](t, input)
+	}
+}
+
+func TestConfiguredHookMatcherGroupAcceptsAndCanonicalizesRustOptions(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{input: `{"hooks":[]}`, want: `{"matcher":null,"hooks":[]}`},
+		{input: `{"matcher":null,"hooks":[]}`, want: `{"matcher":null,"hooks":[]}`},
+		{
+			input: `{"matcher":"","hooks":[{"type":"prompt"},{"type":"command","command":"run","async":false},{"type":"agent"}]}`,
+			want:  `{"matcher":"","hooks":[{"type":"prompt"},{"type":"command","command":"run","commandWindows":null,"timeoutSec":null,"async":false,"statusMessage":null},{"type":"agent"}]}`,
+		},
+	}
+	for _, tc := range cases {
+		var value ConfiguredHookMatcherGroup
+		assertManagedHooksRoundTrip(t, tc.input, tc.want, &value)
+	}
+}
+
+func TestConfiguredHookMatcherGroupRejectsMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		`null`, `[]`, `"value"`, `1`, `true`, `{}`,
+		`{"hooks":null}`,
+		`{"hooks":{}}`,
+		`{"hooks":[null]}`,
+		`{"hooks":[{"type":"other"}]}`,
+		`{"matcher":1,"hooks":[]}`,
+		`{"matcher":null,"hooks":[],"extra":true}`,
+		`{"hooks":[]} {}`,
+	} {
+		assertJSONRejects[ConfiguredHookMatcherGroup](t, input)
+	}
+}
+
+func TestManagedHooksRequirementsAcceptExactWireForms(t *testing.T) {
+	minimal := `{"PreToolUse":[],"PermissionRequest":[],"PostToolUse":[],"PreCompact":[],"PostCompact":[],"SessionStart":[],"UserPromptSubmit":[],"SubagentStart":[],"SubagentStop":[],"Stop":[]}`
+	minimalCanonical := `{"managedDir":null,"windowsManagedDir":null,"PreToolUse":[],"PermissionRequest":[],"PostToolUse":[],"PreCompact":[],"PostCompact":[],"SessionStart":[],"UserPromptSubmit":[],"SubagentStart":[],"SubagentStop":[],"Stop":[]}`
+	var omittedOptions ManagedHooksRequirements
+	assertManagedHooksRoundTrip(t, minimal, minimalCanonical, &omittedOptions)
+
+	full := `{"managedDir":"","windowsManagedDir":"C:\\\\hooks","PreToolUse":[{"matcher":"tool","hooks":[{"type":"command","command":"run","commandWindows":null,"timeoutSec":0,"async":false,"statusMessage":null}]}],"PermissionRequest":[{"matcher":null,"hooks":[{"type":"prompt"}]}],"PostToolUse":[{"matcher":"*","hooks":[{"type":"agent"},{"type":"agent"}]}],"PreCompact":[],"PostCompact":[],"SessionStart":[],"UserPromptSubmit":[],"SubagentStart":[],"SubagentStop":[],"Stop":[]}`
+	var fullValue ManagedHooksRequirements
+	assertManagedHooksRoundTrip(t, full, full, &fullValue)
+}
+
+func TestManagedHooksRequirementsRejectMalformedWireForms(t *testing.T) {
+	base := map[string]any{
+		"PreToolUse": []any{}, "PermissionRequest": []any{}, "PostToolUse": []any{},
+		"PreCompact": []any{}, "PostCompact": []any{}, "SessionStart": []any{},
+		"UserPromptSubmit": []any{}, "SubagentStart": []any{}, "SubagentStop": []any{}, "Stop": []any{},
+	}
+	for _, field := range []string{
+		"PreToolUse", "PermissionRequest", "PostToolUse", "PreCompact", "PostCompact",
+		"SessionStart", "UserPromptSubmit", "SubagentStart", "SubagentStop", "Stop",
+	} {
+		copy := cloneManagedHooksMap(base)
+		delete(copy, field)
+		assertJSONRejects[ManagedHooksRequirements](t, string(mustMarshalManagedHooks(t, copy)))
+		copy = cloneManagedHooksMap(base)
+		copy[field] = nil
+		assertJSONRejects[ManagedHooksRequirements](t, string(mustMarshalManagedHooks(t, copy)))
+	}
+	for _, input := range []string{
+		`null`, `[]`, `"value"`, `1`, `true`, `{}`,
+		`{"managedDir":1,"PreToolUse":[],"PermissionRequest":[],"PostToolUse":[],"PreCompact":[],"PostCompact":[],"SessionStart":[],"UserPromptSubmit":[],"SubagentStart":[],"SubagentStop":[],"Stop":[]}`,
+		`{"windowsManagedDir":false,"PreToolUse":[],"PermissionRequest":[],"PostToolUse":[],"PreCompact":[],"PostCompact":[],"SessionStart":[],"UserPromptSubmit":[],"SubagentStart":[],"SubagentStop":[],"Stop":[]}`,
+		`{"PreToolUse":[null],"PermissionRequest":[],"PostToolUse":[],"PreCompact":[],"PostCompact":[],"SessionStart":[],"UserPromptSubmit":[],"SubagentStart":[],"SubagentStop":[],"Stop":[]}`,
+		`{"preToolUse":[],"PermissionRequest":[],"PostToolUse":[],"PreCompact":[],"PostCompact":[],"SessionStart":[],"UserPromptSubmit":[],"SubagentStart":[],"SubagentStop":[],"Stop":[]}`,
+		`{"PreToolUse":[],"PermissionRequest":[],"PostToolUse":[],"PreCompact":[],"PostCompact":[],"SessionStart":[],"UserPromptSubmit":[],"SubagentStart":[],"SubagentStop":[],"Stop":[],"extra":true}`,
+		`{"PreToolUse":[],"PermissionRequest":[],"PostToolUse":[],"PreCompact":[],"PostCompact":[],"SessionStart":[],"UserPromptSubmit":[],"SubagentStart":[],"SubagentStop":[],"Stop":[]} {}`,
+	} {
+		assertJSONRejects[ManagedHooksRequirements](t, input)
+	}
+}
+
+func TestManagedHooksRequirementsNilReceiversAndInvalidMarshal(t *testing.T) {
+	var handler *ConfiguredHookHandler
+	if err := handler.UnmarshalJSON([]byte(`{"type":"prompt"}`)); err == nil {
+		t.Fatal("nil ConfiguredHookHandler receiver succeeded")
+	}
+	var group *ConfiguredHookMatcherGroup
+	if err := group.UnmarshalJSON([]byte(`{"hooks":[]}`)); err == nil {
+		t.Fatal("nil ConfiguredHookMatcherGroup receiver succeeded")
+	}
+	var requirements *ManagedHooksRequirements
+	if err := requirements.UnmarshalJSON([]byte(`{}`)); err == nil {
+		t.Fatal("nil ManagedHooksRequirements receiver succeeded")
+	}
+	if _, err := json.Marshal(ConfiguredHookHandler{}); err == nil {
+		t.Fatal("empty ConfiguredHookHandler marshal succeeded")
+	}
+	if _, err := json.Marshal(ConfiguredHookMatcherGroup{}); err == nil {
+		t.Fatal("nil matcher hooks marshal succeeded")
+	}
+	if _, err := json.Marshal(ManagedHooksRequirements{}); err == nil {
+		t.Fatal("nil managed hook arrays marshal succeeded")
+	}
+}
+
+func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
+	names := []string{"ConfiguredHookHandler", "ConfiguredHookMatcherGroup", "ManagedHooksRequirements"}
+	for _, binding := range WireTypeBindings() {
+		for _, name := range names {
+			if slices.Contains(binding.Params, name) || slices.Contains(binding.Result, name) {
+				t.Fatalf("%s unexpectedly bound to %s", name, binding.Method)
+			}
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 330 {
+		t.Fatalf("definition count = %d, want 330", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestManagedHooksRequirementsTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	source := string(generated)
+	for _, want := range []string{
+		`export type ConfiguredHookHandler = {`,
+		`"type": "command";`,
+		`"commandWindows": string | null;`,
+		`"timeoutSec": number | null;`,
+		`"statusMessage": string | null;`,
+		`"type": "prompt";`,
+		`"type": "agent";`,
+		`export type ConfiguredHookMatcherGroup = {`,
+		`"hooks": Array<ConfiguredHookHandler>;`,
+		`"matcher": string | null;`,
+		`export type ManagedHooksRequirements = {`,
+		`"managedDir": string | null;`,
+		`"PreToolUse": Array<ConfiguredHookMatcherGroup>;`,
+		`"PermissionRequest": Array<ConfiguredHookMatcherGroup>;`,
+		`"Stop": Array<ConfiguredHookMatcherGroup>;`,
+	} {
+		if !strings.Contains(source, want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}
+
+func assertManagedHooksRoundTrip(t *testing.T, input, want string, target any) {
+	t.Helper()
+	if err := json.Unmarshal([]byte(input), target); err != nil {
+		t.Fatalf("Unmarshal(%s): %v", input, err)
+	}
+	encoded := mustMarshalManagedHooks(t, target)
+	if string(encoded) != want {
+		t.Fatalf("round trip %s = %s, want %s", input, encoded, want)
+	}
+}
+
+func mustMarshalManagedHooks(t *testing.T, value any) []byte {
+	t.Helper()
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("Marshal(%#v): %v", value, err)
+	}
+	return encoded
+}
+
+func cloneManagedHooksMap(source map[string]any) map[string]any {
+	clone := make(map[string]any, len(source))
+	for key, value := range source {
+		clone[key] = value
+	}
+	return clone
+}

--- a/appserver/protocol/managed_hooks_requirements_types.go
+++ b/appserver/protocol/managed_hooks_requirements_types.go
@@ -1,0 +1,301 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// ConfiguredHookHandler retains one exact public managed-hook handler without
+// executing or binding it to Gollem runtime hook behavior.
+type ConfiguredHookHandler struct {
+	raw json.RawMessage
+}
+
+func (h ConfiguredHookHandler) MarshalJSON() ([]byte, error) {
+	if len(h.raw) == 0 {
+		return nil, errors.New("configured hook handler has no value")
+	}
+	return validateConfiguredHookHandlerJSON(h.raw)
+}
+
+func (h *ConfiguredHookHandler) UnmarshalJSON(data []byte) error {
+	if h == nil {
+		return errors.New("decode configured hook handler into nil receiver")
+	}
+	canonical, err := validateConfiguredHookHandlerJSON(data)
+	if err != nil {
+		return err
+	}
+	h.raw = canonical
+	return nil
+}
+
+func validateConfiguredHookHandlerJSON(data []byte) (json.RawMessage, error) {
+	const objectName = "configured hook handler"
+	payload, err := decodeExactThreadItemObject(
+		data,
+		objectName,
+		"type",
+		"command",
+		"commandWindows",
+		"timeoutSec",
+		"async",
+		"statusMessage",
+	)
+	if err != nil {
+		return nil, err
+	}
+	hookType, err := decodeRequiredThreadItemValue[string](payload, objectName, "type")
+	if err != nil {
+		return nil, err
+	}
+	switch hookType {
+	case "command":
+		command, err := decodeRequiredThreadItemValue[string](payload, "command hook handler", "command")
+		if err != nil {
+			return nil, err
+		}
+		commandWindows, err := decodeOptionalNullableConfigRequirementValue[string](
+			payload, "command hook handler", "commandWindows",
+		)
+		if err != nil {
+			return nil, err
+		}
+		timeoutSec, err := decodeOptionalNullableConfigRequirementValue[uint64](
+			payload, "command hook handler", "timeoutSec",
+		)
+		if err != nil {
+			return nil, err
+		}
+		async, err := decodeRequiredThreadItemValue[bool](payload, "command hook handler", "async")
+		if err != nil {
+			return nil, err
+		}
+		statusMessage, err := decodeOptionalNullableConfigRequirementValue[string](
+			payload, "command hook handler", "statusMessage",
+		)
+		if err != nil {
+			return nil, err
+		}
+		return json.Marshal(struct {
+			Type           string  `json:"type"`
+			Command        string  `json:"command"`
+			CommandWindows *string `json:"commandWindows"`
+			TimeoutSec     *uint64 `json:"timeoutSec"`
+			Async          bool    `json:"async"`
+			StatusMessage  *string `json:"statusMessage"`
+		}{
+			Type: hookType, Command: command, CommandWindows: commandWindows,
+			TimeoutSec: timeoutSec, Async: async, StatusMessage: statusMessage,
+		})
+	case "prompt", "agent":
+		if err := rejectThreadItemFields(payload, hookType+" hook handler", "type"); err != nil {
+			return nil, err
+		}
+		return json.Marshal(struct {
+			Type string `json:"type"`
+		}{Type: hookType})
+	default:
+		return nil, fmt.Errorf("unknown configured hook handler type %q", hookType)
+	}
+}
+
+// ConfiguredHookMatcherGroup is the exact public matcher and non-null handler
+// list used by managed hook requirements.
+type ConfiguredHookMatcherGroup struct {
+	Matcher *string                 `json:"matcher"`
+	Hooks   []ConfiguredHookHandler `json:"hooks" jsonschema:"nonnullable=true"`
+}
+
+func (g ConfiguredHookMatcherGroup) MarshalJSON() ([]byte, error) {
+	if g.Hooks == nil {
+		return nil, errors.New("configured hook matcher group hooks cannot be null")
+	}
+	type wire ConfiguredHookMatcherGroup
+	return json.Marshal(wire(g))
+}
+
+func (g *ConfiguredHookMatcherGroup) UnmarshalJSON(data []byte) error {
+	if g == nil {
+		return errors.New("decode configured hook matcher group into nil receiver")
+	}
+	const objectName = "configured hook matcher group"
+	payload, err := decodeExactThreadItemObject(data, objectName, "matcher", "hooks")
+	if err != nil {
+		return err
+	}
+	matcher, err := decodeOptionalNullableConfigRequirementValue[string](payload, objectName, "matcher")
+	if err != nil {
+		return err
+	}
+	hooks, err := decodeRequiredManagedHookArray[ConfiguredHookHandler](payload, objectName, "hooks")
+	if err != nil {
+		return err
+	}
+	*g = ConfiguredHookMatcherGroup{Matcher: matcher, Hooks: hooks}
+	return nil
+}
+
+// ManagedHooksRequirements is the exact standalone public managed-hook
+// requirements value. It does not imply runtime hook execution or enforcement.
+type ManagedHooksRequirements struct {
+	ManagedDir        *string                      `json:"managedDir"`
+	WindowsManagedDir *string                      `json:"windowsManagedDir"`
+	PreToolUse        []ConfiguredHookMatcherGroup `json:"PreToolUse" jsonschema:"nonnullable=true"`
+	PermissionRequest []ConfiguredHookMatcherGroup `json:"PermissionRequest" jsonschema:"nonnullable=true"`
+	PostToolUse       []ConfiguredHookMatcherGroup `json:"PostToolUse" jsonschema:"nonnullable=true"`
+	PreCompact        []ConfiguredHookMatcherGroup `json:"PreCompact" jsonschema:"nonnullable=true"`
+	PostCompact       []ConfiguredHookMatcherGroup `json:"PostCompact" jsonschema:"nonnullable=true"`
+	SessionStart      []ConfiguredHookMatcherGroup `json:"SessionStart" jsonschema:"nonnullable=true"`
+	UserPromptSubmit  []ConfiguredHookMatcherGroup `json:"UserPromptSubmit" jsonschema:"nonnullable=true"`
+	SubagentStart     []ConfiguredHookMatcherGroup `json:"SubagentStart" jsonschema:"nonnullable=true"`
+	SubagentStop      []ConfiguredHookMatcherGroup `json:"SubagentStop" jsonschema:"nonnullable=true"`
+	Stop              []ConfiguredHookMatcherGroup `json:"Stop" jsonschema:"nonnullable=true"`
+}
+
+func (r ManagedHooksRequirements) MarshalJSON() ([]byte, error) {
+	arrays := []struct {
+		name   string
+		values []ConfiguredHookMatcherGroup
+	}{
+		{name: "PreToolUse", values: r.PreToolUse},
+		{name: "PermissionRequest", values: r.PermissionRequest},
+		{name: "PostToolUse", values: r.PostToolUse},
+		{name: "PreCompact", values: r.PreCompact},
+		{name: "PostCompact", values: r.PostCompact},
+		{name: "SessionStart", values: r.SessionStart},
+		{name: "UserPromptSubmit", values: r.UserPromptSubmit},
+		{name: "SubagentStart", values: r.SubagentStart},
+		{name: "SubagentStop", values: r.SubagentStop},
+		{name: "Stop", values: r.Stop},
+	}
+	for _, array := range arrays {
+		if array.values == nil {
+			return nil, fmt.Errorf("managed hook requirements %s cannot be null", array.name)
+		}
+	}
+	type wire ManagedHooksRequirements
+	return json.Marshal(wire(r))
+}
+
+func (r *ManagedHooksRequirements) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("decode managed hook requirements into nil receiver")
+	}
+	const objectName = "managed hook requirements"
+	payload, err := decodeExactThreadItemObject(
+		data,
+		objectName,
+		"managedDir",
+		"windowsManagedDir",
+		"PreToolUse",
+		"PermissionRequest",
+		"PostToolUse",
+		"PreCompact",
+		"PostCompact",
+		"SessionStart",
+		"UserPromptSubmit",
+		"SubagentStart",
+		"SubagentStop",
+		"Stop",
+	)
+	if err != nil {
+		return err
+	}
+	managedDir, err := decodeOptionalNullableConfigRequirementValue[string](payload, objectName, "managedDir")
+	if err != nil {
+		return err
+	}
+	windowsManagedDir, err := decodeOptionalNullableConfigRequirementValue[string](
+		payload, objectName, "windowsManagedDir",
+	)
+	if err != nil {
+		return err
+	}
+	preToolUse, err := decodeRequiredManagedHookArray[ConfiguredHookMatcherGroup](payload, objectName, "PreToolUse")
+	if err != nil {
+		return err
+	}
+	permissionRequest, err := decodeRequiredManagedHookArray[ConfiguredHookMatcherGroup](payload, objectName, "PermissionRequest")
+	if err != nil {
+		return err
+	}
+	postToolUse, err := decodeRequiredManagedHookArray[ConfiguredHookMatcherGroup](payload, objectName, "PostToolUse")
+	if err != nil {
+		return err
+	}
+	preCompact, err := decodeRequiredManagedHookArray[ConfiguredHookMatcherGroup](payload, objectName, "PreCompact")
+	if err != nil {
+		return err
+	}
+	postCompact, err := decodeRequiredManagedHookArray[ConfiguredHookMatcherGroup](payload, objectName, "PostCompact")
+	if err != nil {
+		return err
+	}
+	sessionStart, err := decodeRequiredManagedHookArray[ConfiguredHookMatcherGroup](payload, objectName, "SessionStart")
+	if err != nil {
+		return err
+	}
+	userPromptSubmit, err := decodeRequiredManagedHookArray[ConfiguredHookMatcherGroup](payload, objectName, "UserPromptSubmit")
+	if err != nil {
+		return err
+	}
+	subagentStart, err := decodeRequiredManagedHookArray[ConfiguredHookMatcherGroup](payload, objectName, "SubagentStart")
+	if err != nil {
+		return err
+	}
+	subagentStop, err := decodeRequiredManagedHookArray[ConfiguredHookMatcherGroup](payload, objectName, "SubagentStop")
+	if err != nil {
+		return err
+	}
+	stop, err := decodeRequiredManagedHookArray[ConfiguredHookMatcherGroup](payload, objectName, "Stop")
+	if err != nil {
+		return err
+	}
+	*r = ManagedHooksRequirements{
+		ManagedDir: managedDir, WindowsManagedDir: windowsManagedDir,
+		PreToolUse: preToolUse, PermissionRequest: permissionRequest,
+		PostToolUse: postToolUse, PreCompact: preCompact, PostCompact: postCompact,
+		SessionStart: sessionStart, UserPromptSubmit: userPromptSubmit,
+		SubagentStart: subagentStart, SubagentStop: subagentStop, Stop: stop,
+	}
+	return nil
+}
+
+func decodeRequiredManagedHookArray[T any](
+	payload map[string]json.RawMessage,
+	objectName string,
+	fieldName string,
+) ([]T, error) {
+	raw, ok := payload[fieldName]
+	if !ok {
+		return nil, fmt.Errorf("%s requires %s", objectName, fieldName)
+	}
+	if isJSONNull(raw) {
+		return nil, fmt.Errorf("%s %s cannot be null", objectName, fieldName)
+	}
+	var elements []json.RawMessage
+	if err := json.Unmarshal(raw, &elements); err != nil {
+		return nil, fmt.Errorf("decode %s %s: %w", objectName, fieldName, err)
+	}
+	values := make([]T, len(elements))
+	for index, element := range elements {
+		if isJSONNull(element) {
+			return nil, fmt.Errorf("decode %s %s[%d]: value cannot be null", objectName, fieldName, index)
+		}
+		if err := json.Unmarshal(element, &values[index]); err != nil {
+			return nil, fmt.Errorf("decode %s %s[%d]: %w", objectName, fieldName, index, err)
+		}
+	}
+	return values, nil
+}
+
+var (
+	_ json.Marshaler   = ConfiguredHookHandler{}
+	_ json.Unmarshaler = (*ConfiguredHookHandler)(nil)
+	_ json.Marshaler   = ConfiguredHookMatcherGroup{}
+	_ json.Unmarshaler = (*ConfiguredHookMatcherGroup)(nil)
+	_ json.Marshaler   = ManagedHooksRequirements{}
+	_ json.Unmarshaler = (*ManagedHooksRequirements)(nil)
+)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 327 {
-		t.Fatalf("definition count = %d, want 327", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 330 {
+		t.Fatalf("definition count = %d, want 330", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 327 {
-		t.Fatalf("definition count = %d, want 327", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 330 {
+		t.Fatalf("definition count = %d, want 330", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 327 {
-		t.Fatalf("definition count = %d, want 327", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 330 {
+		t.Fatalf("definition count = %d, want 330", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 327 {
-		t.Fatalf("definition count = %d, want 327", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 330 {
+		t.Fatalf("definition count = %d, want 330", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 327 {
-		t.Fatalf("definition count = %d, want 327", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 330 {
+		t.Fatalf("definition count = %d, want 330", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 327 {
-		t.Fatalf("definition count = %d, want 327", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 330 {
+		t.Fatalf("definition count = %d, want 330", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 327 {
-		t.Fatalf("definition count = %d, want 327", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 330 {
+		t.Fatalf("definition count = %d, want 330", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 327 {
-		t.Fatalf("definition count = %d, want 327", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 330 {
+		t.Fatalf("definition count = %d, want 330", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 327 {
-		t.Fatalf("definition count = %d, want 327", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 330 {
+		t.Fatalf("definition count = %d, want 330", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 327 {
-		t.Fatalf("definition count = %d, want 327", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 330 {
+		t.Fatalf("definition count = %d, want 330", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 327 {
-		t.Fatalf("definition count = %d, want 327", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 330 {
+		t.Fatalf("definition count = %d, want 330", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -124,6 +124,8 @@ func wireSchemaDefinitions() Schema {
 		{Name: "ConfigRequirements", Type: reflect.TypeFor[ConfigRequirements]()},
 		{Name: "ConfigRequirementsReadResponse", Type: reflect.TypeFor[ConfigRequirementsReadResponse]()},
 		{Name: "ConfigWarningNotification", Type: reflect.TypeFor[ConfigWarningNotification]()},
+		{Name: "ConfiguredHookHandler", Type: reflect.TypeFor[ConfiguredHookHandler]()},
+		{Name: "ConfiguredHookMatcherGroup", Type: reflect.TypeFor[ConfiguredHookMatcherGroup]()},
 		{Name: "ContentItem", Type: reflect.TypeFor[ContentItem]()},
 		{Name: "ContextCompactionItem", Type: reflect.TypeFor[ContextCompactionItem]()},
 		{Name: "DaemonShutdownParams", Type: reflect.TypeFor[DaemonShutdownParams]()},
@@ -197,6 +199,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "LegacyAppPathString", Type: reflect.TypeFor[LegacyAppPathString]()},
 		{Name: "LocalShellAction", Type: reflect.TypeFor[LocalShellAction]()},
 		{Name: "LocalShellStatus", Type: reflect.TypeFor[LocalShellStatus]()},
+		{Name: "ManagedHooksRequirements", Type: reflect.TypeFor[ManagedHooksRequirements]()},
 		{Name: "MCPContent", Type: reflect.TypeFor[MCPContent]()},
 		{Name: "MCPToolCallError", Type: reflect.TypeFor[MCPToolCallError]()},
 		{Name: "MCPToolCallItem", Type: reflect.TypeFor[MCPToolCallItem]()},
@@ -440,6 +443,7 @@ func wireSchemaDefinitions() Schema {
 	schemas["WindowsSandboxSetupMode"] = stringEnumSchema(
 		string(WindowsSandboxSetupModeElevated), string(WindowsSandboxSetupModeUnelevated),
 	)
+	schemas["ConfiguredHookHandler"] = configuredHookHandlerSchema()
 	configRequirementsProperties := schemas["ConfigRequirements"].(Schema)["properties"].(Schema)
 	for _, name := range []string{"allowedPermissionProfiles", "featureRequirements"} {
 		variants := configRequirementsProperties[name].(Schema)["anyOf"].([]any)
@@ -1295,6 +1299,42 @@ func webSearchActionSchema() Schema {
 func webSearchActionVariantSchema(actionType string, requiredFields []string, fields Schema) Schema {
 	properties := Schema{
 		"type": Schema{"type": "string", "enum": []any{actionType}},
+	}
+	for name, schema := range fields {
+		properties[name] = schema
+	}
+	required := []string{"type"}
+	required = append(required, requiredFields...)
+	return Schema{
+		"type":                 "object",
+		"properties":           properties,
+		"required":             required,
+		"additionalProperties": false,
+	}
+}
+
+func configuredHookHandlerSchema() Schema {
+	return Schema{"oneOf": []any{
+		configuredHookHandlerVariantSchema("command", []string{
+			"command", "commandWindows", "timeoutSec", "async", "statusMessage",
+		}, Schema{
+			"command":        Schema{"type": "string"},
+			"commandWindows": nullableStringSchema(),
+			"timeoutSec": Schema{"anyOf": []any{
+				Schema{"type": "integer", "minimum": 0},
+				Schema{"type": "null"},
+			}},
+			"async":         Schema{"type": "boolean"},
+			"statusMessage": nullableStringSchema(),
+		}),
+		configuredHookHandlerVariantSchema("prompt", nil, nil),
+		configuredHookHandlerVariantSchema("agent", nil, nil),
+	}}
+}
+
+func configuredHookHandlerVariantSchema(hookType string, requiredFields []string, fields Schema) Schema {
+	properties := Schema{
+		"type": Schema{"type": "string", "enum": []any{hookType}},
 	}
 	for name, schema := range fields {
 		properties[name] = schema

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -1603,6 +1603,123 @@
       ],
       "type": "object"
     },
+    "ConfiguredHookHandler": {
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "async": {
+              "type": "boolean"
+            },
+            "command": {
+              "type": "string"
+            },
+            "commandWindows": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "statusMessage": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "timeoutSec": {
+              "anyOf": [
+                {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "type": {
+              "enum": [
+                "command"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "command",
+            "commandWindows",
+            "timeoutSec",
+            "async",
+            "statusMessage"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "enum": [
+                "prompt"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "enum": [
+                "agent"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "ConfiguredHookMatcherGroup": {
+      "additionalProperties": false,
+      "properties": {
+        "hooks": {
+          "items": {
+            "$ref": "#/$defs/ConfiguredHookHandler"
+          },
+          "type": "array"
+        },
+        "matcher": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "matcher",
+        "hooks"
+      ],
+      "type": "object"
+    },
     "ContentItem": {
       "oneOf": [
         {
@@ -3801,6 +3918,106 @@
         "content",
         "structuredContent",
         "_meta"
+      ],
+      "type": "object"
+    },
+    "ManagedHooksRequirements": {
+      "additionalProperties": false,
+      "properties": {
+        "PermissionRequest": {
+          "items": {
+            "$ref": "#/$defs/ConfiguredHookMatcherGroup"
+          },
+          "type": "array"
+        },
+        "PostCompact": {
+          "items": {
+            "$ref": "#/$defs/ConfiguredHookMatcherGroup"
+          },
+          "type": "array"
+        },
+        "PostToolUse": {
+          "items": {
+            "$ref": "#/$defs/ConfiguredHookMatcherGroup"
+          },
+          "type": "array"
+        },
+        "PreCompact": {
+          "items": {
+            "$ref": "#/$defs/ConfiguredHookMatcherGroup"
+          },
+          "type": "array"
+        },
+        "PreToolUse": {
+          "items": {
+            "$ref": "#/$defs/ConfiguredHookMatcherGroup"
+          },
+          "type": "array"
+        },
+        "SessionStart": {
+          "items": {
+            "$ref": "#/$defs/ConfiguredHookMatcherGroup"
+          },
+          "type": "array"
+        },
+        "Stop": {
+          "items": {
+            "$ref": "#/$defs/ConfiguredHookMatcherGroup"
+          },
+          "type": "array"
+        },
+        "SubagentStart": {
+          "items": {
+            "$ref": "#/$defs/ConfiguredHookMatcherGroup"
+          },
+          "type": "array"
+        },
+        "SubagentStop": {
+          "items": {
+            "$ref": "#/$defs/ConfiguredHookMatcherGroup"
+          },
+          "type": "array"
+        },
+        "UserPromptSubmit": {
+          "items": {
+            "$ref": "#/$defs/ConfiguredHookMatcherGroup"
+          },
+          "type": "array"
+        },
+        "managedDir": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "windowsManagedDir": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "managedDir",
+        "windowsManagedDir",
+        "PreToolUse",
+        "PermissionRequest",
+        "PostToolUse",
+        "PreCompact",
+        "PostCompact",
+        "SessionStart",
+        "UserPromptSubmit",
+        "SubagentStart",
+        "SubagentStop",
+        "Stop"
       ],
       "type": "object"
     },

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 327 {
-		t.Fatalf("definition count = %d, want 327", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 330 {
+		t.Fatalf("definition count = %d, want 330", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 327 {
-		t.Fatalf("definition count = %d, want 327", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 330 {
+		t.Fatalf("definition count = %d, want 330", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 327 {
-		t.Fatalf("definition count = %d, want 327", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 330 {
+		t.Fatalf("definition count = %d, want 330", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 327 {
-		t.Fatalf("definition count = %d, want 327", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 330 {
+		t.Fatalf("definition count = %d, want 330", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 327 {
-		t.Fatalf("definition count = %d, want 327", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 330 {
+		t.Fatalf("definition count = %d, want 330", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 327 {
-		t.Fatalf("definition count = %d, want 327", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 330 {
+		t.Fatalf("definition count = %d, want 330", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 327 {
-		t.Fatalf("definition count = %d, want 327", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 330 {
+		t.Fatalf("definition count = %d, want 330", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 327 {
-		t.Fatalf("definition count = %d, want 327", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 330 {
+		t.Fatalf("definition count = %d, want 330", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 327 {
-		t.Fatalf("definition count = %d, want 327", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 330 {
+		t.Fatalf("definition count = %d, want 330", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 327 {
-		t.Fatalf("definition count = %d, want 327", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 330 {
+		t.Fatalf("definition count = %d, want 330", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 327 {
-		t.Fatalf("definition count = %d, want 327", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 330 {
+		t.Fatalf("definition count = %d, want 330", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 327 {
-		t.Fatalf("definition count = %d, want 327", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 330 {
+		t.Fatalf("definition count = %d, want 330", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -813,6 +813,24 @@ export type ConfigWarningNotification = {
   "summary": string;
 };
 
+export type ConfiguredHookHandler = {
+  "async": boolean;
+  "command": string;
+  "commandWindows": string | null;
+  "statusMessage": string | null;
+  "timeoutSec": number | null;
+  "type": "command";
+} | {
+  "type": "prompt";
+} | {
+  "type": "agent";
+};
+
+export type ConfiguredHookMatcherGroup = {
+  "hooks": Array<ConfiguredHookHandler>;
+  "matcher": string | null;
+};
+
 export type ContentItem = {
   "text": string;
   "type": "input_text";
@@ -1352,6 +1370,21 @@ export type MCPToolCallResult = {
   "_meta": unknown;
   "content": Array<MCPContent> | null;
   "structuredContent": unknown;
+};
+
+export type ManagedHooksRequirements = {
+  "PermissionRequest": Array<ConfiguredHookMatcherGroup>;
+  "PostCompact": Array<ConfiguredHookMatcherGroup>;
+  "PostToolUse": Array<ConfiguredHookMatcherGroup>;
+  "PreCompact": Array<ConfiguredHookMatcherGroup>;
+  "PreToolUse": Array<ConfiguredHookMatcherGroup>;
+  "SessionStart": Array<ConfiguredHookMatcherGroup>;
+  "Stop": Array<ConfiguredHookMatcherGroup>;
+  "SubagentStart": Array<ConfiguredHookMatcherGroup>;
+  "SubagentStop": Array<ConfiguredHookMatcherGroup>;
+  "UserPromptSubmit": Array<ConfiguredHookMatcherGroup>;
+  "managedDir": string | null;
+  "windowsManagedDir": string | null;
 };
 
 export type McpElicitationArrayType = "array";

--- a/appserver/protocol/typescript/testdata/managed_hooks_requirements_contract.ts
+++ b/appserver/protocol/typescript/testdata/managed_hooks_requirements_contract.ts
@@ -1,0 +1,143 @@
+import type {
+  ConfiguredHookHandler,
+  ConfiguredHookMatcherGroup,
+  ManagedHooksRequirements,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? (<T>() => T extends B ? 1 : 2) extends
+        (<T>() => T extends A ? 1 : 2)
+      ? true
+      : false
+    : false;
+type Expect<T extends true> = T;
+
+type ManagedHooksRequirementsContract = [
+  Expect<Equal<ConfiguredHookHandler,
+    | {
+        type: "command";
+        command: string;
+        commandWindows: string | null;
+        timeoutSec: number | null;
+        async: boolean;
+        statusMessage: string | null;
+      }
+    | { type: "prompt" }
+    | { type: "agent" }
+  >>,
+  Expect<Equal<ConfiguredHookMatcherGroup, {
+    matcher: string | null;
+    hooks: ConfiguredHookHandler[];
+  }>>,
+  Expect<Equal<ManagedHooksRequirements, {
+    managedDir: string | null;
+    windowsManagedDir: string | null;
+    PreToolUse: ConfiguredHookMatcherGroup[];
+    PermissionRequest: ConfiguredHookMatcherGroup[];
+    PostToolUse: ConfiguredHookMatcherGroup[];
+    PreCompact: ConfiguredHookMatcherGroup[];
+    PostCompact: ConfiguredHookMatcherGroup[];
+    SessionStart: ConfiguredHookMatcherGroup[];
+    UserPromptSubmit: ConfiguredHookMatcherGroup[];
+    SubagentStart: ConfiguredHookMatcherGroup[];
+    SubagentStop: ConfiguredHookMatcherGroup[];
+    Stop: ConfiguredHookMatcherGroup[];
+  }>>,
+];
+
+[
+  {
+    type: "command",
+    command: "",
+    commandWindows: null,
+    timeoutSec: null,
+    async: false,
+    statusMessage: null,
+  },
+  {
+    type: "command",
+    command: "run",
+    commandWindows: "run.exe",
+    timeoutSec: 0,
+    async: true,
+    statusMessage: "working",
+  },
+  { type: "prompt" },
+  { type: "agent" },
+] satisfies ConfiguredHookHandler[];
+
+const emptyRequirements = {
+  managedDir: null,
+  windowsManagedDir: null,
+  PreToolUse: [],
+  PermissionRequest: [],
+  PostToolUse: [],
+  PreCompact: [],
+  PostCompact: [],
+  SessionStart: [],
+  UserPromptSubmit: [],
+  SubagentStart: [],
+  SubagentStop: [],
+  Stop: [],
+} satisfies ManagedHooksRequirements;
+
+({
+  managedDir: "",
+  windowsManagedDir: "C:\\hooks",
+  PreToolUse: [{ matcher: "tool", hooks: [{ type: "prompt" }] }],
+  PermissionRequest: [{ matcher: null, hooks: [{ type: "agent" }] }],
+  PostToolUse: [],
+  PreCompact: [],
+  PostCompact: [],
+  SessionStart: [],
+  UserPromptSubmit: [],
+  SubagentStart: [],
+  SubagentStop: [],
+  Stop: [],
+}) satisfies ManagedHooksRequirements;
+
+// @ts-expect-error command is required.
+({ type: "command", commandWindows: null, timeoutSec: null, async: false, statusMessage: null }) satisfies ConfiguredHookHandler;
+// @ts-expect-error async is required.
+({ type: "command", command: "run", commandWindows: null, timeoutSec: null, statusMessage: null }) satisfies ConfiguredHookHandler;
+// @ts-expect-error commandWindows is required nullable.
+({ type: "command", command: "run", timeoutSec: null, async: false, statusMessage: null }) satisfies ConfiguredHookHandler;
+// @ts-expect-error timeoutSec is required nullable.
+({ type: "command", command: "run", commandWindows: null, async: false, statusMessage: null }) satisfies ConfiguredHookHandler;
+// @ts-expect-error statusMessage is required nullable.
+({ type: "command", command: "run", commandWindows: null, timeoutSec: null, async: false }) satisfies ConfiguredHookHandler;
+// @ts-expect-error timeoutSec is a nullable number.
+({ type: "command", command: "run", commandWindows: null, timeoutSec: "1", async: false, statusMessage: null }) satisfies ConfiguredHookHandler;
+// @ts-expect-error prompt is a closed type-only variant.
+({ type: "prompt", command: "run" }) satisfies ConfiguredHookHandler;
+// @ts-expect-error agent is a closed type-only variant.
+({ type: "agent", async: false }) satisfies ConfiguredHookHandler;
+// @ts-expect-error handler discriminators are closed.
+({ type: "other" }) satisfies ConfiguredHookHandler;
+// @ts-expect-error matcher is required nullable.
+({ hooks: [] }) satisfies ConfiguredHookMatcherGroup;
+// @ts-expect-error hooks is required and non-null.
+({ matcher: null, hooks: null }) satisfies ConfiguredHookMatcherGroup;
+// @ts-expect-error hook arrays exclude null members.
+({ matcher: null, hooks: [null] }) satisfies ConfiguredHookMatcherGroup;
+// @ts-expect-error matcher is a nullable string.
+({ matcher: 1, hooks: [] }) satisfies ConfiguredHookMatcherGroup;
+// @ts-expect-error groups are closed.
+({ matcher: null, hooks: [], extra: true }) satisfies ConfiguredHookMatcherGroup;
+// @ts-expect-error every requirements field is required.
+({ Stop: [] }) satisfies ManagedHooksRequirements;
+// @ts-expect-error event keys are case-sensitive.
+({ ...emptyRequirements, preToolUse: [] }) satisfies ManagedHooksRequirements;
+// @ts-expect-error requirement arrays exclude null members.
+({ ...emptyRequirements, PreToolUse: [null] }) satisfies ManagedHooksRequirements;
+// @ts-expect-error managedDir is a nullable string.
+({ ...emptyRequirements, managedDir: false }) satisfies ManagedHooksRequirements;
+// @ts-expect-error nested handlers remain strict.
+({ ...emptyRequirements, Stop: [{ matcher: null, hooks: [{ type: "other" }] }] }) satisfies ManagedHooksRequirements;
+// @ts-expect-error requirements are closed.
+({ ...emptyRequirements, extra: true }) satisfies ManagedHooksRequirements;
+
+declare const contract: ManagedHooksRequirementsContract;
+void contract;

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 327 {
-		t.Fatalf("definition count = %d, want 327", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 330 {
+		t.Fatalf("definition count = %d, want 330", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary

- export exact standalone `ConfiguredHookHandler`, `ConfiguredHookMatcherGroup`, and `ManagedHooksRequirements` protocol contracts
- preserve strict canonical JSON semantics for the handler union, nullable matchers/directories, and all required non-null arrays
- regenerate the Go schema and TypeScript surface without adding runtime dispatch, method, wire, or item bindings

## Contract evidence

- public source commit: `5c19155cbd93bfa099016e7487259f61669823ff`
- normalized three-definition public schema SHA-256: `9fe25fe55a97182bd60b3bf706d68dbe0cfeec4c8c968001c5e4233a3afd838c`
- deliberate red, after correcting a disposable fixture import path: 3 missing exports, 3 false exact identities, 20 unused `@ts-expect-error` directives
- generated schema: 330 definitions / 224 methods / 59 wire bindings / 5 item bindings
- generated schema SHA-256: `4d5504e20d12d158657c8b0e43e56df5e6a95df741dcd272550738db5e470b48`
- generated TypeScript SHA-256: `4c88c3719cbb74bac545660ca32cfd8a7466e69c63f7c04633b51f6e8485f216`
- TypeScript contract fixture SHA-256: `4d02cddba44ab49c29e559d455bec508dcd966a6b2a756e868450fc342d97c26`

## Verification

- focused Go contract tests, including 30 repeated runs and race detection
- 100% statement coverage for every new codec/validation function; aggregate protocol coverage 95.9%
- full protocol normal and race suites
- every non-Monty package under fresh normal and race runs
- `golangci-lint run ./...`, `go vet ./...`, and exact `go mod tidy`
- deterministic generation run twice with identical output; strict TypeScript fixture passes
- configured pre-push hook passes
- feature binary SHA-256: `755a4389f302ab0dbf6652fc16d7e5eac373f6759721a75f3cbdedfc9ec3ae4b`
- all five downstream Slang integration workflows pass
- live compatibility remains 4 requirements / 4 data entries with normalized SHA-256 `b52199eba1a8d047d481a617d3e4a0fd277c4f6029ba65e41600d4ef215c4a65`

Local Monty normal/race/coverage runs were intentionally skipped per project direction because of runtime cost. Repository and hosted checks remain unchanged.