### PR TITLE
feat(protocol): add additional context contracts

### DIFF
--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -1,0 +1,183 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestAdditionalContextSchemasAreExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	assertStringEnum(t, defs["AdditionalContextKind"], "untrusted", "application")
+
+	wantEntry := Schema{
+		"type": "object",
+		"properties": Schema{
+			"value": Schema{"type": "string"},
+			"kind":  Schema{"$ref": "#/$defs/AdditionalContextKind"},
+		},
+		"required":             []string{"kind", "value"},
+		"additionalProperties": true,
+		"x-gollem-typescript-ignore-additional-properties": true,
+	}
+	if got := defs["AdditionalContextEntry"]; !reflect.DeepEqual(got, wantEntry) {
+		t.Fatalf("AdditionalContextEntry schema = %#v, want %#v", got, wantEntry)
+	}
+}
+
+func TestAdditionalContextKindAcceptsExactValues(t *testing.T) {
+	for _, input := range []string{`"untrusted"`, `"application"`} {
+		var kind AdditionalContextKind
+		if err := json.Unmarshal([]byte(input), &kind); err != nil {
+			t.Fatalf("unmarshal AdditionalContextKind %s: %v", input, err)
+		}
+		encoded, err := json.Marshal(kind)
+		if err != nil {
+			t.Fatalf("marshal AdditionalContextKind %s: %v", input, err)
+		}
+		if got := string(encoded); got != input {
+			t.Fatalf("AdditionalContextKind round trip = %s, want %s", got, input)
+		}
+	}
+}
+
+func TestAdditionalContextEntryCanonicalizesOpenInput(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{`{"value":"","kind":"untrusted"}`, `{"value":"","kind":"untrusted"}`},
+		{`{"kind":"application","value":"app context"}`, `{"value":"app context","kind":"application"}`},
+		{`{"future":{"ignored":true},"value":"source","kind":"untrusted"}`, `{"value":"source","kind":"untrusted"}`},
+		{`{"future":1,"future":2,"value":"source","kind":"application"}`, `{"value":"source","kind":"application"}`},
+	}
+	for _, tc := range cases {
+		var entry AdditionalContextEntry
+		if err := json.Unmarshal([]byte(tc.input), &entry); err != nil {
+			t.Fatalf("unmarshal AdditionalContextEntry %s: %v", tc.input, err)
+		}
+		encoded, err := json.Marshal(entry)
+		if err != nil {
+			t.Fatalf("marshal AdditionalContextEntry %s: %v", tc.input, err)
+		}
+		if got := string(encoded); got != tc.want {
+			t.Fatalf("AdditionalContextEntry %s = %s, want %s", tc.input, got, tc.want)
+		}
+
+		var roundTripped AdditionalContextEntry
+		if err := json.Unmarshal(encoded, &roundTripped); err != nil {
+			t.Fatalf("unmarshal canonical AdditionalContextEntry %s: %v", encoded, err)
+		}
+		if !reflect.DeepEqual(roundTripped, entry) {
+			t.Fatalf("AdditionalContextEntry round trip = %#v, want %#v", roundTripped, entry)
+		}
+	}
+}
+
+func TestAdditionalContextContractsRejectMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `""`, `"other"`, `1`, `true`, `{}`, `[]`, `"untrusted" {}`,
+	} {
+		assertJSONRejects[AdditionalContextKind](t, input)
+	}
+
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{}`, `{} {}`, `{} x`,
+		`{"kind":"untrusted"}`,
+		`{"value":"context"}`,
+		`{"value":null,"kind":"untrusted"}`,
+		`{"value":1,"kind":"untrusted"}`,
+		`{"value":[],"kind":"untrusted"}`,
+		`{"value":"context","kind":null}`,
+		`{"value":"context","kind":""}`,
+		`{"value":"context","kind":"other"}`,
+		`{"value":"context","kind":1}`,
+		`{"value":"a","value":"b","kind":"untrusted"}`,
+		`{"value":"context","kind":"untrusted","kind":"application"}`,
+	} {
+		assertJSONRejects[AdditionalContextEntry](t, input)
+	}
+}
+
+func TestAdditionalContextEntryDirectDecoderRejectsMalformedTokenStreams(t *testing.T) {
+	for _, input := range []string{
+		``, `{@`, `{"value"`, `{"value":`, `{"future":`, `{"future":1`, `{} {}`, `{} x`,
+	} {
+		var entry AdditionalContextEntry
+		if err := entry.UnmarshalJSON([]byte(input)); err == nil {
+			t.Errorf("direct AdditionalContextEntry decoder accepted %q", input)
+		}
+	}
+}
+
+func TestAdditionalContextNilReceiversAndInvalidMarshalFailClosed(t *testing.T) {
+	var kind *AdditionalContextKind
+	if err := kind.UnmarshalJSON([]byte(`"untrusted"`)); err == nil {
+		t.Fatal("nil AdditionalContextKind receiver succeeded")
+	}
+	var entry *AdditionalContextEntry
+	if err := entry.UnmarshalJSON([]byte(`{"value":"context","kind":"untrusted"}`)); err == nil {
+		t.Fatal("nil AdditionalContextEntry receiver succeeded")
+	}
+
+	for name, value := range map[string]any{
+		"kind":  AdditionalContextKind("other"),
+		"entry": AdditionalContextEntry{Value: "context", Kind: AdditionalContextKind("other")},
+	} {
+		if _, err := json.Marshal(value); err == nil {
+			t.Errorf("invalid AdditionalContext %s marshaled", name)
+		}
+	}
+}
+
+func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
+	names := []string{"AdditionalContextKind", "AdditionalContextEntry"}
+	for _, binding := range WireTypeBindings() {
+		for _, name := range names {
+			if slices.Contains(binding.Params, name) || slices.Contains(binding.Result, name) {
+				t.Fatalf("%s unexpectedly bound to %s", name, binding.Method)
+			}
+		}
+	}
+	defs := JSONSchema()["$defs"].(Schema)
+	for _, paramsName := range []string{"TurnStartParams", "TurnSteerParams"} {
+		properties := defs[paramsName].(Schema)["properties"].(Schema)
+		if _, exists := properties["additionalContext"]; exists {
+			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
+		}
+	}
+	if got := len(defs); got != 358 {
+		t.Fatalf("definition count = %d, want 358", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestAdditionalContextTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	for _, want := range []string{
+		`export type AdditionalContextKind = "untrusted" | "application";`,
+		`export type AdditionalContextEntry = {`,
+		`"kind": AdditionalContextKind;`,
+		`"value": string;`,
+	} {
+		if !strings.Contains(string(generated), want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}
+
+var (
+	_ json.Marshaler   = AdditionalContextKind("")
+	_ json.Unmarshaler = (*AdditionalContextKind)(nil)
+	_ json.Unmarshaler = (*AdditionalContextEntry)(nil)
+)

--- a/appserver/protocol/additional_context_types.go
+++ b/appserver/protocol/additional_context_types.go
@@ -1,0 +1,106 @@
+package protocol
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// AdditionalContextKind is the exact closed public context trust category.
+type AdditionalContextKind string
+
+const (
+	AdditionalContextKindUntrusted   AdditionalContextKind = "untrusted"
+	AdditionalContextKindApplication AdditionalContextKind = "application"
+)
+
+func (k AdditionalContextKind) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(k, "additional context kind", AdditionalContextKind.valid)
+}
+
+func (k *AdditionalContextKind) UnmarshalJSON(data []byte) error {
+	return unmarshalThreadTurnLeafEnum(data, k, "additional context kind", AdditionalContextKind.valid)
+}
+
+func (k AdditionalContextKind) valid() bool {
+	return k == AdditionalContextKindUntrusted || k == AdditionalContextKindApplication
+}
+
+// AdditionalContextEntry is an exact standalone public context fragment. Its
+// decoder ignores unknown fields for Rust-compatible input evolution while
+// canonical output contains only the two public fields.
+type AdditionalContextEntry struct {
+	Value string                `json:"value"`
+	Kind  AdditionalContextKind `json:"kind"`
+}
+
+func (e *AdditionalContextEntry) UnmarshalJSON(data []byte) error {
+	if e == nil {
+		return errors.New("decode additional context entry into nil receiver")
+	}
+	payload, err := decodeAdditionalContextEntryObject(data)
+	if err != nil {
+		return err
+	}
+	value, err := decodeRequiredThreadItemValue[string](payload, "additional context entry", "value")
+	if err != nil {
+		return err
+	}
+	kind, err := decodeRequiredThreadItemValue[AdditionalContextKind](payload, "additional context entry", "kind")
+	if err != nil {
+		return err
+	}
+	*e = AdditionalContextEntry{Value: value, Kind: kind}
+	return nil
+}
+
+func decodeAdditionalContextEntryObject(data []byte) (map[string]json.RawMessage, error) {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	opening, err := decoder.Token()
+	if err != nil {
+		return nil, fmt.Errorf("decode additional context entry: %w", err)
+	}
+	if opening != json.Delim('{') {
+		return nil, errors.New("additional context entry must be an object")
+	}
+	payload := make(map[string]json.RawMessage, 2)
+	seen := make(map[string]bool, 2)
+	for decoder.More() {
+		token, err := decoder.Token()
+		if err != nil {
+			return nil, fmt.Errorf("decode additional context entry field name: %w", err)
+		}
+		name := token.(string)
+		var raw json.RawMessage
+		if err := decoder.Decode(&raw); err != nil {
+			return nil, fmt.Errorf("decode additional context entry field %q: %w", name, err)
+		}
+		if name != "value" && name != "kind" {
+			continue
+		}
+		if seen[name] {
+			return nil, fmt.Errorf("duplicate additional context entry field %q", name)
+		}
+		seen[name] = true
+		payload[name] = append(json.RawMessage(nil), raw...)
+	}
+	if _, err := decoder.Token(); err != nil {
+		return nil, fmt.Errorf("decode additional context entry: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return nil, errors.New("additional context entry must contain one JSON value")
+		}
+		return nil, fmt.Errorf("decode additional context entry trailing value: %w", err)
+	}
+	return payload, nil
+}
+
+var (
+	_ json.Marshaler   = AdditionalContextKind("")
+	_ json.Unmarshaler = (*AdditionalContextKind)(nil)
+	_ json.Unmarshaler = (*AdditionalContextEntry)(nil)
+)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
-		t.Fatalf("definition count = %d, want 356", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
+		t.Fatalf("definition count = %d, want 358", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
-		t.Fatalf("definition count = %d, want 356", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
+		t.Fatalf("definition count = %d, want 358", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
-		t.Fatalf("definition count = %d, want 356", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
+		t.Fatalf("definition count = %d, want 358", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
-		t.Fatalf("definition count = %d, want 356", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
+		t.Fatalf("definition count = %d, want 358", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
-		t.Fatalf("definition count = %d, want 356", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
+		t.Fatalf("definition count = %d, want 358", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
-		t.Fatalf("definition count = %d, want 356", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
+		t.Fatalf("definition count = %d, want 358", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
-		t.Fatalf("definition count = %d, want 356", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
+		t.Fatalf("definition count = %d, want 358", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
-		t.Fatalf("definition count = %d, want 356", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
+		t.Fatalf("definition count = %d, want 358", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
-		t.Fatalf("definition count = %d, want 356", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
+		t.Fatalf("definition count = %d, want 358", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 356 {
-		t.Fatalf("definition count = %d, want 356", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 358 {
+		t.Fatalf("definition count = %d, want 358", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
-		t.Fatalf("definition count = %d, want 356", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
+		t.Fatalf("definition count = %d, want 358", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
-		t.Fatalf("definition count = %d, want 356", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
+		t.Fatalf("definition count = %d, want 358", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
-		t.Fatalf("definition count = %d, want 356", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
+		t.Fatalf("definition count = %d, want 358", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
-		t.Fatalf("definition count = %d, want 356", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
+		t.Fatalf("definition count = %d, want 358", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
-		t.Fatalf("definition count = %d, want 356", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
+		t.Fatalf("definition count = %d, want 358", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
-		t.Fatalf("definition count = %d, want 356", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
+		t.Fatalf("definition count = %d, want 358", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
-		t.Fatalf("definition count = %d, want 356", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
+		t.Fatalf("definition count = %d, want 358", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
-		t.Fatalf("definition count = %d, want 356", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
+		t.Fatalf("definition count = %d, want 358", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
-		t.Fatalf("definition count = %d, want 356", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
+		t.Fatalf("definition count = %d, want 358", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 356 {
-		t.Fatalf("definition count = %d, want 356", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 358 {
+		t.Fatalf("definition count = %d, want 358", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 356 {
-		t.Fatalf("definition count = %d, want 356", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 358 {
+		t.Fatalf("definition count = %d, want 358", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 356 {
-		t.Fatalf("definition count = %d, want 356", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 358 {
+		t.Fatalf("definition count = %d, want 358", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 356 {
-		t.Fatalf("definition count = %d, want 356", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 358 {
+		t.Fatalf("definition count = %d, want 358", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 356 {
-		t.Fatalf("definition count = %d, want 356", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 358 {
+		t.Fatalf("definition count = %d, want 358", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -86,6 +86,8 @@ func wireSchemaDefinitions() Schema {
 		{Name: "AgentMessageDeltaNotification", Type: reflect.TypeFor[AgentMessageDeltaNotification]()},
 		{Name: "AgentMessageInputContent", Type: reflect.TypeFor[AgentMessageInputContent]()},
 		{Name: "AgentPath", Type: reflect.TypeFor[AgentPath]()},
+		{Name: "AdditionalContextEntry", Type: reflect.TypeFor[AdditionalContextEntry]()},
+		{Name: "AdditionalContextKind", Type: reflect.TypeFor[AdditionalContextKind]()},
 		{Name: "AdditionalFileSystemPermissions", Type: reflect.TypeFor[AdditionalFileSystemPermissions]()},
 		{Name: "AdditionalNetworkPermissions", Type: reflect.TypeFor[AdditionalNetworkPermissions]()},
 		{Name: "AdditionalPermissionProfile", Type: reflect.TypeFor[AdditionalPermissionProfile]()},
@@ -459,6 +461,10 @@ func wireSchemaDefinitions() Schema {
 	)
 	schemas["SortDirection"] = stringEnumSchema(string(SortDirectionAsc), string(SortDirectionDesc))
 	schemas["InputModality"] = stringEnumSchema(string(InputModalityText), string(InputModalityImage))
+	schemas["AdditionalContextKind"] = stringEnumSchema(
+		string(AdditionalContextKindUntrusted), string(AdditionalContextKindApplication),
+	)
+	schemas["AdditionalContextEntry"] = additionalContextEntrySchema()
 	schemas["AgentPath"] = Schema{"type": "string"}
 	schemas["ReasoningEffort"] = Schema{"type": "string", "minLength": 1}
 	schemas["ResidencyRequirement"] = stringEnumSchema(string(ResidencyRequirementUS))
@@ -1556,6 +1562,19 @@ func configReadResponseSchema() Schema {
 			}),
 		},
 		"required":             []string{"config", "origins", "layers"},
+		"additionalProperties": true,
+		"x-gollem-typescript-ignore-additional-properties": true,
+	}
+}
+
+func additionalContextEntrySchema() Schema {
+	return Schema{
+		"type": "object",
+		"properties": Schema{
+			"value": Schema{"type": "string"},
+			"kind":  Schema{"$ref": "#/$defs/AdditionalContextKind"},
+		},
+		"required":             []string{"kind", "value"},
 		"additionalProperties": true,
 		"x-gollem-typescript-ignore-additional-properties": true,
 	}

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -27,6 +27,30 @@
       ],
       "type": "object"
     },
+    "AdditionalContextEntry": {
+      "additionalProperties": true,
+      "properties": {
+        "kind": {
+          "$ref": "#/$defs/AdditionalContextKind"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "value"
+      ],
+      "type": "object",
+      "x-gollem-typescript-ignore-additional-properties": true
+    },
+    "AdditionalContextKind": {
+      "enum": [
+        "untrusted",
+        "application"
+      ],
+      "type": "string"
+    },
     "AdditionalFileSystemPermissions": {
       "additionalProperties": false,
       "properties": {

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 356 {
-		t.Fatalf("definition count = %d, want 356", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 358 {
+		t.Fatalf("definition count = %d, want 358", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
-		t.Fatalf("definition count = %d, want 356", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
+		t.Fatalf("definition count = %d, want 358", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
-		t.Fatalf("definition count = %d, want 356", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
+		t.Fatalf("definition count = %d, want 358", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
-		t.Fatalf("definition count = %d, want 356", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
+		t.Fatalf("definition count = %d, want 358", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
-		t.Fatalf("definition count = %d, want 356", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
+		t.Fatalf("definition count = %d, want 358", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
-		t.Fatalf("definition count = %d, want 356", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
+		t.Fatalf("definition count = %d, want 358", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 356 {
-		t.Fatalf("definition count = %d, want 356", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 358 {
+		t.Fatalf("definition count = %d, want 358", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 356 {
-		t.Fatalf("definition count = %d, want 356", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 358 {
+		t.Fatalf("definition count = %d, want 358", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
-		t.Fatalf("definition count = %d, want 356", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
+		t.Fatalf("definition count = %d, want 358", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
-		t.Fatalf("definition count = %d, want 356", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
+		t.Fatalf("definition count = %d, want 358", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
-		t.Fatalf("definition count = %d, want 356", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
+		t.Fatalf("definition count = %d, want 358", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
-		t.Fatalf("definition count = %d, want 356", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
+		t.Fatalf("definition count = %d, want 358", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -499,6 +499,13 @@ export type ActivePermissionProfile = {
   "id": string;
 };
 
+export type AdditionalContextEntry = {
+  "kind": AdditionalContextKind;
+  "value": string;
+};
+
+export type AdditionalContextKind = "untrusted" | "application";
+
 export type AdditionalFileSystemPermissions = {
   "entries"?: Array<FileSystemSandboxEntry>;
   "globScanMaxDepth"?: number;

--- a/appserver/protocol/typescript/testdata/additional_context_contract.ts
+++ b/appserver/protocol/typescript/testdata/additional_context_contract.ts
@@ -1,0 +1,58 @@
+import type {
+  AdditionalContextEntry,
+  AdditionalContextKind,
+  TurnStartParams,
+  TurnSteerParams,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? (<T>() => T extends B ? 1 : 2) extends
+        (<T>() => T extends A ? 1 : 2)
+      ? true
+      : false
+    : false;
+type Expect<T extends true> = T;
+
+type Contracts = [
+  Expect<Equal<AdditionalContextKind, "untrusted" | "application">>,
+  Expect<Equal<AdditionalContextEntry, {
+    kind: AdditionalContextKind;
+    value: string;
+  }>>,
+];
+
+export const kinds = ["untrusted", "application"] satisfies AdditionalContextKind[];
+export const empty = { value: "", kind: "untrusted" } satisfies AdditionalContextEntry;
+export const application = {
+  value: "application context",
+  kind: "application",
+} satisfies AdditionalContextEntry;
+
+// @ts-expect-error context kinds are closed.
+export const rejectUnknownKind = "other" satisfies AdditionalContextKind;
+// @ts-expect-error context kinds are non-null.
+export const rejectNullKind = null satisfies AdditionalContextKind;
+// @ts-expect-error value is required.
+export const rejectMissingValue = { kind: "untrusted" } satisfies AdditionalContextEntry;
+// @ts-expect-error value is non-null.
+export const rejectNullValue = { value: null, kind: "untrusted" } satisfies AdditionalContextEntry;
+// @ts-expect-error value is a string.
+export const rejectNumericValue = { value: 1, kind: "untrusted" } satisfies AdditionalContextEntry;
+// @ts-expect-error kind is required.
+export const rejectMissingEntryKind = { value: "context" } satisfies AdditionalContextEntry;
+// @ts-expect-error kind is non-null.
+export const rejectNullEntryKind = { value: "context", kind: null } satisfies AdditionalContextEntry;
+// @ts-expect-error entry kinds remain closed.
+export const rejectEntryKind = { value: "context", kind: "other" } satisfies AdditionalContextEntry;
+// @ts-expect-error generated entry TypeScript remains closed.
+export const rejectUnknownEntryField = { value: "context", kind: "untrusted", future: true } satisfies AdditionalContextEntry;
+// @ts-expect-error entries are objects.
+export const rejectNullEntry = null satisfies AdditionalContextEntry;
+// @ts-expect-error fixed turn/start params still exclude experimental additional context.
+export const rejectTurnStartBinding = { threadId: "thread", input: [], additionalContext: {} } satisfies TurnStartParams;
+// @ts-expect-error fixed turn/steer params still exclude experimental additional context.
+export const rejectTurnSteerBinding = { threadId: "thread", input: [], expectedTurnId: "turn", additionalContext: {} } satisfies TurnSteerParams;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 356 {
-		t.Fatalf("definition count = %d, want 356", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
+		t.Fatalf("definition count = %d, want 358", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary

- export exact standalone `AdditionalContextKind` and `AdditionalContextEntry` protocol values
- preserve Rust-compatible open entry decoding while keeping generated TypeScript closed
- keep experimental `additionalContext` absent from fixed `TurnStartParams` and `TurnSteerParams`
- regenerate the protocol schema and TypeScript artifact at 358 definitions with unchanged method and item bindings

## Validation

- deliberate-red Go and strict TypeScript contracts
- 30 focused repetitions and focused race
- 100% focused statement coverage for every new function and schema helper
- full protocol suite and all 59 non-Monty packages under normal and race tests
- `golangci-lint`, `go vet`, `go mod tidy`, deterministic generation, strict TypeScript, and configured pre-push
- all five real Slang stdio, Unix-socket, and WebSocket workflows
- fixed-workspace normalized baseline/feature `config/read` equality

Local `ext/monty` normal, race, and coverage suites were skipped under the standing project direction; hosted checks remain unchanged.
