### PR TITLE
Export exact config write contracts

### DIFF
--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 337 {
-		t.Fatalf("definition count = %d, want 337", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
+		t.Fatalf("definition count = %d, want 343", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 337 {
-		t.Fatalf("definition count = %d, want 337", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
+		t.Fatalf("definition count = %d, want 343", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 337 {
-		t.Fatalf("definition count = %d, want 337", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
+		t.Fatalf("definition count = %d, want 343", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 337 {
-		t.Fatalf("definition count = %d, want 337", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
+		t.Fatalf("definition count = %d, want 343", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -1,0 +1,429 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestConfigWriteContractSchemasAreExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+
+	if got := defs["MergeStrategy"]; !reflect.DeepEqual(got, Schema{
+		"type": "string", "enum": []any{"replace", "upsert"},
+	}) {
+		t.Fatalf("MergeStrategy schema = %#v", got)
+	}
+	if got := defs["WriteStatus"]; !reflect.DeepEqual(got, Schema{
+		"type": "string", "enum": []any{"ok", "okOverridden"},
+	}) {
+		t.Fatalf("WriteStatus schema = %#v", got)
+	}
+
+	edit := defs["ConfigEdit"].(Schema)
+	assertClosedObjectSchema(t, edit, "keyPath", "value", "mergeStrategy")
+	editProperties := edit["properties"].(Schema)
+	assertConfigWriteSchemaProperty(t, editProperties, "keyPath", Schema{"type": "string"})
+	assertConfigWriteSchemaRef(t, editProperties, "value", "JsonValue")
+	assertConfigWriteSchemaRef(t, editProperties, "mergeStrategy", "MergeStrategy")
+
+	valueParams := defs["ConfigValueWriteParams"].(Schema)
+	assertConfigWriteClosedSchemaRequired(
+		t,
+		valueParams,
+		[]string{"keyPath", "value", "mergeStrategy"},
+		"keyPath", "value", "mergeStrategy", "filePath", "expectedVersion",
+	)
+	valueProperties := valueParams["properties"].(Schema)
+	assertConfigWriteSchemaProperty(t, valueProperties, "keyPath", Schema{"type": "string"})
+	assertConfigWriteSchemaRef(t, valueProperties, "value", "JsonValue")
+	assertConfigWriteSchemaRef(t, valueProperties, "mergeStrategy", "MergeStrategy")
+	assertConfigNullableSchema(t, valueProperties["filePath"], Schema{"type": "string"})
+	assertConfigWriteSchemaDescription(t, valueProperties, "filePath", configWriteFilePathDescription)
+	assertConfigNullableSchema(t, valueProperties["expectedVersion"], Schema{"type": "string"})
+
+	batchParams := defs["ConfigBatchWriteParams"].(Schema)
+	assertConfigWriteClosedSchemaRequired(
+		t,
+		batchParams,
+		[]string{"edits"},
+		"edits", "filePath", "expectedVersion", "reloadUserConfig",
+	)
+	batchProperties := batchParams["properties"].(Schema)
+	if got := batchProperties["edits"]; !reflect.DeepEqual(got, Schema{
+		"type": "array", "items": Schema{"$ref": "#/$defs/ConfigEdit"},
+	}) {
+		t.Fatalf("ConfigBatchWriteParams edits schema = %#v", got)
+	}
+	assertConfigNullableSchema(t, batchProperties["filePath"], Schema{"type": "string"})
+	assertConfigWriteSchemaDescription(t, batchProperties, "filePath", configWriteFilePathDescription)
+	assertConfigNullableSchema(t, batchProperties["expectedVersion"], Schema{"type": "string"})
+	assertConfigWriteSchemaProperty(t, batchProperties, "reloadUserConfig", Schema{
+		"type":        "boolean",
+		"description": "When true, hot-reload the updated user config into all loaded threads after writing.",
+	})
+
+	response := defs["ConfigWriteResponse"].(Schema)
+	assertClosedObjectSchema(t, response, "status", "version", "filePath", "overriddenMetadata")
+	responseProperties := response["properties"].(Schema)
+	assertConfigWriteSchemaRef(t, responseProperties, "status", "WriteStatus")
+	assertConfigWriteSchemaProperty(t, responseProperties, "version", Schema{"type": "string"})
+	assertConfigWriteSchemaProperty(t, responseProperties, "filePath", Schema{
+		"$ref":        "#/$defs/AbsolutePathBuf",
+		"description": "Canonical path to the config file that was written.",
+	})
+	assertConfigNullableSchema(
+		t,
+		responseProperties["overriddenMetadata"],
+		Schema{"$ref": "#/$defs/OverriddenMetadata"},
+	)
+}
+
+func TestConfigWriteContractEnumsAcceptExactValues(t *testing.T) {
+	for _, test := range []struct {
+		input  string
+		target any
+	}{
+		{`"replace"`, new(MergeStrategy)},
+		{`"upsert"`, new(MergeStrategy)},
+		{`"ok"`, new(WriteStatus)},
+		{`"okOverridden"`, new(WriteStatus)},
+	} {
+		if err := json.Unmarshal([]byte(test.input), test.target); err != nil {
+			t.Errorf("Unmarshal(%s): %v", test.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(test.target)
+		if err != nil || string(encoded) != test.input {
+			t.Errorf("round trip %s = %s, %v", test.input, encoded, err)
+		}
+	}
+}
+
+func TestConfigEditAcceptsExactWireForms(t *testing.T) {
+	for _, test := range []struct {
+		input string
+		want  string
+	}{
+		{
+			`{"keyPath":"","value":null,"mergeStrategy":"replace"}`,
+			`{"keyPath":"","value":null,"mergeStrategy":"replace"}`,
+		},
+		{
+			`{"keyPath":"model.reasoning","value":{"integer":9007199254740993,"decimal":1.234567890123456789,"items":[false,null,"value"]},"mergeStrategy":"upsert"}`,
+			`{"keyPath":"model.reasoning","value":{"decimal":1.234567890123456789,"integer":9007199254740993,"items":[false,null,"value"]},"mergeStrategy":"upsert"}`,
+		},
+	} {
+		var value ConfigEdit
+		assertConfigWriteRoundTrip(t, test.input, test.want, &value)
+	}
+}
+
+func TestConfigValueWriteParamsAcceptExactWireForms(t *testing.T) {
+	for _, test := range []struct {
+		input string
+		want  string
+	}{
+		{
+			`{"keyPath":"","value":null,"mergeStrategy":"replace"}`,
+			`{"keyPath":"","value":null,"mergeStrategy":"replace","filePath":null,"expectedVersion":null}`,
+		},
+		{
+			`{"keyPath":"model","value":[],"mergeStrategy":"upsert","filePath":null,"expectedVersion":null}`,
+			`{"keyPath":"model","value":[],"mergeStrategy":"upsert","filePath":null,"expectedVersion":null}`,
+		},
+		{
+			`{"keyPath":"model","value":{"nested":[9007199254740993,true]},"mergeStrategy":"replace","filePath":"relative/config.toml","expectedVersion":""}`,
+			`{"keyPath":"model","value":{"nested":[9007199254740993,true]},"mergeStrategy":"replace","filePath":"relative/config.toml","expectedVersion":""}`,
+		},
+	} {
+		var value ConfigValueWriteParams
+		assertConfigWriteRoundTrip(t, test.input, test.want, &value)
+	}
+}
+
+func TestConfigBatchWriteParamsAcceptExactWireForms(t *testing.T) {
+	for _, test := range []struct {
+		input string
+		want  string
+	}{
+		{
+			`{"edits":[]}`,
+			`{"edits":[],"filePath":null,"expectedVersion":null}`,
+		},
+		{
+			`{"edits":[],"filePath":null,"expectedVersion":null,"reloadUserConfig":false}`,
+			`{"edits":[],"filePath":null,"expectedVersion":null}`,
+		},
+		{
+			`{"edits":[{"keyPath":"first","value":1,"mergeStrategy":"replace"},{"keyPath":"first","value":{"large":9007199254740993},"mergeStrategy":"upsert"}],"filePath":"config.toml","expectedVersion":"v1","reloadUserConfig":true}`,
+			`{"edits":[{"keyPath":"first","value":1,"mergeStrategy":"replace"},{"keyPath":"first","value":{"large":9007199254740993},"mergeStrategy":"upsert"}],"filePath":"config.toml","expectedVersion":"v1","reloadUserConfig":true}`,
+		},
+	} {
+		var value ConfigBatchWriteParams
+		assertConfigWriteRoundTrip(t, test.input, test.want, &value)
+	}
+}
+
+func TestConfigWriteResponseAcceptsExactWireForms(t *testing.T) {
+	for _, test := range []struct {
+		input string
+		want  string
+	}{
+		{
+			`{"status":"ok","version":"","filePath":"/workspace/../workspace/config.toml"}`,
+			`{"status":"ok","version":"","filePath":"/workspace/config.toml","overriddenMetadata":null}`,
+		},
+		{
+			`{"status":"okOverridden","version":"v2","filePath":"/workspace/config.toml","overriddenMetadata":null}`,
+			`{"status":"okOverridden","version":"v2","filePath":"/workspace/config.toml","overriddenMetadata":null}`,
+		},
+		{
+			`{"status":"okOverridden","version":"v3","filePath":"/workspace/config.toml","overriddenMetadata":{"message":"overridden","overridingLayer":{"name":{"type":"user","file":"/home/user/.codex/config.toml"},"version":"managed"},"effectiveValue":{"large":9007199254740993}}}`,
+			`{"status":"okOverridden","version":"v3","filePath":"/workspace/config.toml","overriddenMetadata":{"message":"overridden","overridingLayer":{"name":{"type":"user","file":"/home/user/.codex/config.toml","profile":null},"version":"managed"},"effectiveValue":{"large":9007199254740993}}}`,
+		},
+	} {
+		var value ConfigWriteResponse
+		assertConfigWriteRoundTrip(t, test.input, test.want, &value)
+	}
+}
+
+func TestConfigWriteContractEnumsRejectMalformedWireForms(t *testing.T) {
+	for _, input := range []string{`null`, `[]`, `{}`, `1`, `true`, `""`, `"merge"`, `"Replace"`, `"ok_overridden"`} {
+		assertJSONRejects[MergeStrategy](t, input)
+		assertJSONRejects[WriteStatus](t, input)
+	}
+}
+
+func TestConfigEditRejectsMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		`null`, `[]`, `"value"`, `1`, `true`, `{}`,
+		`{"value":null,"mergeStrategy":"replace"}`,
+		`{"keyPath":null,"value":null,"mergeStrategy":"replace"}`,
+		`{"keyPath":"key","mergeStrategy":"replace"}`,
+		`{"keyPath":"key","value":,"mergeStrategy":"replace"}`,
+		`{"keyPath":"key","value":null}`,
+		`{"keyPath":"key","value":null,"mergeStrategy":null}`,
+		`{"keyPath":"key","value":null,"mergeStrategy":"merge"}`,
+		`{"keyPath":"key","value":null,"mergeStrategy":"replace","extra":true}`,
+		`{"keyPath":"key","value":null,"mergeStrategy":"replace"} {}`,
+	} {
+		assertJSONRejects[ConfigEdit](t, input)
+	}
+}
+
+func TestConfigValueWriteParamsRejectsMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		`null`, `[]`, `"value"`, `1`, `true`, `{}`,
+		`{"value":null,"mergeStrategy":"replace"}`,
+		`{"keyPath":null,"value":null,"mergeStrategy":"replace"}`,
+		`{"keyPath":"key","mergeStrategy":"replace"}`,
+		`{"keyPath":"key","value":null}`,
+		`{"keyPath":"key","value":null,"mergeStrategy":"merge"}`,
+		`{"keyPath":"key","value":null,"mergeStrategy":"replace","filePath":1}`,
+		`{"keyPath":"key","value":null,"mergeStrategy":"replace","expectedVersion":false}`,
+		`{"key":"key","value":null,"mergeStrategy":"replace"}`,
+		`{"keyPath":"key","value":null,"merge_strategy":"replace"}`,
+		`{"keyPath":"key","value":null,"mergeStrategy":"replace","extra":true}`,
+		`{"keyPath":"key","value":null,"mergeStrategy":"replace"} {}`,
+	} {
+		assertJSONRejects[ConfigValueWriteParams](t, input)
+	}
+}
+
+func TestConfigBatchWriteParamsRejectsMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		`null`, `[]`, `"value"`, `1`, `true`, `{}`,
+		`{"edits":null}`,
+		`{"edits":{}}`,
+		`{"edits":[null]}`,
+		`{"edits":[{}]}`,
+		`{"edits":[{"keyPath":"key","value":null,"mergeStrategy":"merge"}]}`,
+		`{"edits":[],"filePath":1}`,
+		`{"edits":[],"expectedVersion":false}`,
+		`{"edits":[],"reloadUserConfig":null}`,
+		`{"edits":[],"reloadUserConfig":1}`,
+		`{"entries":[]}`,
+		`{"values":{}}`,
+		`{"edits":[],"reload_user_config":true}`,
+		`{"edits":[],"extra":true}`,
+		`{"edits":[]} {}`,
+	} {
+		assertJSONRejects[ConfigBatchWriteParams](t, input)
+	}
+}
+
+func TestConfigWriteResponseRejectsMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		`null`, `[]`, `"value"`, `1`, `true`, `{}`,
+		`{"version":"v1","filePath":"/config.toml"}`,
+		`{"status":null,"version":"v1","filePath":"/config.toml"}`,
+		`{"status":"accepted","version":"v1","filePath":"/config.toml"}`,
+		`{"status":"ok","filePath":"/config.toml"}`,
+		`{"status":"ok","version":null,"filePath":"/config.toml"}`,
+		`{"status":"ok","version":"v1"}`,
+		`{"status":"ok","version":"v1","filePath":null}`,
+		`{"status":"ok","version":"v1","filePath":"relative/config.toml"}`,
+		`{"status":"ok","version":"v1","filePath":"/config.toml","overriddenMetadata":1}`,
+		`{"status":"ok","version":"v1","filePath":"/config.toml","overriddenMetadata":{"message":"value","overridingLayer":{"name":{"type":"sessionFlags"},"version":"v1"}}}`,
+		`{"status":"ok","version":"v1","filePath":"/config.toml","path":"/other"}`,
+		`{"status":"ok","version":"v1","filePath":"/config.toml","extra":true}`,
+		`{"status":"ok","version":"v1","filePath":"/config.toml"} {}`,
+	} {
+		assertJSONRejects[ConfigWriteResponse](t, input)
+	}
+}
+
+func TestConfigWriteContractNilReceiversAndInvalidMarshal(t *testing.T) {
+	var strategy *MergeStrategy
+	if err := strategy.UnmarshalJSON([]byte(`"replace"`)); err == nil {
+		t.Fatal("nil MergeStrategy receiver succeeded")
+	}
+	var status *WriteStatus
+	if err := status.UnmarshalJSON([]byte(`"ok"`)); err == nil {
+		t.Fatal("nil WriteStatus receiver succeeded")
+	}
+	var edit *ConfigEdit
+	if err := edit.UnmarshalJSON([]byte(`{"keyPath":"key","value":null,"mergeStrategy":"replace"}`)); err == nil {
+		t.Fatal("nil ConfigEdit receiver succeeded")
+	}
+	var valueParams *ConfigValueWriteParams
+	if err := valueParams.UnmarshalJSON([]byte(`{"keyPath":"key","value":null,"mergeStrategy":"replace"}`)); err == nil {
+		t.Fatal("nil ConfigValueWriteParams receiver succeeded")
+	}
+	var batchParams *ConfigBatchWriteParams
+	if err := batchParams.UnmarshalJSON([]byte(`{"edits":[]}`)); err == nil {
+		t.Fatal("nil ConfigBatchWriteParams receiver succeeded")
+	}
+	var response *ConfigWriteResponse
+	if err := response.UnmarshalJSON([]byte(`{"status":"ok","version":"v1","filePath":"/config.toml"}`)); err == nil {
+		t.Fatal("nil ConfigWriteResponse receiver succeeded")
+	}
+
+	for name, value := range map[string]any{
+		"strategy":     MergeStrategy("merge"),
+		"status":       WriteStatus("accepted"),
+		"edit":         ConfigEdit{},
+		"value params": ConfigValueWriteParams{},
+		"batch params": ConfigBatchWriteParams{},
+		"response":     ConfigWriteResponse{},
+	} {
+		if _, err := json.Marshal(value); err == nil {
+			t.Errorf("empty/invalid %s marshal succeeded", name)
+		}
+	}
+}
+
+func TestConfigWriteContractsRemainStandalone(t *testing.T) {
+	names := []string{
+		"MergeStrategy",
+		"WriteStatus",
+		"ConfigEdit",
+		"ConfigValueWriteParams",
+		"ConfigBatchWriteParams",
+		"ConfigWriteResponse",
+	}
+	for _, binding := range WireTypeBindings() {
+		for _, name := range names {
+			if slices.Contains(binding.Params, name) || slices.Contains(binding.Result, name) {
+				t.Fatalf("%s unexpectedly bound to %s", name, binding.Method)
+			}
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
+		t.Fatalf("definition count = %d, want 343", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestConfigWriteContractTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	source := string(generated)
+	for _, want := range []string{
+		`export type MergeStrategy = "replace" | "upsert";`,
+		`export type WriteStatus = "ok" | "okOverridden";`,
+		`export type ConfigEdit = {`,
+		`"mergeStrategy": MergeStrategy;`,
+		`export type ConfigValueWriteParams = {`,
+		`"filePath"?: string | null;`,
+		`"expectedVersion"?: string | null;`,
+		`export type ConfigBatchWriteParams = {`,
+		`"edits": Array<ConfigEdit>;`,
+		`"reloadUserConfig"?: boolean;`,
+		`export type ConfigWriteResponse = {`,
+		`"status": WriteStatus;`,
+		`"filePath": AbsolutePathBuf;`,
+		`"overriddenMetadata": OverriddenMetadata | null;`,
+	} {
+		if !strings.Contains(source, want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}
+
+func assertConfigWriteClosedSchemaRequired(
+	t *testing.T,
+	schema Schema,
+	required []string,
+	properties ...string,
+) {
+	t.Helper()
+	if schema["type"] != "object" || schema["additionalProperties"] != false {
+		t.Fatalf("schema is not a closed object: %#v", schema)
+	}
+	if got := schemaRequiredNames(schema); !slices.Equal(got, required) {
+		t.Fatalf("schema required = %v, want %v", got, required)
+	}
+	gotProperties := schema["properties"].(Schema)
+	if len(gotProperties) != len(properties) {
+		t.Fatalf("schema properties = %v, want %v", gotProperties, properties)
+	}
+	for _, name := range properties {
+		if _, ok := gotProperties[name]; !ok {
+			t.Errorf("schema missing property %q", name)
+		}
+	}
+}
+
+func assertConfigWriteSchemaProperty(t *testing.T, properties Schema, fieldName string, want Schema) {
+	t.Helper()
+	if got := properties[fieldName]; !reflect.DeepEqual(got, want) {
+		t.Errorf("%s schema = %#v, want %#v", fieldName, got, want)
+	}
+}
+
+func assertConfigWriteSchemaRef(t *testing.T, properties Schema, fieldName, definitionName string) {
+	t.Helper()
+	assertConfigWriteSchemaProperty(t, properties, fieldName, Schema{"$ref": "#/$defs/" + definitionName})
+}
+
+const configWriteFilePathDescription = "Path to the config file to write; defaults to the user's `config.toml` when omitted."
+
+func assertConfigWriteSchemaDescription(t *testing.T, properties Schema, fieldName, want string) {
+	t.Helper()
+	field, ok := properties[fieldName].(Schema)
+	if !ok || field["description"] != want {
+		t.Errorf("%s description = %#v, want %q", fieldName, field["description"], want)
+	}
+}
+
+func assertConfigWriteRoundTrip(t *testing.T, input, want string, target any) {
+	t.Helper()
+	if err := json.Unmarshal([]byte(input), target); err != nil {
+		t.Fatalf("Unmarshal(%s): %v", input, err)
+	}
+	encoded, err := json.Marshal(target)
+	if err != nil || string(encoded) != want {
+		t.Fatalf("round trip %s = %s, %v; want %s", input, encoded, err, want)
+	}
+}

--- a/appserver/protocol/config_write_contracts_types.go
+++ b/appserver/protocol/config_write_contracts_types.go
@@ -1,0 +1,311 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// MergeStrategy is the exact closed public config-write merge strategy.
+type MergeStrategy string
+
+const (
+	MergeStrategyReplace MergeStrategy = "replace"
+	MergeStrategyUpsert  MergeStrategy = "upsert"
+)
+
+func (s MergeStrategy) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(s, "config merge strategy", MergeStrategy.valid)
+}
+
+func (s *MergeStrategy) UnmarshalJSON(data []byte) error {
+	return unmarshalThreadTurnLeafEnum(data, s, "config merge strategy", MergeStrategy.valid)
+}
+
+func (s MergeStrategy) valid() bool {
+	return s == MergeStrategyReplace || s == MergeStrategyUpsert
+}
+
+// WriteStatus is the exact closed public config-write result status.
+type WriteStatus string
+
+const (
+	WriteStatusOK           WriteStatus = "ok"
+	WriteStatusOKOverridden WriteStatus = "okOverridden"
+)
+
+func (s WriteStatus) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(s, "config write status", WriteStatus.valid)
+}
+
+func (s *WriteStatus) UnmarshalJSON(data []byte) error {
+	return unmarshalThreadTurnLeafEnum(data, s, "config write status", WriteStatus.valid)
+}
+
+func (s WriteStatus) valid() bool {
+	return s == WriteStatusOK || s == WriteStatusOKOverridden
+}
+
+// ConfigEdit is one exact public key-path edit.
+type ConfigEdit struct {
+	KeyPath       string        `json:"keyPath"`
+	Value         JsonValue     `json:"value"`
+	MergeStrategy MergeStrategy `json:"mergeStrategy"`
+}
+
+func (e *ConfigEdit) UnmarshalJSON(data []byte) error {
+	if e == nil {
+		return errors.New("decode config edit into nil receiver")
+	}
+	const objectName = "config edit"
+	payload, err := decodeExactThreadItemObject(data, objectName, "keyPath", "value", "mergeStrategy")
+	if err != nil {
+		return err
+	}
+	keyPath, err := decodeRequiredThreadItemValue[string](payload, objectName, "keyPath")
+	if err != nil {
+		return err
+	}
+	value, err := decodeRequiredThreadItemJSONValue(payload, objectName, "value")
+	if err != nil {
+		return err
+	}
+	mergeStrategy, err := decodeRequiredThreadItemValue[MergeStrategy](payload, objectName, "mergeStrategy")
+	if err != nil {
+		return err
+	}
+	*e = ConfigEdit{KeyPath: keyPath, Value: value, MergeStrategy: mergeStrategy}
+	return nil
+}
+
+// ConfigValueWriteParams is the exact standalone public single-value write
+// request. Gollem's live memory-backed request remains a separate contract.
+type ConfigValueWriteParams struct {
+	KeyPath         string        `json:"keyPath"`
+	Value           JsonValue     `json:"value"`
+	MergeStrategy   MergeStrategy `json:"mergeStrategy"`
+	FilePath        *string       `json:"filePath,omitempty"`
+	ExpectedVersion *string       `json:"expectedVersion,omitempty"`
+}
+
+func (p ConfigValueWriteParams) MarshalJSON() ([]byte, error) {
+	type wire struct {
+		KeyPath         string        `json:"keyPath"`
+		Value           JsonValue     `json:"value"`
+		MergeStrategy   MergeStrategy `json:"mergeStrategy"`
+		FilePath        *string       `json:"filePath"`
+		ExpectedVersion *string       `json:"expectedVersion"`
+	}
+	return json.Marshal(wire(p))
+}
+
+func (p *ConfigValueWriteParams) UnmarshalJSON(data []byte) error {
+	if p == nil {
+		return errors.New("decode config value-write params into nil receiver")
+	}
+	const objectName = "config value-write params"
+	payload, err := decodeExactThreadItemObject(
+		data,
+		objectName,
+		"keyPath",
+		"value",
+		"mergeStrategy",
+		"filePath",
+		"expectedVersion",
+	)
+	if err != nil {
+		return err
+	}
+	keyPath, err := decodeRequiredThreadItemValue[string](payload, objectName, "keyPath")
+	if err != nil {
+		return err
+	}
+	value, err := decodeRequiredThreadItemJSONValue(payload, objectName, "value")
+	if err != nil {
+		return err
+	}
+	mergeStrategy, err := decodeRequiredThreadItemValue[MergeStrategy](payload, objectName, "mergeStrategy")
+	if err != nil {
+		return err
+	}
+	filePath, err := decodeOptionalNullableConfigWriteValue[string](payload, objectName, "filePath")
+	if err != nil {
+		return err
+	}
+	expectedVersion, err := decodeOptionalNullableConfigWriteValue[string](payload, objectName, "expectedVersion")
+	if err != nil {
+		return err
+	}
+	*p = ConfigValueWriteParams{
+		KeyPath:         keyPath,
+		Value:           value,
+		MergeStrategy:   mergeStrategy,
+		FilePath:        filePath,
+		ExpectedVersion: expectedVersion,
+	}
+	return nil
+}
+
+// ConfigBatchWriteParams is the exact standalone public ordered edit batch.
+type ConfigBatchWriteParams struct {
+	Edits            []ConfigEdit `json:"edits" jsonschema:"nonnullable=true"`
+	FilePath         *string      `json:"filePath,omitempty"`
+	ExpectedVersion  *string      `json:"expectedVersion,omitempty"`
+	ReloadUserConfig bool         `json:"reloadUserConfig,omitempty"`
+}
+
+func (p ConfigBatchWriteParams) MarshalJSON() ([]byte, error) {
+	if p.Edits == nil {
+		return nil, errors.New("config batch-write params edits cannot be null")
+	}
+	type wire struct {
+		Edits            []ConfigEdit `json:"edits"`
+		FilePath         *string      `json:"filePath"`
+		ExpectedVersion  *string      `json:"expectedVersion"`
+		ReloadUserConfig bool         `json:"reloadUserConfig,omitempty"`
+	}
+	return json.Marshal(wire(p))
+}
+
+func (p *ConfigBatchWriteParams) UnmarshalJSON(data []byte) error {
+	if p == nil {
+		return errors.New("decode config batch-write params into nil receiver")
+	}
+	const objectName = "config batch-write params"
+	payload, err := decodeExactThreadItemObject(
+		data,
+		objectName,
+		"edits",
+		"filePath",
+		"expectedVersion",
+		"reloadUserConfig",
+	)
+	if err != nil {
+		return err
+	}
+	edits, err := decodeRequiredThreadItemArray[ConfigEdit](payload, objectName, "edits")
+	if err != nil {
+		return err
+	}
+	filePath, err := decodeOptionalNullableConfigWriteValue[string](payload, objectName, "filePath")
+	if err != nil {
+		return err
+	}
+	expectedVersion, err := decodeOptionalNullableConfigWriteValue[string](payload, objectName, "expectedVersion")
+	if err != nil {
+		return err
+	}
+	reloadUserConfig, err := decodeOptionalConfigWriteBool(payload, objectName, "reloadUserConfig")
+	if err != nil {
+		return err
+	}
+	*p = ConfigBatchWriteParams{
+		Edits:            edits,
+		FilePath:         filePath,
+		ExpectedVersion:  expectedVersion,
+		ReloadUserConfig: reloadUserConfig,
+	}
+	return nil
+}
+
+// ConfigWriteResponse is the exact standalone public config-write result.
+// Gollem's live value/entry snapshot remains a separate response contract.
+type ConfigWriteResponse struct {
+	Status             WriteStatus         `json:"status"`
+	Version            string              `json:"version"`
+	FilePath           AbsolutePathBuf     `json:"filePath"`
+	OverriddenMetadata *OverriddenMetadata `json:"overriddenMetadata"`
+}
+
+func (r *ConfigWriteResponse) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("decode config-write response into nil receiver")
+	}
+	const objectName = "config-write response"
+	payload, err := decodeExactThreadItemObject(
+		data,
+		objectName,
+		"status",
+		"version",
+		"filePath",
+		"overriddenMetadata",
+	)
+	if err != nil {
+		return err
+	}
+	status, err := decodeRequiredThreadItemValue[WriteStatus](payload, objectName, "status")
+	if err != nil {
+		return err
+	}
+	version, err := decodeRequiredThreadItemValue[string](payload, objectName, "version")
+	if err != nil {
+		return err
+	}
+	filePath, err := decodeRequiredThreadItemValue[AbsolutePathBuf](payload, objectName, "filePath")
+	if err != nil {
+		return err
+	}
+	overriddenMetadata, err := decodeOptionalNullableConfigWriteValue[OverriddenMetadata](
+		payload,
+		objectName,
+		"overriddenMetadata",
+	)
+	if err != nil {
+		return err
+	}
+	*r = ConfigWriteResponse{
+		Status:             status,
+		Version:            version,
+		FilePath:           filePath,
+		OverriddenMetadata: overriddenMetadata,
+	}
+	return nil
+}
+
+func decodeOptionalNullableConfigWriteValue[T any](
+	payload map[string]json.RawMessage,
+	objectName string,
+	fieldName string,
+) (*T, error) {
+	raw, ok := payload[fieldName]
+	if !ok || isJSONNull(raw) {
+		return nil, nil
+	}
+	var value T
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return nil, fmt.Errorf("decode %s %s: %w", objectName, fieldName, err)
+	}
+	return &value, nil
+}
+
+func decodeOptionalConfigWriteBool(
+	payload map[string]json.RawMessage,
+	objectName string,
+	fieldName string,
+) (bool, error) {
+	raw, ok := payload[fieldName]
+	if !ok {
+		return false, nil
+	}
+	if isJSONNull(raw) {
+		return false, fmt.Errorf("decode %s %s: value cannot be null", objectName, fieldName)
+	}
+	var value bool
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return false, fmt.Errorf("decode %s %s: %w", objectName, fieldName, err)
+	}
+	return value, nil
+}
+
+var (
+	_ json.Marshaler   = MergeStrategy("")
+	_ json.Unmarshaler = (*MergeStrategy)(nil)
+	_ json.Marshaler   = WriteStatus("")
+	_ json.Unmarshaler = (*WriteStatus)(nil)
+	_ json.Unmarshaler = (*ConfigEdit)(nil)
+	_ json.Marshaler   = ConfigValueWriteParams{}
+	_ json.Unmarshaler = (*ConfigValueWriteParams)(nil)
+	_ json.Marshaler   = ConfigBatchWriteParams{}
+	_ json.Unmarshaler = (*ConfigBatchWriteParams)(nil)
+	_ json.Unmarshaler = (*ConfigWriteResponse)(nil)
+)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 337 {
-		t.Fatalf("definition count = %d, want 337", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
+		t.Fatalf("definition count = %d, want 343", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 337 {
-		t.Fatalf("definition count = %d, want 337", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 343 {
+		t.Fatalf("definition count = %d, want 343", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 337 {
-		t.Fatalf("definition count = %d, want 337", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
+		t.Fatalf("definition count = %d, want 343", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 337 {
-		t.Fatalf("definition count = %d, want 337", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
+		t.Fatalf("definition count = %d, want 343", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 337 {
-		t.Fatalf("definition count = %d, want 337", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
+		t.Fatalf("definition count = %d, want 343", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 337 {
-		t.Fatalf("definition count = %d, want 337", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
+		t.Fatalf("definition count = %d, want 343", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 337 {
-		t.Fatalf("definition count = %d, want 337", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
+		t.Fatalf("definition count = %d, want 343", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 337 {
-		t.Fatalf("definition count = %d, want 337", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
+		t.Fatalf("definition count = %d, want 343", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 337 {
-		t.Fatalf("definition count = %d, want 337", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
+		t.Fatalf("definition count = %d, want 343", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 337 {
-		t.Fatalf("definition count = %d, want 337", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
+		t.Fatalf("definition count = %d, want 343", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 337 {
-		t.Fatalf("definition count = %d, want 337", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 343 {
+		t.Fatalf("definition count = %d, want 343", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 337 {
-		t.Fatalf("definition count = %d, want 337", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 343 {
+		t.Fatalf("definition count = %d, want 343", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 337 {
-		t.Fatalf("definition count = %d, want 337", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 343 {
+		t.Fatalf("definition count = %d, want 343", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 337 {
-		t.Fatalf("definition count = %d, want 337", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 343 {
+		t.Fatalf("definition count = %d, want 343", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 337 {
-		t.Fatalf("definition count = %d, want 337", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 343 {
+		t.Fatalf("definition count = %d, want 343", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -121,12 +121,16 @@ func wireSchemaDefinitions() Schema {
 		{Name: "CommandExecutionOutputDeltaNotificationParams", Type: reflect.TypeFor[CommandExecutionOutputDeltaNotificationParams]()},
 		{Name: "CommandExecutionSource", Type: reflect.TypeFor[CommandExecutionSource]()},
 		{Name: "ComputerUseRequirements", Type: reflect.TypeFor[ComputerUseRequirements]()},
+		{Name: "ConfigBatchWriteParams", Type: reflect.TypeFor[ConfigBatchWriteParams]()},
+		{Name: "ConfigEdit", Type: reflect.TypeFor[ConfigEdit]()},
 		{Name: "ConfigLayer", Type: reflect.TypeFor[ConfigLayer]()},
 		{Name: "ConfigLayerMetadata", Type: reflect.TypeFor[ConfigLayerMetadata]()},
 		{Name: "ConfigLayerSource", Type: reflect.TypeFor[ConfigLayerSource]()},
 		{Name: "ConfigRequirements", Type: reflect.TypeFor[ConfigRequirements]()},
 		{Name: "ConfigRequirementsReadResponse", Type: reflect.TypeFor[ConfigRequirementsReadResponse]()},
+		{Name: "ConfigValueWriteParams", Type: reflect.TypeFor[ConfigValueWriteParams]()},
 		{Name: "ConfigWarningNotification", Type: reflect.TypeFor[ConfigWarningNotification]()},
+		{Name: "ConfigWriteResponse", Type: reflect.TypeFor[ConfigWriteResponse]()},
 		{Name: "ConfiguredHookHandler", Type: reflect.TypeFor[ConfiguredHookHandler]()},
 		{Name: "ConfiguredHookMatcherGroup", Type: reflect.TypeFor[ConfiguredHookMatcherGroup]()},
 		{Name: "ContentItem", Type: reflect.TypeFor[ContentItem]()},
@@ -214,6 +218,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "McpToolCallResult", Type: reflect.TypeFor[McpToolCallResult]()},
 		{Name: "MemoryCitation", Type: reflect.TypeFor[MemoryCitation]()},
 		{Name: "MemoryCitationEntry", Type: reflect.TypeFor[MemoryCitationEntry]()},
+		{Name: "MergeStrategy", Type: reflect.TypeFor[MergeStrategy]()},
 		{Name: "MessagePhase", Type: reflect.TypeFor[MessagePhase]()},
 		{Name: "Model", Type: reflect.TypeFor[Model]()},
 		{Name: "ModelAvailabilityNux", Type: reflect.TypeFor[ModelAvailabilityNux]()},
@@ -400,6 +405,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "WebSearchMode", Type: reflect.TypeFor[WebSearchMode]()},
 		{Name: "WarningNotification", Type: reflect.TypeFor[WarningNotification]()},
 		{Name: "WindowsSandboxSetupMode", Type: reflect.TypeFor[WindowsSandboxSetupMode]()},
+		{Name: "WriteStatus", Type: reflect.TypeFor[WriteStatus]()},
 		// Register exact public names after their aliases so nested schemas refer
 		// to the public names. JSON and TypeScript output remain key-sorted.
 		{Name: "ContextCompactedNotification", Type: reflect.TypeFor[ContextCompactedNotification]()},
@@ -456,7 +462,24 @@ func wireSchemaDefinitions() Schema {
 	schemas["NetworkUnixSocketPermission"] = stringEnumSchema(
 		string(NetworkUnixSocketPermissionAllow), string(NetworkUnixSocketPermissionDeny),
 	)
+	schemas["MergeStrategy"] = stringEnumSchema(
+		string(MergeStrategyReplace), string(MergeStrategyUpsert),
+	)
+	schemas["WriteStatus"] = stringEnumSchema(
+		string(WriteStatusOK), string(WriteStatusOKOverridden),
+	)
 	schemas["ConfigLayerSource"] = configLayerSourceSchema()
+	const configFilePathDescription = "Path to the config file to write; defaults to the user's `config.toml` when omitted."
+	for _, definition := range []string{"ConfigValueWriteParams", "ConfigBatchWriteParams"} {
+		properties := schemas[definition].(Schema)["properties"].(Schema)
+		properties["filePath"].(Schema)["description"] = configFilePathDescription
+	}
+	configBatchProperties := schemas["ConfigBatchWriteParams"].(Schema)["properties"].(Schema)
+	configBatchProperties["reloadUserConfig"].(Schema)["description"] =
+		"When true, hot-reload the updated user config into all loaded threads after writing."
+	configWriteResponseProperties := schemas["ConfigWriteResponse"].(Schema)["properties"].(Schema)
+	configWriteResponseProperties["filePath"].(Schema)["description"] =
+		"Canonical path to the config file that was written."
 	schemas["ConfiguredHookHandler"] = configuredHookHandlerSchema()
 	configRequirementsProperties := schemas["ConfigRequirements"].(Schema)["properties"].(Schema)
 	for _, name := range []string{"allowedPermissionProfiles", "featureRequirements"} {

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -1384,6 +1384,66 @@
       ],
       "type": "object"
     },
+    "ConfigBatchWriteParams": {
+      "additionalProperties": false,
+      "properties": {
+        "edits": {
+          "items": {
+            "$ref": "#/$defs/ConfigEdit"
+          },
+          "type": "array"
+        },
+        "expectedVersion": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "filePath": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Path to the config file to write; defaults to the user's `config.toml` when omitted."
+        },
+        "reloadUserConfig": {
+          "description": "When true, hot-reload the updated user config into all loaded threads after writing.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "edits"
+      ],
+      "type": "object"
+    },
+    "ConfigEdit": {
+      "additionalProperties": false,
+      "properties": {
+        "keyPath": {
+          "type": "string"
+        },
+        "mergeStrategy": {
+          "$ref": "#/$defs/MergeStrategy"
+        },
+        "value": {
+          "$ref": "#/$defs/JsonValue"
+        }
+      },
+      "required": [
+        "keyPath",
+        "value",
+        "mergeStrategy"
+      ],
+      "type": "object"
+    },
     "ConfigLayer": {
       "additionalProperties": false,
       "properties": {
@@ -1788,6 +1848,47 @@
       ],
       "type": "object"
     },
+    "ConfigValueWriteParams": {
+      "additionalProperties": false,
+      "properties": {
+        "expectedVersion": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "filePath": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Path to the config file to write; defaults to the user's `config.toml` when omitted."
+        },
+        "keyPath": {
+          "type": "string"
+        },
+        "mergeStrategy": {
+          "$ref": "#/$defs/MergeStrategy"
+        },
+        "value": {
+          "$ref": "#/$defs/JsonValue"
+        }
+      },
+      "required": [
+        "keyPath",
+        "value",
+        "mergeStrategy"
+      ],
+      "type": "object"
+    },
     "ConfigWarningNotification": {
       "additionalProperties": false,
       "properties": {
@@ -1814,6 +1915,38 @@
       "required": [
         "summary",
         "details"
+      ],
+      "type": "object"
+    },
+    "ConfigWriteResponse": {
+      "additionalProperties": false,
+      "properties": {
+        "filePath": {
+          "$ref": "#/$defs/AbsolutePathBuf",
+          "description": "Canonical path to the config file that was written."
+        },
+        "overriddenMetadata": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OverriddenMetadata"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "status": {
+          "$ref": "#/$defs/WriteStatus"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "status",
+        "version",
+        "filePath",
+        "overriddenMetadata"
       ],
       "type": "object"
     },
@@ -5112,6 +5245,13 @@
         "note"
       ],
       "type": "object"
+    },
+    "MergeStrategy": {
+      "enum": [
+        "replace",
+        "upsert"
+      ],
+      "type": "string"
     },
     "MessagePhase": {
       "enum": [
@@ -11972,6 +12112,13 @@
       "enum": [
         "elevated",
         "unelevated"
+      ],
+      "type": "string"
+    },
+    "WriteStatus": {
+      "enum": [
+        "ok",
+        "okOverridden"
       ],
       "type": "string"
     }

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 337 {
-		t.Fatalf("definition count = %d, want 337", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 343 {
+		t.Fatalf("definition count = %d, want 343", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 337 {
-		t.Fatalf("definition count = %d, want 337", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
+		t.Fatalf("definition count = %d, want 343", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 337 {
-		t.Fatalf("definition count = %d, want 337", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
+		t.Fatalf("definition count = %d, want 343", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 337 {
-		t.Fatalf("definition count = %d, want 337", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
+		t.Fatalf("definition count = %d, want 343", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 337 {
-		t.Fatalf("definition count = %d, want 337", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
+		t.Fatalf("definition count = %d, want 343", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 337 {
-		t.Fatalf("definition count = %d, want 337", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
+		t.Fatalf("definition count = %d, want 343", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 337 {
-		t.Fatalf("definition count = %d, want 337", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 343 {
+		t.Fatalf("definition count = %d, want 343", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 337 {
-		t.Fatalf("definition count = %d, want 337", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 343 {
+		t.Fatalf("definition count = %d, want 343", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 337 {
-		t.Fatalf("definition count = %d, want 337", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
+		t.Fatalf("definition count = %d, want 343", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 337 {
-		t.Fatalf("definition count = %d, want 337", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
+		t.Fatalf("definition count = %d, want 343", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 337 {
-		t.Fatalf("definition count = %d, want 337", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
+		t.Fatalf("definition count = %d, want 343", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 337 {
-		t.Fatalf("definition count = %d, want 337", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
+		t.Fatalf("definition count = %d, want 343", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -786,6 +786,19 @@ export type ComputerUseRequirements = {
   "allowLockedComputerUse": boolean | null;
 };
 
+export type ConfigBatchWriteParams = {
+  "edits": Array<ConfigEdit>;
+  "expectedVersion"?: string | null;
+  "filePath"?: string | null;
+  "reloadUserConfig"?: boolean;
+};
+
+export type ConfigEdit = {
+  "keyPath": string;
+  "mergeStrategy": MergeStrategy;
+  "value": JsonValue;
+};
+
 export type ConfigLayer = {
   "config": JsonValue;
   "disabledReason": string | null;
@@ -845,11 +858,26 @@ export type ConfigRequirementsReadResponse = {
   "requirements": ConfigRequirements | null;
 };
 
+export type ConfigValueWriteParams = {
+  "expectedVersion"?: string | null;
+  "filePath"?: string | null;
+  "keyPath": string;
+  "mergeStrategy": MergeStrategy;
+  "value": JsonValue;
+};
+
 export type ConfigWarningNotification = {
   "details": string | null;
   "path"?: string;
   "range"?: TextRange;
   "summary": string;
+};
+
+export type ConfigWriteResponse = {
+  "filePath": AbsolutePathBuf;
+  "overriddenMetadata": OverriddenMetadata | null;
+  "status": WriteStatus;
+  "version": string;
 };
 
 export type ConfiguredHookHandler = {
@@ -1633,6 +1661,8 @@ export type MemoryCitationEntry = {
   "note": string;
   "path": string;
 };
+
+export type MergeStrategy = "replace" | "upsert";
 
 export type MessagePhase = "commentary" | "final_answer";
 
@@ -2936,6 +2966,8 @@ export type WebSearchItem = {
 export type WebSearchMode = "disabled" | "cached" | "indexed" | "live";
 
 export type WindowsSandboxSetupMode = "elevated" | "unelevated";
+
+export type WriteStatus = "ok" | "okOverridden";
 
 export type WireTypeBinding = {
   "method": KnownMethod;

--- a/appserver/protocol/typescript/testdata/config_write_contracts_contract.ts
+++ b/appserver/protocol/typescript/testdata/config_write_contracts_contract.ts
@@ -1,0 +1,168 @@
+import type {
+  ConfigBatchWriteParams,
+  ConfigEdit,
+  ConfigValueWriteParams,
+  ConfigWriteResponse,
+  JsonValue,
+  MergeStrategy,
+  OverriddenMetadata,
+  WriteStatus,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? (<T>() => T extends B ? 1 : 2) extends
+        (<T>() => T extends A ? 1 : 2)
+      ? true
+      : false
+    : false;
+type Expect<T extends true> = T;
+
+type MergeStrategyContract = Expect<Equal<MergeStrategy, "replace" | "upsert">>;
+type WriteStatusContract = Expect<Equal<WriteStatus, "ok" | "okOverridden">>;
+type ConfigEditContract = Expect<Equal<ConfigEdit, {
+  keyPath: string;
+  value: JsonValue;
+  mergeStrategy: MergeStrategy;
+}>>;
+type ConfigValueWriteParamsContract = Expect<Equal<ConfigValueWriteParams, {
+  keyPath: string;
+  value: JsonValue;
+  mergeStrategy: MergeStrategy;
+  filePath?: string | null;
+  expectedVersion?: string | null;
+}>>;
+type ConfigBatchWriteParamsContract = Expect<Equal<ConfigBatchWriteParams, {
+  edits: ConfigEdit[];
+  filePath?: string | null;
+  expectedVersion?: string | null;
+  reloadUserConfig?: boolean;
+}>>;
+type ConfigWriteResponseContract = Expect<Equal<ConfigWriteResponse, {
+  status: WriteStatus;
+  version: string;
+  filePath: string;
+  overriddenMetadata: OverriddenMetadata | null;
+}>>;
+
+"replace" satisfies MergeStrategy;
+"upsert" satisfies MergeStrategy;
+"ok" satisfies WriteStatus;
+"okOverridden" satisfies WriteStatus;
+({ keyPath: "", value: null, mergeStrategy: "replace" }) satisfies ConfigEdit;
+({
+  keyPath: "model.reasoning",
+  value: { nested: [9007199254740993, true, null] },
+  mergeStrategy: "upsert",
+}) satisfies ConfigEdit;
+({ keyPath: "model", value: null, mergeStrategy: "replace" }) satisfies ConfigValueWriteParams;
+({
+  keyPath: "model",
+  value: [],
+  mergeStrategy: "upsert",
+  filePath: null,
+  expectedVersion: "",
+}) satisfies ConfigValueWriteParams;
+({ edits: [] }) satisfies ConfigBatchWriteParams;
+({
+  edits: [
+    { keyPath: "model", value: "first", mergeStrategy: "replace" },
+    { keyPath: "model", value: "second", mergeStrategy: "upsert" },
+  ],
+  filePath: null,
+  expectedVersion: "v1",
+  reloadUserConfig: false,
+}) satisfies ConfigBatchWriteParams;
+({
+  status: "ok",
+  version: "",
+  filePath: "/workspace/config.toml",
+  overriddenMetadata: null,
+}) satisfies ConfigWriteResponse;
+({
+  status: "okOverridden",
+  version: "v2",
+  filePath: "/workspace/config.toml",
+  overriddenMetadata: {
+    message: "overridden",
+    overridingLayer: { name: { type: "sessionFlags" }, version: "managed" },
+    effectiveValue: { nested: [9007199254740993, false] },
+  },
+}) satisfies ConfigWriteResponse;
+
+// @ts-expect-error merge strategy is closed.
+"merge" satisfies MergeStrategy;
+// @ts-expect-error write status is closed.
+"accepted" satisfies WriteStatus;
+
+// @ts-expect-error edit requires keyPath.
+({ value: null, mergeStrategy: "replace" }) satisfies ConfigEdit;
+// @ts-expect-error edit requires value.
+({ keyPath: "model", mergeStrategy: "replace" }) satisfies ConfigEdit;
+// @ts-expect-error edit value is JSON, not undefined.
+({ keyPath: "model", value: undefined, mergeStrategy: "replace" }) satisfies ConfigEdit;
+// @ts-expect-error edit merge strategy is exact.
+({ keyPath: "model", value: null, mergeStrategy: "merge" }) satisfies ConfigEdit;
+// @ts-expect-error edit is closed.
+({ keyPath: "model", value: null, mergeStrategy: "replace", extra: true }) satisfies ConfigEdit;
+
+// @ts-expect-error value write requires keyPath.
+({ value: null, mergeStrategy: "replace" }) satisfies ConfigValueWriteParams;
+// @ts-expect-error value write requires value.
+({ keyPath: "model", mergeStrategy: "replace" }) satisfies ConfigValueWriteParams;
+// @ts-expect-error value write requires mergeStrategy.
+({ keyPath: "model", value: null }) satisfies ConfigValueWriteParams;
+// @ts-expect-error keyPath is a string.
+({ keyPath: 1, value: null, mergeStrategy: "replace" }) satisfies ConfigValueWriteParams;
+// @ts-expect-error optional filePath cannot be explicit undefined.
+({ keyPath: "model", value: null, mergeStrategy: "replace", filePath: undefined }) satisfies ConfigValueWriteParams;
+// @ts-expect-error expectedVersion is a nullable string.
+({ keyPath: "model", value: null, mergeStrategy: "replace", expectedVersion: false }) satisfies ConfigValueWriteParams;
+// @ts-expect-error value write is closed.
+({ keyPath: "model", value: null, mergeStrategy: "replace", key: "model" }) satisfies ConfigValueWriteParams;
+
+// @ts-expect-error batch write requires edits.
+({}) satisfies ConfigBatchWriteParams;
+// @ts-expect-error edits are non-null.
+({ edits: null }) satisfies ConfigBatchWriteParams;
+// @ts-expect-error edit members are non-null.
+({ edits: [null] }) satisfies ConfigBatchWriteParams;
+// @ts-expect-error nested edits remain exact.
+({ edits: [{ keyPath: "model", value: null, mergeStrategy: "merge" }] }) satisfies ConfigBatchWriteParams;
+// @ts-expect-error optional filePath cannot be explicit undefined.
+({ edits: [], filePath: undefined }) satisfies ConfigBatchWriteParams;
+// @ts-expect-error reloadUserConfig is a non-null boolean.
+({ edits: [], reloadUserConfig: null }) satisfies ConfigBatchWriteParams;
+// @ts-expect-error batch write is closed.
+({ edits: [], entries: [] }) satisfies ConfigBatchWriteParams;
+
+// @ts-expect-error response requires status.
+({ version: "v1", filePath: "/config.toml", overriddenMetadata: null }) satisfies ConfigWriteResponse;
+// @ts-expect-error response status is exact.
+({ status: "accepted", version: "v1", filePath: "/config.toml", overriddenMetadata: null }) satisfies ConfigWriteResponse;
+// @ts-expect-error response requires version.
+({ status: "ok", filePath: "/config.toml", overriddenMetadata: null }) satisfies ConfigWriteResponse;
+// @ts-expect-error response requires filePath.
+({ status: "ok", version: "v1", overriddenMetadata: null }) satisfies ConfigWriteResponse;
+// @ts-expect-error filePath is a string.
+({ status: "ok", version: "v1", filePath: 1, overriddenMetadata: null }) satisfies ConfigWriteResponse;
+// @ts-expect-error overriddenMetadata is required nullable.
+({ status: "ok", version: "v1", filePath: "/config.toml" }) satisfies ConfigWriteResponse;
+// @ts-expect-error nested override metadata remains exact.
+({ status: "ok", version: "v1", filePath: "/config.toml", overriddenMetadata: { message: "value", overridingLayer: { name: { type: "sessionFlags" }, version: "v1" } } }) satisfies ConfigWriteResponse;
+// @ts-expect-error response is closed.
+({ status: "ok", version: "v1", filePath: "/config.toml", overriddenMetadata: null, extra: true }) satisfies ConfigWriteResponse;
+
+declare const mergeStrategyContract: MergeStrategyContract;
+declare const writeStatusContract: WriteStatusContract;
+declare const configEditContract: ConfigEditContract;
+declare const valueWriteContract: ConfigValueWriteParamsContract;
+declare const batchWriteContract: ConfigBatchWriteParamsContract;
+declare const responseContract: ConfigWriteResponseContract;
+void mergeStrategyContract;
+void writeStatusContract;
+void configEditContract;
+void valueWriteContract;
+void batchWriteContract;
+void responseContract;

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 337 {
-		t.Fatalf("definition count = %d, want 337", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
+		t.Fatalf("definition count = %d, want 343", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary

- export exact public `MergeStrategy`, `WriteStatus`, `ConfigEdit`, `ConfigValueWriteParams`, `ConfigBatchWriteParams`, and `ConfigWriteResponse` contracts
- preserve Codex JSON/TypeScript optionality, nullability, enum closure, absolute response paths, and public schema descriptions
- keep the contracts standalone because Gollem's live memory-backed config write API has a different wire shape

## Validation

- full non-Monty normal and race suites
- focused 30x, race, and 100% new-code coverage checks
- full lint, vet, tidy, deterministic generation, and strict TypeScript
- all five real Slang stdio/Unix-socket/WebSocket workflows against the feature binary
- configured pre-push hook (Monty race skipped by repository setting)