### PR TITLE
feat(protocol): add exact config layer source

### DIFF
--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -1,0 +1,183 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestConfigLayerSourceSchemaIsExact(t *testing.T) {
+	definition := JSONSchema()["$defs"].(Schema)["ConfigLayerSource"].(Schema)
+	variants, ok := definition["oneOf"].([]any)
+	if !ok || len(variants) != 8 {
+		t.Fatalf("ConfigLayerSource oneOf = %#v, want eight variants", definition["oneOf"])
+	}
+	want := map[string]struct {
+		required []string
+		refs     map[string]string
+	}{
+		"mdm":                             {required: []string{"type", "domain", "key"}},
+		"system":                          {required: []string{"type", "file"}, refs: map[string]string{"file": "AbsolutePathBuf"}},
+		"enterpriseManaged":               {required: []string{"type", "id", "name"}},
+		"user":                            {required: []string{"type", "file", "profile"}, refs: map[string]string{"file": "AbsolutePathBuf"}},
+		"project":                         {required: []string{"type", "dotCodexFolder"}, refs: map[string]string{"dotCodexFolder": "AbsolutePathBuf"}},
+		"sessionFlags":                    {required: []string{"type"}},
+		"legacyManagedConfigTomlFromFile": {required: []string{"type", "file"}, refs: map[string]string{"file": "AbsolutePathBuf"}},
+		"legacyManagedConfigTomlFromMdm":  {required: []string{"type"}},
+	}
+	seen := map[string]bool{}
+	for _, raw := range variants {
+		variant := raw.(Schema)
+		if variant["type"] != "object" || variant["additionalProperties"] != false {
+			t.Fatalf("ConfigLayerSource variant is not a closed object: %#v", variant)
+		}
+		properties := variant["properties"].(Schema)
+		typeSchema := properties["type"].(Schema)
+		enums := typeSchema["enum"].([]any)
+		if len(enums) != 1 {
+			t.Fatalf("ConfigLayerSource discriminant = %#v", typeSchema)
+		}
+		kind := enums[0].(string)
+		expected, found := want[kind]
+		if !found {
+			t.Fatalf("unexpected ConfigLayerSource variant %q", kind)
+		}
+		seen[kind] = true
+		gotRequired := append([]string(nil), variant["required"].([]string)...)
+		slices.Sort(gotRequired)
+		wantRequired := append([]string(nil), expected.required...)
+		slices.Sort(wantRequired)
+		if !reflect.DeepEqual(gotRequired, wantRequired) {
+			t.Errorf("%s required = %v, want %v", kind, gotRequired, wantRequired)
+		}
+		for field, ref := range expected.refs {
+			if got := properties[field].(Schema)["$ref"]; got != "#/$defs/"+ref {
+				t.Errorf("%s.%s ref = %v, want %s", kind, field, got, ref)
+			}
+		}
+		if kind == "user" {
+			assertConfigNullableSchema(t, properties["profile"], Schema{"type": "string"})
+		}
+	}
+	if len(seen) != len(want) {
+		t.Fatalf("ConfigLayerSource variants = %v, want %v", seen, want)
+	}
+}
+
+func TestConfigLayerSourceAcceptsExactWireForms(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		input     string
+		canonical string
+		kind      string
+	}{
+		{"mdm", `{"type":"mdm","domain":"","key":""}`, `{"type":"mdm","domain":"","key":""}`, "mdm"},
+		{"system", `{"type":"system","file":"/workspace/../workspace/system.toml"}`, `{"type":"system","file":"/workspace/system.toml"}`, "system"},
+		{"enterprise", `{"type":"enterpriseManaged","id":"","name":"Managed"}`, `{"type":"enterpriseManaged","id":"","name":"Managed"}`, "enterpriseManaged"},
+		{"user omitted profile", `{"type":"user","file":"/home/user/.codex/config.toml"}`, `{"type":"user","file":"/home/user/.codex/config.toml","profile":null}`, "user"},
+		{"user null profile", `{"type":"user","file":"/home/user/.codex/config.toml","profile":null}`, `{"type":"user","file":"/home/user/.codex/config.toml","profile":null}`, "user"},
+		{"user profile", `{"type":"user","file":"/home/user/.codex/config.toml","profile":""}`, `{"type":"user","file":"/home/user/.codex/config.toml","profile":""}`, "user"},
+		{"project", `{"type":"project","dotCodexFolder":"/workspace/.codex"}`, `{"type":"project","dotCodexFolder":"/workspace/.codex"}`, "project"},
+		{"session", `{"type":"sessionFlags"}`, `{"type":"sessionFlags"}`, "sessionFlags"},
+		{"legacy file", `{"type":"legacyManagedConfigTomlFromFile","file":"/etc/codex/managed_config.toml"}`, `{"type":"legacyManagedConfigTomlFromFile","file":"/etc/codex/managed_config.toml"}`, "legacyManagedConfigTomlFromFile"},
+		{"legacy MDM", `{"type":"legacyManagedConfigTomlFromMdm"}`, `{"type":"legacyManagedConfigTomlFromMdm"}`, "legacyManagedConfigTomlFromMdm"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var value ConfigLayerSource
+			if err := json.Unmarshal([]byte(test.input), &value); err != nil {
+				t.Fatalf("UnmarshalJSON: %v", err)
+			}
+			if value.Type() != test.kind {
+				t.Errorf("Type() = %q, want %q", value.Type(), test.kind)
+			}
+			got, err := json.Marshal(value)
+			if err != nil {
+				t.Fatalf("MarshalJSON: %v", err)
+			}
+			if string(got) != test.canonical {
+				t.Errorf("canonical JSON = %s, want %s", got, test.canonical)
+			}
+		})
+	}
+}
+
+func TestConfigLayerSourceRejectsMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		`null`, `[]`, `"mdm"`, `1`, `true`, `{}`,
+		`{"type":"unknown"}`,
+		`{"type":"mdm","domain":"d"}`,
+		`{"type":"mdm","domain":1,"key":"k"}`,
+		`{"type":"mdm","domain":"d","key":1}`,
+		`{"type":"mdm","domain":"d","key":"k","extra":true}`,
+		`{"type":"system"}`,
+		`{"type":"system","file":"relative.toml"}`,
+		`{"type":"enterpriseManaged","id":"id"}`,
+		`{"type":"enterpriseManaged","id":1,"name":"Managed"}`,
+		`{"type":"enterpriseManaged","id":"id","name":null}`,
+		`{"type":"user","file":null,"profile":null}`,
+		`{"type":"user","file":"/config.toml","profile":1}`,
+		`{"type":"user","file":"/config.toml","profile":null,"domain":"d"}`,
+		`{"type":"project","dotCodexFolder":"relative"}`,
+		`{"type":"sessionFlags","file":"/config.toml"}`,
+		`{"type":"legacyManagedConfigTomlFromFile"}`,
+		`{"type":"legacyManagedConfigTomlFromMdm","file":"/config.toml"}`,
+		`{"type":"project","file":"/workspace/.codex"}`,
+		`{"type":"sessionFlags"} {}`,
+	} {
+		assertJSONRejects[ConfigLayerSource](t, input)
+	}
+}
+
+func TestConfigLayerSourceNilReceiverAndEmptyMarshal(t *testing.T) {
+	var target *ConfigLayerSource
+	if err := target.UnmarshalJSON([]byte(`{"type":"sessionFlags"}`)); err == nil {
+		t.Fatal("nil ConfigLayerSource receiver succeeded")
+	}
+	if _, err := json.Marshal(ConfigLayerSource{}); err == nil {
+		t.Fatal("empty ConfigLayerSource marshal succeeded")
+	}
+}
+
+func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
+	for _, binding := range WireTypeBindings() {
+		if slices.Contains(binding.Params, "ConfigLayerSource") || slices.Contains(binding.Result, "ConfigLayerSource") {
+			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 334 {
+		t.Fatalf("definition count = %d, want 334", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestConfigLayerSourceTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	source := string(generated)
+	for _, want := range []string{
+		`export type ConfigLayerSource =`,
+		`"type": "mdm";`,
+		`"type": "system";`,
+		`"type": "enterpriseManaged";`,
+		`"type": "user";`,
+		`"profile": string | null;`,
+		`"type": "project";`,
+		`"dotCodexFolder": AbsolutePathBuf;`,
+		`"type": "sessionFlags";`,
+		`"type": "legacyManagedConfigTomlFromFile";`,
+		`"type": "legacyManagedConfigTomlFromMdm";`,
+	} {
+		if !strings.Contains(source, want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}

--- a/appserver/protocol/config_layer_source_types.go
+++ b/appserver/protocol/config_layer_source_types.go
@@ -1,0 +1,163 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// ConfigLayerSource is the exact public origin of a configuration layer. It is
+// standalone from Gollem's live in-memory configuration service.
+type ConfigLayerSource struct {
+	raw json.RawMessage
+}
+
+func (s ConfigLayerSource) MarshalJSON() ([]byte, error) {
+	if len(s.raw) == 0 {
+		return nil, errors.New("config layer source is empty")
+	}
+	return validateConfigLayerSourceJSON(s.raw)
+}
+
+func (s *ConfigLayerSource) UnmarshalJSON(data []byte) error {
+	if s == nil {
+		return errors.New("decode config layer source into nil receiver")
+	}
+	canonical, err := validateConfigLayerSourceJSON(data)
+	if err != nil {
+		return err
+	}
+	s.raw = canonical
+	return nil
+}
+
+func (s ConfigLayerSource) Type() string {
+	return permissionUnionDiscriminant(s.raw, "type")
+}
+
+func validateConfigLayerSourceJSON(data []byte) (json.RawMessage, error) {
+	payload, err := decodeExactThreadItemObject(
+		data,
+		"config layer source",
+		"type",
+		"domain",
+		"key",
+		"file",
+		"id",
+		"name",
+		"profile",
+		"dotCodexFolder",
+	)
+	if err != nil {
+		return nil, err
+	}
+	typeName, err := decodeRequiredThreadItemValue[string](payload, "config layer source", "type")
+	if err != nil {
+		return nil, err
+	}
+	switch typeName {
+	case "mdm":
+		if err := requirePermissionFields(payload, []string{"type", "domain", "key"}, "type", "domain", "key"); err != nil {
+			return nil, err
+		}
+		domain, err := decodeRequiredThreadItemValue[string](payload, "MDM config layer source", "domain")
+		if err != nil {
+			return nil, err
+		}
+		key, err := decodeRequiredThreadItemValue[string](payload, "MDM config layer source", "key")
+		if err != nil {
+			return nil, err
+		}
+		return json.Marshal(struct {
+			Type   string `json:"type"`
+			Domain string `json:"domain"`
+			Key    string `json:"key"`
+		}{Type: typeName, Domain: domain, Key: key})
+	case "system":
+		return canonicalConfigLayerFileSource(payload, typeName, "system config layer source")
+	case "enterpriseManaged":
+		if err := requirePermissionFields(payload, []string{"type", "id", "name"}, "type", "id", "name"); err != nil {
+			return nil, err
+		}
+		id, err := decodeRequiredThreadItemValue[string](payload, "enterprise-managed config layer source", "id")
+		if err != nil {
+			return nil, err
+		}
+		name, err := decodeRequiredThreadItemValue[string](payload, "enterprise-managed config layer source", "name")
+		if err != nil {
+			return nil, err
+		}
+		return json.Marshal(struct {
+			Type string `json:"type"`
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		}{Type: typeName, ID: id, Name: name})
+	case "user":
+		if err := requirePermissionFields(payload, []string{"type", "file", "profile"}, "type", "file"); err != nil {
+			return nil, err
+		}
+		file, err := decodeRequiredThreadItemValue[AbsolutePathBuf](payload, "user config layer source", "file")
+		if err != nil {
+			return nil, err
+		}
+		profile, err := decodeOptionalNullableConfigRequirementValue[string](
+			payload,
+			"user config layer source",
+			"profile",
+		)
+		if err != nil {
+			return nil, err
+		}
+		return json.Marshal(struct {
+			Type    string          `json:"type"`
+			File    AbsolutePathBuf `json:"file"`
+			Profile *string         `json:"profile"`
+		}{Type: typeName, File: file, Profile: profile})
+	case "project":
+		if err := requirePermissionFields(payload, []string{"type", "dotCodexFolder"}, "type", "dotCodexFolder"); err != nil {
+			return nil, err
+		}
+		folder, err := decodeRequiredThreadItemValue[AbsolutePathBuf](payload, "project config layer source", "dotCodexFolder")
+		if err != nil {
+			return nil, err
+		}
+		return json.Marshal(struct {
+			Type           string          `json:"type"`
+			DotCodexFolder AbsolutePathBuf `json:"dotCodexFolder"`
+		}{Type: typeName, DotCodexFolder: folder})
+	case "sessionFlags", "legacyManagedConfigTomlFromMdm":
+		if err := requirePermissionFields(payload, []string{"type"}, "type"); err != nil {
+			return nil, err
+		}
+		return json.Marshal(struct {
+			Type string `json:"type"`
+		}{Type: typeName})
+	case "legacyManagedConfigTomlFromFile":
+		return canonicalConfigLayerFileSource(payload, typeName, "legacy managed-file config layer source")
+	default:
+		return nil, fmt.Errorf("unsupported config layer source type %q", typeName)
+	}
+}
+
+func canonicalConfigLayerFileSource(
+	payload map[string]json.RawMessage,
+	typeName string,
+	objectName string,
+) (json.RawMessage, error) {
+	if err := requirePermissionFields(payload, []string{"type", "file"}, "type", "file"); err != nil {
+		return nil, err
+	}
+	file, err := decodeRequiredThreadItemValue[AbsolutePathBuf](payload, objectName, "file")
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(struct {
+		Type string          `json:"type"`
+		File AbsolutePathBuf `json:"file"`
+	}{Type: typeName, File: file})
+}
+
+var (
+	_ json.Marshaler   = ConfigLayerSource{}
+	_ json.Unmarshaler = (*ConfigLayerSource)(nil)
+)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 333 {
-		t.Fatalf("definition count = %d, want 333", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 334 {
+		t.Fatalf("definition count = %d, want 334", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 333 {
-		t.Fatalf("definition count = %d, want 333", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 334 {
+		t.Fatalf("definition count = %d, want 334", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 333 {
-		t.Fatalf("definition count = %d, want 333", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 334 {
+		t.Fatalf("definition count = %d, want 334", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 333 {
-		t.Fatalf("definition count = %d, want 333", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 334 {
+		t.Fatalf("definition count = %d, want 334", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 333 {
-		t.Fatalf("definition count = %d, want 333", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 334 {
+		t.Fatalf("definition count = %d, want 334", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 333 {
-		t.Fatalf("definition count = %d, want 333", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 334 {
+		t.Fatalf("definition count = %d, want 334", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 333 {
-		t.Fatalf("definition count = %d, want 333", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 334 {
+		t.Fatalf("definition count = %d, want 334", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 333 {
-		t.Fatalf("definition count = %d, want 333", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 334 {
+		t.Fatalf("definition count = %d, want 334", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 333 {
-		t.Fatalf("definition count = %d, want 333", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 334 {
+		t.Fatalf("definition count = %d, want 334", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 333 {
-		t.Fatalf("definition count = %d, want 333", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 334 {
+		t.Fatalf("definition count = %d, want 334", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 333 {
-		t.Fatalf("definition count = %d, want 333", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 334 {
+		t.Fatalf("definition count = %d, want 334", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 333 {
-		t.Fatalf("definition count = %d, want 333", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 334 {
+		t.Fatalf("definition count = %d, want 334", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 333 {
-		t.Fatalf("definition count = %d, want 333", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 334 {
+		t.Fatalf("definition count = %d, want 334", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 333 {
-		t.Fatalf("definition count = %d, want 333", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 334 {
+		t.Fatalf("definition count = %d, want 334", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 333 {
-		t.Fatalf("definition count = %d, want 333", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 334 {
+		t.Fatalf("definition count = %d, want 334", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 333 {
-		t.Fatalf("definition count = %d, want 333", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 334 {
+		t.Fatalf("definition count = %d, want 334", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 333 {
-		t.Fatalf("definition count = %d, want 333", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 334 {
+		t.Fatalf("definition count = %d, want 334", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -121,6 +121,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "CommandExecutionOutputDeltaNotificationParams", Type: reflect.TypeFor[CommandExecutionOutputDeltaNotificationParams]()},
 		{Name: "CommandExecutionSource", Type: reflect.TypeFor[CommandExecutionSource]()},
 		{Name: "ComputerUseRequirements", Type: reflect.TypeFor[ComputerUseRequirements]()},
+		{Name: "ConfigLayerSource", Type: reflect.TypeFor[ConfigLayerSource]()},
 		{Name: "ConfigRequirements", Type: reflect.TypeFor[ConfigRequirements]()},
 		{Name: "ConfigRequirementsReadResponse", Type: reflect.TypeFor[ConfigRequirementsReadResponse]()},
 		{Name: "ConfigWarningNotification", Type: reflect.TypeFor[ConfigWarningNotification]()},
@@ -452,6 +453,7 @@ func wireSchemaDefinitions() Schema {
 	schemas["NetworkUnixSocketPermission"] = stringEnumSchema(
 		string(NetworkUnixSocketPermissionAllow), string(NetworkUnixSocketPermissionDeny),
 	)
+	schemas["ConfigLayerSource"] = configLayerSourceSchema()
 	schemas["ConfiguredHookHandler"] = configuredHookHandlerSchema()
 	configRequirementsProperties := schemas["ConfigRequirements"].(Schema)["properties"].(Schema)
 	for _, name := range []string{"allowedPermissionProfiles", "featureRequirements"} {
@@ -1349,6 +1351,53 @@ func configuredHookHandlerSchema() Schema {
 		configuredHookHandlerVariantSchema("prompt", nil, nil),
 		configuredHookHandlerVariantSchema("agent", nil, nil),
 	}}
+}
+
+func configLayerSourceSchema() Schema {
+	absolutePath := Schema{"$ref": "#/$defs/AbsolutePathBuf"}
+	return Schema{"oneOf": []any{
+		configLayerSourceVariant("mdm", []string{"domain", "key"}, Schema{
+			"domain": Schema{"type": "string"},
+			"key":    Schema{"type": "string"},
+		}),
+		configLayerSourceVariant("system", []string{"file"}, Schema{
+			"file": absolutePath,
+		}),
+		configLayerSourceVariant("enterpriseManaged", []string{"id", "name"}, Schema{
+			"id":   Schema{"type": "string"},
+			"name": Schema{"type": "string"},
+		}),
+		configLayerSourceVariant("user", []string{"file", "profile"}, Schema{
+			"file": absolutePath,
+			"profile": Schema{"anyOf": []any{
+				Schema{"type": "string"},
+				Schema{"type": "null"},
+			}},
+		}),
+		configLayerSourceVariant("project", []string{"dotCodexFolder"}, Schema{
+			"dotCodexFolder": absolutePath,
+		}),
+		configLayerSourceVariant("sessionFlags", nil, nil),
+		configLayerSourceVariant("legacyManagedConfigTomlFromFile", []string{"file"}, Schema{
+			"file": absolutePath,
+		}),
+		configLayerSourceVariant("legacyManagedConfigTomlFromMdm", nil, nil),
+	}}
+}
+
+func configLayerSourceVariant(typeName string, requiredFields []string, fields Schema) Schema {
+	properties := Schema{"type": stringEnumSchema(typeName)}
+	for name, schema := range fields {
+		properties[name] = schema
+	}
+	required := []string{"type"}
+	required = append(required, requiredFields...)
+	return Schema{
+		"type":                 "object",
+		"properties":           properties,
+		"required":             required,
+		"additionalProperties": false,
+	}
 }
 
 func configuredHookHandlerVariantSchema(hookType string, requiredFields []string, fields Schema) Schema {

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -1384,6 +1384,173 @@
       ],
       "type": "object"
     },
+    "ConfigLayerSource": {
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "domain": {
+              "type": "string"
+            },
+            "key": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "mdm"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "domain",
+            "key"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "file": {
+              "$ref": "#/$defs/AbsolutePathBuf"
+            },
+            "type": {
+              "enum": [
+                "system"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "file"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "enterpriseManaged"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "id",
+            "name"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "file": {
+              "$ref": "#/$defs/AbsolutePathBuf"
+            },
+            "profile": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "type": {
+              "enum": [
+                "user"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "file",
+            "profile"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dotCodexFolder": {
+              "$ref": "#/$defs/AbsolutePathBuf"
+            },
+            "type": {
+              "enum": [
+                "project"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "dotCodexFolder"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "enum": [
+                "sessionFlags"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "file": {
+              "$ref": "#/$defs/AbsolutePathBuf"
+            },
+            "type": {
+              "enum": [
+                "legacyManagedConfigTomlFromFile"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "file"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "enum": [
+                "legacyManagedConfigTomlFromMdm"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        }
+      ]
+    },
     "ConfigRequirements": {
       "additionalProperties": false,
       "properties": {

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 333 {
-		t.Fatalf("definition count = %d, want 333", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 334 {
+		t.Fatalf("definition count = %d, want 334", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 333 {
-		t.Fatalf("definition count = %d, want 333", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 334 {
+		t.Fatalf("definition count = %d, want 334", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 333 {
-		t.Fatalf("definition count = %d, want 333", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 334 {
+		t.Fatalf("definition count = %d, want 334", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 333 {
-		t.Fatalf("definition count = %d, want 333", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 334 {
+		t.Fatalf("definition count = %d, want 334", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 333 {
-		t.Fatalf("definition count = %d, want 333", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 334 {
+		t.Fatalf("definition count = %d, want 334", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 333 {
-		t.Fatalf("definition count = %d, want 333", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 334 {
+		t.Fatalf("definition count = %d, want 334", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 333 {
-		t.Fatalf("definition count = %d, want 333", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 334 {
+		t.Fatalf("definition count = %d, want 334", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 333 {
-		t.Fatalf("definition count = %d, want 333", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 334 {
+		t.Fatalf("definition count = %d, want 334", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 333 {
-		t.Fatalf("definition count = %d, want 333", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 334 {
+		t.Fatalf("definition count = %d, want 334", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 333 {
-		t.Fatalf("definition count = %d, want 333", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 334 {
+		t.Fatalf("definition count = %d, want 334", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 333 {
-		t.Fatalf("definition count = %d, want 333", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 334 {
+		t.Fatalf("definition count = %d, want 334", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 333 {
-		t.Fatalf("definition count = %d, want 333", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 334 {
+		t.Fatalf("definition count = %d, want 334", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -786,6 +786,33 @@ export type ComputerUseRequirements = {
   "allowLockedComputerUse": boolean | null;
 };
 
+export type ConfigLayerSource = {
+  "domain": string;
+  "key": string;
+  "type": "mdm";
+} | {
+  "file": AbsolutePathBuf;
+  "type": "system";
+} | {
+  "id": string;
+  "name": string;
+  "type": "enterpriseManaged";
+} | {
+  "file": AbsolutePathBuf;
+  "profile": string | null;
+  "type": "user";
+} | {
+  "dotCodexFolder": AbsolutePathBuf;
+  "type": "project";
+} | {
+  "type": "sessionFlags";
+} | {
+  "file": AbsolutePathBuf;
+  "type": "legacyManagedConfigTomlFromFile";
+} | {
+  "type": "legacyManagedConfigTomlFromMdm";
+};
+
 export type ConfigRequirements = {
   "allowAppshots": boolean | null;
   "allowManagedHooksOnly": boolean | null;

--- a/appserver/protocol/typescript/testdata/config_layer_source_contract.ts
+++ b/appserver/protocol/typescript/testdata/config_layer_source_contract.ts
@@ -1,0 +1,71 @@
+import type {
+  AbsolutePathBuf,
+  ConfigLayerSource,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? (<T>() => T extends B ? 1 : 2) extends
+        (<T>() => T extends A ? 1 : 2)
+      ? true
+      : false
+    : false;
+type Expect<T extends true> = T;
+
+type ConfigLayerSourceContract = Expect<Equal<ConfigLayerSource,
+  | { type: "mdm"; domain: string; key: string }
+  | { type: "system"; file: AbsolutePathBuf }
+  | { type: "enterpriseManaged"; id: string; name: string }
+  | { type: "user"; file: AbsolutePathBuf; profile: string | null }
+  | { type: "project"; dotCodexFolder: AbsolutePathBuf }
+  | { type: "sessionFlags" }
+  | { type: "legacyManagedConfigTomlFromFile"; file: AbsolutePathBuf }
+  | { type: "legacyManagedConfigTomlFromMdm" }
+>>;
+
+({ type: "mdm", domain: "", key: "" }) satisfies ConfigLayerSource;
+({ type: "system", file: "/etc/codex/config.toml" }) satisfies ConfigLayerSource;
+({ type: "enterpriseManaged", id: "", name: "Managed" }) satisfies ConfigLayerSource;
+({ type: "user", file: "/home/user/.codex/config.toml", profile: null }) satisfies ConfigLayerSource;
+({ type: "user", file: "/home/user/.codex/config.toml", profile: "" }) satisfies ConfigLayerSource;
+({ type: "project", dotCodexFolder: "/workspace/.codex" }) satisfies ConfigLayerSource;
+({ type: "sessionFlags" }) satisfies ConfigLayerSource;
+({ type: "legacyManagedConfigTomlFromFile", file: "/etc/codex/managed_config.toml" }) satisfies ConfigLayerSource;
+({ type: "legacyManagedConfigTomlFromMdm" }) satisfies ConfigLayerSource;
+
+// @ts-expect-error discriminants are closed.
+({ type: "unknown" }) satisfies ConfigLayerSource;
+// @ts-expect-error the discriminant is required.
+({ domain: "d", key: "k" }) satisfies ConfigLayerSource;
+// @ts-expect-error mdm requires domain.
+({ type: "mdm", key: "k" }) satisfies ConfigLayerSource;
+// @ts-expect-error mdm requires a string key.
+({ type: "mdm", domain: "d", key: 1 }) satisfies ConfigLayerSource;
+// @ts-expect-error variants are closed.
+({ type: "mdm", domain: "d", key: "k", extra: true }) satisfies ConfigLayerSource;
+// @ts-expect-error system requires file.
+({ type: "system" }) satisfies ConfigLayerSource;
+// @ts-expect-error system file is non-null.
+({ type: "system", file: null }) satisfies ConfigLayerSource;
+// @ts-expect-error enterpriseManaged requires name.
+({ type: "enterpriseManaged", id: "id" }) satisfies ConfigLayerSource;
+// @ts-expect-error enterpriseManaged name is non-null.
+({ type: "enterpriseManaged", id: "id", name: null }) satisfies ConfigLayerSource;
+// @ts-expect-error user profile is required nullable.
+({ type: "user", file: "/config.toml" }) satisfies ConfigLayerSource;
+// @ts-expect-error user profile is a nullable string.
+({ type: "user", file: "/config.toml", profile: 1 }) satisfies ConfigLayerSource;
+// @ts-expect-error project requires dotCodexFolder.
+({ type: "project" }) satisfies ConfigLayerSource;
+// @ts-expect-error type-only variants are closed.
+({ type: "sessionFlags", file: "/config.toml" }) satisfies ConfigLayerSource;
+// @ts-expect-error legacy file source requires file.
+({ type: "legacyManagedConfigTomlFromFile" }) satisfies ConfigLayerSource;
+// @ts-expect-error legacy MDM source is type-only.
+({ type: "legacyManagedConfigTomlFromMdm", file: "/config.toml" }) satisfies ConfigLayerSource;
+// @ts-expect-error fields cannot cross variants.
+({ type: "project", file: "/workspace/.codex" }) satisfies ConfigLayerSource;
+
+declare const contract: ConfigLayerSourceContract;
+void contract;

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 333 {
-		t.Fatalf("definition count = %d, want 333", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 334 {
+		t.Fatalf("definition count = %d, want 334", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary

- add the exact eight-variant `ConfigLayerSource` public tagged union from Codex `5c19155cbd93bfa099016e7487259f61669823ff`
- validate and canonicalize all wire forms, including absolute paths and required-nullable user profiles
- generate a closed JSON Schema and exact TypeScript union with strict positive and malformed-shape contracts
- keep the type standalone: no method/item binding or live configuration behavior changes

## Validation

- focused contract tests repeated 30 times
- focused race tests and 100% statement coverage for the new codec/validator
- full 59-package non-Monty tests and race tests
- `go vet`, `golangci-lint`, `go mod tidy`, `git diff --check`
- byte-stable `go generate ./appserver/protocol` and strict TypeScript compile
- all five Slang real-binary stdio, Unix-socket, WebSocket, and approval workflows
- live `configRequirements/read` result unchanged at SHA-256 `b52199eba1a8d047d481a617d3e4a0fd277c4f6029ba65e41600d4ef215c4a65`
- pre-push gate passed with only the configured Monty race package skipped