### PR TITLE
Export exact standalone auto-review decision source

### DIFF
--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 360 {
-		t.Fatalf("definition count = %d, want 360", got)
+	if got := len(defs); got != 361 {
+		t.Fatalf("definition count = %d, want 361", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
-		t.Fatalf("definition count = %d, want 360", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
+		t.Fatalf("definition count = %d, want 361", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
-		t.Fatalf("definition count = %d, want 360", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
+		t.Fatalf("definition count = %d, want 361", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -1,0 +1,80 @@
+package protocol
+
+import (
+	"encoding/json"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestAutoReviewDecisionSourceSchemaIsExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	assertStringEnum(t, defs["AutoReviewDecisionSource"], "agent")
+}
+
+func TestAutoReviewDecisionSourceAcceptsExactValue(t *testing.T) {
+	var source AutoReviewDecisionSource
+	if err := json.Unmarshal([]byte(`"agent"`), &source); err != nil {
+		t.Fatalf("unmarshal AutoReviewDecisionSource: %v", err)
+	}
+	encoded, err := json.Marshal(source)
+	if err != nil {
+		t.Fatalf("marshal AutoReviewDecisionSource: %v", err)
+	}
+	if got, want := string(encoded), `"agent"`; got != want {
+		t.Fatalf("AutoReviewDecisionSource round trip = %s, want %s", got, want)
+	}
+}
+
+func TestAutoReviewDecisionSourceRejectsMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `""`, `"other"`, `"Agent"`, `1`, `true`, `{}`, `[]`,
+		`"agent" {}`, `"agent" x`,
+	} {
+		assertJSONRejects[AutoReviewDecisionSource](t, input)
+	}
+}
+
+func TestAutoReviewDecisionSourceNilReceiverAndInvalidMarshalFailClosed(t *testing.T) {
+	var source *AutoReviewDecisionSource
+	if err := source.UnmarshalJSON([]byte(`"agent"`)); err == nil {
+		t.Fatal("nil AutoReviewDecisionSource receiver succeeded")
+	}
+	if _, err := json.Marshal(AutoReviewDecisionSource("other")); err == nil {
+		t.Fatal("invalid AutoReviewDecisionSource marshaled")
+	}
+}
+
+func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
+	for _, binding := range WireTypeBindings() {
+		if slices.Contains(binding.Params, "AutoReviewDecisionSource") ||
+			slices.Contains(binding.Result, "AutoReviewDecisionSource") {
+			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
+		t.Fatalf("definition count = %d, want 361", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestAutoReviewDecisionSourceTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	want := `export type AutoReviewDecisionSource = "agent";`
+	if !strings.Contains(string(generated), want) {
+		t.Errorf("generated TypeScript missing %q", want)
+	}
+}
+
+var (
+	_ json.Marshaler   = AutoReviewDecisionSource("")
+	_ json.Unmarshaler = (*AutoReviewDecisionSource)(nil)
+)

--- a/appserver/protocol/auto_review_decision_source_types.go
+++ b/appserver/protocol/auto_review_decision_source_types.go
@@ -1,0 +1,37 @@
+package protocol
+
+import "encoding/json"
+
+// AutoReviewDecisionSource is the exact closed public source for a terminal
+// approval auto-review decision. It is standalone from Guardian review runtime.
+type AutoReviewDecisionSource string
+
+const (
+	AutoReviewDecisionSourceAgent AutoReviewDecisionSource = "agent"
+)
+
+func (s AutoReviewDecisionSource) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(
+		s,
+		"auto-review decision source",
+		AutoReviewDecisionSource.valid,
+	)
+}
+
+func (s *AutoReviewDecisionSource) UnmarshalJSON(data []byte) error {
+	return unmarshalThreadTurnLeafEnum(
+		data,
+		s,
+		"auto-review decision source",
+		AutoReviewDecisionSource.valid,
+	)
+}
+
+func (s AutoReviewDecisionSource) valid() bool {
+	return s == AutoReviewDecisionSourceAgent
+}
+
+var (
+	_ json.Marshaler   = AutoReviewDecisionSource("")
+	_ json.Unmarshaler = (*AutoReviewDecisionSource)(nil)
+)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
-		t.Fatalf("definition count = %d, want 360", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
+		t.Fatalf("definition count = %d, want 361", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
-		t.Fatalf("definition count = %d, want 360", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
+		t.Fatalf("definition count = %d, want 361", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
-		t.Fatalf("definition count = %d, want 360", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
+		t.Fatalf("definition count = %d, want 361", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
-		t.Fatalf("definition count = %d, want 360", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
+		t.Fatalf("definition count = %d, want 361", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
-		t.Fatalf("definition count = %d, want 360", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
+		t.Fatalf("definition count = %d, want 361", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
-		t.Fatalf("definition count = %d, want 360", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
+		t.Fatalf("definition count = %d, want 361", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
-		t.Fatalf("definition count = %d, want 360", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
+		t.Fatalf("definition count = %d, want 361", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
-		t.Fatalf("definition count = %d, want 360", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
+		t.Fatalf("definition count = %d, want 361", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
-		t.Fatalf("definition count = %d, want 360", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
+		t.Fatalf("definition count = %d, want 361", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 360 {
-		t.Fatalf("definition count = %d, want 360", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 361 {
+		t.Fatalf("definition count = %d, want 361", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
-		t.Fatalf("definition count = %d, want 360", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
+		t.Fatalf("definition count = %d, want 361", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
-		t.Fatalf("definition count = %d, want 360", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
+		t.Fatalf("definition count = %d, want 361", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
-		t.Fatalf("definition count = %d, want 360", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
+		t.Fatalf("definition count = %d, want 361", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
-		t.Fatalf("definition count = %d, want 360", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
+		t.Fatalf("definition count = %d, want 361", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
-		t.Fatalf("definition count = %d, want 360", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
+		t.Fatalf("definition count = %d, want 361", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
-		t.Fatalf("definition count = %d, want 360", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
+		t.Fatalf("definition count = %d, want 361", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
-		t.Fatalf("definition count = %d, want 360", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
+		t.Fatalf("definition count = %d, want 361", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
-		t.Fatalf("definition count = %d, want 360", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
+		t.Fatalf("definition count = %d, want 361", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
-		t.Fatalf("definition count = %d, want 360", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
+		t.Fatalf("definition count = %d, want 361", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 360 {
-		t.Fatalf("definition count = %d, want 360", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 361 {
+		t.Fatalf("definition count = %d, want 361", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 360 {
-		t.Fatalf("definition count = %d, want 360", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 361 {
+		t.Fatalf("definition count = %d, want 361", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 360 {
-		t.Fatalf("definition count = %d, want 360", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 361 {
+		t.Fatalf("definition count = %d, want 361", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 360 {
-		t.Fatalf("definition count = %d, want 360", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 361 {
+		t.Fatalf("definition count = %d, want 361", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 360 {
-		t.Fatalf("definition count = %d, want 360", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 361 {
+		t.Fatalf("definition count = %d, want 361", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -100,6 +100,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "ApprovalsReviewer", Type: reflect.TypeFor[ApprovalsReviewer]()},
 		{Name: "AskForApproval", Type: reflect.TypeFor[AskForApproval]()},
 		{Name: "AutoCompactTokenLimitScope", Type: reflect.TypeFor[AutoCompactTokenLimitScope]()},
+		{Name: "AutoReviewDecisionSource", Type: reflect.TypeFor[AutoReviewDecisionSource]()},
 		{Name: "ByteRange", Type: reflect.TypeFor[ByteRange]()},
 		{Name: "ClientInfo", Type: reflect.TypeFor[ClientInfo]()},
 		{Name: "CodexErrorInfo", Type: reflect.TypeFor[CodexErrorInfo]()},
@@ -480,6 +481,9 @@ func wireSchemaDefinitions() Schema {
 		string(AuthModeAgentIdentity),
 		string(AuthModePersonalAccessToken),
 		string(AuthModeBedrockAPIKey),
+	)
+	schemas["AutoReviewDecisionSource"] = stringEnumSchema(
+		string(AutoReviewDecisionSourceAgent),
 	)
 	schemas["ReasoningEffort"] = Schema{"type": "string", "minLength": 1}
 	schemas["ResidencyRequirement"] = stringEnumSchema(string(ResidencyRequirementUS))

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -413,6 +413,12 @@
         }
       ]
     },
+    "AutoReviewDecisionSource": {
+      "enum": [
+        "agent"
+      ],
+      "type": "string"
+    },
     "ByteRange": {
       "additionalProperties": false,
       "properties": {

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 360 {
-		t.Fatalf("definition count = %d, want 360", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 361 {
+		t.Fatalf("definition count = %d, want 361", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
-		t.Fatalf("definition count = %d, want 360", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
+		t.Fatalf("definition count = %d, want 361", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
-		t.Fatalf("definition count = %d, want 360", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
+		t.Fatalf("definition count = %d, want 361", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
-		t.Fatalf("definition count = %d, want 360", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
+		t.Fatalf("definition count = %d, want 361", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
-		t.Fatalf("definition count = %d, want 360", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
+		t.Fatalf("definition count = %d, want 361", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
-		t.Fatalf("definition count = %d, want 360", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
+		t.Fatalf("definition count = %d, want 361", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 360 {
-		t.Fatalf("definition count = %d, want 360", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 361 {
+		t.Fatalf("definition count = %d, want 361", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 360 {
-		t.Fatalf("definition count = %d, want 360", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 361 {
+		t.Fatalf("definition count = %d, want 361", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
-		t.Fatalf("definition count = %d, want 360", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
+		t.Fatalf("definition count = %d, want 361", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
-		t.Fatalf("definition count = %d, want 360", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
+		t.Fatalf("definition count = %d, want 361", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
-		t.Fatalf("definition count = %d, want 360", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
+		t.Fatalf("definition count = %d, want 361", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
-		t.Fatalf("definition count = %d, want 360", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
+		t.Fatalf("definition count = %d, want 361", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -582,6 +582,8 @@ export type AuthMode = "apikey" | "chatgpt" | "chatgptAuthTokens" | "headers" | 
 
 export type AutoCompactTokenLimitScope = "total" | "body_after_prefix";
 
+export type AutoReviewDecisionSource = "agent";
+
 export type ByteRange = {
   "end": number;
   "start": number;

--- a/appserver/protocol/typescript/testdata/auto_review_decision_source_contract.ts
+++ b/appserver/protocol/typescript/testdata/auto_review_decision_source_contract.ts
@@ -1,0 +1,28 @@
+import type { AutoReviewDecisionSource } from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? (<T>() => T extends B ? 1 : 2) extends
+        (<T>() => T extends A ? 1 : 2)
+      ? true
+      : false
+    : false;
+type Expect<T extends true> = T;
+
+type Contract = Expect<Equal<AutoReviewDecisionSource, "agent">>;
+
+export const source = "agent" satisfies AutoReviewDecisionSource;
+
+// @ts-expect-error decision sources are closed.
+export const rejectUnknown = "other" satisfies AutoReviewDecisionSource;
+// @ts-expect-error exact lowercase spelling is required.
+export const rejectCase = "Agent" satisfies AutoReviewDecisionSource;
+// @ts-expect-error empty strings are not decision sources.
+export const rejectEmpty = "" satisfies AutoReviewDecisionSource;
+// @ts-expect-error decision sources are non-null.
+export const rejectNull = null satisfies AutoReviewDecisionSource;
+// @ts-expect-error decision sources are strings.
+export const rejectNumber = 1 satisfies AutoReviewDecisionSource;
+
+void (null as unknown as Contract);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 360 {
-		t.Fatalf("definition count = %d, want 360", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
+		t.Fatalf("definition count = %d, want 361", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary

- export exact standalone public `AutoReviewDecisionSource` with the pinned Codex wire literal `\"agent\"`
- reject unknown, wrong-case, empty, null, non-string, malformed/trailing, nil-receiver, and invalid constructed values
- generate the exact JSON Schema and TypeScript union while keeping all method/item bindings unchanged
- raise the deterministic definition count from 360 to 361

This intentionally does not bind or synthesize `ItemGuardianApprovalReviewCompletedNotification`, implement Guardian review/action/status/risk types or event replay, bind `item/autoApprovalReview/completed`, alias Gollem's Guardian denied-action stub, or add runtime behavior.

## Verification

- reconciled against Codex `5c19155cbd93bfa099016e7487259f61669823ff`
- deliberate red: six missing Go references; one missing TypeScript export, one false equality, and five unused malformed-case directives
- focused tests 30x and focused race
- all three new codec functions at 100% focused statement coverage
- full protocol and every non-Monty package under fresh normal/race suites
- `golangci-lint run ./...` (0 issues), `go vet ./...`, and no-diff `go mod tidy`
- byte-identical deterministic generation and strict TypeScript compile
- configured pre-push and push-time hooks
- all five existing Slang stdio/Unix-socket/WebSocket workflows against the feature binary
- normalized live `config/read` exactly equal to the #160 baseline at SHA-256 `03b45db25969809300d8181399f6693246a4809da4c25fe338757dc8e96e664e` with five values/five entries; only five `updatedAt` fields were removed
- `git diff --check`

Generated hashes:

- schema: `2c81065d02224cd2f704d2e33df8d8c5d380a9c94cc289c11e19bc2c2cb91943`
- TypeScript: `669d0c063e4295a73cbbb65df21bfe72110d0b39495ca8b3b98e40b6052e52cf`
- strict fixture: `6bf00aaa057ef28c7d0b2d76230a096e8c22f6c9f8e057a2eb393a74a19607ab`
- feature trimpath binary: `c52807b1eeea63d1af0db1ad83eb3144c8eead5afc0e1d1b09297e841dacdb58`

Local `ext/monty` normal/race/coverage tests remain skipped per standing direction with `hooks.skipMontyRace=true`; hosted repository checks are unchanged.