### PR TITLE
appserver/protocol: export network requirements

### DIFF
--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 330 {
-		t.Fatalf("definition count = %d, want 330", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 333 {
+		t.Fatalf("definition count = %d, want 333", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 330 {
-		t.Fatalf("definition count = %d, want 330", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 333 {
+		t.Fatalf("definition count = %d, want 333", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 330 {
-		t.Fatalf("definition count = %d, want 330", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 333 {
+		t.Fatalf("definition count = %d, want 333", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 330 {
-		t.Fatalf("definition count = %d, want 330", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 333 {
+		t.Fatalf("definition count = %d, want 333", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 330 {
-		t.Fatalf("definition count = %d, want 330", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 333 {
+		t.Fatalf("definition count = %d, want 333", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 330 {
-		t.Fatalf("definition count = %d, want 330", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 333 {
+		t.Fatalf("definition count = %d, want 333", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 330 {
-		t.Fatalf("definition count = %d, want 330", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 333 {
+		t.Fatalf("definition count = %d, want 333", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 330 {
-		t.Fatalf("definition count = %d, want 330", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 333 {
+		t.Fatalf("definition count = %d, want 333", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 330 {
-		t.Fatalf("definition count = %d, want 330", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 333 {
+		t.Fatalf("definition count = %d, want 333", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 330 {
-		t.Fatalf("definition count = %d, want 330", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 333 {
+		t.Fatalf("definition count = %d, want 333", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 330 {
-		t.Fatalf("definition count = %d, want 330", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 333 {
+		t.Fatalf("definition count = %d, want 333", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -1,0 +1,207 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestNetworkRequirementSchemasAreExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	for _, name := range []string{"NetworkDomainPermission", "NetworkUnixSocketPermission"} {
+		got := defs[name].(Schema)
+		if got["type"] != "string" || !reflect.DeepEqual(got["enum"], []any{"allow", "deny"}) {
+			t.Errorf("%s schema = %#v, want allow/deny string enum", name, got)
+		}
+	}
+
+	fields := []string{
+		"enabled", "httpPort", "socksPort", "allowUpstreamProxy",
+		"dangerouslyAllowNonLoopbackProxy", "dangerouslyAllowAllUnixSockets",
+		"domains", "managedAllowedDomainsOnly", "allowedDomains", "deniedDomains",
+		"unixSockets", "allowUnixSockets", "allowLocalBinding",
+	}
+	requirements := defs["NetworkRequirements"].(Schema)
+	assertClosedObjectSchema(t, requirements, fields...)
+	properties := requirements["properties"].(Schema)
+	for _, name := range []string{
+		"enabled", "allowUpstreamProxy", "dangerouslyAllowNonLoopbackProxy",
+		"dangerouslyAllowAllUnixSockets", "managedAllowedDomainsOnly", "allowLocalBinding",
+	} {
+		assertConfigNullableSchema(t, properties[name], Schema{"type": "boolean"})
+	}
+	for _, name := range []string{"httpPort", "socksPort"} {
+		assertConfigNullableSchema(t, properties[name], Schema{
+			"type": "integer", "minimum": 0, "maximum": 65535,
+		})
+	}
+	assertConfigNullableSchema(
+		t,
+		properties["domains"],
+		networkRequirementsMapSchema("NetworkDomainPermission"),
+	)
+	assertConfigNullableSchema(
+		t,
+		properties["unixSockets"],
+		networkRequirementsMapSchema("NetworkUnixSocketPermission"),
+	)
+	for _, name := range []string{"allowedDomains", "deniedDomains", "allowUnixSockets"} {
+		assertConfigNullableSchema(t, properties[name], Schema{
+			"type": "array", "items": Schema{"type": "string"},
+		})
+	}
+}
+
+func TestNetworkRequirementLeafValuesAreExact(t *testing.T) {
+	for _, value := range []NetworkDomainPermission{
+		NetworkDomainPermissionAllow, NetworkDomainPermissionDeny,
+	} {
+		assertConfigRequirementEnumRoundTrip(t, value)
+	}
+	for _, value := range []NetworkUnixSocketPermission{
+		NetworkUnixSocketPermissionAllow, NetworkUnixSocketPermissionDeny,
+	} {
+		assertConfigRequirementEnumRoundTrip(t, value)
+	}
+
+	for _, input := range []string{`null`, `"permit"`, `""`, `1`, `true`, `[]`, `"allow" {}`} {
+		assertJSONRejects[NetworkDomainPermission](t, input)
+		assertJSONRejects[NetworkUnixSocketPermission](t, input)
+	}
+}
+
+func TestNetworkRequirementsAcceptExactWireForms(t *testing.T) {
+	nullCanonical := `{"enabled":null,"httpPort":null,"socksPort":null,"allowUpstreamProxy":null,"dangerouslyAllowNonLoopbackProxy":null,"dangerouslyAllowAllUnixSockets":null,"domains":null,"managedAllowedDomainsOnly":null,"allowedDomains":null,"deniedDomains":null,"unixSockets":null,"allowUnixSockets":null,"allowLocalBinding":null}`
+	var omitted NetworkRequirements
+	assertConfigRequirementsRoundTrip(t, `{}`, nullCanonical, &omitted)
+	var explicitNull NetworkRequirements
+	assertConfigRequirementsRoundTrip(t, nullCanonical, nullCanonical, &explicitNull)
+	emptyCollections := `{"domains":{},"allowedDomains":[],"deniedDomains":[],"unixSockets":{},"allowUnixSockets":[]}`
+	emptyCollectionsCanonical := `{"enabled":null,"httpPort":null,"socksPort":null,"allowUpstreamProxy":null,"dangerouslyAllowNonLoopbackProxy":null,"dangerouslyAllowAllUnixSockets":null,"domains":{},"managedAllowedDomainsOnly":null,"allowedDomains":[],"deniedDomains":[],"unixSockets":{},"allowUnixSockets":[],"allowLocalBinding":null}`
+	var emptyValues NetworkRequirements
+	assertConfigRequirementsRoundTrip(t, emptyCollections, emptyCollectionsCanonical, &emptyValues)
+
+	full := `{"enabled":false,"httpPort":0,"socksPort":65535,"allowUpstreamProxy":true,"dangerouslyAllowNonLoopbackProxy":false,"dangerouslyAllowAllUnixSockets":true,"domains":{"":"allow","example.com":"deny"},"managedAllowedDomainsOnly":false,"allowedDomains":["","example.com","example.com"],"deniedDomains":[],"unixSockets":{"":"deny","/tmp/codex.sock":"allow"},"allowUnixSockets":["","/tmp/codex.sock","/tmp/codex.sock"],"allowLocalBinding":true}`
+	var fullValue NetworkRequirements
+	assertConfigRequirementsRoundTrip(t, full, full, &fullValue)
+}
+
+func TestNetworkRequirementsRejectMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		`null`, `[]`, `"value"`, `1`, `true`,
+		`{"enabled":0}`,
+		`{"httpPort":"80"}`,
+		`{"httpPort":-1}`,
+		`{"httpPort":1.5}`,
+		`{"httpPort":65536}`,
+		`{"socksPort":-1}`,
+		`{"socksPort":1.5}`,
+		`{"socksPort":65536}`,
+		`{"allowUpstreamProxy":"true"}`,
+		`{"dangerouslyAllowNonLoopbackProxy":0}`,
+		`{"dangerouslyAllowAllUnixSockets":[]}`,
+		`{"domains":[]}`,
+		`{"domains":{"example.com":null}}`,
+		`{"domains":{"example.com":"permit"}}`,
+		`{"managedAllowedDomainsOnly":1}`,
+		`{"allowedDomains":{}}`,
+		`{"allowedDomains":[null]}`,
+		`{"deniedDomains":[1]}`,
+		`{"unixSockets":[]}`,
+		`{"unixSockets":{"/tmp/codex.sock":null}}`,
+		`{"unixSockets":{"/tmp/codex.sock":"permit"}}`,
+		`{"allowUnixSockets":[null]}`,
+		`{"allowLocalBinding":"false"}`,
+		`{"extra":true}`,
+		`{} {}`,
+	} {
+		assertJSONRejects[NetworkRequirements](t, input)
+	}
+}
+
+func TestNetworkRequirementsNilReceiversAndInvalidMarshal(t *testing.T) {
+	var domain *NetworkDomainPermission
+	if err := domain.UnmarshalJSON([]byte(`"allow"`)); err == nil {
+		t.Fatal("nil NetworkDomainPermission receiver succeeded")
+	}
+	var socket *NetworkUnixSocketPermission
+	if err := socket.UnmarshalJSON([]byte(`"allow"`)); err == nil {
+		t.Fatal("nil NetworkUnixSocketPermission receiver succeeded")
+	}
+	var requirements *NetworkRequirements
+	if err := requirements.UnmarshalJSON([]byte(`{}`)); err == nil {
+		t.Fatal("nil NetworkRequirements receiver succeeded")
+	}
+	if _, err := json.Marshal(NetworkDomainPermission("permit")); err == nil {
+		t.Fatal("invalid NetworkDomainPermission marshal succeeded")
+	}
+	if _, err := json.Marshal(NetworkUnixSocketPermission("permit")); err == nil {
+		t.Fatal("invalid NetworkUnixSocketPermission marshal succeeded")
+	}
+	invalidDomains := map[string]NetworkDomainPermission{"example.com": "permit"}
+	if _, err := json.Marshal(NetworkRequirements{Domains: &invalidDomains}); err == nil {
+		t.Fatal("invalid nested domain permission marshal succeeded")
+	}
+	invalidSockets := map[string]NetworkUnixSocketPermission{"/tmp/codex.sock": "permit"}
+	if _, err := json.Marshal(NetworkRequirements{UnixSockets: &invalidSockets}); err == nil {
+		t.Fatal("invalid nested Unix-socket permission marshal succeeded")
+	}
+}
+
+func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
+	names := []string{"NetworkDomainPermission", "NetworkUnixSocketPermission", "NetworkRequirements"}
+	for _, binding := range WireTypeBindings() {
+		for _, name := range names {
+			if slices.Contains(binding.Params, name) || slices.Contains(binding.Result, name) {
+				t.Fatalf("%s unexpectedly bound to %s", name, binding.Method)
+			}
+		}
+	}
+	configProperties := JSONSchema()["$defs"].(Schema)["ConfigRequirements"].(Schema)["properties"].(Schema)
+	if _, ok := configProperties["network"]; ok {
+		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 333 {
+		t.Fatalf("definition count = %d, want 333", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestNetworkRequirementsTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	source := string(generated)
+	for _, want := range []string{
+		`export type NetworkDomainPermission = "allow" | "deny";`,
+		`export type NetworkUnixSocketPermission = "allow" | "deny";`,
+		`export type NetworkRequirements = {`,
+		`"enabled": boolean | null;`,
+		`"httpPort": number | null;`,
+		`"socksPort": number | null;`,
+		`"domains": { [key in string]?: NetworkDomainPermission } | null;`,
+		`"allowedDomains": Array<string> | null;`,
+		`"unixSockets": { [key in string]?: NetworkUnixSocketPermission } | null;`,
+		`"allowUnixSockets": Array<string> | null;`,
+		`"allowLocalBinding": boolean | null;`,
+	} {
+		if !strings.Contains(source, want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}
+
+func networkRequirementsMapSchema(permission string) Schema {
+	return Schema{
+		"type": "object", "additionalProperties": Schema{"$ref": "#/$defs/" + permission},
+		"x-gollem-typescript-optional-map": true,
+	}
+}

--- a/appserver/protocol/network_requirements_types.go
+++ b/appserver/protocol/network_requirements_types.go
@@ -1,0 +1,220 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// NetworkDomainPermission is the exact closed public domain permission.
+type NetworkDomainPermission string
+
+const (
+	NetworkDomainPermissionAllow NetworkDomainPermission = "allow"
+	NetworkDomainPermissionDeny  NetworkDomainPermission = "deny"
+)
+
+func (p NetworkDomainPermission) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(p, "network domain permission", NetworkDomainPermission.valid)
+}
+
+func (p *NetworkDomainPermission) UnmarshalJSON(data []byte) error {
+	return unmarshalThreadTurnLeafEnum(data, p, "network domain permission", NetworkDomainPermission.valid)
+}
+
+func (p NetworkDomainPermission) valid() bool {
+	return p == NetworkDomainPermissionAllow || p == NetworkDomainPermissionDeny
+}
+
+// NetworkUnixSocketPermission is the exact closed public Unix-socket permission.
+type NetworkUnixSocketPermission string
+
+const (
+	NetworkUnixSocketPermissionAllow NetworkUnixSocketPermission = "allow"
+	NetworkUnixSocketPermissionDeny  NetworkUnixSocketPermission = "deny"
+)
+
+func (p NetworkUnixSocketPermission) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(p, "network Unix-socket permission", NetworkUnixSocketPermission.valid)
+}
+
+func (p *NetworkUnixSocketPermission) UnmarshalJSON(data []byte) error {
+	return unmarshalThreadTurnLeafEnum(
+		data,
+		p,
+		"network Unix-socket permission",
+		NetworkUnixSocketPermission.valid,
+	)
+}
+
+func (p NetworkUnixSocketPermission) valid() bool {
+	return p == NetworkUnixSocketPermissionAllow || p == NetworkUnixSocketPermissionDeny
+}
+
+// NetworkRequirements is the exact standalone public network-requirements
+// value. It does not configure a proxy or imply runtime network enforcement.
+type NetworkRequirements struct {
+	Enabled                          *bool                                   `json:"enabled"`
+	HTTPPort                         *uint16                                 `json:"httpPort"`
+	SOCKSPort                        *uint16                                 `json:"socksPort"`
+	AllowUpstreamProxy               *bool                                   `json:"allowUpstreamProxy"`
+	DangerouslyAllowNonLoopbackProxy *bool                                   `json:"dangerouslyAllowNonLoopbackProxy"`
+	DangerouslyAllowAllUnixSockets   *bool                                   `json:"dangerouslyAllowAllUnixSockets"`
+	Domains                          *map[string]NetworkDomainPermission     `json:"domains"`
+	ManagedAllowedDomainsOnly        *bool                                   `json:"managedAllowedDomainsOnly"`
+	AllowedDomains                   *[]string                               `json:"allowedDomains"`
+	DeniedDomains                    *[]string                               `json:"deniedDomains"`
+	UnixSockets                      *map[string]NetworkUnixSocketPermission `json:"unixSockets"`
+	AllowUnixSockets                 *[]string                               `json:"allowUnixSockets"`
+	AllowLocalBinding                *bool                                   `json:"allowLocalBinding"`
+}
+
+func (r *NetworkRequirements) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("decode network requirements into nil receiver")
+	}
+	const objectName = "network requirements"
+	payload, err := decodeExactThreadItemObject(
+		data,
+		objectName,
+		"enabled",
+		"httpPort",
+		"socksPort",
+		"allowUpstreamProxy",
+		"dangerouslyAllowNonLoopbackProxy",
+		"dangerouslyAllowAllUnixSockets",
+		"domains",
+		"managedAllowedDomainsOnly",
+		"allowedDomains",
+		"deniedDomains",
+		"unixSockets",
+		"allowUnixSockets",
+		"allowLocalBinding",
+	)
+	if err != nil {
+		return err
+	}
+	enabled, err := decodeOptionalNullableConfigRequirementValue[bool](payload, objectName, "enabled")
+	if err != nil {
+		return err
+	}
+	httpPort, err := decodeOptionalNullableConfigRequirementValue[uint16](payload, objectName, "httpPort")
+	if err != nil {
+		return err
+	}
+	socksPort, err := decodeOptionalNullableConfigRequirementValue[uint16](payload, objectName, "socksPort")
+	if err != nil {
+		return err
+	}
+	allowUpstreamProxy, err := decodeOptionalNullableConfigRequirementValue[bool](
+		payload, objectName, "allowUpstreamProxy",
+	)
+	if err != nil {
+		return err
+	}
+	dangerouslyAllowNonLoopbackProxy, err := decodeOptionalNullableConfigRequirementValue[bool](
+		payload, objectName, "dangerouslyAllowNonLoopbackProxy",
+	)
+	if err != nil {
+		return err
+	}
+	dangerouslyAllowAllUnixSockets, err := decodeOptionalNullableConfigRequirementValue[bool](
+		payload, objectName, "dangerouslyAllowAllUnixSockets",
+	)
+	if err != nil {
+		return err
+	}
+	domains, err := decodeOptionalNullableNetworkRequirementMap[NetworkDomainPermission](
+		payload, objectName, "domains",
+	)
+	if err != nil {
+		return err
+	}
+	managedAllowedDomainsOnly, err := decodeOptionalNullableConfigRequirementValue[bool](
+		payload, objectName, "managedAllowedDomainsOnly",
+	)
+	if err != nil {
+		return err
+	}
+	allowedDomains, err := decodeOptionalNullableConfigRequirementArray[string](
+		payload, objectName, "allowedDomains",
+	)
+	if err != nil {
+		return err
+	}
+	deniedDomains, err := decodeOptionalNullableConfigRequirementArray[string](
+		payload, objectName, "deniedDomains",
+	)
+	if err != nil {
+		return err
+	}
+	unixSockets, err := decodeOptionalNullableNetworkRequirementMap[NetworkUnixSocketPermission](
+		payload, objectName, "unixSockets",
+	)
+	if err != nil {
+		return err
+	}
+	allowUnixSockets, err := decodeOptionalNullableConfigRequirementArray[string](
+		payload, objectName, "allowUnixSockets",
+	)
+	if err != nil {
+		return err
+	}
+	allowLocalBinding, err := decodeOptionalNullableConfigRequirementValue[bool](
+		payload, objectName, "allowLocalBinding",
+	)
+	if err != nil {
+		return err
+	}
+	*r = NetworkRequirements{
+		Enabled:                          enabled,
+		HTTPPort:                         httpPort,
+		SOCKSPort:                        socksPort,
+		AllowUpstreamProxy:               allowUpstreamProxy,
+		DangerouslyAllowNonLoopbackProxy: dangerouslyAllowNonLoopbackProxy,
+		DangerouslyAllowAllUnixSockets:   dangerouslyAllowAllUnixSockets,
+		Domains:                          domains,
+		ManagedAllowedDomainsOnly:        managedAllowedDomainsOnly,
+		AllowedDomains:                   allowedDomains,
+		DeniedDomains:                    deniedDomains,
+		UnixSockets:                      unixSockets,
+		AllowUnixSockets:                 allowUnixSockets,
+		AllowLocalBinding:                allowLocalBinding,
+	}
+	return nil
+}
+
+func decodeOptionalNullableNetworkRequirementMap[T any](
+	payload map[string]json.RawMessage,
+	objectName string,
+	fieldName string,
+) (*map[string]T, error) {
+	raw, ok := payload[fieldName]
+	if !ok || isJSONNull(raw) {
+		return nil, nil
+	}
+	var entries map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &entries); err != nil {
+		return nil, fmt.Errorf("decode %s %s: %w", objectName, fieldName, err)
+	}
+	values := make(map[string]T, len(entries))
+	for name, encoded := range entries {
+		if isJSONNull(encoded) {
+			return nil, fmt.Errorf("decode %s %s[%q]: value cannot be null", objectName, fieldName, name)
+		}
+		var value T
+		if err := json.Unmarshal(encoded, &value); err != nil {
+			return nil, fmt.Errorf("decode %s %s[%q]: %w", objectName, fieldName, name, err)
+		}
+		values[name] = value
+	}
+	return &values, nil
+}
+
+var (
+	_ json.Marshaler   = NetworkDomainPermission("")
+	_ json.Unmarshaler = (*NetworkDomainPermission)(nil)
+	_ json.Marshaler   = NetworkUnixSocketPermission("")
+	_ json.Unmarshaler = (*NetworkUnixSocketPermission)(nil)
+	_ json.Unmarshaler = (*NetworkRequirements)(nil)
+)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 330 {
-		t.Fatalf("definition count = %d, want 330", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 333 {
+		t.Fatalf("definition count = %d, want 333", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 330 {
-		t.Fatalf("definition count = %d, want 330", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 333 {
+		t.Fatalf("definition count = %d, want 333", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 330 {
-		t.Fatalf("definition count = %d, want 330", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 333 {
+		t.Fatalf("definition count = %d, want 333", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 330 {
-		t.Fatalf("definition count = %d, want 330", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 333 {
+		t.Fatalf("definition count = %d, want 333", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 330 {
-		t.Fatalf("definition count = %d, want 330", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 333 {
+		t.Fatalf("definition count = %d, want 333", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -226,6 +226,9 @@ func wireSchemaDefinitions() Schema {
 		{Name: "ModelVerification", Type: reflect.TypeFor[ModelVerification]()},
 		{Name: "ModelVerificationNotification", Type: reflect.TypeFor[ModelVerificationNotification]()},
 		{Name: "ModelsRequirements", Type: reflect.TypeFor[ModelsRequirements]()},
+		{Name: "NetworkDomainPermission", Type: reflect.TypeFor[NetworkDomainPermission]()},
+		{Name: "NetworkRequirements", Type: reflect.TypeFor[NetworkRequirements]()},
+		{Name: "NetworkUnixSocketPermission", Type: reflect.TypeFor[NetworkUnixSocketPermission]()},
 		{Name: "NewThreadModelDefaults", Type: reflect.TypeFor[NewThreadModelDefaults]()},
 		{Name: "NonSteerableTurnKind", Type: reflect.TypeFor[NonSteerableTurnKind]()},
 		{Name: "McpElicitationArrayType", Type: reflect.TypeFor[McpElicitationArrayType]()},
@@ -443,10 +446,26 @@ func wireSchemaDefinitions() Schema {
 	schemas["WindowsSandboxSetupMode"] = stringEnumSchema(
 		string(WindowsSandboxSetupModeElevated), string(WindowsSandboxSetupModeUnelevated),
 	)
+	schemas["NetworkDomainPermission"] = stringEnumSchema(
+		string(NetworkDomainPermissionAllow), string(NetworkDomainPermissionDeny),
+	)
+	schemas["NetworkUnixSocketPermission"] = stringEnumSchema(
+		string(NetworkUnixSocketPermissionAllow), string(NetworkUnixSocketPermissionDeny),
+	)
 	schemas["ConfiguredHookHandler"] = configuredHookHandlerSchema()
 	configRequirementsProperties := schemas["ConfigRequirements"].(Schema)["properties"].(Schema)
 	for _, name := range []string{"allowedPermissionProfiles", "featureRequirements"} {
 		variants := configRequirementsProperties[name].(Schema)["anyOf"].([]any)
+		variants[0].(Schema)["x-gollem-typescript-optional-map"] = true
+	}
+	networkRequirementsProperties := schemas["NetworkRequirements"].(Schema)["properties"].(Schema)
+	for _, name := range []string{"httpPort", "socksPort"} {
+		variants := networkRequirementsProperties[name].(Schema)["anyOf"].([]any)
+		variants[0].(Schema)["minimum"] = 0
+		variants[0].(Schema)["maximum"] = 65535
+	}
+	for _, name := range []string{"domains", "unixSockets"} {
+		variants := networkRequirementsProperties[name].(Schema)["anyOf"].([]any)
 		variants[0].(Schema)["x-gollem-typescript-optional-map"] = true
 	}
 	schemas["ModelListParams"] = modelListParamsSchema()

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -5360,6 +5360,13 @@
       ],
       "type": "string"
     },
+    "NetworkDomainPermission": {
+      "enum": [
+        "allow",
+        "deny"
+      ],
+      "type": "string"
+    },
     "NetworkPolicyAmendment": {
       "additionalProperties": false,
       "properties": {
@@ -5377,6 +5384,185 @@
       "type": "object"
     },
     "NetworkPolicyRuleAction": {
+      "enum": [
+        "allow",
+        "deny"
+      ],
+      "type": "string"
+    },
+    "NetworkRequirements": {
+      "additionalProperties": false,
+      "properties": {
+        "allowLocalBinding": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "allowUnixSockets": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "allowUpstreamProxy": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "allowedDomains": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dangerouslyAllowAllUnixSockets": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dangerouslyAllowNonLoopbackProxy": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "deniedDomains": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "domains": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "$ref": "#/$defs/NetworkDomainPermission"
+              },
+              "type": "object",
+              "x-gollem-typescript-optional-map": true
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "enabled": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "httpPort": {
+          "anyOf": [
+            {
+              "maximum": 65535,
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "managedAllowedDomainsOnly": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "socksPort": {
+          "anyOf": [
+            {
+              "maximum": 65535,
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "unixSockets": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "$ref": "#/$defs/NetworkUnixSocketPermission"
+              },
+              "type": "object",
+              "x-gollem-typescript-optional-map": true
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "enabled",
+        "httpPort",
+        "socksPort",
+        "allowUpstreamProxy",
+        "dangerouslyAllowNonLoopbackProxy",
+        "dangerouslyAllowAllUnixSockets",
+        "domains",
+        "managedAllowedDomainsOnly",
+        "allowedDomains",
+        "deniedDomains",
+        "unixSockets",
+        "allowUnixSockets",
+        "allowLocalBinding"
+      ],
+      "type": "object"
+    },
+    "NetworkUnixSocketPermission": {
       "enum": [
         "allow",
         "deny"

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 330 {
-		t.Fatalf("definition count = %d, want 330", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 333 {
+		t.Fatalf("definition count = %d, want 333", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 330 {
-		t.Fatalf("definition count = %d, want 330", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 333 {
+		t.Fatalf("definition count = %d, want 333", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 330 {
-		t.Fatalf("definition count = %d, want 330", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 333 {
+		t.Fatalf("definition count = %d, want 333", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 330 {
-		t.Fatalf("definition count = %d, want 330", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 333 {
+		t.Fatalf("definition count = %d, want 333", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 330 {
-		t.Fatalf("definition count = %d, want 330", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 333 {
+		t.Fatalf("definition count = %d, want 333", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 330 {
-		t.Fatalf("definition count = %d, want 330", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 333 {
+		t.Fatalf("definition count = %d, want 333", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 330 {
-		t.Fatalf("definition count = %d, want 330", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 333 {
+		t.Fatalf("definition count = %d, want 333", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 330 {
-		t.Fatalf("definition count = %d, want 330", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 333 {
+		t.Fatalf("definition count = %d, want 333", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 330 {
-		t.Fatalf("definition count = %d, want 330", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 333 {
+		t.Fatalf("definition count = %d, want 333", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 330 {
-		t.Fatalf("definition count = %d, want 330", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 333 {
+		t.Fatalf("definition count = %d, want 333", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 330 {
-		t.Fatalf("definition count = %d, want 330", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 333 {
+		t.Fatalf("definition count = %d, want 333", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 330 {
-		t.Fatalf("definition count = %d, want 330", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 333 {
+		t.Fatalf("definition count = %d, want 333", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -1695,12 +1695,32 @@ export type ModelsRequirements = {
 
 export type NetworkAccess = "restricted" | "enabled";
 
+export type NetworkDomainPermission = "allow" | "deny";
+
 export type NetworkPolicyAmendment = {
   "action": NetworkPolicyRuleAction;
   "host": string;
 };
 
 export type NetworkPolicyRuleAction = "allow" | "deny";
+
+export type NetworkRequirements = {
+  "allowLocalBinding": boolean | null;
+  "allowUnixSockets": Array<string> | null;
+  "allowUpstreamProxy": boolean | null;
+  "allowedDomains": Array<string> | null;
+  "dangerouslyAllowAllUnixSockets": boolean | null;
+  "dangerouslyAllowNonLoopbackProxy": boolean | null;
+  "deniedDomains": Array<string> | null;
+  "domains": { [key in string]?: NetworkDomainPermission } | null;
+  "enabled": boolean | null;
+  "httpPort": number | null;
+  "managedAllowedDomainsOnly": boolean | null;
+  "socksPort": number | null;
+  "unixSockets": { [key in string]?: NetworkUnixSocketPermission } | null;
+};
+
+export type NetworkUnixSocketPermission = "allow" | "deny";
 
 export type NewThreadModelDefaults = {
   "model": string | null;

--- a/appserver/protocol/typescript/testdata/network_requirements_contract.ts
+++ b/appserver/protocol/typescript/testdata/network_requirements_contract.ts
@@ -1,0 +1,106 @@
+import type {
+  NetworkDomainPermission,
+  NetworkRequirements,
+  NetworkUnixSocketPermission,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? (<T>() => T extends B ? 1 : 2) extends
+        (<T>() => T extends A ? 1 : 2)
+      ? true
+      : false
+    : false;
+type Expect<T extends true> = T;
+
+type NetworkRequirementsContract = [
+  Expect<Equal<NetworkDomainPermission, "allow" | "deny">>,
+  Expect<Equal<NetworkUnixSocketPermission, "allow" | "deny">>,
+  Expect<Equal<NetworkRequirements, {
+    enabled: boolean | null;
+    httpPort: number | null;
+    socksPort: number | null;
+    allowUpstreamProxy: boolean | null;
+    dangerouslyAllowNonLoopbackProxy: boolean | null;
+    dangerouslyAllowAllUnixSockets: boolean | null;
+    domains: { [key in string]?: NetworkDomainPermission } | null;
+    managedAllowedDomainsOnly: boolean | null;
+    allowedDomains: string[] | null;
+    deniedDomains: string[] | null;
+    unixSockets: { [key in string]?: NetworkUnixSocketPermission } | null;
+    allowUnixSockets: string[] | null;
+    allowLocalBinding: boolean | null;
+  }>>,
+];
+
+"allow" satisfies NetworkDomainPermission;
+"deny" satisfies NetworkDomainPermission;
+"allow" satisfies NetworkUnixSocketPermission;
+"deny" satisfies NetworkUnixSocketPermission;
+
+export const nullNetworkRequirements = {
+  enabled: null,
+  httpPort: null,
+  socksPort: null,
+  allowUpstreamProxy: null,
+  dangerouslyAllowNonLoopbackProxy: null,
+  dangerouslyAllowAllUnixSockets: null,
+  domains: null,
+  managedAllowedDomainsOnly: null,
+  allowedDomains: null,
+  deniedDomains: null,
+  unixSockets: null,
+  allowUnixSockets: null,
+  allowLocalBinding: null,
+} satisfies NetworkRequirements;
+
+export const fullNetworkRequirements = {
+  enabled: false,
+  httpPort: 0,
+  socksPort: 65535,
+  allowUpstreamProxy: true,
+  dangerouslyAllowNonLoopbackProxy: false,
+  dangerouslyAllowAllUnixSockets: true,
+  domains: { "": "allow", "example.com": "deny" },
+  managedAllowedDomainsOnly: false,
+  allowedDomains: ["", "example.com", "example.com"],
+  deniedDomains: [],
+  unixSockets: { "": "deny", "/tmp/codex.sock": "allow" },
+  allowUnixSockets: ["", "/tmp/codex.sock", "/tmp/codex.sock"],
+  allowLocalBinding: true,
+} satisfies NetworkRequirements;
+
+// @ts-expect-error domain permissions are closed.
+"permit" satisfies NetworkDomainPermission;
+// @ts-expect-error Unix-socket permissions are closed.
+"permit" satisfies NetworkUnixSocketPermission;
+// @ts-expect-error every network-requirements field is required.
+({}) satisfies NetworkRequirements;
+// @ts-expect-error enabled is required nullable.
+({ enabled: null }) satisfies NetworkRequirements;
+// @ts-expect-error socksPort is required nullable.
+({ ...nullNetworkRequirements, socksPort: undefined }) satisfies NetworkRequirements;
+// @ts-expect-error ports are nullable numbers.
+({ ...nullNetworkRequirements, httpPort: "80" }) satisfies NetworkRequirements;
+// @ts-expect-error domain maps exclude null values.
+({ ...nullNetworkRequirements, domains: { "example.com": null } }) satisfies NetworkRequirements;
+// @ts-expect-error domain map values are closed.
+({ ...nullNetworkRequirements, domains: { "example.com": "permit" } }) satisfies NetworkRequirements;
+// @ts-expect-error allowed-domain arrays exclude null members.
+({ ...nullNetworkRequirements, allowedDomains: [null] }) satisfies NetworkRequirements;
+// @ts-expect-error denied-domain arrays contain strings.
+({ ...nullNetworkRequirements, deniedDomains: [1] }) satisfies NetworkRequirements;
+// @ts-expect-error Unix-socket maps exclude null values.
+({ ...nullNetworkRequirements, unixSockets: { "/tmp/codex.sock": null } }) satisfies NetworkRequirements;
+// @ts-expect-error Unix-socket map values are closed.
+({ ...nullNetworkRequirements, unixSockets: { "/tmp/codex.sock": "permit" } }) satisfies NetworkRequirements;
+// @ts-expect-error allowed Unix-socket arrays exclude null members.
+({ ...nullNetworkRequirements, allowUnixSockets: [null] }) satisfies NetworkRequirements;
+// @ts-expect-error allowLocalBinding is a nullable boolean.
+({ ...nullNetworkRequirements, allowLocalBinding: 1 }) satisfies NetworkRequirements;
+// @ts-expect-error network requirements are closed.
+({ ...nullNetworkRequirements, extra: true }) satisfies NetworkRequirements;
+
+declare const contract: NetworkRequirementsContract;
+void contract;

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 330 {
-		t.Fatalf("definition count = %d, want 330", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 333 {
+		t.Fatalf("definition count = %d, want 333", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary

- export exact standalone `NetworkDomainPermission`, `NetworkUnixSocketPermission`, and `NetworkRequirements` values from public Codex `5c19155cbd93bfa099016e7487259f61669823ff`
- add strict closed Go codecs with Rust-option omission canonicalization, `uint16` bounds, enum-valued open maps, legacy arrays, and malformed-input rejection
- generate deterministic JSON Schema and TypeScript without widening `ConfigRequirements` or adding method, item, proxy, permission, or enforcement bindings

## Verification

- deliberate red: absent Go names only; strict TypeScript reported 3 missing exports, 3 false identities, and 15 unused malformed-negative directives
- `go test ./appserver/protocol -run ^'TestNetwork' -count=30`\n- focused race; all 8 new codec/helper functions at 100% statement coverage; aggregate protocol coverage 96.0%\n- fresh full normal and race suites across every non-Monty package\n- `golangci-lint run ./...` (0 issues), `go vet ./...`, and tidy verification\n- deterministic generation and strict TypeScript compilation; 333 definitions, 224 methods, 59 wire bindings, 5 item bindings\n- configured pre-push gate passed with `hooks.skipMontyRace=true`; repository/hosted Monty checks remain unchanged\n- all 5 existing Slang stdio/Unix-socket/WebSocket workflows pass against the feature binary\n- live `configRequirements/read` is byte-identical to baseline at SHA-256 `b52199eba1a8d047d481a617d3e4a0fd277c4f6029ba65e41600d4ef215c4a65`\n\nGenerated SHA-256: schema `fa3c1993394485f644a1804aa5589a69ce599cc501238e402d9e8232a943326a`, TypeScript `a2c071cf4625867fb6dfea491eb178039790350ae7f3b44ea6dd7992f8715457`, strict fixture `c7cc0ddf41b5fdd7a4c80d3fa735f485b4e8a06cce11f1d14cc0837684bedcfd`.