### PR TITLE
Export exact public config contract

### DIFF
--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
-		t.Fatalf("definition count = %d, want 354", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
+		t.Fatalf("definition count = %d, want 355", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
-		t.Fatalf("definition count = %d, want 354", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
+		t.Fatalf("definition count = %d, want 355", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
-		t.Fatalf("definition count = %d, want 354", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
+		t.Fatalf("definition count = %d, want 355", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
-		t.Fatalf("definition count = %d, want 354", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
+		t.Fatalf("definition count = %d, want 355", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
-		t.Fatalf("definition count = %d, want 354", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
+		t.Fatalf("definition count = %d, want 355", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
-		t.Fatalf("definition count = %d, want 354", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
+		t.Fatalf("definition count = %d, want 355", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
-		t.Fatalf("definition count = %d, want 354", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
+		t.Fatalf("definition count = %d, want 355", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
-		t.Fatalf("definition count = %d, want 354", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
+		t.Fatalf("definition count = %d, want 355", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 354 {
-		t.Fatalf("definition count = %d, want 354", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 355 {
+		t.Fatalf("definition count = %d, want 355", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
-		t.Fatalf("definition count = %d, want 354", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
+		t.Fatalf("definition count = %d, want 355", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
-		t.Fatalf("definition count = %d, want 354", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
+		t.Fatalf("definition count = %d, want 355", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
-		t.Fatalf("definition count = %d, want 354", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
+		t.Fatalf("definition count = %d, want 355", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
-		t.Fatalf("definition count = %d, want 354", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
+		t.Fatalf("definition count = %d, want 355", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
-		t.Fatalf("definition count = %d, want 354", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
+		t.Fatalf("definition count = %d, want 355", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
-		t.Fatalf("definition count = %d, want 354", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
+		t.Fatalf("definition count = %d, want 355", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
-		t.Fatalf("definition count = %d, want 354", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
+		t.Fatalf("definition count = %d, want 355", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
-		t.Fatalf("definition count = %d, want 354", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
+		t.Fatalf("definition count = %d, want 355", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -1,0 +1,338 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+var publicConfigFieldNames = []string{
+	"model",
+	"review_model",
+	"model_context_window",
+	"model_auto_compact_token_limit",
+	"model_auto_compact_token_limit_scope",
+	"model_provider",
+	"approval_policy",
+	"approvals_reviewer",
+	"sandbox_mode",
+	"sandbox_workspace_write",
+	"forced_chatgpt_workspace_id",
+	"forced_login_method",
+	"web_search",
+	"tools",
+	"instructions",
+	"developer_instructions",
+	"compact_prompt",
+	"model_reasoning_effort",
+	"model_reasoning_summary",
+	"model_verbosity",
+	"service_tier",
+	"analytics",
+	"desktop",
+}
+
+func TestPublicConfigSchemaIsExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	want := publicConfigContractSchema()
+	if got := defs["Config"]; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Config schema = %#v, want %#v", got, want)
+	}
+}
+
+func TestPublicConfigCanonicalizesOmittedFieldsToNull(t *testing.T) {
+	var value Config
+	if err := json.Unmarshal([]byte(`{}`), &value); err != nil {
+		t.Fatalf("unmarshal empty Config: %v", err)
+	}
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal empty Config: %v", err)
+	}
+	if got, want := string(encoded), emptyPublicConfigJSON(); got != want {
+		t.Fatalf("empty Config = %s, want %s", got, want)
+	}
+
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(encoded, &fields); err != nil {
+		t.Fatalf("decode canonical Config: %v", err)
+	}
+	if len(fields) != len(publicConfigFieldNames) {
+		t.Fatalf("canonical Config fields = %d, want %d", len(fields), len(publicConfigFieldNames))
+	}
+	for _, name := range publicConfigFieldNames {
+		if got := string(fields[name]); got != "null" {
+			t.Errorf("canonical Config %s = %q, want null", name, got)
+		}
+	}
+}
+
+func TestPublicConfigPreservesExactKnownAndOpenValues(t *testing.T) {
+	input := `{
+		"model":"gpt-5",
+		"review_model":"reviewer",
+		"model_context_window":-9223372036854775808,
+		"model_auto_compact_token_limit":9223372036854775807,
+		"model_auto_compact_token_limit_scope":"body_after_prefix",
+		"model_provider":"provider",
+		"approval_policy":{"granular":{"mcp_elicitations":true,"request_permissions":false,"rules":true,"sandbox_approval":false,"skill_approval":true}},
+		"approvals_reviewer":"guardian_subagent",
+		"sandbox_mode":"workspace-write",
+		"sandbox_workspace_write":{"writable_roots":["","relative","/absolute"],"network_access":true,"exclude_tmpdir_env_var":false,"exclude_slash_tmp":true,"future":true},
+		"forced_chatgpt_workspace_id":["","workspace","workspace"],
+		"forced_login_method":"api",
+		"web_search":"live",
+		"tools":{"web_search":{"context_size":"high","allowed_domains":["","example.com","example.com"],"location":{"country":"US","region":null,"city":"New York","timezone":"America/New_York"}},"future":true},
+		"instructions":"instructions",
+		"developer_instructions":"developer",
+		"compact_prompt":"compact",
+		"model_reasoning_effort":"xhigh",
+		"model_reasoning_summary":"detailed",
+		"model_verbosity":"high",
+		"service_tier":"priority",
+		"analytics":{"enabled":true,"sample_rate":0.125,"nested":{"integer":9007199254740993}},
+		"desktop":{"theme":"dark","nested":[9007199254740993,true,null]},
+		"future_flag":false,
+		"future_nested":{"integer":9007199254740993,"array":["value",null]}
+	}`
+	var value Config
+	if err := json.Unmarshal([]byte(input), &value); err != nil {
+		t.Fatalf("unmarshal full Config: %v", err)
+	}
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal full Config: %v", err)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(encoded, &fields); err != nil {
+		t.Fatalf("decode full Config output: %v", err)
+	}
+	if got, want := len(fields), len(publicConfigFieldNames)+2; got != want {
+		t.Fatalf("full Config fields = %d, want %d", got, want)
+	}
+	for name, want := range map[string]string{
+		"model_context_window":           `-9223372036854775808`,
+		"model_auto_compact_token_limit": `9223372036854775807`,
+		"forced_chatgpt_workspace_id":    `["","workspace","workspace"]`,
+		"sandbox_workspace_write":        `{"writable_roots":["","relative","/absolute"],"network_access":true,"exclude_tmpdir_env_var":false,"exclude_slash_tmp":true}`,
+		"future_flag":                    `false`,
+		"future_nested":                  `{"array":["value",null],"integer":9007199254740993}`,
+	} {
+		if got := string(fields[name]); got != want {
+			t.Errorf("full Config %s = %s, want %s", name, got, want)
+		}
+	}
+	if !strings.Contains(string(fields["analytics"]), `9007199254740993`) {
+		t.Fatalf("analytics lost exact integer: %s", fields["analytics"])
+	}
+	if !strings.Contains(string(fields["desktop"]), `9007199254740993`) {
+		t.Fatalf("desktop lost exact integer: %s", fields["desktop"])
+	}
+
+	var roundTripped Config
+	if err := json.Unmarshal(encoded, &roundTripped); err != nil {
+		t.Fatalf("unmarshal canonical Config: %v", err)
+	}
+	reencoded, err := json.Marshal(roundTripped)
+	if err != nil {
+		t.Fatalf("remarshal canonical Config: %v", err)
+	}
+	if string(reencoded) != string(encoded) {
+		t.Fatalf("Config canonical output changed:\nfirst: %s\nsecond: %s", encoded, reencoded)
+	}
+}
+
+func TestPublicConfigAcceptsNullAndOpenAdditionalJSON(t *testing.T) {
+	for _, input := range []string{
+		`{"model":null}`,
+		`{"desktop":{}}`,
+		`{"analytics":null,"tools":null}`,
+		`{"apps":{"untyped":true}}`,
+		`{"future":null}`,
+		`{"future":[9007199254740993,{"nested":true}]}`,
+		`{"future":1,"future":2}`,
+	} {
+		var value Config
+		if err := json.Unmarshal([]byte(input), &value); err != nil {
+			t.Errorf("Config rejected %s: %v", input, err)
+			continue
+		}
+		if _, err := json.Marshal(value); err != nil {
+			t.Errorf("Config failed to marshal %s: %v", input, err)
+		}
+	}
+}
+
+func TestPublicConfigRejectsMalformedKnownFields(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{} {}`, `{} x`,
+		`{"model":`, `{"future":1`,
+		`{"model":1}`,
+		`{"review_model":false}`,
+		`{"model_context_window":9223372036854775808}`,
+		`{"model_context_window":-9223372036854775809}`,
+		`{"model_context_window":1.5}`,
+		`{"model_context_window":1e3}`,
+		`{"model_auto_compact_token_limit":"100"}`,
+		`{"model_auto_compact_token_limit_scope":"bodyAfterPrefix"}`,
+		`{"model_provider":[]}`,
+		`{"approval_policy":"always"}`,
+		`{"approvals_reviewer":"guardian"}`,
+		`{"sandbox_mode":"workspace_write"}`,
+		`{"sandbox_workspace_write":{"network_access":null}}`,
+		`{"forced_chatgpt_workspace_id":["workspace",1]}`,
+		`{"forced_login_method":"oauth"}`,
+		`{"web_search":"enabled"}`,
+		`{"tools":{"web_search":false}}`,
+		`{"instructions":{}}`,
+		`{"developer_instructions":[]}`,
+		`{"compact_prompt":true}`,
+		`{"model_reasoning_effort":""}`,
+		`{"model_reasoning_summary":"brief"}`,
+		`{"model_verbosity":"max"}`,
+		`{"service_tier":1}`,
+		`{"analytics":{"enabled":"true"}}`,
+		`{"desktop":[]}`,
+		`{"model":null,"model":"gpt-5"}`,
+		`{"analytics":null,"analytics":{"enabled":true}}`,
+	} {
+		assertJSONRejects[Config](t, input)
+	}
+}
+
+func TestPublicConfigDirectDecoderRejectsMalformedTokenStreams(t *testing.T) {
+	for _, input := range []string{
+		``,
+		`{@`,
+		`{"future"`,
+		`{"model":`,
+		`{"future":1`,
+		`{} {}`,
+		`{} x`,
+	} {
+		var value Config
+		if err := value.UnmarshalJSON([]byte(input)); err == nil {
+			t.Errorf("direct Config decoder accepted %q", input)
+		}
+	}
+}
+
+func TestPublicConfigMarshalRejectsInvalidAndConflictingValues(t *testing.T) {
+	for name, value := range map[string]Config{
+		"known additional field": {
+			Additional: map[string]JsonValue{"model": {raw: json.RawMessage(`"shadow"`)}},
+		},
+		"invalid additional JSON": {
+			Additional: map[string]JsonValue{"future": {}},
+		},
+		"invalid desktop JSON": {
+			Desktop: map[string]JsonValue{"future": {}},
+		},
+		"invalid reasoning effort": {
+			ModelReasoningEffort: func() *ReasoningEffort { value := ReasoningEffort(""); return &value }(),
+		},
+		"invalid verbosity": {
+			ModelVerbosity: func() *Verbosity { value := Verbosity("max"); return &value }(),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := json.Marshal(value); err == nil {
+				t.Fatal("invalid Config marshaled")
+			}
+		})
+	}
+}
+
+func TestPublicConfigNilReceiver(t *testing.T) {
+	var value *Config
+	if err := value.UnmarshalJSON([]byte(`{}`)); err == nil {
+		t.Fatal("nil Config receiver succeeded")
+	}
+}
+
+func TestPublicConfigRemainsStandalone(t *testing.T) {
+	for _, binding := range WireTypeBindings() {
+		if slices.Contains(binding.Params, "Config") || slices.Contains(binding.Result, "Config") {
+			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
+		t.Fatalf("definition count = %d, want 355", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestPublicConfigTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	for _, want := range []string{
+		`export type Config = ({`,
+		`"model_context_window": number | null;`,
+		`"sandbox_workspace_write": SandboxWorkspaceWrite | null;`,
+		`} & { [key in string]?: JsonValue });`,
+	} {
+		if !strings.Contains(string(generated), want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}
+
+func publicConfigContractSchema() Schema {
+	nullable := nullableConfigPrerequisiteSchema
+	approvalsReviewer := nullable(Schema{"$ref": "#/$defs/ApprovalsReviewer"})
+	approvalsReviewer["description"] = "[UNSTABLE] Optional default for where approval requests are routed for review."
+	properties := Schema{
+		"model":                                nullable(Schema{"type": "string"}),
+		"review_model":                         nullable(Schema{"type": "string"}),
+		"model_context_window":                 nullable(Schema{"type": "integer"}),
+		"model_auto_compact_token_limit":       nullable(Schema{"type": "integer"}),
+		"model_auto_compact_token_limit_scope": nullable(Schema{"$ref": "#/$defs/AutoCompactTokenLimitScope"}),
+		"model_provider":                       nullable(Schema{"type": "string"}),
+		"approval_policy":                      nullable(Schema{"$ref": "#/$defs/AskForApproval"}),
+		"approvals_reviewer":                   approvalsReviewer,
+		"sandbox_mode":                         nullable(Schema{"$ref": "#/$defs/SandboxMode"}),
+		"sandbox_workspace_write":              nullable(Schema{"$ref": "#/$defs/SandboxWorkspaceWrite"}),
+		"forced_chatgpt_workspace_id":          nullable(Schema{"$ref": "#/$defs/ForcedChatgptWorkspaceIds"}),
+		"forced_login_method":                  nullable(Schema{"$ref": "#/$defs/ForcedLoginMethod"}),
+		"web_search":                           nullable(Schema{"$ref": "#/$defs/WebSearchMode"}),
+		"tools":                                nullable(Schema{"$ref": "#/$defs/ToolsV2"}),
+		"instructions":                         nullable(Schema{"type": "string"}),
+		"developer_instructions":               nullable(Schema{"type": "string"}),
+		"compact_prompt":                       nullable(Schema{"type": "string"}),
+		"model_reasoning_effort":               nullable(Schema{"$ref": "#/$defs/ReasoningEffort"}),
+		"model_reasoning_summary":              nullable(Schema{"$ref": "#/$defs/ReasoningSummary"}),
+		"model_verbosity":                      nullable(Schema{"$ref": "#/$defs/Verbosity"}),
+		"service_tier":                         nullable(Schema{"type": "string"}),
+		"analytics":                            nullable(Schema{"$ref": "#/$defs/AnalyticsConfig"}),
+		"desktop": nullable(Schema{
+			"type":                             "object",
+			"additionalProperties":             Schema{"$ref": "#/$defs/JsonValue"},
+			"x-gollem-typescript-optional-map": true,
+		}),
+	}
+	return Schema{
+		"type":                             "object",
+		"properties":                       properties,
+		"required":                         append([]string(nil), publicConfigFieldNames...),
+		"additionalProperties":             Schema{"$ref": "#/$defs/JsonValue"},
+		"x-gollem-typescript-optional-map": true,
+	}
+}
+
+func emptyPublicConfigJSON() string {
+	return `{"analytics":null,"approval_policy":null,"approvals_reviewer":null,"compact_prompt":null,"desktop":null,"developer_instructions":null,"forced_chatgpt_workspace_id":null,"forced_login_method":null,"instructions":null,"model":null,"model_auto_compact_token_limit":null,"model_auto_compact_token_limit_scope":null,"model_context_window":null,"model_provider":null,"model_reasoning_effort":null,"model_reasoning_summary":null,"model_verbosity":null,"review_model":null,"sandbox_mode":null,"sandbox_workspace_write":null,"service_tier":null,"tools":null,"web_search":null}`
+}
+
+var (
+	_ json.Marshaler   = Config{}
+	_ json.Unmarshaler = (*Config)(nil)
+)

--- a/appserver/protocol/public_config_types.go
+++ b/appserver/protocol/public_config_types.go
@@ -1,0 +1,325 @@
+package protocol
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// Config is the exact standalone public effective-config value. It is kept
+// separate from Gollem's memory-backed app-server config service.
+type Config struct {
+	Model                           *string                     `json:"model"`
+	ReviewModel                     *string                     `json:"review_model"`
+	ModelContextWindow              *int64                      `json:"model_context_window"`
+	ModelAutoCompactTokenLimit      *int64                      `json:"model_auto_compact_token_limit"`
+	ModelAutoCompactTokenLimitScope *AutoCompactTokenLimitScope `json:"model_auto_compact_token_limit_scope"`
+	ModelProvider                   *string                     `json:"model_provider"`
+	ApprovalPolicy                  *AskForApproval             `json:"approval_policy"`
+	ApprovalsReviewer               *ApprovalsReviewer          `json:"approvals_reviewer"`
+	SandboxMode                     *SandboxMode                `json:"sandbox_mode"`
+	SandboxWorkspaceWrite           *SandboxWorkspaceWrite      `json:"sandbox_workspace_write"`
+	ForcedChatgptWorkspaceID        *ForcedChatgptWorkspaceIds  `json:"forced_chatgpt_workspace_id"`
+	ForcedLoginMethod               *ForcedLoginMethod          `json:"forced_login_method"`
+	WebSearch                       *WebSearchMode              `json:"web_search"`
+	Tools                           *ToolsV2                    `json:"tools"`
+	Instructions                    *string                     `json:"instructions"`
+	DeveloperInstructions           *string                     `json:"developer_instructions"`
+	CompactPrompt                   *string                     `json:"compact_prompt"`
+	ModelReasoningEffort            *ReasoningEffort            `json:"model_reasoning_effort"`
+	ModelReasoningSummary           *ReasoningSummary           `json:"model_reasoning_summary"`
+	ModelVerbosity                  *Verbosity                  `json:"model_verbosity"`
+	ServiceTier                     *string                     `json:"service_tier"`
+	Analytics                       *AnalyticsConfig            `json:"analytics"`
+	Desktop                         map[string]JsonValue        `json:"desktop"`
+	Additional                      map[string]JsonValue        `json:"-"`
+}
+
+func (c Config) MarshalJSON() ([]byte, error) {
+	fields := make(map[string]json.RawMessage, len(c.Additional)+len(publicConfigKnownFields))
+	for name, value := range c.Additional {
+		if isPublicConfigKnownField(name) {
+			return nil, fmt.Errorf("Config additional fields cannot redefine %s", name)
+		}
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			return nil, fmt.Errorf("encode Config additional field %q: %w", name, err)
+		}
+		fields[name] = encoded
+	}
+	for name, value := range map[string]any{
+		"model":                                c.Model,
+		"review_model":                         c.ReviewModel,
+		"model_context_window":                 c.ModelContextWindow,
+		"model_auto_compact_token_limit":       c.ModelAutoCompactTokenLimit,
+		"model_auto_compact_token_limit_scope": c.ModelAutoCompactTokenLimitScope,
+		"model_provider":                       c.ModelProvider,
+		"approval_policy":                      c.ApprovalPolicy,
+		"approvals_reviewer":                   c.ApprovalsReviewer,
+		"sandbox_mode":                         c.SandboxMode,
+		"sandbox_workspace_write":              c.SandboxWorkspaceWrite,
+		"forced_chatgpt_workspace_id":          c.ForcedChatgptWorkspaceID,
+		"forced_login_method":                  c.ForcedLoginMethod,
+		"web_search":                           c.WebSearch,
+		"tools":                                c.Tools,
+		"instructions":                         c.Instructions,
+		"developer_instructions":               c.DeveloperInstructions,
+		"compact_prompt":                       c.CompactPrompt,
+		"model_reasoning_effort":               c.ModelReasoningEffort,
+		"model_reasoning_summary":              c.ModelReasoningSummary,
+		"model_verbosity":                      c.ModelVerbosity,
+		"service_tier":                         c.ServiceTier,
+		"analytics":                            c.Analytics,
+		"desktop":                              c.Desktop,
+	} {
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			return nil, fmt.Errorf("encode Config field %s: %w", name, err)
+		}
+		fields[name] = encoded
+	}
+	return json.Marshal(fields)
+}
+
+func (c *Config) UnmarshalJSON(data []byte) error {
+	if c == nil {
+		return errors.New("decode Config into nil receiver")
+	}
+	payload, err := decodePublicConfigObject(data)
+	if err != nil {
+		return err
+	}
+	model, err := decodePublicConfigValue[string](payload, "model")
+	if err != nil {
+		return err
+	}
+	reviewModel, err := decodePublicConfigValue[string](payload, "review_model")
+	if err != nil {
+		return err
+	}
+	modelContextWindow, err := decodePublicConfigValue[int64](payload, "model_context_window")
+	if err != nil {
+		return err
+	}
+	modelAutoCompactTokenLimit, err := decodePublicConfigValue[int64](payload, "model_auto_compact_token_limit")
+	if err != nil {
+		return err
+	}
+	modelAutoCompactLimitScope, err := decodePublicConfigValue[AutoCompactTokenLimitScope](
+		payload, "model_auto_compact_token_limit_scope",
+	)
+	if err != nil {
+		return err
+	}
+	modelProvider, err := decodePublicConfigValue[string](payload, "model_provider")
+	if err != nil {
+		return err
+	}
+	approvalPolicy, err := decodePublicConfigValue[AskForApproval](payload, "approval_policy")
+	if err != nil {
+		return err
+	}
+	approvalsReviewer, err := decodePublicConfigValue[ApprovalsReviewer](payload, "approvals_reviewer")
+	if err != nil {
+		return err
+	}
+	sandboxMode, err := decodePublicConfigValue[SandboxMode](payload, "sandbox_mode")
+	if err != nil {
+		return err
+	}
+	sandboxWorkspaceWrite, err := decodePublicConfigValue[SandboxWorkspaceWrite](
+		payload, "sandbox_workspace_write",
+	)
+	if err != nil {
+		return err
+	}
+	forcedChatgptWorkspaceID, err := decodePublicConfigValue[ForcedChatgptWorkspaceIds](
+		payload, "forced_chatgpt_workspace_id",
+	)
+	if err != nil {
+		return err
+	}
+	forcedLoginMethod, err := decodePublicConfigValue[ForcedLoginMethod](payload, "forced_login_method")
+	if err != nil {
+		return err
+	}
+	webSearch, err := decodePublicConfigValue[WebSearchMode](payload, "web_search")
+	if err != nil {
+		return err
+	}
+	tools, err := decodePublicConfigValue[ToolsV2](payload, "tools")
+	if err != nil {
+		return err
+	}
+	instructions, err := decodePublicConfigValue[string](payload, "instructions")
+	if err != nil {
+		return err
+	}
+	developerInstructions, err := decodePublicConfigValue[string](payload, "developer_instructions")
+	if err != nil {
+		return err
+	}
+	compactPrompt, err := decodePublicConfigValue[string](payload, "compact_prompt")
+	if err != nil {
+		return err
+	}
+	modelReasoningEffort, err := decodePublicConfigValue[ReasoningEffort](payload, "model_reasoning_effort")
+	if err != nil {
+		return err
+	}
+	modelReasoningSummary, err := decodePublicConfigValue[ReasoningSummary](payload, "model_reasoning_summary")
+	if err != nil {
+		return err
+	}
+	modelVerbosity, err := decodePublicConfigValue[Verbosity](payload, "model_verbosity")
+	if err != nil {
+		return err
+	}
+	serviceTier, err := decodePublicConfigValue[string](payload, "service_tier")
+	if err != nil {
+		return err
+	}
+	analytics, err := decodePublicConfigValue[AnalyticsConfig](payload, "analytics")
+	if err != nil {
+		return err
+	}
+	desktop, err := decodePublicConfigValue[map[string]JsonValue](payload, "desktop")
+	if err != nil {
+		return err
+	}
+
+	additional := make(map[string]JsonValue, len(payload))
+	for name, raw := range payload {
+		if isPublicConfigKnownField(name) {
+			continue
+		}
+		additional[name] = JsonValue{raw: append(json.RawMessage(nil), raw...)}
+	}
+	*c = Config{
+		Model:                           model,
+		ReviewModel:                     reviewModel,
+		ModelContextWindow:              modelContextWindow,
+		ModelAutoCompactTokenLimit:      modelAutoCompactTokenLimit,
+		ModelAutoCompactTokenLimitScope: modelAutoCompactLimitScope,
+		ModelProvider:                   modelProvider,
+		ApprovalPolicy:                  approvalPolicy,
+		ApprovalsReviewer:               approvalsReviewer,
+		SandboxMode:                     sandboxMode,
+		SandboxWorkspaceWrite:           sandboxWorkspaceWrite,
+		ForcedChatgptWorkspaceID:        forcedChatgptWorkspaceID,
+		ForcedLoginMethod:               forcedLoginMethod,
+		WebSearch:                       webSearch,
+		Tools:                           tools,
+		Instructions:                    instructions,
+		DeveloperInstructions:           developerInstructions,
+		CompactPrompt:                   compactPrompt,
+		ModelReasoningEffort:            modelReasoningEffort,
+		ModelReasoningSummary:           modelReasoningSummary,
+		ModelVerbosity:                  modelVerbosity,
+		ServiceTier:                     serviceTier,
+		Analytics:                       analytics,
+		Desktop:                         dereferencePublicConfigMap(desktop),
+		Additional:                      additional,
+	}
+	return nil
+}
+
+func decodePublicConfigObject(data []byte) (map[string]json.RawMessage, error) {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	opening, err := decoder.Token()
+	if err != nil {
+		return nil, fmt.Errorf("decode Config: %w", err)
+	}
+	if opening != json.Delim('{') {
+		return nil, errors.New("Config must be an object")
+	}
+	payload := make(map[string]json.RawMessage)
+	seenKnown := make(map[string]bool, len(publicConfigKnownFields))
+	for decoder.More() {
+		token, err := decoder.Token()
+		if err != nil {
+			return nil, fmt.Errorf("decode Config field name: %w", err)
+		}
+		name := token.(string)
+		if isPublicConfigKnownField(name) {
+			if seenKnown[name] {
+				return nil, fmt.Errorf("duplicate Config field %q", name)
+			}
+			seenKnown[name] = true
+		}
+		var raw json.RawMessage
+		if err := decoder.Decode(&raw); err != nil {
+			return nil, fmt.Errorf("decode Config field %q: %w", name, err)
+		}
+		payload[name] = append(json.RawMessage(nil), raw...)
+	}
+	_, err = decoder.Token()
+	if err != nil {
+		return nil, fmt.Errorf("decode Config: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return nil, errors.New("Config must contain one JSON value")
+		}
+		return nil, fmt.Errorf("decode Config trailing value: %w", err)
+	}
+	return payload, nil
+}
+
+func decodePublicConfigValue[T any](payload map[string]json.RawMessage, name string) (*T, error) {
+	value, err := decodeOptionalNullableConfigRequirementValue[T](payload, "Config", name)
+	if err != nil {
+		return nil, err
+	}
+	return value, nil
+}
+
+func dereferencePublicConfigMap(value *map[string]JsonValue) map[string]JsonValue {
+	if value == nil {
+		return nil
+	}
+	return *value
+}
+
+func isPublicConfigKnownField(name string) bool {
+	for _, known := range publicConfigKnownFields {
+		if name == known {
+			return true
+		}
+	}
+	return false
+}
+
+var publicConfigKnownFields = []string{
+	"model",
+	"review_model",
+	"model_context_window",
+	"model_auto_compact_token_limit",
+	"model_auto_compact_token_limit_scope",
+	"model_provider",
+	"approval_policy",
+	"approvals_reviewer",
+	"sandbox_mode",
+	"sandbox_workspace_write",
+	"forced_chatgpt_workspace_id",
+	"forced_login_method",
+	"web_search",
+	"tools",
+	"instructions",
+	"developer_instructions",
+	"compact_prompt",
+	"model_reasoning_effort",
+	"model_reasoning_summary",
+	"model_verbosity",
+	"service_tier",
+	"analytics",
+	"desktop",
+}
+
+var (
+	_ json.Marshaler   = Config{}
+	_ json.Unmarshaler = (*Config)(nil)
+)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 354 {
-		t.Fatalf("definition count = %d, want 354", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 355 {
+		t.Fatalf("definition count = %d, want 355", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 354 {
-		t.Fatalf("definition count = %d, want 354", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 355 {
+		t.Fatalf("definition count = %d, want 355", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 354 {
-		t.Fatalf("definition count = %d, want 354", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 355 {
+		t.Fatalf("definition count = %d, want 355", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 354 {
-		t.Fatalf("definition count = %d, want 354", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 355 {
+		t.Fatalf("definition count = %d, want 355", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 354 {
-		t.Fatalf("definition count = %d, want 354", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 355 {
+		t.Fatalf("definition count = %d, want 355", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -123,6 +123,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "CommandExecutionOutputDeltaNotificationParams", Type: reflect.TypeFor[CommandExecutionOutputDeltaNotificationParams]()},
 		{Name: "CommandExecutionSource", Type: reflect.TypeFor[CommandExecutionSource]()},
 		{Name: "ComputerUseRequirements", Type: reflect.TypeFor[ComputerUseRequirements]()},
+		{Name: "Config", Type: reflect.TypeFor[Config]()},
 		{Name: "ConfigBatchWriteParams", Type: reflect.TypeFor[ConfigBatchWriteParams]()},
 		{Name: "ConfigEdit", Type: reflect.TypeFor[ConfigEdit]()},
 		{Name: "ConfigLayer", Type: reflect.TypeFor[ConfigLayer]()},
@@ -482,6 +483,7 @@ func wireSchemaDefinitions() Schema {
 	for name, schema := range configPrerequisiteSchemas() {
 		schemas[name] = schema
 	}
+	schemas["Config"] = publicConfigSchema()
 	schemas["ConfigLayerSource"] = configLayerSourceSchema()
 	configReadProperties := schemas["ConfigReadParams"].(Schema)["properties"].(Schema)
 	configReadProperties["cwd"].(Schema)["description"] = configReadCWDDescription
@@ -1486,6 +1488,50 @@ func configPrerequisiteSchemas() map[string]Schema {
 			"required":             []string{"context_size", "allowed_domains", "location"},
 			"additionalProperties": false,
 		},
+	}
+}
+
+func publicConfigSchema() Schema {
+	nullable := func(value Schema) Schema {
+		return Schema{"anyOf": []any{value, Schema{"type": "null"}}}
+	}
+	approvalsReviewer := nullable(Schema{"$ref": "#/$defs/ApprovalsReviewer"})
+	approvalsReviewer["description"] =
+		"[UNSTABLE] Optional default for where approval requests are routed for review."
+	return Schema{
+		"type": "object",
+		"properties": Schema{
+			"model":                                nullable(Schema{"type": "string"}),
+			"review_model":                         nullable(Schema{"type": "string"}),
+			"model_context_window":                 nullable(Schema{"type": "integer"}),
+			"model_auto_compact_token_limit":       nullable(Schema{"type": "integer"}),
+			"model_auto_compact_token_limit_scope": nullable(Schema{"$ref": "#/$defs/AutoCompactTokenLimitScope"}),
+			"model_provider":                       nullable(Schema{"type": "string"}),
+			"approval_policy":                      nullable(Schema{"$ref": "#/$defs/AskForApproval"}),
+			"approvals_reviewer":                   approvalsReviewer,
+			"sandbox_mode":                         nullable(Schema{"$ref": "#/$defs/SandboxMode"}),
+			"sandbox_workspace_write":              nullable(Schema{"$ref": "#/$defs/SandboxWorkspaceWrite"}),
+			"forced_chatgpt_workspace_id":          nullable(Schema{"$ref": "#/$defs/ForcedChatgptWorkspaceIds"}),
+			"forced_login_method":                  nullable(Schema{"$ref": "#/$defs/ForcedLoginMethod"}),
+			"web_search":                           nullable(Schema{"$ref": "#/$defs/WebSearchMode"}),
+			"tools":                                nullable(Schema{"$ref": "#/$defs/ToolsV2"}),
+			"instructions":                         nullable(Schema{"type": "string"}),
+			"developer_instructions":               nullable(Schema{"type": "string"}),
+			"compact_prompt":                       nullable(Schema{"type": "string"}),
+			"model_reasoning_effort":               nullable(Schema{"$ref": "#/$defs/ReasoningEffort"}),
+			"model_reasoning_summary":              nullable(Schema{"$ref": "#/$defs/ReasoningSummary"}),
+			"model_verbosity":                      nullable(Schema{"$ref": "#/$defs/Verbosity"}),
+			"service_tier":                         nullable(Schema{"type": "string"}),
+			"analytics":                            nullable(Schema{"$ref": "#/$defs/AnalyticsConfig"}),
+			"desktop": nullable(Schema{
+				"type":                             "object",
+				"additionalProperties":             Schema{"$ref": "#/$defs/JsonValue"},
+				"x-gollem-typescript-optional-map": true,
+			}),
+		},
+		"required":                         append([]string(nil), publicConfigKnownFields...),
+		"additionalProperties":             Schema{"$ref": "#/$defs/JsonValue"},
+		"x-gollem-typescript-optional-map": true,
 	}
 }
 

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -1425,6 +1425,275 @@
       ],
       "type": "object"
     },
+    "Config": {
+      "additionalProperties": {
+        "$ref": "#/$defs/JsonValue"
+      },
+      "properties": {
+        "analytics": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AnalyticsConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "approval_policy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AskForApproval"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "approvals_reviewer": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ApprovalsReviewer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "[UNSTABLE] Optional default for where approval requests are routed for review."
+        },
+        "compact_prompt": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "desktop": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "$ref": "#/$defs/JsonValue"
+              },
+              "type": "object",
+              "x-gollem-typescript-optional-map": true
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "developer_instructions": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "forced_chatgpt_workspace_id": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ForcedChatgptWorkspaceIds"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "forced_login_method": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ForcedLoginMethod"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "instructions": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "model": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "model_auto_compact_token_limit": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "model_auto_compact_token_limit_scope": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AutoCompactTokenLimitScope"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "model_context_window": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "model_provider": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "model_reasoning_effort": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ReasoningEffort"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "model_reasoning_summary": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ReasoningSummary"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "model_verbosity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Verbosity"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "review_model": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "sandbox_mode": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SandboxMode"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "sandbox_workspace_write": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SandboxWorkspaceWrite"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "service_tier": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "tools": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ToolsV2"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "web_search": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WebSearchMode"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "model",
+        "review_model",
+        "model_context_window",
+        "model_auto_compact_token_limit",
+        "model_auto_compact_token_limit_scope",
+        "model_provider",
+        "approval_policy",
+        "approvals_reviewer",
+        "sandbox_mode",
+        "sandbox_workspace_write",
+        "forced_chatgpt_workspace_id",
+        "forced_login_method",
+        "web_search",
+        "tools",
+        "instructions",
+        "developer_instructions",
+        "compact_prompt",
+        "model_reasoning_effort",
+        "model_reasoning_summary",
+        "model_verbosity",
+        "service_tier",
+        "analytics",
+        "desktop"
+      ],
+      "type": "object",
+      "x-gollem-typescript-optional-map": true
+    },
     "ConfigBatchWriteParams": {
       "additionalProperties": false,
       "properties": {

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 354 {
-		t.Fatalf("definition count = %d, want 354", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 355 {
+		t.Fatalf("definition count = %d, want 355", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
-		t.Fatalf("definition count = %d, want 354", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
+		t.Fatalf("definition count = %d, want 355", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
-		t.Fatalf("definition count = %d, want 354", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
+		t.Fatalf("definition count = %d, want 355", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
-		t.Fatalf("definition count = %d, want 354", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
+		t.Fatalf("definition count = %d, want 355", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
-		t.Fatalf("definition count = %d, want 354", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
+		t.Fatalf("definition count = %d, want 355", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
-		t.Fatalf("definition count = %d, want 354", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
+		t.Fatalf("definition count = %d, want 355", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 354 {
-		t.Fatalf("definition count = %d, want 354", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 355 {
+		t.Fatalf("definition count = %d, want 355", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 354 {
-		t.Fatalf("definition count = %d, want 354", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 355 {
+		t.Fatalf("definition count = %d, want 355", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
-		t.Fatalf("definition count = %d, want 354", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
+		t.Fatalf("definition count = %d, want 355", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
-		t.Fatalf("definition count = %d, want 354", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
+		t.Fatalf("definition count = %d, want 355", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
-		t.Fatalf("definition count = %d, want 354", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
+		t.Fatalf("definition count = %d, want 355", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
-		t.Fatalf("definition count = %d, want 354", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
+		t.Fatalf("definition count = %d, want 355", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -792,6 +792,32 @@ export type ComputerUseRequirements = {
   "allowLockedComputerUse": boolean | null;
 };
 
+export type Config = ({
+  "analytics": AnalyticsConfig | null;
+  "approval_policy": AskForApproval | null;
+  "approvals_reviewer": ApprovalsReviewer | null;
+  "compact_prompt": string | null;
+  "desktop": { [key in string]?: JsonValue } | null;
+  "developer_instructions": string | null;
+  "forced_chatgpt_workspace_id": ForcedChatgptWorkspaceIds | null;
+  "forced_login_method": ForcedLoginMethod | null;
+  "instructions": string | null;
+  "model": string | null;
+  "model_auto_compact_token_limit": number | null;
+  "model_auto_compact_token_limit_scope": AutoCompactTokenLimitScope | null;
+  "model_context_window": number | null;
+  "model_provider": string | null;
+  "model_reasoning_effort": ReasoningEffort | null;
+  "model_reasoning_summary": ReasoningSummary | null;
+  "model_verbosity": Verbosity | null;
+  "review_model": string | null;
+  "sandbox_mode": SandboxMode | null;
+  "sandbox_workspace_write": SandboxWorkspaceWrite | null;
+  "service_tier": string | null;
+  "tools": ToolsV2 | null;
+  "web_search": WebSearchMode | null;
+} & { [key in string]?: JsonValue });
+
 export type ConfigBatchWriteParams = {
   "edits": Array<ConfigEdit>;
   "expectedVersion"?: string | null;

--- a/appserver/protocol/typescript/testdata/public_config_contract.ts
+++ b/appserver/protocol/typescript/testdata/public_config_contract.ts
@@ -1,0 +1,155 @@
+import type {
+  AnalyticsConfig,
+  ApprovalsReviewer,
+  AskForApproval,
+  AutoCompactTokenLimitScope,
+  Config,
+  ForcedChatgptWorkspaceIds,
+  ForcedLoginMethod,
+  JsonValue,
+  ReasoningEffort,
+  ReasoningSummary,
+  SandboxMode,
+  SandboxWorkspaceWrite,
+  ToolsV2,
+  Verbosity,
+  WebSearchMode,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? (<T>() => T extends B ? 1 : 2) extends
+        (<T>() => T extends A ? 1 : 2)
+      ? true
+      : false
+    : false;
+type Expect<T extends true> = T;
+
+type PublicConfigShape = {
+  model: string | null;
+  review_model: string | null;
+  model_context_window: number | null;
+  model_auto_compact_token_limit: number | null;
+  model_auto_compact_token_limit_scope: AutoCompactTokenLimitScope | null;
+  model_provider: string | null;
+  approval_policy: AskForApproval | null;
+  approvals_reviewer: ApprovalsReviewer | null;
+  sandbox_mode: SandboxMode | null;
+  sandbox_workspace_write: SandboxWorkspaceWrite | null;
+  forced_chatgpt_workspace_id: ForcedChatgptWorkspaceIds | null;
+  forced_login_method: ForcedLoginMethod | null;
+  web_search: WebSearchMode | null;
+  tools: ToolsV2 | null;
+  instructions: string | null;
+  developer_instructions: string | null;
+  compact_prompt: string | null;
+  model_reasoning_effort: ReasoningEffort | null;
+  model_reasoning_summary: ReasoningSummary | null;
+  model_verbosity: Verbosity | null;
+  service_tier: string | null;
+  analytics: AnalyticsConfig | null;
+  desktop: { [key in string]?: JsonValue } | null;
+} & { [key in string]?: JsonValue };
+
+type PublicConfigContract = Expect<Equal<Config, PublicConfigShape>>;
+
+const emptyConfig = {
+  model: null,
+  review_model: null,
+  model_context_window: null,
+  model_auto_compact_token_limit: null,
+  model_auto_compact_token_limit_scope: null,
+  model_provider: null,
+  approval_policy: null,
+  approvals_reviewer: null,
+  sandbox_mode: null,
+  sandbox_workspace_write: null,
+  forced_chatgpt_workspace_id: null,
+  forced_login_method: null,
+  web_search: null,
+  tools: null,
+  instructions: null,
+  developer_instructions: null,
+  compact_prompt: null,
+  model_reasoning_effort: null,
+  model_reasoning_summary: null,
+  model_verbosity: null,
+  service_tier: null,
+  analytics: null,
+  desktop: null,
+} satisfies Config;
+
+({
+  ...emptyConfig,
+  model: "gpt-5",
+  model_context_window: 200000,
+  model_auto_compact_token_limit: 180000,
+  model_auto_compact_token_limit_scope: "body_after_prefix",
+  approval_policy: "on-request",
+  approvals_reviewer: "guardian_subagent",
+  sandbox_mode: "workspace-write",
+  sandbox_workspace_write: {
+    writable_roots: ["", "relative", "/absolute"],
+    network_access: true,
+    exclude_tmpdir_env_var: false,
+    exclude_slash_tmp: true,
+  },
+  forced_chatgpt_workspace_id: ["", "workspace", "workspace"],
+  forced_login_method: "api",
+  web_search: "live",
+  tools: { web_search: null },
+  model_reasoning_effort: "xhigh",
+  model_reasoning_summary: "detailed",
+  model_verbosity: "high",
+  analytics: { enabled: true, nested: { value: [9007199254740993, null] } },
+  desktop: { theme: "dark", nested: [true, null] },
+  apps: { untyped: true },
+  future: [9007199254740993, { nested: true }],
+}) satisfies Config;
+
+// @ts-expect-error every known field is required nullable.
+({}) satisfies Config;
+// @ts-expect-error one missing known field is still invalid.
+({ model: null }) satisfies Config;
+// @ts-expect-error known fields cannot be explicit undefined.
+({ ...emptyConfig, model: undefined }) satisfies Config;
+// @ts-expect-error context windows are JSON numbers in the generated binding.
+({ ...emptyConfig, model_context_window: 1n }) satisfies Config;
+// @ts-expect-error context windows exclude strings.
+({ ...emptyConfig, model_context_window: "200000" }) satisfies Config;
+// @ts-expect-error auto-compact scope is closed.
+({ ...emptyConfig, model_auto_compact_token_limit_scope: "bodyAfterPrefix" }) satisfies Config;
+// @ts-expect-error approval policy uses the exact public union.
+({ ...emptyConfig, approval_policy: "always" }) satisfies Config;
+// @ts-expect-error reviewer is closed.
+({ ...emptyConfig, approvals_reviewer: "guardian" }) satisfies Config;
+// @ts-expect-error sandbox mode is closed.
+({ ...emptyConfig, sandbox_mode: "workspace_write" }) satisfies Config;
+// @ts-expect-error sandbox config has an exact generated shape.
+({ ...emptyConfig, sandbox_workspace_write: { writable_roots: [], network_access: false, exclude_tmpdir_env_var: false, exclude_slash_tmp: false, future: true } }) satisfies Config;
+// @ts-expect-error workspace-id arrays contain strings only.
+({ ...emptyConfig, forced_chatgpt_workspace_id: ["workspace", 1] }) satisfies Config;
+// @ts-expect-error forced login method is closed.
+({ ...emptyConfig, forced_login_method: "oauth" }) satisfies Config;
+// @ts-expect-error web-search mode is closed.
+({ ...emptyConfig, web_search: "enabled" }) satisfies Config;
+// @ts-expect-error tools require the exact generated shape.
+({ ...emptyConfig, tools: { web_search: false } }) satisfies Config;
+// @ts-expect-error instructions are nullable strings.
+({ ...emptyConfig, instructions: {} }) satisfies Config;
+// @ts-expect-error reasoning summary is closed.
+({ ...emptyConfig, model_reasoning_summary: "brief" }) satisfies Config;
+// @ts-expect-error verbosity is closed.
+({ ...emptyConfig, model_verbosity: "max" }) satisfies Config;
+// @ts-expect-error analytics enabled is a nullable boolean.
+({ ...emptyConfig, analytics: { enabled: "true" } }) satisfies Config;
+// @ts-expect-error desktop values must be JSON.
+({ ...emptyConfig, desktop: { callback: () => true } }) satisfies Config;
+// @ts-expect-error flattened additional values must be JSON.
+({ ...emptyConfig, future: () => true }) satisfies Config;
+// @ts-expect-error Config is an object.
+null satisfies Config;
+
+declare const publicConfigContract: PublicConfigContract;
+void publicConfigContract;

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 354 {
-		t.Fatalf("definition count = %d, want 354", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
+		t.Fatalf("definition count = %d, want 355", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary

- export exact standalone public `Config` over the now-complete prerequisite graph
- preserve all 23 known nullable snake-case fields, signed int64 bounds, flattened open precision-safe JSON, and duplicate-known-field rejection
- generate exact schema and TypeScript while keeping `config/read`, all method/item bindings, and runtime behavior unchanged
- advance deterministic output to 355 definitions with 59 method and 5 item bindings

## Verification

- deliberate red: 9 undefined Go references; 1 missing TypeScript export, 1 false identity, and 22 unused negative directives
- 30 focused repetitions and focused race
- 100% statement coverage for every new method/helper
- full non-Monty normal and race suites
- `golangci-lint run` (0 issues), `go vet ./...`, `go mod tidy`
- deterministic schema and TypeScript regeneration
- strict TypeScript fixture
- exact normalized baseline/candidate live `config/read` equality
- all five Slang stdio, Unix-socket, and WebSocket workflows

Local Monty normal/race/coverage tests remain intentionally skipped per standing direction with `hooks.skipMontyRace=true`; hosted tests are unchanged.