### PR TITLE
feat(protocol): add ConfigReadParams contract

### DIFF
--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
-		t.Fatalf("definition count = %d, want 343", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
+		t.Fatalf("definition count = %d, want 344", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
-		t.Fatalf("definition count = %d, want 343", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
+		t.Fatalf("definition count = %d, want 344", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -1,0 +1,105 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestConfigReadParamsSchemaIsExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	schema := defs["ConfigReadParams"].(Schema)
+	assertConfigWriteClosedSchemaRequired(t, schema, nil, "cwd", "includeLayers")
+	properties := schema["properties"].(Schema)
+	assertConfigWriteSchemaProperty(t, properties, "includeLayers", Schema{"type": "boolean"})
+	assertConfigNullableSchema(t, properties["cwd"], Schema{"type": "string"})
+	assertConfigWriteSchemaDescription(t, properties, "cwd", configReadCWDDescription)
+}
+
+func TestConfigReadParamsAcceptsExactWireForms(t *testing.T) {
+	for _, test := range []struct {
+		input string
+		want  string
+	}{
+		{`{}`, `{"cwd":null}`},
+		{`{"includeLayers":false}`, `{"cwd":null}`},
+		{`{"includeLayers":true}`, `{"includeLayers":true,"cwd":null}`},
+		{`{"cwd":null}`, `{"cwd":null}`},
+		{`{"cwd":""}`, `{"cwd":""}`},
+		{`{"includeLayers":true,"cwd":"relative/project"}`, `{"includeLayers":true,"cwd":"relative/project"}`},
+		{`{"includeLayers":false,"cwd":"/workspace/project"}`, `{"cwd":"/workspace/project"}`},
+	} {
+		var value ConfigReadParams
+		assertConfigWriteRoundTrip(t, test.input, test.want, &value)
+	}
+}
+
+func TestConfigReadParamsRejectsMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		`null`, `[]`, `"value"`, `1`, `true`,
+		`{"includeLayers":null}`,
+		`{"includeLayers":"false"}`,
+		`{"includeLayers":0}`,
+		`{"cwd":false}`,
+		`{"cwd":1}`,
+		`{"include_layers":true}`,
+		`{"keys":[]}`,
+		`{"includeValues":true}`,
+		`{"extra":true}`,
+		`{} {}`,
+	} {
+		assertJSONRejects[ConfigReadParams](t, input)
+	}
+}
+
+func TestConfigReadParamsNilReceiver(t *testing.T) {
+	var params *ConfigReadParams
+	if err := params.UnmarshalJSON([]byte(`{}`)); err == nil {
+		t.Fatal("nil ConfigReadParams receiver succeeded")
+	}
+}
+
+func TestConfigReadParamsRemainsStandalone(t *testing.T) {
+	for _, binding := range WireTypeBindings() {
+		if slices.Contains(binding.Params, "ConfigReadParams") || slices.Contains(binding.Result, "ConfigReadParams") {
+			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
+		t.Fatalf("definition count = %d, want 344", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestConfigReadParamsTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	if want := `export type ConfigReadParams = {`; !strings.Contains(string(generated), want) {
+		t.Fatalf("generated TypeScript missing %q", want)
+	}
+	want := Schema{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties": Schema{
+			"cwd": Schema{
+				"anyOf":       []any{Schema{"type": "string"}, Schema{"type": "null"}},
+				"description": configReadCWDDescription,
+			},
+			"includeLayers": Schema{"type": "boolean"},
+		},
+	}
+	if got := JSONSchema()["$defs"].(Schema)["ConfigReadParams"]; !reflect.DeepEqual(got, want) {
+		t.Fatalf("ConfigReadParams schema = %#v, want %#v", got, want)
+	}
+}
+
+var _ json.Unmarshaler = (*ConfigReadParams)(nil)

--- a/appserver/protocol/config_read_params_types.go
+++ b/appserver/protocol/config_read_params_types.go
@@ -1,0 +1,49 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+const configReadCWDDescription = "Optional working directory to resolve project config layers. If specified, return the effective config as seen from that directory (i.e., including any project layers between `cwd` and the project/repo root)."
+
+// ConfigReadParams is the exact standalone public config-read request.
+// Gollem's live key-filtered request remains a separate contract.
+type ConfigReadParams struct {
+	IncludeLayers bool    `json:"includeLayers,omitempty"`
+	CWD           *string `json:"cwd,omitempty"`
+}
+
+func (p ConfigReadParams) MarshalJSON() ([]byte, error) {
+	type wire struct {
+		IncludeLayers bool    `json:"includeLayers,omitempty"`
+		CWD           *string `json:"cwd"`
+	}
+	return json.Marshal(wire(p))
+}
+
+func (p *ConfigReadParams) UnmarshalJSON(data []byte) error {
+	if p == nil {
+		return errors.New("decode config-read params into nil receiver")
+	}
+	const objectName = "config-read params"
+	payload, err := decodeExactThreadItemObject(data, objectName, "includeLayers", "cwd")
+	if err != nil {
+		return err
+	}
+	includeLayers, err := decodeOptionalConfigBool(payload, objectName, "includeLayers")
+	if err != nil {
+		return err
+	}
+	cwd, err := decodeOptionalNullableConfigValue[string](payload, objectName, "cwd")
+	if err != nil {
+		return err
+	}
+	*p = ConfigReadParams{IncludeLayers: includeLayers, CWD: cwd}
+	return nil
+}
+
+var (
+	_ json.Marshaler   = ConfigReadParams{}
+	_ json.Unmarshaler = (*ConfigReadParams)(nil)
+)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
-		t.Fatalf("definition count = %d, want 343", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
+		t.Fatalf("definition count = %d, want 344", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
-		t.Fatalf("definition count = %d, want 343", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
+		t.Fatalf("definition count = %d, want 344", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
-		t.Fatalf("definition count = %d, want 343", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
+		t.Fatalf("definition count = %d, want 344", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_write_contracts_types.go
+++ b/appserver/protocol/config_write_contracts_types.go
@@ -128,11 +128,11 @@ func (p *ConfigValueWriteParams) UnmarshalJSON(data []byte) error {
 	if err != nil {
 		return err
 	}
-	filePath, err := decodeOptionalNullableConfigWriteValue[string](payload, objectName, "filePath")
+	filePath, err := decodeOptionalNullableConfigValue[string](payload, objectName, "filePath")
 	if err != nil {
 		return err
 	}
-	expectedVersion, err := decodeOptionalNullableConfigWriteValue[string](payload, objectName, "expectedVersion")
+	expectedVersion, err := decodeOptionalNullableConfigValue[string](payload, objectName, "expectedVersion")
 	if err != nil {
 		return err
 	}
@@ -187,15 +187,15 @@ func (p *ConfigBatchWriteParams) UnmarshalJSON(data []byte) error {
 	if err != nil {
 		return err
 	}
-	filePath, err := decodeOptionalNullableConfigWriteValue[string](payload, objectName, "filePath")
+	filePath, err := decodeOptionalNullableConfigValue[string](payload, objectName, "filePath")
 	if err != nil {
 		return err
 	}
-	expectedVersion, err := decodeOptionalNullableConfigWriteValue[string](payload, objectName, "expectedVersion")
+	expectedVersion, err := decodeOptionalNullableConfigValue[string](payload, objectName, "expectedVersion")
 	if err != nil {
 		return err
 	}
-	reloadUserConfig, err := decodeOptionalConfigWriteBool(payload, objectName, "reloadUserConfig")
+	reloadUserConfig, err := decodeOptionalConfigBool(payload, objectName, "reloadUserConfig")
 	if err != nil {
 		return err
 	}
@@ -245,7 +245,7 @@ func (r *ConfigWriteResponse) UnmarshalJSON(data []byte) error {
 	if err != nil {
 		return err
 	}
-	overriddenMetadata, err := decodeOptionalNullableConfigWriteValue[OverriddenMetadata](
+	overriddenMetadata, err := decodeOptionalNullableConfigValue[OverriddenMetadata](
 		payload,
 		objectName,
 		"overriddenMetadata",
@@ -262,7 +262,7 @@ func (r *ConfigWriteResponse) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func decodeOptionalNullableConfigWriteValue[T any](
+func decodeOptionalNullableConfigValue[T any](
 	payload map[string]json.RawMessage,
 	objectName string,
 	fieldName string,
@@ -278,7 +278,7 @@ func decodeOptionalNullableConfigWriteValue[T any](
 	return &value, nil
 }
 
-func decodeOptionalConfigWriteBool(
+func decodeOptionalConfigBool(
 	payload map[string]json.RawMessage,
 	objectName string,
 	fieldName string,

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
-		t.Fatalf("definition count = %d, want 343", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
+		t.Fatalf("definition count = %d, want 344", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 343 {
-		t.Fatalf("definition count = %d, want 343", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 344 {
+		t.Fatalf("definition count = %d, want 344", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
-		t.Fatalf("definition count = %d, want 343", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
+		t.Fatalf("definition count = %d, want 344", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
-		t.Fatalf("definition count = %d, want 343", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
+		t.Fatalf("definition count = %d, want 344", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
-		t.Fatalf("definition count = %d, want 343", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
+		t.Fatalf("definition count = %d, want 344", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
-		t.Fatalf("definition count = %d, want 343", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
+		t.Fatalf("definition count = %d, want 344", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
-		t.Fatalf("definition count = %d, want 343", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
+		t.Fatalf("definition count = %d, want 344", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
-		t.Fatalf("definition count = %d, want 343", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
+		t.Fatalf("definition count = %d, want 344", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
-		t.Fatalf("definition count = %d, want 343", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
+		t.Fatalf("definition count = %d, want 344", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
-		t.Fatalf("definition count = %d, want 343", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
+		t.Fatalf("definition count = %d, want 344", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 343 {
-		t.Fatalf("definition count = %d, want 343", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 344 {
+		t.Fatalf("definition count = %d, want 344", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 343 {
-		t.Fatalf("definition count = %d, want 343", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 344 {
+		t.Fatalf("definition count = %d, want 344", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 343 {
-		t.Fatalf("definition count = %d, want 343", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 344 {
+		t.Fatalf("definition count = %d, want 344", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 343 {
-		t.Fatalf("definition count = %d, want 343", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 344 {
+		t.Fatalf("definition count = %d, want 344", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 343 {
-		t.Fatalf("definition count = %d, want 343", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 344 {
+		t.Fatalf("definition count = %d, want 344", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -126,6 +126,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "ConfigLayer", Type: reflect.TypeFor[ConfigLayer]()},
 		{Name: "ConfigLayerMetadata", Type: reflect.TypeFor[ConfigLayerMetadata]()},
 		{Name: "ConfigLayerSource", Type: reflect.TypeFor[ConfigLayerSource]()},
+		{Name: "ConfigReadParams", Type: reflect.TypeFor[ConfigReadParams]()},
 		{Name: "ConfigRequirements", Type: reflect.TypeFor[ConfigRequirements]()},
 		{Name: "ConfigRequirementsReadResponse", Type: reflect.TypeFor[ConfigRequirementsReadResponse]()},
 		{Name: "ConfigValueWriteParams", Type: reflect.TypeFor[ConfigValueWriteParams]()},
@@ -469,6 +470,8 @@ func wireSchemaDefinitions() Schema {
 		string(WriteStatusOK), string(WriteStatusOKOverridden),
 	)
 	schemas["ConfigLayerSource"] = configLayerSourceSchema()
+	configReadProperties := schemas["ConfigReadParams"].(Schema)["properties"].(Schema)
+	configReadProperties["cwd"].(Schema)["description"] = configReadCWDDescription
 	const configFilePathDescription = "Path to the config file to write; defaults to the user's `config.toml` when omitted."
 	for _, definition := range []string{"ConfigValueWriteParams", "ConfigBatchWriteParams"} {
 		properties := schemas[definition].(Schema)["properties"].(Schema)

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -1658,6 +1658,26 @@
         }
       ]
     },
+    "ConfigReadParams": {
+      "additionalProperties": false,
+      "properties": {
+        "cwd": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional working directory to resolve project config layers. If specified, return the effective config as seen from that directory (i.e., including any project layers between `cwd` and the project/repo root)."
+        },
+        "includeLayers": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
     "ConfigRequirements": {
       "additionalProperties": false,
       "properties": {

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 343 {
-		t.Fatalf("definition count = %d, want 343", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 344 {
+		t.Fatalf("definition count = %d, want 344", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
-		t.Fatalf("definition count = %d, want 343", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
+		t.Fatalf("definition count = %d, want 344", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
-		t.Fatalf("definition count = %d, want 343", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
+		t.Fatalf("definition count = %d, want 344", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
-		t.Fatalf("definition count = %d, want 343", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
+		t.Fatalf("definition count = %d, want 344", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
-		t.Fatalf("definition count = %d, want 343", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
+		t.Fatalf("definition count = %d, want 344", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
-		t.Fatalf("definition count = %d, want 343", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
+		t.Fatalf("definition count = %d, want 344", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 343 {
-		t.Fatalf("definition count = %d, want 343", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 344 {
+		t.Fatalf("definition count = %d, want 344", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 343 {
-		t.Fatalf("definition count = %d, want 343", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 344 {
+		t.Fatalf("definition count = %d, want 344", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
-		t.Fatalf("definition count = %d, want 343", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
+		t.Fatalf("definition count = %d, want 344", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
-		t.Fatalf("definition count = %d, want 343", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
+		t.Fatalf("definition count = %d, want 344", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
-		t.Fatalf("definition count = %d, want 343", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
+		t.Fatalf("definition count = %d, want 344", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
-		t.Fatalf("definition count = %d, want 343", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
+		t.Fatalf("definition count = %d, want 344", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -838,6 +838,11 @@ export type ConfigLayerSource = {
   "type": "legacyManagedConfigTomlFromMdm";
 };
 
+export type ConfigReadParams = {
+  "cwd"?: string | null;
+  "includeLayers"?: boolean;
+};
+
 export type ConfigRequirements = {
   "allowAppshots": boolean | null;
   "allowManagedHooksOnly": boolean | null;

--- a/appserver/protocol/typescript/testdata/config_read_params_contract.ts
+++ b/appserver/protocol/typescript/testdata/config_read_params_contract.ts
@@ -1,0 +1,45 @@
+import type { ConfigReadParams } from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? (<T>() => T extends B ? 1 : 2) extends
+        (<T>() => T extends A ? 1 : 2)
+      ? true
+      : false
+    : false;
+type Expect<T extends true> = T;
+
+type ConfigReadParamsContract = Expect<Equal<ConfigReadParams, {
+  cwd?: string | null;
+  includeLayers?: boolean;
+}>>;
+
+({}) satisfies ConfigReadParams;
+({ includeLayers: false }) satisfies ConfigReadParams;
+({ includeLayers: true, cwd: null }) satisfies ConfigReadParams;
+({ cwd: "" }) satisfies ConfigReadParams;
+({ cwd: "relative/project" }) satisfies ConfigReadParams;
+({ cwd: "/workspace/project" }) satisfies ConfigReadParams;
+
+// @ts-expect-error includeLayers is a non-null boolean.
+({ includeLayers: null }) satisfies ConfigReadParams;
+// @ts-expect-error includeLayers is a boolean.
+({ includeLayers: "false" }) satisfies ConfigReadParams;
+// @ts-expect-error cwd is a nullable string.
+({ cwd: false }) satisfies ConfigReadParams;
+// @ts-expect-error optional cwd cannot be explicit undefined.
+({ cwd: undefined }) satisfies ConfigReadParams;
+// @ts-expect-error the public request excludes live keys.
+({ keys: [] }) satisfies ConfigReadParams;
+// @ts-expect-error the public request excludes live includeValues.
+({ includeValues: true }) satisfies ConfigReadParams;
+// @ts-expect-error wire fields use camel case.
+({ include_layers: true }) satisfies ConfigReadParams;
+// @ts-expect-error the request is closed.
+({ extra: true }) satisfies ConfigReadParams;
+// @ts-expect-error the request is an object.
+null satisfies ConfigReadParams;
+
+declare const configReadParamsContract: ConfigReadParamsContract;
+void configReadParamsContract;

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 343 {
-		t.Fatalf("definition count = %d, want 343", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
+		t.Fatalf("definition count = %d, want 344", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- add the exact standalone public `ConfigReadParams` wire contract
- preserve upstream optional/nullable `cwd` and default-false `includeLayers` semantics
- generate schema and TypeScript bindings with strict Go and TypeScript fixtures
- keep config/read method inference unknown because the live Gollem request is incompatible

## Verification
- `go test ./appserver/protocol -run TestConfigReadParams -count=30`
- `go test -race ./appserver/protocol -run TestConfigReadParams`
- focused coverage: 100% for both new methods
- all non-Monty normal and race package suites
- `tsc --project appserver/protocol/typescript/tsconfig.json`
- `golangci-lint run ./...`
- `go vet ./...`
- `go mod tidy` clean
- deterministic protocol generation