### PR TITLE
feat(protocol): add config prerequisite contracts

### DIFF
--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
-		t.Fatalf("definition count = %d, want 344", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
+		t.Fatalf("definition count = %d, want 354", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
-		t.Fatalf("definition count = %d, want 344", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
+		t.Fatalf("definition count = %d, want 354", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -1,0 +1,398 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestConfigPrerequisiteSchemasAreExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	want := map[string]Schema{
+		"AnalyticsConfig": {
+			"type": "object",
+			"properties": Schema{
+				"enabled": nullableConfigPrerequisiteSchema(Schema{"type": "boolean"}),
+			},
+			"required":                         []string{"enabled"},
+			"additionalProperties":             Schema{"$ref": "#/$defs/JsonValue"},
+			"x-gollem-typescript-optional-map": true,
+		},
+		"AutoCompactTokenLimitScope": {
+			"description": "Selects which part of the active context is charged against `model_auto_compact_token_limit`.",
+			"oneOf": []any{
+				Schema{
+					"type":        "string",
+					"enum":        []any{"total"},
+					"description": "Count the full active context against the limit.",
+				},
+				Schema{
+					"type":        "string",
+					"enum":        []any{"body_after_prefix"},
+					"description": "Count sampled output and later growth after the carried window prefix.",
+				},
+			},
+		},
+		"ForcedChatgptWorkspaceIds": {
+			"anyOf": []any{
+				Schema{"type": "string"},
+				Schema{"type": "array", "items": Schema{"type": "string"}},
+			},
+			"description": "Backward-compatible API shape for ChatGPT workspace login restrictions.",
+		},
+		"ForcedLoginMethod": stringEnumSchema("chatgpt", "api"),
+		"SandboxWorkspaceWrite": {
+			"type": "object",
+			"properties": Schema{
+				"writable_roots": Schema{
+					"type": "array", "items": Schema{"type": "string"}, "default": []any{},
+				},
+				"network_access":         Schema{"type": "boolean", "default": false},
+				"exclude_tmpdir_env_var": Schema{"type": "boolean", "default": false},
+				"exclude_slash_tmp":      Schema{"type": "boolean", "default": false},
+			},
+			"required": []string{
+				"writable_roots", "network_access", "exclude_tmpdir_env_var", "exclude_slash_tmp",
+			},
+			"additionalProperties":                             true,
+			"x-gollem-typescript-ignore-additional-properties": true,
+		},
+		"ToolsV2": {
+			"type": "object",
+			"properties": Schema{
+				"web_search": nullableConfigPrerequisiteSchema(Schema{"$ref": "#/$defs/WebSearchToolConfig"}),
+			},
+			"required":             []string{"web_search"},
+			"additionalProperties": true,
+			"x-gollem-typescript-ignore-additional-properties": true,
+		},
+		"Verbosity": {
+			"type":        "string",
+			"enum":        []any{"low", "medium", "high"},
+			"description": "Controls output length/detail on GPT-5 models via the Responses API. Serialized with lowercase values to match the OpenAI API.",
+		},
+		"WebSearchContextSize": stringEnumSchema("low", "medium", "high"),
+		"WebSearchLocation": {
+			"type": "object",
+			"properties": Schema{
+				"country":  nullableConfigPrerequisiteSchema(Schema{"type": "string"}),
+				"region":   nullableConfigPrerequisiteSchema(Schema{"type": "string"}),
+				"city":     nullableConfigPrerequisiteSchema(Schema{"type": "string"}),
+				"timezone": nullableConfigPrerequisiteSchema(Schema{"type": "string"}),
+			},
+			"required":             []string{"country", "region", "city", "timezone"},
+			"additionalProperties": false,
+		},
+		"WebSearchToolConfig": {
+			"type": "object",
+			"properties": Schema{
+				"context_size": nullableConfigPrerequisiteSchema(Schema{"$ref": "#/$defs/WebSearchContextSize"}),
+				"allowed_domains": nullableConfigPrerequisiteSchema(Schema{
+					"type": "array", "items": Schema{"type": "string"},
+				}),
+				"location": nullableConfigPrerequisiteSchema(Schema{"$ref": "#/$defs/WebSearchLocation"}),
+			},
+			"required":             []string{"context_size", "allowed_domains", "location"},
+			"additionalProperties": false,
+		},
+	}
+	for name, expected := range want {
+		if got := defs[name]; !reflect.DeepEqual(got, expected) {
+			t.Errorf("%s schema = %#v, want %#v", name, got, expected)
+		}
+	}
+}
+
+func TestConfigPrerequisiteEnumsAcceptOnlyExactValues(t *testing.T) {
+	assertConfigPrerequisiteEnum[AutoCompactTokenLimitScope](t, "total", "body_after_prefix")
+	assertConfigPrerequisiteEnum[ForcedLoginMethod](t, "chatgpt", "api")
+	assertConfigPrerequisiteEnum[Verbosity](t, "low", "medium", "high")
+	assertConfigPrerequisiteEnum[WebSearchContextSize](t, "low", "medium", "high")
+}
+
+func TestForcedChatgptWorkspaceIdsAcceptsExactWireForms(t *testing.T) {
+	for _, test := range []struct {
+		input string
+		want  string
+	}{
+		{`""`, `""`},
+		{`"workspace"`, `"workspace"`},
+		{`[]`, `[]`},
+		{`["","workspace","workspace"]`, `["","workspace","workspace"]`},
+	} {
+		var value ForcedChatgptWorkspaceIds
+		assertConfigPrerequisiteRoundTrip(t, test.input, test.want, &value)
+	}
+	for _, input := range []string{
+		`null`, `true`, `1`, `{}`, `[null]`, `["workspace",1]`, `{} {}`,
+	} {
+		assertJSONRejects[ForcedChatgptWorkspaceIds](t, input)
+	}
+	var zero ForcedChatgptWorkspaceIds
+	if _, err := json.Marshal(zero); err == nil {
+		t.Fatal("empty ForcedChatgptWorkspaceIds marshaled")
+	}
+}
+
+func TestAnalyticsConfigPreservesOpenPrecisionSafeValues(t *testing.T) {
+	for _, test := range []struct {
+		input string
+		want  string
+	}{
+		{`{}`, `{"enabled":null}`},
+		{`{"enabled":null}`, `{"enabled":null}`},
+		{`{"enabled":false}`, `{"enabled":false}`},
+		{`{"enabled":true,"nested":{"value":[9007199254740993,true,null]},"z":"last"}`, `{"enabled":true,"nested":{"value":[9007199254740993,true,null]},"z":"last"}`},
+		{`{"empty":[],"enabled":null}`, `{"empty":[],"enabled":null}`},
+	} {
+		var value AnalyticsConfig
+		assertConfigPrerequisiteRoundTrip(t, test.input, test.want, &value)
+	}
+	for _, input := range []string{
+		`null`, `[]`, `"value"`, `1`, `true`,
+		`{"enabled":"true"}`, `{"enabled":0}`, `{} {}`,
+	} {
+		assertJSONRejects[AnalyticsConfig](t, input)
+	}
+	invalid := AnalyticsConfig{Additional: map[string]JsonValue{"bad": {}}}
+	if _, err := json.Marshal(invalid); err == nil {
+		t.Fatal("AnalyticsConfig with invalid JsonValue marshaled")
+	}
+	conflicting := AnalyticsConfig{Additional: map[string]JsonValue{"enabled": {}}}
+	if _, err := json.Marshal(conflicting); err == nil {
+		t.Fatal("AnalyticsConfig with conflicting enabled field marshaled")
+	}
+}
+
+func TestSandboxWorkspaceWriteDefaultsAndIgnoresAdditionalFields(t *testing.T) {
+	const defaults = `{"writable_roots":[],"network_access":false,"exclude_tmpdir_env_var":false,"exclude_slash_tmp":false}`
+	for _, test := range []struct {
+		input string
+		want  string
+	}{
+		{`{}`, defaults},
+		{`{"writable_roots":[],"network_access":false,"exclude_tmpdir_env_var":false,"exclude_slash_tmp":false}`, defaults},
+		{`{"writable_roots":["","relative","/absolute"],"network_access":true,"exclude_tmpdir_env_var":true,"exclude_slash_tmp":true}`, `{"writable_roots":["","relative","/absolute"],"network_access":true,"exclude_tmpdir_env_var":true,"exclude_slash_tmp":true}`},
+		{`{"future":{"nested":true}}`, defaults},
+	} {
+		var value SandboxWorkspaceWrite
+		assertConfigPrerequisiteRoundTrip(t, test.input, test.want, &value)
+	}
+	for _, input := range []string{
+		`null`, `[]`, `"value"`,
+		`{"writable_roots":null}`,
+		`{"writable_roots":{}}`,
+		`{"writable_roots":[null]}`,
+		`{"writable_roots":[1]}`,
+		`{"network_access":null}`,
+		`{"network_access":"true"}`,
+		`{"exclude_tmpdir_env_var":0}`,
+		`{"exclude_slash_tmp":null}`,
+		`{} {}`,
+	} {
+		assertJSONRejects[SandboxWorkspaceWrite](t, input)
+	}
+	encoded, err := json.Marshal(SandboxWorkspaceWrite{})
+	if err != nil || string(encoded) != defaults {
+		t.Fatalf("zero SandboxWorkspaceWrite = %s, %v", encoded, err)
+	}
+}
+
+func TestWebSearchConfigGraphCanonicalizesNullableFields(t *testing.T) {
+	const emptyLocation = `{"country":null,"region":null,"city":null,"timezone":null}`
+	for _, test := range []struct {
+		input string
+		want  string
+	}{
+		{`{}`, emptyLocation},
+		{`{"country":null,"region":"","city":"New York","timezone":"America/New_York"}`, `{"country":null,"region":"","city":"New York","timezone":"America/New_York"}`},
+	} {
+		var value WebSearchLocation
+		assertConfigPrerequisiteRoundTrip(t, test.input, test.want, &value)
+	}
+
+	const emptyTool = `{"context_size":null,"allowed_domains":null,"location":null}`
+	for _, test := range []struct {
+		input string
+		want  string
+	}{
+		{`{}`, emptyTool},
+		{`{"context_size":null,"allowed_domains":null,"location":null}`, emptyTool},
+		{`{"context_size":"high","allowed_domains":[],"location":{}}`, `{"context_size":"high","allowed_domains":[],"location":` + emptyLocation + `}`},
+		{`{"context_size":"low","allowed_domains":["","example.com","example.com"],"location":{"country":"US"}}`, `{"context_size":"low","allowed_domains":["","example.com","example.com"],"location":{"country":"US","region":null,"city":null,"timezone":null}}`},
+	} {
+		var value WebSearchToolConfig
+		assertConfigPrerequisiteRoundTrip(t, test.input, test.want, &value)
+	}
+
+	for _, test := range []struct {
+		input string
+		want  string
+	}{
+		{`{}`, `{"web_search":null}`},
+		{`{"web_search":null}`, `{"web_search":null}`},
+		{`{"web_search":{}}`, `{"web_search":` + emptyTool + `}`},
+		{`{"future":true}`, `{"web_search":null}`},
+	} {
+		var value ToolsV2
+		assertConfigPrerequisiteRoundTrip(t, test.input, test.want, &value)
+	}
+}
+
+func TestWebSearchConfigGraphRejectsMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		`null`, `[]`,
+		`{"country":1}`,
+		`{"region":false}`,
+		`{"city":[]}`,
+		`{"timezone":{}}`,
+		`{"extra":true}`,
+		`{} {}`,
+	} {
+		assertJSONRejects[WebSearchLocation](t, input)
+	}
+	for _, input := range []string{
+		`null`, `[]`,
+		`{"context_size":"large"}`,
+		`{"context_size":1}`,
+		`{"allowed_domains":"example.com"}`,
+		`{"allowed_domains":[null]}`,
+		`{"allowed_domains":[1]}`,
+		`{"location":false}`,
+		`{"location":{"extra":true}}`,
+		`{"extra":true}`,
+		`{} {}`,
+	} {
+		assertJSONRejects[WebSearchToolConfig](t, input)
+	}
+	for _, input := range []string{
+		`null`, `[]`, `{"web_search":false}`, `{"web_search":{"extra":true}}`, `{} {}`,
+	} {
+		assertJSONRejects[ToolsV2](t, input)
+	}
+}
+
+func TestConfigPrerequisiteNilReceivers(t *testing.T) {
+	var analytics *AnalyticsConfig
+	if err := analytics.UnmarshalJSON([]byte(`{}`)); err == nil {
+		t.Fatal("nil AnalyticsConfig receiver succeeded")
+	}
+	var workspace *ForcedChatgptWorkspaceIds
+	if err := workspace.UnmarshalJSON([]byte(`"workspace"`)); err == nil {
+		t.Fatal("nil ForcedChatgptWorkspaceIds receiver succeeded")
+	}
+	var sandbox *SandboxWorkspaceWrite
+	if err := sandbox.UnmarshalJSON([]byte(`{}`)); err == nil {
+		t.Fatal("nil SandboxWorkspaceWrite receiver succeeded")
+	}
+	var location *WebSearchLocation
+	if err := location.UnmarshalJSON([]byte(`{}`)); err == nil {
+		t.Fatal("nil WebSearchLocation receiver succeeded")
+	}
+	var tool *WebSearchToolConfig
+	if err := tool.UnmarshalJSON([]byte(`{}`)); err == nil {
+		t.Fatal("nil WebSearchToolConfig receiver succeeded")
+	}
+	var tools *ToolsV2
+	if err := tools.UnmarshalJSON([]byte(`{}`)); err == nil {
+		t.Fatal("nil ToolsV2 receiver succeeded")
+	}
+}
+
+func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
+	names := []string{
+		"AnalyticsConfig",
+		"AutoCompactTokenLimitScope",
+		"ForcedChatgptWorkspaceIds",
+		"ForcedLoginMethod",
+		"SandboxWorkspaceWrite",
+		"ToolsV2",
+		"Verbosity",
+		"WebSearchContextSize",
+		"WebSearchLocation",
+		"WebSearchToolConfig",
+	}
+	for _, binding := range WireTypeBindings() {
+		for _, name := range names {
+			if slices.Contains(binding.Params, name) || slices.Contains(binding.Result, name) {
+				t.Fatalf("%s unexpectedly bound to %s", name, binding.Method)
+			}
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
+		t.Fatalf("definition count = %d, want 354", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestConfigPrerequisiteTypeScriptExportsArePresent(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	for _, name := range []string{
+		"AnalyticsConfig",
+		"AutoCompactTokenLimitScope",
+		"ForcedChatgptWorkspaceIds",
+		"ForcedLoginMethod",
+		"SandboxWorkspaceWrite",
+		"ToolsV2",
+		"Verbosity",
+		"WebSearchContextSize",
+		"WebSearchLocation",
+		"WebSearchToolConfig",
+	} {
+		if want := "export type " + name + " ="; !strings.Contains(string(generated), want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}
+
+func nullableConfigPrerequisiteSchema(value Schema) Schema {
+	return Schema{"anyOf": []any{value, Schema{"type": "null"}}}
+}
+
+func assertConfigPrerequisiteEnum[T any](t *testing.T, values ...string) {
+	t.Helper()
+	for _, value := range values {
+		var decoded T
+		assertConfigPrerequisiteRoundTrip(t, `"`+value+`"`, `"`+value+`"`, &decoded)
+	}
+	for _, input := range []string{`null`, `true`, `1`, `""`, `"unknown"`, `{}`, `[]`, `"unknown" {}`} {
+		assertJSONRejects[T](t, input)
+	}
+	var zero T
+	if _, err := json.Marshal(zero); err == nil {
+		t.Fatalf("zero %T marshaled", zero)
+	}
+}
+
+func assertConfigPrerequisiteRoundTrip(t *testing.T, input, want string, target any) {
+	t.Helper()
+	if err := json.Unmarshal([]byte(input), target); err != nil {
+		t.Fatalf("unmarshal %s: %v", input, err)
+	}
+	got, err := json.Marshal(target)
+	if err != nil {
+		t.Fatalf("marshal %s: %v", input, err)
+	}
+	if string(got) != want {
+		t.Fatalf("round trip %s = %s, want %s", input, got, want)
+	}
+}
+
+var (
+	_ json.Unmarshaler = (*AnalyticsConfig)(nil)
+	_ json.Unmarshaler = (*ForcedChatgptWorkspaceIds)(nil)
+	_ json.Unmarshaler = (*SandboxWorkspaceWrite)(nil)
+	_ json.Unmarshaler = (*WebSearchLocation)(nil)
+	_ json.Unmarshaler = (*WebSearchToolConfig)(nil)
+	_ json.Unmarshaler = (*ToolsV2)(nil)
+)

--- a/appserver/protocol/config_prerequisites_types.go
+++ b/appserver/protocol/config_prerequisites_types.go
@@ -1,0 +1,426 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// AutoCompactTokenLimitScope selects the context charged against the automatic
+// compaction token limit.
+type AutoCompactTokenLimitScope string
+
+const (
+	AutoCompactTokenLimitScopeTotal           AutoCompactTokenLimitScope = "total"
+	AutoCompactTokenLimitScopeBodyAfterPrefix AutoCompactTokenLimitScope = "body_after_prefix"
+)
+
+func (s AutoCompactTokenLimitScope) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(s, "automatic compaction token-limit scope", AutoCompactTokenLimitScope.valid)
+}
+
+func (s *AutoCompactTokenLimitScope) UnmarshalJSON(data []byte) error {
+	return unmarshalThreadTurnLeafEnum(data, s, "automatic compaction token-limit scope", AutoCompactTokenLimitScope.valid)
+}
+
+func (s AutoCompactTokenLimitScope) valid() bool {
+	return s == AutoCompactTokenLimitScopeTotal || s == AutoCompactTokenLimitScopeBodyAfterPrefix
+}
+
+// ForcedLoginMethod is the exact closed public login method.
+type ForcedLoginMethod string
+
+const (
+	ForcedLoginMethodChatGPT ForcedLoginMethod = "chatgpt"
+	ForcedLoginMethodAPI     ForcedLoginMethod = "api"
+)
+
+func (m ForcedLoginMethod) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(m, "forced login method", ForcedLoginMethod.valid)
+}
+
+func (m *ForcedLoginMethod) UnmarshalJSON(data []byte) error {
+	return unmarshalThreadTurnLeafEnum(data, m, "forced login method", ForcedLoginMethod.valid)
+}
+
+func (m ForcedLoginMethod) valid() bool {
+	return m == ForcedLoginMethodChatGPT || m == ForcedLoginMethodAPI
+}
+
+// Verbosity is the exact closed public model verbosity.
+type Verbosity string
+
+const (
+	VerbosityLow    Verbosity = "low"
+	VerbosityMedium Verbosity = "medium"
+	VerbosityHigh   Verbosity = "high"
+)
+
+func (v Verbosity) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(v, "model verbosity", Verbosity.valid)
+}
+
+func (v *Verbosity) UnmarshalJSON(data []byte) error {
+	return unmarshalThreadTurnLeafEnum(data, v, "model verbosity", Verbosity.valid)
+}
+
+func (v Verbosity) valid() bool {
+	switch v {
+	case VerbosityLow, VerbosityMedium, VerbosityHigh:
+		return true
+	default:
+		return false
+	}
+}
+
+// WebSearchContextSize is the exact closed public web-search context size.
+type WebSearchContextSize string
+
+const (
+	WebSearchContextSizeLow    WebSearchContextSize = "low"
+	WebSearchContextSizeMedium WebSearchContextSize = "medium"
+	WebSearchContextSizeHigh   WebSearchContextSize = "high"
+)
+
+func (s WebSearchContextSize) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(s, "web-search context size", WebSearchContextSize.valid)
+}
+
+func (s *WebSearchContextSize) UnmarshalJSON(data []byte) error {
+	return unmarshalThreadTurnLeafEnum(data, s, "web-search context size", WebSearchContextSize.valid)
+}
+
+func (s WebSearchContextSize) valid() bool {
+	switch s {
+	case WebSearchContextSizeLow, WebSearchContextSizeMedium, WebSearchContextSizeHigh:
+		return true
+	default:
+		return false
+	}
+}
+
+// ForcedChatgptWorkspaceIds preserves whether the public compatibility value
+// used its single-workspace or multiple-workspace wire form.
+type ForcedChatgptWorkspaceIds struct {
+	raw json.RawMessage
+}
+
+func (i ForcedChatgptWorkspaceIds) MarshalJSON() ([]byte, error) {
+	if len(i.raw) == 0 {
+		return nil, errors.New("forced ChatGPT workspace IDs have no value")
+	}
+	return validateForcedChatgptWorkspaceIDsJSON(i.raw)
+}
+
+func (i *ForcedChatgptWorkspaceIds) UnmarshalJSON(data []byte) error {
+	if i == nil {
+		return errors.New("decode forced ChatGPT workspace IDs into nil receiver")
+	}
+	canonical, err := validateForcedChatgptWorkspaceIDsJSON(data)
+	if err != nil {
+		return err
+	}
+	i.raw = canonical
+	return nil
+}
+
+func validateForcedChatgptWorkspaceIDsJSON(data []byte) (json.RawMessage, error) {
+	if isJSONNull(data) {
+		return nil, errors.New("forced ChatGPT workspace IDs cannot be null")
+	}
+	var single string
+	if err := json.Unmarshal(data, &single); err == nil {
+		return json.Marshal(single)
+	}
+	var elements []json.RawMessage
+	if err := json.Unmarshal(data, &elements); err != nil {
+		return nil, fmt.Errorf("decode forced ChatGPT workspace IDs: %w", err)
+	}
+	values := make([]string, len(elements))
+	for index, element := range elements {
+		if isJSONNull(element) {
+			return nil, fmt.Errorf("decode forced ChatGPT workspace IDs[%d]: value cannot be null", index)
+		}
+		if err := json.Unmarshal(element, &values[index]); err != nil {
+			return nil, fmt.Errorf("decode forced ChatGPT workspace IDs[%d]: %w", index, err)
+		}
+	}
+	return json.Marshal(values)
+}
+
+// AnalyticsConfig preserves public flattened analytics fields as exact JSON
+// values while keeping enabled as the one known nullable field.
+type AnalyticsConfig struct {
+	Enabled    *bool                `json:"enabled"`
+	Additional map[string]JsonValue `json:"-"`
+}
+
+func (c AnalyticsConfig) MarshalJSON() ([]byte, error) {
+	fields := make(map[string]json.RawMessage, len(c.Additional)+1)
+	for name, value := range c.Additional {
+		if name == "enabled" {
+			return nil, errors.New("analytics additional fields cannot redefine enabled")
+		}
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			return nil, fmt.Errorf("encode analytics field %q: %w", name, err)
+		}
+		fields[name] = encoded
+	}
+	enabled := json.RawMessage("null")
+	if c.Enabled != nil {
+		if *c.Enabled {
+			enabled = json.RawMessage("true")
+		} else {
+			enabled = json.RawMessage("false")
+		}
+	}
+	fields["enabled"] = enabled
+	return json.Marshal(fields)
+}
+
+func (c *AnalyticsConfig) UnmarshalJSON(data []byte) error {
+	if c == nil {
+		return errors.New("decode analytics config into nil receiver")
+	}
+	const objectName = "analytics config"
+	payload, err := decodeOpenConfigPrerequisiteObject(data, objectName)
+	if err != nil {
+		return err
+	}
+	enabled, err := decodeOptionalNullableConfigRequirementValue[bool](payload, objectName, "enabled")
+	if err != nil {
+		return err
+	}
+	additional := make(map[string]JsonValue, len(payload))
+	for name, raw := range payload {
+		if name == "enabled" {
+			continue
+		}
+		additional[name] = JsonValue{raw: append(json.RawMessage(nil), raw...)}
+	}
+	*c = AnalyticsConfig{Enabled: enabled, Additional: additional}
+	return nil
+}
+
+// SandboxWorkspaceWrite is the exact public writable-workspace sandbox
+// configuration. Unknown fields are accepted for Rust-compatible evolution.
+type SandboxWorkspaceWrite struct {
+	WritableRoots       []string `json:"writable_roots"`
+	NetworkAccess       bool     `json:"network_access"`
+	ExcludeTmpdirEnvVar bool     `json:"exclude_tmpdir_env_var"`
+	ExcludeSlashTmp     bool     `json:"exclude_slash_tmp"`
+}
+
+func (w SandboxWorkspaceWrite) MarshalJSON() ([]byte, error) {
+	writableRoots := w.WritableRoots
+	if writableRoots == nil {
+		writableRoots = []string{}
+	}
+	return json.Marshal(struct {
+		WritableRoots       []string `json:"writable_roots"`
+		NetworkAccess       bool     `json:"network_access"`
+		ExcludeTmpdirEnvVar bool     `json:"exclude_tmpdir_env_var"`
+		ExcludeSlashTmp     bool     `json:"exclude_slash_tmp"`
+	}{
+		WritableRoots:       writableRoots,
+		NetworkAccess:       w.NetworkAccess,
+		ExcludeTmpdirEnvVar: w.ExcludeTmpdirEnvVar,
+		ExcludeSlashTmp:     w.ExcludeSlashTmp,
+	})
+}
+
+func (w *SandboxWorkspaceWrite) UnmarshalJSON(data []byte) error {
+	if w == nil {
+		return errors.New("decode sandbox workspace-write config into nil receiver")
+	}
+	const objectName = "sandbox workspace-write config"
+	payload, err := decodeOpenConfigPrerequisiteObject(data, objectName)
+	if err != nil {
+		return err
+	}
+	writableRoots, err := decodeDefaultedConfigPrerequisiteStringArray(payload, objectName, "writable_roots")
+	if err != nil {
+		return err
+	}
+	networkAccess, err := decodeOptionalConfigBool(payload, objectName, "network_access")
+	if err != nil {
+		return err
+	}
+	excludeTmpdirEnvVar, err := decodeOptionalConfigBool(payload, objectName, "exclude_tmpdir_env_var")
+	if err != nil {
+		return err
+	}
+	excludeSlashTmp, err := decodeOptionalConfigBool(payload, objectName, "exclude_slash_tmp")
+	if err != nil {
+		return err
+	}
+	*w = SandboxWorkspaceWrite{
+		WritableRoots:       writableRoots,
+		NetworkAccess:       networkAccess,
+		ExcludeTmpdirEnvVar: excludeTmpdirEnvVar,
+		ExcludeSlashTmp:     excludeSlashTmp,
+	}
+	return nil
+}
+
+// WebSearchLocation is the exact closed public web-search location.
+type WebSearchLocation struct {
+	Country  *string `json:"country"`
+	Region   *string `json:"region"`
+	City     *string `json:"city"`
+	Timezone *string `json:"timezone"`
+}
+
+func (l *WebSearchLocation) UnmarshalJSON(data []byte) error {
+	if l == nil {
+		return errors.New("decode web-search location into nil receiver")
+	}
+	const objectName = "web-search location"
+	payload, err := decodeExactThreadItemObject(data, objectName, "country", "region", "city", "timezone")
+	if err != nil {
+		return err
+	}
+	country, err := decodeOptionalNullableConfigRequirementValue[string](payload, objectName, "country")
+	if err != nil {
+		return err
+	}
+	region, err := decodeOptionalNullableConfigRequirementValue[string](payload, objectName, "region")
+	if err != nil {
+		return err
+	}
+	city, err := decodeOptionalNullableConfigRequirementValue[string](payload, objectName, "city")
+	if err != nil {
+		return err
+	}
+	timezone, err := decodeOptionalNullableConfigRequirementValue[string](payload, objectName, "timezone")
+	if err != nil {
+		return err
+	}
+	*l = WebSearchLocation{Country: country, Region: region, City: city, Timezone: timezone}
+	return nil
+}
+
+// WebSearchToolConfig is the exact closed public web-search tool config.
+type WebSearchToolConfig struct {
+	ContextSize    *WebSearchContextSize `json:"context_size"`
+	AllowedDomains []string              `json:"allowed_domains"`
+	Location       *WebSearchLocation    `json:"location"`
+}
+
+func (c *WebSearchToolConfig) UnmarshalJSON(data []byte) error {
+	if c == nil {
+		return errors.New("decode web-search tool config into nil receiver")
+	}
+	const objectName = "web-search tool config"
+	payload, err := decodeExactThreadItemObject(data, objectName, "context_size", "allowed_domains", "location")
+	if err != nil {
+		return err
+	}
+	contextSize, err := decodeOptionalNullableConfigRequirementValue[WebSearchContextSize](
+		payload, objectName, "context_size",
+	)
+	if err != nil {
+		return err
+	}
+	allowedDomainsValue, err := decodeOptionalNullableConfigRequirementArray[string](
+		payload, objectName, "allowed_domains",
+	)
+	if err != nil {
+		return err
+	}
+	var allowedDomains []string
+	if allowedDomainsValue != nil {
+		allowedDomains = *allowedDomainsValue
+	}
+	location, err := decodeOptionalNullableConfigRequirementValue[WebSearchLocation](payload, objectName, "location")
+	if err != nil {
+		return err
+	}
+	*c = WebSearchToolConfig{ContextSize: contextSize, AllowedDomains: allowedDomains, Location: location}
+	return nil
+}
+
+// ToolsV2 is the public v2 tool configuration. Unknown top-level fields are
+// accepted for Rust-compatible evolution; known nested configs stay strict.
+type ToolsV2 struct {
+	WebSearch *WebSearchToolConfig `json:"web_search"`
+}
+
+func (t *ToolsV2) UnmarshalJSON(data []byte) error {
+	if t == nil {
+		return errors.New("decode v2 tools config into nil receiver")
+	}
+	const objectName = "v2 tools config"
+	payload, err := decodeOpenConfigPrerequisiteObject(data, objectName)
+	if err != nil {
+		return err
+	}
+	webSearch, err := decodeOptionalNullableConfigRequirementValue[WebSearchToolConfig](
+		payload, objectName, "web_search",
+	)
+	if err != nil {
+		return err
+	}
+	*t = ToolsV2{WebSearch: webSearch}
+	return nil
+}
+
+func decodeOpenConfigPrerequisiteObject(data []byte, objectName string) (map[string]json.RawMessage, error) {
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return nil, fmt.Errorf("decode %s: %w", objectName, err)
+	}
+	if payload == nil {
+		return nil, fmt.Errorf("%s must be an object", objectName)
+	}
+	return payload, nil
+}
+
+func decodeDefaultedConfigPrerequisiteStringArray(
+	payload map[string]json.RawMessage,
+	objectName string,
+	fieldName string,
+) ([]string, error) {
+	raw, ok := payload[fieldName]
+	if !ok {
+		return []string{}, nil
+	}
+	if isJSONNull(raw) {
+		return nil, fmt.Errorf("decode %s %s: value cannot be null", objectName, fieldName)
+	}
+	var elements []json.RawMessage
+	if err := json.Unmarshal(raw, &elements); err != nil {
+		return nil, fmt.Errorf("decode %s %s: %w", objectName, fieldName, err)
+	}
+	values := make([]string, len(elements))
+	for index, element := range elements {
+		if isJSONNull(element) {
+			return nil, fmt.Errorf("decode %s %s[%d]: value cannot be null", objectName, fieldName, index)
+		}
+		if err := json.Unmarshal(element, &values[index]); err != nil {
+			return nil, fmt.Errorf("decode %s %s[%d]: %w", objectName, fieldName, index, err)
+		}
+	}
+	return values, nil
+}
+
+var (
+	_ json.Marshaler   = AutoCompactTokenLimitScope("")
+	_ json.Unmarshaler = (*AutoCompactTokenLimitScope)(nil)
+	_ json.Marshaler   = ForcedLoginMethod("")
+	_ json.Unmarshaler = (*ForcedLoginMethod)(nil)
+	_ json.Marshaler   = Verbosity("")
+	_ json.Unmarshaler = (*Verbosity)(nil)
+	_ json.Marshaler   = WebSearchContextSize("")
+	_ json.Unmarshaler = (*WebSearchContextSize)(nil)
+	_ json.Marshaler   = ForcedChatgptWorkspaceIds{}
+	_ json.Unmarshaler = (*ForcedChatgptWorkspaceIds)(nil)
+	_ json.Marshaler   = AnalyticsConfig{}
+	_ json.Unmarshaler = (*AnalyticsConfig)(nil)
+	_ json.Marshaler   = SandboxWorkspaceWrite{}
+	_ json.Unmarshaler = (*SandboxWorkspaceWrite)(nil)
+	_ json.Unmarshaler = (*WebSearchLocation)(nil)
+	_ json.Unmarshaler = (*WebSearchToolConfig)(nil)
+	_ json.Unmarshaler = (*ToolsV2)(nil)
+)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
-		t.Fatalf("definition count = %d, want 344", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
+		t.Fatalf("definition count = %d, want 354", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
-		t.Fatalf("definition count = %d, want 344", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
+		t.Fatalf("definition count = %d, want 354", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
-		t.Fatalf("definition count = %d, want 344", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
+		t.Fatalf("definition count = %d, want 354", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
-		t.Fatalf("definition count = %d, want 344", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
+		t.Fatalf("definition count = %d, want 354", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
-		t.Fatalf("definition count = %d, want 344", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
+		t.Fatalf("definition count = %d, want 354", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 344 {
-		t.Fatalf("definition count = %d, want 344", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 354 {
+		t.Fatalf("definition count = %d, want 354", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
-		t.Fatalf("definition count = %d, want 344", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
+		t.Fatalf("definition count = %d, want 354", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
-		t.Fatalf("definition count = %d, want 344", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
+		t.Fatalf("definition count = %d, want 354", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
-		t.Fatalf("definition count = %d, want 344", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
+		t.Fatalf("definition count = %d, want 354", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
-		t.Fatalf("definition count = %d, want 344", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
+		t.Fatalf("definition count = %d, want 354", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
-		t.Fatalf("definition count = %d, want 344", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
+		t.Fatalf("definition count = %d, want 354", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
-		t.Fatalf("definition count = %d, want 344", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
+		t.Fatalf("definition count = %d, want 354", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
-		t.Fatalf("definition count = %d, want 344", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
+		t.Fatalf("definition count = %d, want 354", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
-		t.Fatalf("definition count = %d, want 344", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
+		t.Fatalf("definition count = %d, want 354", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 344 {
-		t.Fatalf("definition count = %d, want 344", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 354 {
+		t.Fatalf("definition count = %d, want 354", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 344 {
-		t.Fatalf("definition count = %d, want 344", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 354 {
+		t.Fatalf("definition count = %d, want 354", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 344 {
-		t.Fatalf("definition count = %d, want 344", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 354 {
+		t.Fatalf("definition count = %d, want 354", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 344 {
-		t.Fatalf("definition count = %d, want 344", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 354 {
+		t.Fatalf("definition count = %d, want 354", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 344 {
-		t.Fatalf("definition count = %d, want 344", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 354 {
+		t.Fatalf("definition count = %d, want 354", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -89,11 +89,13 @@ func wireSchemaDefinitions() Schema {
 		{Name: "AdditionalFileSystemPermissions", Type: reflect.TypeFor[AdditionalFileSystemPermissions]()},
 		{Name: "AdditionalNetworkPermissions", Type: reflect.TypeFor[AdditionalNetworkPermissions]()},
 		{Name: "AdditionalPermissionProfile", Type: reflect.TypeFor[AdditionalPermissionProfile]()},
+		{Name: "AnalyticsConfig", Type: reflect.TypeFor[AnalyticsConfig]()},
 		{Name: "ApprovalRequestBase", Type: reflect.TypeFor[ApprovalRequestBase]()},
 		{Name: "ApprovalRespondParams", Type: reflect.TypeFor[ApprovalRespondParams]()},
 		{Name: "ApprovalRespondResult", Type: reflect.TypeFor[ApprovalRespondResult]()},
 		{Name: "ApprovalsReviewer", Type: reflect.TypeFor[ApprovalsReviewer]()},
 		{Name: "AskForApproval", Type: reflect.TypeFor[AskForApproval]()},
+		{Name: "AutoCompactTokenLimitScope", Type: reflect.TypeFor[AutoCompactTokenLimitScope]()},
 		{Name: "ByteRange", Type: reflect.TypeFor[ByteRange]()},
 		{Name: "ClientInfo", Type: reflect.TypeFor[ClientInfo]()},
 		{Name: "CodexErrorInfo", Type: reflect.TypeFor[CodexErrorInfo]()},
@@ -166,6 +168,8 @@ func wireSchemaDefinitions() Schema {
 		{Name: "FileSystemSandboxEntry", Type: reflect.TypeFor[FileSystemSandboxEntry]()},
 		{Name: "FileSystemSpecialPath", Type: reflect.TypeFor[FileSystemSpecialPath]()},
 		{Name: "FileChangedNotification", Type: reflect.TypeFor[FileChangedNotification]()},
+		{Name: "ForcedChatgptWorkspaceIds", Type: reflect.TypeFor[ForcedChatgptWorkspaceIds]()},
+		{Name: "ForcedLoginMethod", Type: reflect.TypeFor[ForcedLoginMethod]()},
 		{Name: "FsChangedNotification", Type: reflect.TypeFor[FsChangedNotification]()},
 		{Name: "FsCopyParams", Type: reflect.TypeFor[FsCopyParams]()},
 		{Name: "FsCopyResponse", Type: reflect.TypeFor[FsCopyResponse]()},
@@ -294,6 +298,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "ResponsesApiWebSearchAction", Type: reflect.TypeFor[ResponsesApiWebSearchAction]()},
 		{Name: "SandboxMode", Type: reflect.TypeFor[SandboxMode]()},
 		{Name: "SandboxPolicy", Type: reflect.TypeFor[SandboxPolicy]()},
+		{Name: "SandboxWorkspaceWrite", Type: reflect.TypeFor[SandboxWorkspaceWrite]()},
 		{Name: "ServerRequestResolvedNotificationParams", Type: reflect.TypeFor[ServerRequestResolvedNotificationParams]()},
 		{Name: "ServerCapabilities", Type: reflect.TypeFor[ServerCapabilities]()},
 		{Name: "SessionSource", Type: reflect.TypeFor[SessionSource]()},
@@ -380,6 +385,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "ToolRequestUserInputParams", Type: reflect.TypeFor[ToolRequestUserInputParams]()},
 		{Name: "ToolRequestUserInputQuestion", Type: reflect.TypeFor[ToolRequestUserInputQuestion]()},
 		{Name: "ToolRequestUserInputResponse", Type: reflect.TypeFor[ToolRequestUserInputResponse]()},
+		{Name: "ToolsV2", Type: reflect.TypeFor[ToolsV2]()},
 		{Name: "Turn", Type: reflect.TypeFor[Turn]()},
 		{Name: "TurnCompletedNotification", Type: reflect.TypeFor[TurnCompletedNotification]()},
 		{Name: "TurnDiffUpdatedNotificationParams", Type: reflect.TypeFor[TurnDiffUpdatedNotificationParams]()},
@@ -401,9 +407,13 @@ func wireSchemaDefinitions() Schema {
 		{Name: "TurnStartedNotification", Type: reflect.TypeFor[TurnStartedNotification]()},
 		{Name: "TurnsPage", Type: reflect.TypeFor[TurnsPage]()},
 		{Name: "UserInput", Type: reflect.TypeFor[UserInput]()},
+		{Name: "Verbosity", Type: reflect.TypeFor[Verbosity]()},
 		{Name: "WebSearchAction", Type: reflect.TypeFor[WebSearchAction]()},
+		{Name: "WebSearchContextSize", Type: reflect.TypeFor[WebSearchContextSize]()},
 		{Name: "WebSearchItem", Type: reflect.TypeFor[WebSearchItem]()},
+		{Name: "WebSearchLocation", Type: reflect.TypeFor[WebSearchLocation]()},
 		{Name: "WebSearchMode", Type: reflect.TypeFor[WebSearchMode]()},
+		{Name: "WebSearchToolConfig", Type: reflect.TypeFor[WebSearchToolConfig]()},
 		{Name: "WarningNotification", Type: reflect.TypeFor[WarningNotification]()},
 		{Name: "WindowsSandboxSetupMode", Type: reflect.TypeFor[WindowsSandboxSetupMode]()},
 		{Name: "WriteStatus", Type: reflect.TypeFor[WriteStatus]()},
@@ -469,6 +479,9 @@ func wireSchemaDefinitions() Schema {
 	schemas["WriteStatus"] = stringEnumSchema(
 		string(WriteStatusOK), string(WriteStatusOKOverridden),
 	)
+	for name, schema := range configPrerequisiteSchemas() {
+		schemas[name] = schema
+	}
 	schemas["ConfigLayerSource"] = configLayerSourceSchema()
 	configReadProperties := schemas["ConfigReadParams"].(Schema)["properties"].(Schema)
 	configReadProperties["cwd"].(Schema)["description"] = configReadCWDDescription
@@ -1380,6 +1393,100 @@ func configuredHookHandlerSchema() Schema {
 		configuredHookHandlerVariantSchema("prompt", nil, nil),
 		configuredHookHandlerVariantSchema("agent", nil, nil),
 	}}
+}
+
+func configPrerequisiteSchemas() map[string]Schema {
+	nullable := func(value Schema) Schema {
+		return Schema{"anyOf": []any{value, Schema{"type": "null"}}}
+	}
+	return map[string]Schema{
+		"AnalyticsConfig": {
+			"type": "object",
+			"properties": Schema{
+				"enabled": nullable(Schema{"type": "boolean"}),
+			},
+			"required":                         []string{"enabled"},
+			"additionalProperties":             Schema{"$ref": "#/$defs/JsonValue"},
+			"x-gollem-typescript-optional-map": true,
+		},
+		"AutoCompactTokenLimitScope": {
+			"description": "Selects which part of the active context is charged against `model_auto_compact_token_limit`.",
+			"oneOf": []any{
+				Schema{
+					"type":        "string",
+					"enum":        []any{"total"},
+					"description": "Count the full active context against the limit.",
+				},
+				Schema{
+					"type":        "string",
+					"enum":        []any{"body_after_prefix"},
+					"description": "Count sampled output and later growth after the carried window prefix.",
+				},
+			},
+		},
+		"ForcedChatgptWorkspaceIds": {
+			"anyOf": []any{
+				Schema{"type": "string"},
+				Schema{"type": "array", "items": Schema{"type": "string"}},
+			},
+			"description": "Backward-compatible API shape for ChatGPT workspace login restrictions.",
+		},
+		"ForcedLoginMethod": stringEnumSchema("chatgpt", "api"),
+		"SandboxWorkspaceWrite": {
+			"type": "object",
+			"properties": Schema{
+				"writable_roots": Schema{
+					"type": "array", "items": Schema{"type": "string"}, "default": []any{},
+				},
+				"network_access":         Schema{"type": "boolean", "default": false},
+				"exclude_tmpdir_env_var": Schema{"type": "boolean", "default": false},
+				"exclude_slash_tmp":      Schema{"type": "boolean", "default": false},
+			},
+			"required": []string{
+				"writable_roots", "network_access", "exclude_tmpdir_env_var", "exclude_slash_tmp",
+			},
+			"additionalProperties":                             true,
+			"x-gollem-typescript-ignore-additional-properties": true,
+		},
+		"ToolsV2": {
+			"type": "object",
+			"properties": Schema{
+				"web_search": nullable(Schema{"$ref": "#/$defs/WebSearchToolConfig"}),
+			},
+			"required":             []string{"web_search"},
+			"additionalProperties": true,
+			"x-gollem-typescript-ignore-additional-properties": true,
+		},
+		"Verbosity": {
+			"type":        "string",
+			"enum":        []any{"low", "medium", "high"},
+			"description": "Controls output length/detail on GPT-5 models via the Responses API. Serialized with lowercase values to match the OpenAI API.",
+		},
+		"WebSearchContextSize": stringEnumSchema("low", "medium", "high"),
+		"WebSearchLocation": {
+			"type": "object",
+			"properties": Schema{
+				"country":  nullable(Schema{"type": "string"}),
+				"region":   nullable(Schema{"type": "string"}),
+				"city":     nullable(Schema{"type": "string"}),
+				"timezone": nullable(Schema{"type": "string"}),
+			},
+			"required":             []string{"country", "region", "city", "timezone"},
+			"additionalProperties": false,
+		},
+		"WebSearchToolConfig": {
+			"type": "object",
+			"properties": Schema{
+				"context_size": nullable(Schema{"$ref": "#/$defs/WebSearchContextSize"}),
+				"allowed_domains": nullable(Schema{
+					"type": "array", "items": Schema{"type": "string"},
+				}),
+				"location": nullable(Schema{"$ref": "#/$defs/WebSearchLocation"}),
+			},
+			"required":             []string{"context_size", "allowed_domains", "location"},
+			"additionalProperties": false,
+		},
+	}
 }
 
 func configLayerSourceSchema() Schema {

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -193,6 +193,28 @@
     "AgentPath": {
       "type": "string"
     },
+    "AnalyticsConfig": {
+      "additionalProperties": {
+        "$ref": "#/$defs/JsonValue"
+      },
+      "properties": {
+        "enabled": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "enabled"
+      ],
+      "type": "object",
+      "x-gollem-typescript-optional-map": true
+    },
     "ApprovalRequestBase": {
       "additionalProperties": false,
       "properties": {
@@ -324,6 +346,25 @@
         {
           "enum": [
             "never"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "AutoCompactTokenLimitScope": {
+      "description": "Selects which part of the active context is charged against `model_auto_compact_token_limit`.",
+      "oneOf": [
+        {
+          "description": "Count the full active context against the limit.",
+          "enum": [
+            "total"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Count sampled output and later growth after the carried window prefix.",
+          "enum": [
+            "body_after_prefix"
           ],
           "type": "string"
         }
@@ -3186,6 +3227,27 @@
         "diff"
       ],
       "type": "object"
+    },
+    "ForcedChatgptWorkspaceIds": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      ],
+      "description": "Backward-compatible API shape for ChatGPT workspace login restrictions."
+    },
+    "ForcedLoginMethod": {
+      "enum": [
+        "chatgpt",
+        "api"
+      ],
+      "type": "string"
     },
     "FsChangedNotification": {
       "additionalProperties": false,
@@ -7517,6 +7579,38 @@
         }
       ]
     },
+    "SandboxWorkspaceWrite": {
+      "additionalProperties": true,
+      "properties": {
+        "exclude_slash_tmp": {
+          "default": false,
+          "type": "boolean"
+        },
+        "exclude_tmpdir_env_var": {
+          "default": false,
+          "type": "boolean"
+        },
+        "network_access": {
+          "default": false,
+          "type": "boolean"
+        },
+        "writable_roots": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "writable_roots",
+        "network_access",
+        "exclude_tmpdir_env_var",
+        "exclude_slash_tmp"
+      ],
+      "type": "object",
+      "x-gollem-typescript-ignore-additional-properties": true
+    },
     "ServerCapabilities": {
       "additionalProperties": false,
       "properties": {
@@ -11248,6 +11342,26 @@
       ],
       "type": "object"
     },
+    "ToolsV2": {
+      "additionalProperties": true,
+      "properties": {
+        "web_search": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WebSearchToolConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "web_search"
+      ],
+      "type": "object",
+      "x-gollem-typescript-ignore-additional-properties": true
+    },
     "Turn": {
       "additionalProperties": false,
       "properties": {
@@ -11947,6 +12061,15 @@
         }
       ]
     },
+    "Verbosity": {
+      "description": "Controls output length/detail on GPT-5 models via the Responses API. Serialized with lowercase values to match the OpenAI API.",
+      "enum": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "type": "string"
+    },
     "WarningNotification": {
       "additionalProperties": false,
       "properties": {
@@ -12092,6 +12215,14 @@
         }
       ]
     },
+    "WebSearchContextSize": {
+      "enum": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "type": "string"
+    },
     "WebSearchItem": {
       "additionalProperties": false,
       "properties": {
@@ -12119,6 +12250,58 @@
       ],
       "type": "object"
     },
+    "WebSearchLocation": {
+      "additionalProperties": false,
+      "properties": {
+        "city": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "country": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "region": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "timezone": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "country",
+        "region",
+        "city",
+        "timezone"
+      ],
+      "type": "object"
+    },
     "WebSearchMode": {
       "enum": [
         "disabled",
@@ -12127,6 +12310,50 @@
         "live"
       ],
       "type": "string"
+    },
+    "WebSearchToolConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "allowed_domains": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "context_size": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WebSearchContextSize"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "location": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WebSearchLocation"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "context_size",
+        "allowed_domains",
+        "location"
+      ],
+      "type": "object"
     },
     "WindowsSandboxSetupMode": {
       "enum": [

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 344 {
-		t.Fatalf("definition count = %d, want 344", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 354 {
+		t.Fatalf("definition count = %d, want 354", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
-		t.Fatalf("definition count = %d, want 344", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
+		t.Fatalf("definition count = %d, want 354", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
-		t.Fatalf("definition count = %d, want 344", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
+		t.Fatalf("definition count = %d, want 354", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
-		t.Fatalf("definition count = %d, want 344", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
+		t.Fatalf("definition count = %d, want 354", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
-		t.Fatalf("definition count = %d, want 344", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
+		t.Fatalf("definition count = %d, want 354", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
-		t.Fatalf("definition count = %d, want 344", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
+		t.Fatalf("definition count = %d, want 354", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 344 {
-		t.Fatalf("definition count = %d, want 344", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 354 {
+		t.Fatalf("definition count = %d, want 354", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 344 {
-		t.Fatalf("definition count = %d, want 344", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 354 {
+		t.Fatalf("definition count = %d, want 354", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
-		t.Fatalf("definition count = %d, want 344", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
+		t.Fatalf("definition count = %d, want 354", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
-		t.Fatalf("definition count = %d, want 344", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
+		t.Fatalf("definition count = %d, want 354", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
-		t.Fatalf("definition count = %d, want 344", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
+		t.Fatalf("definition count = %d, want 354", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
-		t.Fatalf("definition count = %d, want 344", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
+		t.Fatalf("definition count = %d, want 354", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -319,9 +319,14 @@ func typeScriptObjectType(schema Schema, indent int) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		return "(" + objectType + " & Record<string, " + valueType + ">)", nil
+		additionalType := "Record<string, " + valueType + ">"
+		if optional, _ := schema["x-gollem-typescript-optional-map"].(bool); optional {
+			additionalType = "{ [key in string]?: " + valueType + " }"
+		}
+		return "(" + objectType + " & " + additionalType + ")", nil
 	}
-	if additionalAllowed {
+	ignoreAdditional, _ := schema["x-gollem-typescript-ignore-additional-properties"].(bool)
+	if additionalAllowed && !ignoreAdditional {
 		return "(" + objectType + " & Record<string, unknown>)", nil
 	}
 	return objectType, nil

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -532,6 +532,10 @@ export type AgentMessageInputContent = {
 
 export type AgentPath = string;
 
+export type AnalyticsConfig = ({
+  "enabled": boolean | null;
+} & { [key in string]?: JsonValue });
+
 export type ApprovalRequestBase = {
   "itemId": string;
   "reason"?: string;
@@ -564,6 +568,8 @@ export type AskForApproval = "untrusted" | "on-request" | {
     "skill_approval": boolean;
   };
 } | "never";
+
+export type AutoCompactTokenLimitScope = "total" | "body_after_prefix";
 
 export type ByteRange = {
   "end": number;
@@ -1166,6 +1172,10 @@ export type FileUpdateChange = {
   "kind": PatchChangeKind;
   "path": string;
 };
+
+export type ForcedChatgptWorkspaceIds = string | Array<string>;
+
+export type ForcedLoginMethod = "chatgpt" | "api";
 
 export type FsChangedNotification = {
   "changedPaths": Array<AbsolutePathBuf>;
@@ -2085,6 +2095,13 @@ export type SandboxPolicy = {
   "writableRoots": Array<AbsolutePathBuf>;
 };
 
+export type SandboxWorkspaceWrite = {
+  "exclude_slash_tmp": boolean;
+  "exclude_tmpdir_env_var": boolean;
+  "network_access": boolean;
+  "writable_roots": Array<string>;
+};
+
 export type ServerCapabilities = {
   "experimental"?: Array<string> | null;
   "protocolSchema": boolean;
@@ -2799,6 +2816,10 @@ export type ToolRequestUserInputResponse = {
   "answers": Record<string, ToolRequestUserInputAnswer>;
 };
 
+export type ToolsV2 = {
+  "web_search": WebSearchToolConfig | null;
+};
+
 export type Turn = {
   "completedAt": number | null;
   "durationMs": number | null;
@@ -2942,6 +2963,8 @@ export type UserInput = {
   "type": "mention";
 };
 
+export type Verbosity = "low" | "medium" | "high";
+
 export type WarningNotification = {
   "message": string;
   "threadId": string | null;
@@ -2962,13 +2985,28 @@ export type WebSearchAction = {
   "type": "other";
 };
 
+export type WebSearchContextSize = "low" | "medium" | "high";
+
 export type WebSearchItem = {
   "action": WebSearchAction | null;
   "id": string;
   "query": string;
 };
 
+export type WebSearchLocation = {
+  "city": string | null;
+  "country": string | null;
+  "region": string | null;
+  "timezone": string | null;
+};
+
 export type WebSearchMode = "disabled" | "cached" | "indexed" | "live";
+
+export type WebSearchToolConfig = {
+  "allowed_domains": Array<string> | null;
+  "context_size": WebSearchContextSize | null;
+  "location": WebSearchLocation | null;
+};
 
 export type WindowsSandboxSetupMode = "elevated" | "unelevated";
 

--- a/appserver/protocol/typescript/testdata/config_prerequisites_contract.ts
+++ b/appserver/protocol/typescript/testdata/config_prerequisites_contract.ts
@@ -1,0 +1,145 @@
+import type {
+  AnalyticsConfig,
+  AutoCompactTokenLimitScope,
+  ForcedChatgptWorkspaceIds,
+  ForcedLoginMethod,
+  JsonValue,
+  SandboxWorkspaceWrite,
+  ToolsV2,
+  Verbosity,
+  WebSearchContextSize,
+  WebSearchLocation,
+  WebSearchToolConfig,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? (<T>() => T extends B ? 1 : 2) extends
+        (<T>() => T extends A ? 1 : 2)
+      ? true
+      : false
+    : false;
+type Expect<T extends true> = T;
+
+type ConfigPrerequisiteContracts = [
+  Expect<Equal<AutoCompactTokenLimitScope, "total" | "body_after_prefix">>,
+  Expect<Equal<ForcedLoginMethod, "chatgpt" | "api">>,
+  Expect<Equal<Verbosity, "low" | "medium" | "high">>,
+  Expect<Equal<WebSearchContextSize, "low" | "medium" | "high">>,
+  Expect<Equal<ForcedChatgptWorkspaceIds, string | Array<string>>>,
+  Expect<Equal<AnalyticsConfig, {
+    enabled: boolean | null;
+  } & { [key in string]?: JsonValue }>>,
+  Expect<Equal<SandboxWorkspaceWrite, {
+    writable_roots: Array<string>;
+    network_access: boolean;
+    exclude_tmpdir_env_var: boolean;
+    exclude_slash_tmp: boolean;
+  }>>,
+  Expect<Equal<WebSearchLocation, {
+    country: string | null;
+    region: string | null;
+    city: string | null;
+    timezone: string | null;
+  }>>,
+  Expect<Equal<WebSearchToolConfig, {
+    context_size: WebSearchContextSize | null;
+    allowed_domains: Array<string> | null;
+    location: WebSearchLocation | null;
+  }>>,
+  Expect<Equal<ToolsV2, { web_search: WebSearchToolConfig | null }>>,
+];
+
+"total" satisfies AutoCompactTokenLimitScope;
+"body_after_prefix" satisfies AutoCompactTokenLimitScope;
+"chatgpt" satisfies ForcedLoginMethod;
+"api" satisfies ForcedLoginMethod;
+"low" satisfies Verbosity;
+"medium" satisfies Verbosity;
+"high" satisfies Verbosity;
+"low" satisfies WebSearchContextSize;
+"medium" satisfies WebSearchContextSize;
+"high" satisfies WebSearchContextSize;
+"" satisfies ForcedChatgptWorkspaceIds;
+[] satisfies ForcedChatgptWorkspaceIds;
+["", "workspace", "workspace"] satisfies ForcedChatgptWorkspaceIds;
+({ enabled: null }) satisfies AnalyticsConfig;
+({ enabled: false, nested: { value: [9007199254740993, true, null] } }) satisfies AnalyticsConfig;
+({
+  writable_roots: ["", "relative", "/absolute"],
+  network_access: false,
+  exclude_tmpdir_env_var: false,
+  exclude_slash_tmp: true,
+}) satisfies SandboxWorkspaceWrite;
+({ country: null, region: "", city: "New York", timezone: "America/New_York" }) satisfies WebSearchLocation;
+({ context_size: null, allowed_domains: null, location: null }) satisfies WebSearchToolConfig;
+({
+  context_size: "high",
+  allowed_domains: ["", "example.com", "example.com"],
+  location: { country: "US", region: null, city: null, timezone: null },
+}) satisfies WebSearchToolConfig;
+({ web_search: null }) satisfies ToolsV2;
+({ web_search: { context_size: null, allowed_domains: [], location: null } }) satisfies ToolsV2;
+
+// @ts-expect-error auto-compact scope is closed.
+"bodyAfterPrefix" satisfies AutoCompactTokenLimitScope;
+// @ts-expect-error forced login method is closed.
+"oauth" satisfies ForcedLoginMethod;
+// @ts-expect-error verbosity is closed.
+"max" satisfies Verbosity;
+// @ts-expect-error web-search context size is closed.
+"large" satisfies WebSearchContextSize;
+
+// @ts-expect-error workspace ids exclude null.
+null satisfies ForcedChatgptWorkspaceIds;
+// @ts-expect-error workspace-id arrays contain strings only.
+["workspace", 1] satisfies ForcedChatgptWorkspaceIds;
+// @ts-expect-error workspace ids exclude object forms.
+({ workspace: "id" }) satisfies ForcedChatgptWorkspaceIds;
+
+// @ts-expect-error enabled is required nullable.
+({}) satisfies AnalyticsConfig;
+// @ts-expect-error enabled is a nullable boolean.
+({ enabled: "true" }) satisfies AnalyticsConfig;
+// @ts-expect-error enabled cannot be explicit undefined.
+({ enabled: undefined }) satisfies AnalyticsConfig;
+// @ts-expect-error additional analytics values must be JSON.
+({ enabled: null, callback: () => true }) satisfies AnalyticsConfig;
+
+// @ts-expect-error sandbox fields are required despite decoder defaults.
+({}) satisfies SandboxWorkspaceWrite;
+// @ts-expect-error writable roots are non-null.
+({ writable_roots: null, network_access: false, exclude_tmpdir_env_var: false, exclude_slash_tmp: false }) satisfies SandboxWorkspaceWrite;
+// @ts-expect-error writable-root members are strings.
+({ writable_roots: [1], network_access: false, exclude_tmpdir_env_var: false, exclude_slash_tmp: false }) satisfies SandboxWorkspaceWrite;
+// @ts-expect-error network access is boolean.
+({ writable_roots: [], network_access: null, exclude_tmpdir_env_var: false, exclude_slash_tmp: false }) satisfies SandboxWorkspaceWrite;
+// @ts-expect-error generated sandbox TypeScript remains closed.
+({ writable_roots: [], network_access: false, exclude_tmpdir_env_var: false, exclude_slash_tmp: false, future: true }) satisfies SandboxWorkspaceWrite;
+
+// @ts-expect-error location fields are required nullable.
+({}) satisfies WebSearchLocation;
+// @ts-expect-error location fields are nullable strings.
+({ country: 1, region: null, city: null, timezone: null }) satisfies WebSearchLocation;
+// @ts-expect-error location is closed.
+({ country: null, region: null, city: null, timezone: null, extra: true }) satisfies WebSearchLocation;
+
+// @ts-expect-error tool fields are required nullable.
+({}) satisfies WebSearchToolConfig;
+// @ts-expect-error domain members are strings.
+({ context_size: null, allowed_domains: [null], location: null }) satisfies WebSearchToolConfig;
+// @ts-expect-error context size uses the closed enum.
+({ context_size: "large", allowed_domains: null, location: null }) satisfies WebSearchToolConfig;
+// @ts-expect-error web-search tool config is closed.
+({ context_size: null, allowed_domains: null, location: null, extra: true }) satisfies WebSearchToolConfig;
+
+// @ts-expect-error web_search is required nullable.
+({}) satisfies ToolsV2;
+// @ts-expect-error web_search is nullable config, not boolean.
+({ web_search: false }) satisfies ToolsV2;
+// @ts-expect-error generated tools TypeScript remains closed.
+({ web_search: null, future: true }) satisfies ToolsV2;
+
+declare const configPrerequisiteContracts: ConfigPrerequisiteContracts;
+void configPrerequisiteContracts;

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 344 {
-		t.Fatalf("definition count = %d, want 344", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
+		t.Fatalf("definition count = %d, want 354", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- add exact standalone Go and JSON contracts for ten public Config prerequisite definitions
- preserve canonical nullable/default/open-object behavior and precision-safe analytics values
- generate exact Codex-compatible TypeScript while keeping method and item bindings unchanged

## Verification
- focused contract suite, 30 consecutive runs
- focused race and 100% statement coverage for the new runtime module
- full non-Monty normal and race suites
- strict TypeScript fixture
- golangci-lint, go vet, go mod tidy
- deterministic schema and TypeScript regeneration
- pre-push lint/race/vet/tidy gate

Local Monty tests were intentionally skipped via hooks.skipMontyRace=true; hosted repository checks remain unchanged.