### PR TITLE
feat(protocol): add config read response contract

### DIFF
--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
-		t.Fatalf("definition count = %d, want 355", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
+		t.Fatalf("definition count = %d, want 356", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
-		t.Fatalf("definition count = %d, want 355", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
+		t.Fatalf("definition count = %d, want 356", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
-		t.Fatalf("definition count = %d, want 355", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
+		t.Fatalf("definition count = %d, want 356", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
-		t.Fatalf("definition count = %d, want 355", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
+		t.Fatalf("definition count = %d, want 356", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -1,0 +1,234 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestConfigReadResponseSchemaIsExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	want := Schema{
+		"type": "object",
+		"properties": Schema{
+			"config": Schema{"$ref": "#/$defs/Config"},
+			"origins": Schema{
+				"type":                             "object",
+				"additionalProperties":             Schema{"$ref": "#/$defs/ConfigLayerMetadata"},
+				"x-gollem-typescript-optional-map": true,
+			},
+			"layers": nullableConfigPrerequisiteSchema(Schema{
+				"type":  "array",
+				"items": Schema{"$ref": "#/$defs/ConfigLayer"},
+			}),
+		},
+		"required":             []string{"config", "origins", "layers"},
+		"additionalProperties": true,
+		"x-gollem-typescript-ignore-additional-properties": true,
+	}
+	if got := defs["ConfigReadResponse"]; !reflect.DeepEqual(got, want) {
+		t.Fatalf("ConfigReadResponse schema = %#v, want %#v", got, want)
+	}
+}
+
+func TestConfigReadResponseCanonicalizesOmittedLayers(t *testing.T) {
+	for _, input := range []string{
+		`{"config":{},"origins":{}}`,
+		`{"config":{},"origins":{},"layers":null}`,
+		`{"config":{},"origins":{},"future":{"ignored":true}}`,
+		`{"config":{},"origins":{},"future":1,"future":2}`,
+	} {
+		var value ConfigReadResponse
+		if err := json.Unmarshal([]byte(input), &value); err != nil {
+			t.Fatalf("unmarshal ConfigReadResponse %s: %v", input, err)
+		}
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			t.Fatalf("marshal ConfigReadResponse %s: %v", input, err)
+		}
+		want := `{"config":` + emptyPublicConfigJSON() + `,"origins":{},"layers":null}`
+		if got := string(encoded); got != want {
+			t.Fatalf("ConfigReadResponse %s = %s, want %s", input, got, want)
+		}
+	}
+}
+
+func TestConfigReadResponsePreservesNestedValuesAndOrder(t *testing.T) {
+	input := `{
+		"config":{"model":"gpt-5","future":{"integer":9007199254740993}},
+		"origins":{
+			"":{"name":{"type":"sessionFlags"},"version":""},
+			"model":{"name":{"type":"user","file":"/home/user/../user/.codex/config.toml"},"version":"v1"}
+		},
+		"layers":[
+			{"name":{"type":"project","dotCodexFolder":"/workspace/../workspace/.codex"},"version":"v2","config":{"integer":9007199254740993}},
+			{"name":{"type":"sessionFlags"},"version":"v3","config":null,"disabledReason":"policy"},
+			{"name":{"type":"sessionFlags"},"version":"v3","config":null,"disabledReason":"policy"}
+		],
+		"future":true
+	}`
+	var value ConfigReadResponse
+	if err := json.Unmarshal([]byte(input), &value); err != nil {
+		t.Fatalf("unmarshal full ConfigReadResponse: %v", err)
+	}
+	if got, want := len(value.Origins), 2; got != want {
+		t.Fatalf("origins = %d, want %d", got, want)
+	}
+	if got, want := len(value.Layers), 3; got != want {
+		t.Fatalf("layers = %d, want %d", got, want)
+	}
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal full ConfigReadResponse: %v", err)
+	}
+	if strings.Contains(string(encoded), `"future":true`) {
+		t.Fatalf("unknown response field survived canonical output: %s", encoded)
+	}
+	for _, want := range []string{
+		`"future":{"integer":9007199254740993}`,
+		`"file":"/home/user/.codex/config.toml","profile":null`,
+		`"dotCodexFolder":"/workspace/.codex"`,
+		`"integer":9007199254740993`,
+	} {
+		if !strings.Contains(string(encoded), want) {
+			t.Errorf("canonical response missing %s: %s", want, encoded)
+		}
+	}
+	if got := strings.Count(string(encoded), `"version":"v3"`); got != 2 {
+		t.Errorf("duplicate ordered layers = %d, want 2: %s", got, encoded)
+	}
+
+	var roundTripped ConfigReadResponse
+	if err := json.Unmarshal(encoded, &roundTripped); err != nil {
+		t.Fatalf("unmarshal canonical ConfigReadResponse: %v", err)
+	}
+	reencoded, err := json.Marshal(roundTripped)
+	if err != nil {
+		t.Fatalf("remarshal canonical ConfigReadResponse: %v", err)
+	}
+	if string(reencoded) != string(encoded) {
+		t.Fatalf("canonical response changed:\nfirst: %s\nsecond: %s", encoded, reencoded)
+	}
+}
+
+func TestConfigReadResponseOriginsUseLastDuplicateValue(t *testing.T) {
+	input := `{"config":{},"origins":{"model":{"name":{"type":"sessionFlags"},"version":"v1"},"model":{"name":{"type":"sessionFlags"},"version":"v2"}}}`
+	var value ConfigReadResponse
+	if err := json.Unmarshal([]byte(input), &value); err != nil {
+		t.Fatalf("unmarshal duplicate origin: %v", err)
+	}
+	if got := value.Origins["model"].Version; got != "v2" {
+		t.Fatalf("duplicate origin version = %q, want v2", got)
+	}
+}
+
+func TestConfigReadResponseRejectsMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{}`, `{} {}`, `{} x`,
+		`{"origins":{}}`,
+		`{"config":null,"origins":{}}`,
+		`{"config":[],"origins":{}}`,
+		`{"config":{"model":1},"origins":{}}`,
+		`{"config":{}}`,
+		`{"config":{},"origins":null}`,
+		`{"config":{},"origins":[]}`,
+		`{"config":{},"origins":{"model":null}}`,
+		`{"config":{},"origins":{"model":{}}}`,
+		`{"config":{},"origins":{"model":{"name":{"type":"sessionFlags"}}}}`,
+		`{"config":{},"origins":{"model":{"name":{"type":"sessionFlags"},"version":"v1","extra":true}}}`,
+		`{"config":{},"origins":{},"layers":{}}`,
+		`{"config":{},"origins":{},"layers":[null]}`,
+		`{"config":{},"origins":{},"layers":[{}]}`,
+		`{"config":{},"origins":{},"layers":[{"name":{"type":"sessionFlags"},"version":"v1","config":null,"extra":true}]}`,
+		`{"config":{},"origins":{},"layers":[{"name":{"type":"sessionFlags"},"version":"v1","config":{"bad":}}]}`,
+		`{"config":{},"config":{},"origins":{}}`,
+		`{"config":{},"origins":{},"origins":{}}`,
+		`{"config":{},"origins":{},"layers":null,"layers":[]}`,
+	} {
+		assertJSONRejects[ConfigReadResponse](t, input)
+	}
+}
+
+func TestConfigReadResponseDirectDecoderRejectsMalformedTokenStreams(t *testing.T) {
+	for _, input := range []string{
+		``, `{@`, `{"config"`, `{"config":`, `{"future":1`, `{} {}`, `{} x`,
+	} {
+		var value ConfigReadResponse
+		if err := value.UnmarshalJSON([]byte(input)); err == nil {
+			t.Errorf("direct ConfigReadResponse decoder accepted %q", input)
+		}
+	}
+}
+
+func TestConfigReadResponseMarshalRejectsInvalidConstructedValues(t *testing.T) {
+	var valid ConfigReadResponse
+	if err := json.Unmarshal([]byte(`{"config":{},"origins":{"model":{"name":{"type":"sessionFlags"},"version":"v1"}},"layers":[{"name":{"type":"sessionFlags"},"version":"v1","config":null}]}`), &valid); err != nil {
+		t.Fatalf("decode valid response: %v", err)
+	}
+	invalidConfig := valid
+	invalidConfig.Config = Config{Additional: map[string]JsonValue{"future": {}}}
+	invalidOrigin := valid
+	invalidOrigin.Origins = map[string]ConfigLayerMetadata{"model": {}}
+	invalidLayer := valid
+	invalidLayer.Layers[0].Config = JsonValue{}
+	for name, value := range map[string]ConfigReadResponse{
+		"nil origins":    {},
+		"invalid config": invalidConfig,
+		"invalid origin": invalidOrigin,
+		"invalid layer":  invalidLayer,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := json.Marshal(value); err == nil {
+				t.Fatal("invalid ConfigReadResponse marshaled")
+			}
+		})
+	}
+}
+
+func TestConfigReadResponseNilReceiver(t *testing.T) {
+	var value *ConfigReadResponse
+	if err := value.UnmarshalJSON([]byte(`{"config":{},"origins":{}}`)); err == nil {
+		t.Fatal("nil ConfigReadResponse receiver succeeded")
+	}
+}
+
+func TestConfigReadResponseRemainsStandalone(t *testing.T) {
+	for _, binding := range WireTypeBindings() {
+		if slices.Contains(binding.Params, "ConfigReadResponse") || slices.Contains(binding.Result, "ConfigReadResponse") {
+			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
+		t.Fatalf("definition count = %d, want 356", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestConfigReadResponseTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	for _, want := range []string{
+		`export type ConfigReadResponse = {`,
+		`"config": Config;`,
+		`"origins": { [key in string]?: ConfigLayerMetadata };`,
+		`"layers": Array<ConfigLayer> | null;`,
+	} {
+		if !strings.Contains(string(generated), want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}
+
+var (
+	_ json.Marshaler   = ConfigReadResponse{}
+	_ json.Unmarshaler = (*ConfigReadResponse)(nil)
+)

--- a/appserver/protocol/config_read_response_types.go
+++ b/appserver/protocol/config_read_response_types.go
@@ -1,0 +1,159 @@
+package protocol
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// ConfigReadResponse is the exact standalone public effective-config response.
+// It is kept separate from Gollem's memory-backed config/read result.
+type ConfigReadResponse struct {
+	Config  Config                         `json:"config"`
+	Origins map[string]ConfigLayerMetadata `json:"origins"`
+	Layers  []ConfigLayer                  `json:"layers"`
+}
+
+func (r ConfigReadResponse) MarshalJSON() ([]byte, error) {
+	if r.Origins == nil {
+		return nil, errors.New("ConfigReadResponse origins must be a non-null object")
+	}
+	type wireConfigReadResponse struct {
+		Config  Config                         `json:"config"`
+		Origins map[string]ConfigLayerMetadata `json:"origins"`
+		Layers  []ConfigLayer                  `json:"layers"`
+	}
+	return json.Marshal(wireConfigReadResponse(r))
+}
+
+func (r *ConfigReadResponse) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("decode ConfigReadResponse into nil receiver")
+	}
+	payload, err := decodeConfigReadResponseObject(data)
+	if err != nil {
+		return err
+	}
+	config, err := decodeRequiredThreadItemValue[Config](payload, "ConfigReadResponse", "config")
+	if err != nil {
+		return err
+	}
+	origins, err := decodeConfigReadResponseOrigins(payload)
+	if err != nil {
+		return err
+	}
+	layers, err := decodeConfigReadResponseLayers(payload)
+	if err != nil {
+		return err
+	}
+	*r = ConfigReadResponse{Config: config, Origins: origins, Layers: layers}
+	return nil
+}
+
+func decodeConfigReadResponseObject(data []byte) (map[string]json.RawMessage, error) {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	opening, err := decoder.Token()
+	if err != nil {
+		return nil, fmt.Errorf("decode ConfigReadResponse: %w", err)
+	}
+	if opening != json.Delim('{') {
+		return nil, errors.New("ConfigReadResponse must be an object")
+	}
+	payload := make(map[string]json.RawMessage, 3)
+	seen := make(map[string]bool, 3)
+	for decoder.More() {
+		token, err := decoder.Token()
+		if err != nil {
+			return nil, fmt.Errorf("decode ConfigReadResponse field name: %w", err)
+		}
+		name := token.(string)
+		var raw json.RawMessage
+		if err := decoder.Decode(&raw); err != nil {
+			return nil, fmt.Errorf("decode ConfigReadResponse field %q: %w", name, err)
+		}
+		if !isConfigReadResponseKnownField(name) {
+			continue
+		}
+		if seen[name] {
+			return nil, fmt.Errorf("duplicate ConfigReadResponse field %q", name)
+		}
+		seen[name] = true
+		payload[name] = append(json.RawMessage(nil), raw...)
+	}
+	if _, err := decoder.Token(); err != nil {
+		return nil, fmt.Errorf("decode ConfigReadResponse: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return nil, errors.New("ConfigReadResponse must contain one JSON value")
+		}
+		return nil, fmt.Errorf("decode ConfigReadResponse trailing value: %w", err)
+	}
+	return payload, nil
+}
+
+func decodeConfigReadResponseOrigins(
+	payload map[string]json.RawMessage,
+) (map[string]ConfigLayerMetadata, error) {
+	raw, ok := payload["origins"]
+	if !ok {
+		return nil, errors.New("ConfigReadResponse requires origins")
+	}
+	if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return nil, errors.New("ConfigReadResponse origins must be a non-null object")
+	}
+	var values map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &values); err != nil {
+		return nil, fmt.Errorf("decode ConfigReadResponse origins: %w", err)
+	}
+	origins := make(map[string]ConfigLayerMetadata, len(values))
+	for name, encoded := range values {
+		if bytes.Equal(bytes.TrimSpace(encoded), []byte("null")) {
+			return nil, fmt.Errorf("ConfigReadResponse origin %q must be non-null", name)
+		}
+		var metadata ConfigLayerMetadata
+		if err := json.Unmarshal(encoded, &metadata); err != nil {
+			return nil, fmt.Errorf("decode ConfigReadResponse origin %q: %w", name, err)
+		}
+		origins[name] = metadata
+	}
+	return origins, nil
+}
+
+func decodeConfigReadResponseLayers(payload map[string]json.RawMessage) ([]ConfigLayer, error) {
+	raw, ok := payload["layers"]
+	if !ok || bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return nil, nil
+	}
+	var values []json.RawMessage
+	if err := json.Unmarshal(raw, &values); err != nil {
+		return nil, fmt.Errorf("decode ConfigReadResponse layers: %w", err)
+	}
+	layers := make([]ConfigLayer, len(values))
+	for index, encoded := range values {
+		if bytes.Equal(bytes.TrimSpace(encoded), []byte("null")) {
+			return nil, fmt.Errorf("ConfigReadResponse layer %d must be non-null", index)
+		}
+		if err := json.Unmarshal(encoded, &layers[index]); err != nil {
+			return nil, fmt.Errorf("decode ConfigReadResponse layer %d: %w", index, err)
+		}
+	}
+	return layers, nil
+}
+
+func isConfigReadResponseKnownField(name string) bool {
+	switch name {
+	case "config", "origins", "layers":
+		return true
+	default:
+		return false
+	}
+}
+
+var (
+	_ json.Marshaler   = ConfigReadResponse{}
+	_ json.Unmarshaler = (*ConfigReadResponse)(nil)
+)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
-		t.Fatalf("definition count = %d, want 355", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
+		t.Fatalf("definition count = %d, want 356", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
-		t.Fatalf("definition count = %d, want 355", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
+		t.Fatalf("definition count = %d, want 356", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
-		t.Fatalf("definition count = %d, want 355", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
+		t.Fatalf("definition count = %d, want 356", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
-		t.Fatalf("definition count = %d, want 355", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
+		t.Fatalf("definition count = %d, want 356", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 355 {
-		t.Fatalf("definition count = %d, want 355", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 356 {
+		t.Fatalf("definition count = %d, want 356", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
-		t.Fatalf("definition count = %d, want 355", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
+		t.Fatalf("definition count = %d, want 356", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
-		t.Fatalf("definition count = %d, want 355", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
+		t.Fatalf("definition count = %d, want 356", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
-		t.Fatalf("definition count = %d, want 355", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
+		t.Fatalf("definition count = %d, want 356", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
-		t.Fatalf("definition count = %d, want 355", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
+		t.Fatalf("definition count = %d, want 356", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
-		t.Fatalf("definition count = %d, want 355", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
+		t.Fatalf("definition count = %d, want 356", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
-		t.Fatalf("definition count = %d, want 355", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
+		t.Fatalf("definition count = %d, want 356", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
-		t.Fatalf("definition count = %d, want 355", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
+		t.Fatalf("definition count = %d, want 356", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
-		t.Fatalf("definition count = %d, want 355", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
+		t.Fatalf("definition count = %d, want 356", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
-		t.Fatalf("definition count = %d, want 355", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
+		t.Fatalf("definition count = %d, want 356", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 355 {
-		t.Fatalf("definition count = %d, want 355", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 356 {
+		t.Fatalf("definition count = %d, want 356", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 355 {
-		t.Fatalf("definition count = %d, want 355", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 356 {
+		t.Fatalf("definition count = %d, want 356", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 355 {
-		t.Fatalf("definition count = %d, want 355", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 356 {
+		t.Fatalf("definition count = %d, want 356", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 355 {
-		t.Fatalf("definition count = %d, want 355", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 356 {
+		t.Fatalf("definition count = %d, want 356", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 355 {
-		t.Fatalf("definition count = %d, want 355", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 356 {
+		t.Fatalf("definition count = %d, want 356", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -130,6 +130,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "ConfigLayerMetadata", Type: reflect.TypeFor[ConfigLayerMetadata]()},
 		{Name: "ConfigLayerSource", Type: reflect.TypeFor[ConfigLayerSource]()},
 		{Name: "ConfigReadParams", Type: reflect.TypeFor[ConfigReadParams]()},
+		{Name: "ConfigReadResponse", Type: reflect.TypeFor[ConfigReadResponse]()},
 		{Name: "ConfigRequirements", Type: reflect.TypeFor[ConfigRequirements]()},
 		{Name: "ConfigRequirementsReadResponse", Type: reflect.TypeFor[ConfigRequirementsReadResponse]()},
 		{Name: "ConfigValueWriteParams", Type: reflect.TypeFor[ConfigValueWriteParams]()},
@@ -484,6 +485,7 @@ func wireSchemaDefinitions() Schema {
 		schemas[name] = schema
 	}
 	schemas["Config"] = publicConfigSchema()
+	schemas["ConfigReadResponse"] = configReadResponseSchema()
 	schemas["ConfigLayerSource"] = configLayerSourceSchema()
 	configReadProperties := schemas["ConfigReadParams"].(Schema)["properties"].(Schema)
 	configReadProperties["cwd"].(Schema)["description"] = configReadCWDDescription
@@ -1532,6 +1534,30 @@ func publicConfigSchema() Schema {
 		"required":                         append([]string(nil), publicConfigKnownFields...),
 		"additionalProperties":             Schema{"$ref": "#/$defs/JsonValue"},
 		"x-gollem-typescript-optional-map": true,
+	}
+}
+
+func configReadResponseSchema() Schema {
+	nullable := func(value Schema) Schema {
+		return Schema{"anyOf": []any{value, Schema{"type": "null"}}}
+	}
+	return Schema{
+		"type": "object",
+		"properties": Schema{
+			"config": Schema{"$ref": "#/$defs/Config"},
+			"origins": Schema{
+				"type":                             "object",
+				"additionalProperties":             Schema{"$ref": "#/$defs/ConfigLayerMetadata"},
+				"x-gollem-typescript-optional-map": true,
+			},
+			"layers": nullable(Schema{
+				"type":  "array",
+				"items": Schema{"$ref": "#/$defs/ConfigLayer"},
+			}),
+		},
+		"required":             []string{"config", "origins", "layers"},
+		"additionalProperties": true,
+		"x-gollem-typescript-ignore-additional-properties": true,
 	}
 }
 

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -1988,6 +1988,41 @@
       },
       "type": "object"
     },
+    "ConfigReadResponse": {
+      "additionalProperties": true,
+      "properties": {
+        "config": {
+          "$ref": "#/$defs/Config"
+        },
+        "layers": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/ConfigLayer"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "origins": {
+          "additionalProperties": {
+            "$ref": "#/$defs/ConfigLayerMetadata"
+          },
+          "type": "object",
+          "x-gollem-typescript-optional-map": true
+        }
+      },
+      "required": [
+        "config",
+        "origins",
+        "layers"
+      ],
+      "type": "object",
+      "x-gollem-typescript-ignore-additional-properties": true
+    },
     "ConfigRequirements": {
       "additionalProperties": false,
       "properties": {

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 355 {
-		t.Fatalf("definition count = %d, want 355", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 356 {
+		t.Fatalf("definition count = %d, want 356", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
-		t.Fatalf("definition count = %d, want 355", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
+		t.Fatalf("definition count = %d, want 356", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
-		t.Fatalf("definition count = %d, want 355", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
+		t.Fatalf("definition count = %d, want 356", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
-		t.Fatalf("definition count = %d, want 355", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
+		t.Fatalf("definition count = %d, want 356", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
-		t.Fatalf("definition count = %d, want 355", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
+		t.Fatalf("definition count = %d, want 356", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
-		t.Fatalf("definition count = %d, want 355", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
+		t.Fatalf("definition count = %d, want 356", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 355 {
-		t.Fatalf("definition count = %d, want 355", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 356 {
+		t.Fatalf("definition count = %d, want 356", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 355 {
-		t.Fatalf("definition count = %d, want 355", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 356 {
+		t.Fatalf("definition count = %d, want 356", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
-		t.Fatalf("definition count = %d, want 355", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
+		t.Fatalf("definition count = %d, want 356", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
-		t.Fatalf("definition count = %d, want 355", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
+		t.Fatalf("definition count = %d, want 356", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
-		t.Fatalf("definition count = %d, want 355", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
+		t.Fatalf("definition count = %d, want 356", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
-		t.Fatalf("definition count = %d, want 355", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
+		t.Fatalf("definition count = %d, want 356", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -875,6 +875,12 @@ export type ConfigReadParams = {
   "includeLayers"?: boolean;
 };
 
+export type ConfigReadResponse = {
+  "config": Config;
+  "layers": Array<ConfigLayer> | null;
+  "origins": { [key in string]?: ConfigLayerMetadata };
+};
+
 export type ConfigRequirements = {
   "allowAppshots": boolean | null;
   "allowManagedHooksOnly": boolean | null;

--- a/appserver/protocol/typescript/testdata/config_read_response_contract.ts
+++ b/appserver/protocol/typescript/testdata/config_read_response_contract.ts
@@ -1,0 +1,98 @@
+import type {
+  Config,
+  ConfigLayer,
+  ConfigLayerMetadata,
+  ConfigReadResponse,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? (<T>() => T extends B ? 1 : 2) extends
+        (<T>() => T extends A ? 1 : 2)
+      ? true
+      : false
+    : false;
+type Expect<T extends true> = T;
+
+type ConfigReadResponseShape = {
+  config: Config;
+  origins: { [key in string]?: ConfigLayerMetadata };
+  layers: ConfigLayer[] | null;
+};
+
+type ConfigReadResponseContract = Expect<
+  Equal<ConfigReadResponse, ConfigReadResponseShape>
+>;
+
+declare const config: Config;
+
+({ config, origins: {}, layers: null }) satisfies ConfigReadResponse;
+({
+  config,
+  origins: {
+    "": { name: { type: "sessionFlags" }, version: "" },
+    model: {
+      name: { type: "user", file: "/home/user/.codex/config.toml", profile: null },
+      version: "v1",
+    },
+  },
+  layers: [
+    {
+      name: { type: "project", dotCodexFolder: "/workspace/.codex" },
+      version: "v2",
+      config: { integer: 9007199254740993 },
+      disabledReason: null,
+    },
+    {
+      name: { type: "sessionFlags" },
+      version: "v3",
+      config: null,
+      disabledReason: "policy",
+    },
+  ],
+}) satisfies ConfigReadResponse;
+
+// @ts-expect-error config is required.
+({ origins: {}, layers: null }) satisfies ConfigReadResponse;
+// @ts-expect-error config is non-null.
+({ config: null, origins: {}, layers: null }) satisfies ConfigReadResponse;
+// @ts-expect-error origins is required.
+({ config, layers: null }) satisfies ConfigReadResponse;
+// @ts-expect-error origins is non-null.
+({ config, origins: null, layers: null }) satisfies ConfigReadResponse;
+// @ts-expect-error origins is an object map.
+({ config, origins: [], layers: null }) satisfies ConfigReadResponse;
+// @ts-expect-error origin values are non-null metadata.
+({ config, origins: { model: null }, layers: null }) satisfies ConfigReadResponse;
+// @ts-expect-error origin metadata requires version.
+({ config, origins: { model: { name: { type: "sessionFlags" } } }, layers: null }) satisfies ConfigReadResponse;
+// @ts-expect-error origin metadata is closed.
+({ config, origins: { model: { name: { type: "sessionFlags" }, version: "v1", extra: true } }, layers: null }) satisfies ConfigReadResponse;
+// @ts-expect-error layers is generated as required nullable.
+({ config, origins: {} }) satisfies ConfigReadResponse;
+// @ts-expect-error layers cannot be explicit undefined.
+({ config, origins: {}, layers: undefined }) satisfies ConfigReadResponse;
+// @ts-expect-error layers is an array or null.
+({ config, origins: {}, layers: {} }) satisfies ConfigReadResponse;
+// @ts-expect-error layer entries are non-null.
+({ config, origins: {}, layers: [null] }) satisfies ConfigReadResponse;
+// @ts-expect-error layer entries require name.
+({ config, origins: {}, layers: [{ version: "v1", config: null, disabledReason: null }] }) satisfies ConfigReadResponse;
+// @ts-expect-error layer entries are closed.
+({ config, origins: {}, layers: [{ name: { type: "sessionFlags" }, version: "v1", config: null, disabledReason: null, extra: true }] }) satisfies ConfigReadResponse;
+// @ts-expect-error config known fields retain their exact types.
+({ config: { ...config, model: 1 }, origins: {}, layers: null }) satisfies ConfigReadResponse;
+// @ts-expect-error config additional fields must be JSON.
+({ config: { ...config, future: () => true }, origins: {}, layers: null }) satisfies ConfigReadResponse;
+// @ts-expect-error origin values are metadata, not callbacks.
+({ config, origins: { model: () => true }, layers: null }) satisfies ConfigReadResponse;
+// @ts-expect-error nested layer config must be JSON.
+({ config, origins: {}, layers: [{ name: { type: "sessionFlags" }, version: "v1", config: () => true, disabledReason: null }] }) satisfies ConfigReadResponse;
+// @ts-expect-error generated response TypeScript remains closed.
+({ config, origins: {}, layers: null, future: true }) satisfies ConfigReadResponse;
+// @ts-expect-error ConfigReadResponse is an object.
+null satisfies ConfigReadResponse;
+
+declare const configReadResponseContract: ConfigReadResponseContract;
+void configReadResponseContract;

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 355 {
-		t.Fatalf("definition count = %d, want 355", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
+		t.Fatalf("definition count = %d, want 356", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- export the exact standalone public `ConfigReadResponse` contract
- enforce strict required config/origins and canonical nullable layers JSON behavior
- generate the 356-definition schema and TypeScript surface without binding `config/read`

## Verification
- `go test ./appserver/protocol`
- focused contract test repeated 30 times
- focused race and 100% new-code statement coverage
- `go test $(go list ./... | rg -v '/ext/monty$')`
- `go test -race $(go list ./... | rg -v '/ext/monty$')`
- `golangci-lint run`
- `go vet ./...`
- `go mod tidy` (no diff)
- deterministic `go generate ./appserver/protocol`
- strict TypeScript fixture compilation
- baseline/candidate live `config/read` equality
- all five Slang real-daemon integration workflows
- configured pre-push hook (Monty race skipped via `hooks.skipMontyRace=true`)
