### PR TITLE
Export exact standalone auth mode

### DIFF
--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 359 {
-		t.Fatalf("definition count = %d, want 359", got)
+	if got := len(defs); got != 360 {
+		t.Fatalf("definition count = %d, want 360", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
-		t.Fatalf("definition count = %d, want 359", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
+		t.Fatalf("definition count = %d, want 360", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -1,0 +1,102 @@
+package protocol
+
+import (
+	"encoding/json"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestAuthModeSchemaIsExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	assertStringEnum(
+		t,
+		defs["AuthMode"],
+		"apikey",
+		"chatgpt",
+		"chatgptAuthTokens",
+		"headers",
+		"agentIdentity",
+		"personalAccessToken",
+		"bedrockApiKey",
+	)
+}
+
+func TestAuthModeAcceptsExactValues(t *testing.T) {
+	for _, input := range []string{
+		`"apikey"`,
+		`"chatgpt"`,
+		`"chatgptAuthTokens"`,
+		`"headers"`,
+		`"agentIdentity"`,
+		`"personalAccessToken"`,
+		`"bedrockApiKey"`,
+	} {
+		var mode AuthMode
+		if err := json.Unmarshal([]byte(input), &mode); err != nil {
+			t.Fatalf("unmarshal AuthMode %s: %v", input, err)
+		}
+		encoded, err := json.Marshal(mode)
+		if err != nil {
+			t.Fatalf("marshal AuthMode %s: %v", input, err)
+		}
+		if got := string(encoded); got != input {
+			t.Fatalf("AuthMode round trip = %s, want %s", got, input)
+		}
+	}
+}
+
+func TestAuthModeRejectsMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `""`, `"other"`, `"apiKey"`, `"ChatGPT"`,
+		`"chatgptauthtokens"`, `"agentidentity"`, `"personalaccesstoken"`,
+		`"bedrockapikey"`, `1`, `true`, `{}`, `[]`, `"apikey" {}`,
+		`"bedrockApiKey" x`,
+	} {
+		assertJSONRejects[AuthMode](t, input)
+	}
+}
+
+func TestAuthModeNilReceiverAndInvalidMarshalFailClosed(t *testing.T) {
+	var mode *AuthMode
+	if err := mode.UnmarshalJSON([]byte(`"apikey"`)); err == nil {
+		t.Fatal("nil AuthMode receiver succeeded")
+	}
+	if _, err := json.Marshal(AuthMode("other")); err == nil {
+		t.Fatal("invalid AuthMode marshaled")
+	}
+}
+
+func TestAuthModeRemainsStandalone(t *testing.T) {
+	for _, binding := range WireTypeBindings() {
+		if slices.Contains(binding.Params, "AuthMode") ||
+			slices.Contains(binding.Result, "AuthMode") {
+			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
+		t.Fatalf("definition count = %d, want 360", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestAuthModeTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	want := `export type AuthMode = "apikey" | "chatgpt" | "chatgptAuthTokens" | "headers" | "agentIdentity" | "personalAccessToken" | "bedrockApiKey";`
+	if !strings.Contains(string(generated), want) {
+		t.Errorf("generated TypeScript missing %q", want)
+	}
+}
+
+var (
+	_ json.Marshaler   = AuthMode("")
+	_ json.Unmarshaler = (*AuthMode)(nil)
+)

--- a/appserver/protocol/auth_mode_types.go
+++ b/appserver/protocol/auth_mode_types.go
@@ -1,0 +1,45 @@
+package protocol
+
+import "encoding/json"
+
+// AuthMode is the exact closed public authentication-mode value. It is
+// standalone from Gollem's account, credential, and provider runtime.
+type AuthMode string
+
+const (
+	AuthModeAPIKey              AuthMode = "apikey"
+	AuthModeChatGPT             AuthMode = "chatgpt"
+	AuthModeChatGPTAuthTokens   AuthMode = "chatgptAuthTokens"
+	AuthModeHeaders             AuthMode = "headers"
+	AuthModeAgentIdentity       AuthMode = "agentIdentity"
+	AuthModePersonalAccessToken AuthMode = "personalAccessToken"
+	AuthModeBedrockAPIKey       AuthMode = "bedrockApiKey"
+)
+
+func (m AuthMode) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(m, "auth mode", AuthMode.valid)
+}
+
+func (m *AuthMode) UnmarshalJSON(data []byte) error {
+	return unmarshalThreadTurnLeafEnum(data, m, "auth mode", AuthMode.valid)
+}
+
+func (m AuthMode) valid() bool {
+	switch m {
+	case AuthModeAPIKey,
+		AuthModeChatGPT,
+		AuthModeChatGPTAuthTokens,
+		AuthModeHeaders,
+		AuthModeAgentIdentity,
+		AuthModePersonalAccessToken,
+		AuthModeBedrockAPIKey:
+		return true
+	default:
+		return false
+	}
+}
+
+var (
+	_ json.Marshaler   = AuthMode("")
+	_ json.Unmarshaler = (*AuthMode)(nil)
+)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
-		t.Fatalf("definition count = %d, want 359", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
+		t.Fatalf("definition count = %d, want 360", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
-		t.Fatalf("definition count = %d, want 359", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
+		t.Fatalf("definition count = %d, want 360", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
-		t.Fatalf("definition count = %d, want 359", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
+		t.Fatalf("definition count = %d, want 360", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
-		t.Fatalf("definition count = %d, want 359", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
+		t.Fatalf("definition count = %d, want 360", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
-		t.Fatalf("definition count = %d, want 359", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
+		t.Fatalf("definition count = %d, want 360", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
-		t.Fatalf("definition count = %d, want 359", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
+		t.Fatalf("definition count = %d, want 360", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
-		t.Fatalf("definition count = %d, want 359", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
+		t.Fatalf("definition count = %d, want 360", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
-		t.Fatalf("definition count = %d, want 359", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
+		t.Fatalf("definition count = %d, want 360", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
-		t.Fatalf("definition count = %d, want 359", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
+		t.Fatalf("definition count = %d, want 360", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 359 {
-		t.Fatalf("definition count = %d, want 359", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 360 {
+		t.Fatalf("definition count = %d, want 360", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
-		t.Fatalf("definition count = %d, want 359", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
+		t.Fatalf("definition count = %d, want 360", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
-		t.Fatalf("definition count = %d, want 359", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
+		t.Fatalf("definition count = %d, want 360", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
-		t.Fatalf("definition count = %d, want 359", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
+		t.Fatalf("definition count = %d, want 360", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
-		t.Fatalf("definition count = %d, want 359", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
+		t.Fatalf("definition count = %d, want 360", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
-		t.Fatalf("definition count = %d, want 359", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
+		t.Fatalf("definition count = %d, want 360", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
-		t.Fatalf("definition count = %d, want 359", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
+		t.Fatalf("definition count = %d, want 360", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
-		t.Fatalf("definition count = %d, want 359", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
+		t.Fatalf("definition count = %d, want 360", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
-		t.Fatalf("definition count = %d, want 359", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
+		t.Fatalf("definition count = %d, want 360", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
-		t.Fatalf("definition count = %d, want 359", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
+		t.Fatalf("definition count = %d, want 360", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 359 {
-		t.Fatalf("definition count = %d, want 359", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 360 {
+		t.Fatalf("definition count = %d, want 360", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 359 {
-		t.Fatalf("definition count = %d, want 359", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 360 {
+		t.Fatalf("definition count = %d, want 360", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 359 {
-		t.Fatalf("definition count = %d, want 359", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 360 {
+		t.Fatalf("definition count = %d, want 360", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 359 {
-		t.Fatalf("definition count = %d, want 359", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 360 {
+		t.Fatalf("definition count = %d, want 360", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 359 {
-		t.Fatalf("definition count = %d, want 359", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 360 {
+		t.Fatalf("definition count = %d, want 360", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -93,6 +93,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "AdditionalPermissionProfile", Type: reflect.TypeFor[AdditionalPermissionProfile]()},
 		{Name: "AmazonBedrockCredentialSource", Type: reflect.TypeFor[AmazonBedrockCredentialSource]()},
 		{Name: "AnalyticsConfig", Type: reflect.TypeFor[AnalyticsConfig]()},
+		{Name: "AuthMode", Type: reflect.TypeFor[AuthMode]()},
 		{Name: "ApprovalRequestBase", Type: reflect.TypeFor[ApprovalRequestBase]()},
 		{Name: "ApprovalRespondParams", Type: reflect.TypeFor[ApprovalRespondParams]()},
 		{Name: "ApprovalRespondResult", Type: reflect.TypeFor[ApprovalRespondResult]()},
@@ -470,6 +471,15 @@ func wireSchemaDefinitions() Schema {
 	schemas["AmazonBedrockCredentialSource"] = stringEnumSchema(
 		string(AmazonBedrockCredentialSourceCodexManaged),
 		string(AmazonBedrockCredentialSourceAWSManaged),
+	)
+	schemas["AuthMode"] = stringEnumSchema(
+		string(AuthModeAPIKey),
+		string(AuthModeChatGPT),
+		string(AuthModeChatGPTAuthTokens),
+		string(AuthModeHeaders),
+		string(AuthModeAgentIdentity),
+		string(AuthModePersonalAccessToken),
+		string(AuthModeBedrockAPIKey),
 	)
 	schemas["ReasoningEffort"] = Schema{"type": "string", "minLength": 1}
 	schemas["ResidencyRequirement"] = stringEnumSchema(string(ResidencyRequirementUS))

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -382,6 +382,18 @@
         }
       ]
     },
+    "AuthMode": {
+      "enum": [
+        "apikey",
+        "chatgpt",
+        "chatgptAuthTokens",
+        "headers",
+        "agentIdentity",
+        "personalAccessToken",
+        "bedrockApiKey"
+      ],
+      "type": "string"
+    },
     "AutoCompactTokenLimitScope": {
       "description": "Selects which part of the active context is charged against `model_auto_compact_token_limit`.",
       "oneOf": [

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 359 {
-		t.Fatalf("definition count = %d, want 359", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 360 {
+		t.Fatalf("definition count = %d, want 360", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
-		t.Fatalf("definition count = %d, want 359", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
+		t.Fatalf("definition count = %d, want 360", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
-		t.Fatalf("definition count = %d, want 359", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
+		t.Fatalf("definition count = %d, want 360", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
-		t.Fatalf("definition count = %d, want 359", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
+		t.Fatalf("definition count = %d, want 360", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
-		t.Fatalf("definition count = %d, want 359", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
+		t.Fatalf("definition count = %d, want 360", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
-		t.Fatalf("definition count = %d, want 359", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
+		t.Fatalf("definition count = %d, want 360", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 359 {
-		t.Fatalf("definition count = %d, want 359", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 360 {
+		t.Fatalf("definition count = %d, want 360", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 359 {
-		t.Fatalf("definition count = %d, want 359", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 360 {
+		t.Fatalf("definition count = %d, want 360", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
-		t.Fatalf("definition count = %d, want 359", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
+		t.Fatalf("definition count = %d, want 360", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
-		t.Fatalf("definition count = %d, want 359", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
+		t.Fatalf("definition count = %d, want 360", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
-		t.Fatalf("definition count = %d, want 359", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
+		t.Fatalf("definition count = %d, want 360", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
-		t.Fatalf("definition count = %d, want 359", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
+		t.Fatalf("definition count = %d, want 360", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -578,6 +578,8 @@ export type AskForApproval = "untrusted" | "on-request" | {
   };
 } | "never";
 
+export type AuthMode = "apikey" | "chatgpt" | "chatgptAuthTokens" | "headers" | "agentIdentity" | "personalAccessToken" | "bedrockApiKey";
+
 export type AutoCompactTokenLimitScope = "total" | "body_after_prefix";
 
 export type ByteRange = {

--- a/appserver/protocol/typescript/testdata/auth_mode_contract.ts
+++ b/appserver/protocol/typescript/testdata/auth_mode_contract.ts
@@ -1,0 +1,51 @@
+import type { AuthMode } from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? (<T>() => T extends B ? 1 : 2) extends
+        (<T>() => T extends A ? 1 : 2)
+      ? true
+      : false
+    : false;
+type Expect<T extends true> = T;
+
+type Contract = Expect<
+  Equal<
+    AuthMode,
+    | "apikey"
+    | "chatgpt"
+    | "chatgptAuthTokens"
+    | "headers"
+    | "agentIdentity"
+    | "personalAccessToken"
+    | "bedrockApiKey"
+  >
+>;
+
+export const modes = [
+  "apikey",
+  "chatgpt",
+  "chatgptAuthTokens",
+  "headers",
+  "agentIdentity",
+  "personalAccessToken",
+  "bedrockApiKey",
+] satisfies AuthMode[];
+
+// @ts-expect-error auth modes are closed.
+export const rejectUnknown = "other" satisfies AuthMode;
+// @ts-expect-error the API-key mode is all lowercase.
+export const rejectAPIKeyCase = "apiKey" satisfies AuthMode;
+// @ts-expect-error exact ChatGPT casing is required.
+export const rejectChatGPTCase = "ChatGPT" satisfies AuthMode;
+// @ts-expect-error exact Bedrock API-key casing is required.
+export const rejectBedrockCase = "bedrockapikey" satisfies AuthMode;
+// @ts-expect-error empty strings are not auth modes.
+export const rejectEmpty = "" satisfies AuthMode;
+// @ts-expect-error auth modes are non-null.
+export const rejectNull = null satisfies AuthMode;
+// @ts-expect-error auth modes are strings.
+export const rejectNumber = 1 satisfies AuthMode;
+
+void (null as unknown as Contract);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 359 {
-		t.Fatalf("definition count = %d, want 359", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
+		t.Fatalf("definition count = %d, want 360", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary

- export exact standalone public `AuthMode` with all seven pinned Codex wire literals
- reject unknown, wrong-case, empty, null, non-string, malformed/trailing, nil-receiver, and invalid constructed values
- generate the exact JSON Schema and TypeScript union while keeping all method/item bindings unchanged
- raise the deterministic definition count from 359 to 360

This does not bind account/login/read methods, alias Gollem's internal OAuth credential string, store or refresh tokens, select providers/models, grant authentication, or add runtime behavior.

## Verification

- deliberate red: six missing Go references; one missing TypeScript export, one false equality, and seven unused malformed-case directives
- focused tests 30x and focused race
- all three new codec functions at 100% focused statement coverage
- full protocol and every non-Monty package under fresh normal/race suites
- `golangci-lint run ./...` (0 issues), `go vet ./...`, and no-diff `go mod tidy`
- byte-identical deterministic generation and strict TypeScript compile
- configured pre-push and push-time hooks
- all five existing Slang stdio/Unix-socket/WebSocket workflows against the feature binary
- normalized live `config/read` exactly equal to the #159 baseline at SHA-256 `1029117c08406ed86ca471543176359f1a703c5df1f4a3b884009fceb44a53d4` with five values/five entries
- `git diff --check`

Generated hashes:

- schema: `b8bf2e8be56c3c2803e5e4e691c113bef4b9c6f703f423b99bfbacd855122d0f`
- TypeScript: `46509a30bfb9804d5b4e27b5bcd4de563fa07b4f085400ba94d50c6f8e846d1a`
- strict fixture: `a3409f6d0336dbedb74e5492c816b36d0dfb23c748c4dfc97f510dfda7914946`
- feature trimpath binary: `c776f4e72c53cc301a2117b85cf07345a87d4c5701a5f927a856e1826dbfc2c3`

Local `ext/monty` normal/race/coverage tests remain skipped per standing direction with `hooks.skipMontyRace=true`; hosted repository checks are unchanged.
