### PR TITLE
Export Amazon Bedrock credential source

### DIFF
--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 358 {
-		t.Fatalf("definition count = %d, want 358", got)
+	if got := len(defs); got != 359 {
+		t.Fatalf("definition count = %d, want 359", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -1,0 +1,82 @@
+package protocol
+
+import (
+	"encoding/json"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestAmazonBedrockCredentialSourceSchemaIsExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	assertStringEnum(t, defs["AmazonBedrockCredentialSource"], "codexManaged", "awsManaged")
+}
+
+func TestAmazonBedrockCredentialSourceAcceptsExactValues(t *testing.T) {
+	for _, input := range []string{`"codexManaged"`, `"awsManaged"`} {
+		var source AmazonBedrockCredentialSource
+		if err := json.Unmarshal([]byte(input), &source); err != nil {
+			t.Fatalf("unmarshal AmazonBedrockCredentialSource %s: %v", input, err)
+		}
+		encoded, err := json.Marshal(source)
+		if err != nil {
+			t.Fatalf("marshal AmazonBedrockCredentialSource %s: %v", input, err)
+		}
+		if got := string(encoded); got != input {
+			t.Fatalf("AmazonBedrockCredentialSource round trip = %s, want %s", got, input)
+		}
+	}
+}
+
+func TestAmazonBedrockCredentialSourceRejectsMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `""`, `"codexmanaged"`, `"awsmanaged"`, `"other"`,
+		`1`, `true`, `{}`, `[]`, `"codexManaged" {}`, `"awsManaged" x`,
+	} {
+		assertJSONRejects[AmazonBedrockCredentialSource](t, input)
+	}
+}
+
+func TestAmazonBedrockCredentialSourceNilReceiverAndInvalidMarshalFailClosed(t *testing.T) {
+	var source *AmazonBedrockCredentialSource
+	if err := source.UnmarshalJSON([]byte(`"codexManaged"`)); err == nil {
+		t.Fatal("nil AmazonBedrockCredentialSource receiver succeeded")
+	}
+	if _, err := json.Marshal(AmazonBedrockCredentialSource("other")); err == nil {
+		t.Fatal("invalid AmazonBedrockCredentialSource marshaled")
+	}
+}
+
+func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
+	for _, binding := range WireTypeBindings() {
+		if slices.Contains(binding.Params, "AmazonBedrockCredentialSource") ||
+			slices.Contains(binding.Result, "AmazonBedrockCredentialSource") {
+			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
+		t.Fatalf("definition count = %d, want 359", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestAmazonBedrockCredentialSourceTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	want := `export type AmazonBedrockCredentialSource = "codexManaged" | "awsManaged";`
+	if !strings.Contains(string(generated), want) {
+		t.Errorf("generated TypeScript missing %q", want)
+	}
+}
+
+var (
+	_ json.Marshaler   = AmazonBedrockCredentialSource("")
+	_ json.Unmarshaler = (*AmazonBedrockCredentialSource)(nil)
+)

--- a/appserver/protocol/amazon_bedrock_credential_source_types.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_types.go
@@ -1,0 +1,39 @@
+package protocol
+
+import "encoding/json"
+
+// AmazonBedrockCredentialSource is the exact closed public credential
+// ownership mode. It is standalone from Gollem's account and provider runtime.
+type AmazonBedrockCredentialSource string
+
+const (
+	AmazonBedrockCredentialSourceCodexManaged AmazonBedrockCredentialSource = "codexManaged"
+	AmazonBedrockCredentialSourceAWSManaged   AmazonBedrockCredentialSource = "awsManaged"
+)
+
+func (s AmazonBedrockCredentialSource) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(
+		s,
+		"Amazon Bedrock credential source",
+		AmazonBedrockCredentialSource.valid,
+	)
+}
+
+func (s *AmazonBedrockCredentialSource) UnmarshalJSON(data []byte) error {
+	return unmarshalThreadTurnLeafEnum(
+		data,
+		s,
+		"Amazon Bedrock credential source",
+		AmazonBedrockCredentialSource.valid,
+	)
+}
+
+func (s AmazonBedrockCredentialSource) valid() bool {
+	return s == AmazonBedrockCredentialSourceCodexManaged ||
+		s == AmazonBedrockCredentialSourceAWSManaged
+}
+
+var (
+	_ json.Marshaler   = AmazonBedrockCredentialSource("")
+	_ json.Unmarshaler = (*AmazonBedrockCredentialSource)(nil)
+)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
-		t.Fatalf("definition count = %d, want 358", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
+		t.Fatalf("definition count = %d, want 359", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
-		t.Fatalf("definition count = %d, want 358", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
+		t.Fatalf("definition count = %d, want 359", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
-		t.Fatalf("definition count = %d, want 358", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
+		t.Fatalf("definition count = %d, want 359", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
-		t.Fatalf("definition count = %d, want 358", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
+		t.Fatalf("definition count = %d, want 359", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
-		t.Fatalf("definition count = %d, want 358", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
+		t.Fatalf("definition count = %d, want 359", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
-		t.Fatalf("definition count = %d, want 358", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
+		t.Fatalf("definition count = %d, want 359", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
-		t.Fatalf("definition count = %d, want 358", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
+		t.Fatalf("definition count = %d, want 359", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
-		t.Fatalf("definition count = %d, want 358", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
+		t.Fatalf("definition count = %d, want 359", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
-		t.Fatalf("definition count = %d, want 358", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
+		t.Fatalf("definition count = %d, want 359", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 358 {
-		t.Fatalf("definition count = %d, want 358", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 359 {
+		t.Fatalf("definition count = %d, want 359", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
-		t.Fatalf("definition count = %d, want 358", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
+		t.Fatalf("definition count = %d, want 359", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
-		t.Fatalf("definition count = %d, want 358", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
+		t.Fatalf("definition count = %d, want 359", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
-		t.Fatalf("definition count = %d, want 358", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
+		t.Fatalf("definition count = %d, want 359", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
-		t.Fatalf("definition count = %d, want 358", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
+		t.Fatalf("definition count = %d, want 359", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
-		t.Fatalf("definition count = %d, want 358", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
+		t.Fatalf("definition count = %d, want 359", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
-		t.Fatalf("definition count = %d, want 358", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
+		t.Fatalf("definition count = %d, want 359", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
-		t.Fatalf("definition count = %d, want 358", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
+		t.Fatalf("definition count = %d, want 359", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
-		t.Fatalf("definition count = %d, want 358", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
+		t.Fatalf("definition count = %d, want 359", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
-		t.Fatalf("definition count = %d, want 358", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
+		t.Fatalf("definition count = %d, want 359", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 358 {
-		t.Fatalf("definition count = %d, want 358", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 359 {
+		t.Fatalf("definition count = %d, want 359", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 358 {
-		t.Fatalf("definition count = %d, want 358", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 359 {
+		t.Fatalf("definition count = %d, want 359", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 358 {
-		t.Fatalf("definition count = %d, want 358", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 359 {
+		t.Fatalf("definition count = %d, want 359", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 358 {
-		t.Fatalf("definition count = %d, want 358", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 359 {
+		t.Fatalf("definition count = %d, want 359", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 358 {
-		t.Fatalf("definition count = %d, want 358", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 359 {
+		t.Fatalf("definition count = %d, want 359", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -91,6 +91,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "AdditionalFileSystemPermissions", Type: reflect.TypeFor[AdditionalFileSystemPermissions]()},
 		{Name: "AdditionalNetworkPermissions", Type: reflect.TypeFor[AdditionalNetworkPermissions]()},
 		{Name: "AdditionalPermissionProfile", Type: reflect.TypeFor[AdditionalPermissionProfile]()},
+		{Name: "AmazonBedrockCredentialSource", Type: reflect.TypeFor[AmazonBedrockCredentialSource]()},
 		{Name: "AnalyticsConfig", Type: reflect.TypeFor[AnalyticsConfig]()},
 		{Name: "ApprovalRequestBase", Type: reflect.TypeFor[ApprovalRequestBase]()},
 		{Name: "ApprovalRespondParams", Type: reflect.TypeFor[ApprovalRespondParams]()},
@@ -466,6 +467,10 @@ func wireSchemaDefinitions() Schema {
 	)
 	schemas["AdditionalContextEntry"] = additionalContextEntrySchema()
 	schemas["AgentPath"] = Schema{"type": "string"}
+	schemas["AmazonBedrockCredentialSource"] = stringEnumSchema(
+		string(AmazonBedrockCredentialSourceCodexManaged),
+		string(AmazonBedrockCredentialSourceAWSManaged),
+	)
 	schemas["ReasoningEffort"] = Schema{"type": "string", "minLength": 1}
 	schemas["ResidencyRequirement"] = stringEnumSchema(string(ResidencyRequirementUS))
 	schemas["WebSearchMode"] = stringEnumSchema(

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -217,6 +217,13 @@
     "AgentPath": {
       "type": "string"
     },
+    "AmazonBedrockCredentialSource": {
+      "enum": [
+        "codexManaged",
+        "awsManaged"
+      ],
+      "type": "string"
+    },
     "AnalyticsConfig": {
       "additionalProperties": {
         "$ref": "#/$defs/JsonValue"

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 358 {
-		t.Fatalf("definition count = %d, want 358", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 359 {
+		t.Fatalf("definition count = %d, want 359", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
-		t.Fatalf("definition count = %d, want 358", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
+		t.Fatalf("definition count = %d, want 359", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
-		t.Fatalf("definition count = %d, want 358", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
+		t.Fatalf("definition count = %d, want 359", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
-		t.Fatalf("definition count = %d, want 358", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
+		t.Fatalf("definition count = %d, want 359", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
-		t.Fatalf("definition count = %d, want 358", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
+		t.Fatalf("definition count = %d, want 359", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
-		t.Fatalf("definition count = %d, want 358", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
+		t.Fatalf("definition count = %d, want 359", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 358 {
-		t.Fatalf("definition count = %d, want 358", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 359 {
+		t.Fatalf("definition count = %d, want 359", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 358 {
-		t.Fatalf("definition count = %d, want 358", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 359 {
+		t.Fatalf("definition count = %d, want 359", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
-		t.Fatalf("definition count = %d, want 358", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
+		t.Fatalf("definition count = %d, want 359", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
-		t.Fatalf("definition count = %d, want 358", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
+		t.Fatalf("definition count = %d, want 359", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
-		t.Fatalf("definition count = %d, want 358", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
+		t.Fatalf("definition count = %d, want 359", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
-		t.Fatalf("definition count = %d, want 358", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
+		t.Fatalf("definition count = %d, want 359", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -539,6 +539,8 @@ export type AgentMessageInputContent = {
 
 export type AgentPath = string;
 
+export type AmazonBedrockCredentialSource = "codexManaged" | "awsManaged";
+
 export type AnalyticsConfig = ({
   "enabled": boolean | null;
 } & { [key in string]?: JsonValue });

--- a/appserver/protocol/typescript/testdata/amazon_bedrock_credential_source_contract.ts
+++ b/appserver/protocol/typescript/testdata/amazon_bedrock_credential_source_contract.ts
@@ -1,0 +1,28 @@
+import type { AmazonBedrockCredentialSource } from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? (<T>() => T extends B ? 1 : 2) extends
+        (<T>() => T extends A ? 1 : 2)
+      ? true
+      : false
+    : false;
+type Expect<T extends true> = T;
+
+type Contract = Expect<Equal<AmazonBedrockCredentialSource, "codexManaged" | "awsManaged">>;
+
+export const sources = ["codexManaged", "awsManaged"] satisfies AmazonBedrockCredentialSource[];
+
+// @ts-expect-error credential sources are closed.
+export const rejectUnknown = "other" satisfies AmazonBedrockCredentialSource;
+// @ts-expect-error exact camel case is required.
+export const rejectWrongCase = "awsmanaged" satisfies AmazonBedrockCredentialSource;
+// @ts-expect-error empty strings are not credential sources.
+export const rejectEmpty = "" satisfies AmazonBedrockCredentialSource;
+// @ts-expect-error credential sources are non-null.
+export const rejectNull = null satisfies AmazonBedrockCredentialSource;
+// @ts-expect-error credential sources are strings.
+export const rejectNumber = 1 satisfies AmazonBedrockCredentialSource;
+
+void (null as unknown as Contract);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 358 {
-		t.Fatalf("definition count = %d, want 358", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
+		t.Fatalf("definition count = %d, want 359", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary

- export exact standalone `AmazonBedrockCredentialSource` with `codexManaged | awsManaged`
- enforce closed camel-case JSON decoding and fail invalid constructed values on marshal
- generate the 359th schema/TypeScript definition without adding account, method, item, provider, or runtime bindings
- add strict Go and TypeScript positive/negative contracts

## Verification

- deliberate red: six undefined Go references; one missing generated export, one false TypeScript identity, and five unused negative directives
- 30 focused repetitions and focused race
- 100% focused statement coverage for all three new codec methods
- full protocol and every non-Monty package under fresh normal/race suites
- `golangci-lint`, `go vet`, `go mod tidy`, deterministic generation, and strict TypeScript
- configured pre-push hook, with only Monty race skipped per standing direction
- all five existing Slang stdio/approval/Unix-socket/WebSocket workflows
- exact normalized baseline/feature live compatibility

Local Monty normal/race/coverage tests were intentionally skipped; hosted repository checks remain unchanged.
