### PR TITLE
Export standalone cancel-login account contracts

### DIFF
--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 361 {
-		t.Fatalf("definition count = %d, want 361", got)
+	if got := len(defs); got != 364 {
+		t.Fatalf("definition count = %d, want 364", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
-		t.Fatalf("definition count = %d, want 361", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
+		t.Fatalf("definition count = %d, want 364", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
-		t.Fatalf("definition count = %d, want 361", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
+		t.Fatalf("definition count = %d, want 364", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
-		t.Fatalf("definition count = %d, want 361", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
+		t.Fatalf("definition count = %d, want 364", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -1,0 +1,186 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestCancelLoginAccountSchemasAreExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	assertStringEnum(t, defs["CancelLoginAccountStatus"], "canceled", "notFound")
+
+	params := defs["CancelLoginAccountParams"].(Schema)
+	if params["type"] != "object" || params["additionalProperties"] != false {
+		t.Fatalf("CancelLoginAccountParams is not a closed object: %#v", params)
+	}
+	if got := schemaRequiredNames(params); !slices.Equal(got, []string{"loginId"}) {
+		t.Fatalf("CancelLoginAccountParams required = %v", got)
+	}
+	wantParamsProperties := Schema{"loginId": Schema{"type": "string"}}
+	if got, want := params["properties"], wantParamsProperties; !reflect.DeepEqual(got, want) {
+		t.Fatalf("CancelLoginAccountParams properties = %#v, want %#v", got, want)
+	}
+
+	response := defs["CancelLoginAccountResponse"].(Schema)
+	if response["type"] != "object" || response["additionalProperties"] != false {
+		t.Fatalf("CancelLoginAccountResponse is not a closed object: %#v", response)
+	}
+	if got := schemaRequiredNames(response); !slices.Equal(got, []string{"status"}) {
+		t.Fatalf("CancelLoginAccountResponse required = %v", got)
+	}
+	wantResponseProperties := Schema{
+		"status": Schema{"$ref": "#/$defs/CancelLoginAccountStatus"},
+	}
+	if got := response["properties"]; !reflect.DeepEqual(got, wantResponseProperties) {
+		t.Fatalf("CancelLoginAccountResponse properties = %#v, want %#v", got, wantResponseProperties)
+	}
+}
+
+func TestCancelLoginAccountContractsAcceptExactWireForms(t *testing.T) {
+	for _, tc := range []struct {
+		input string
+		want  string
+	}{
+		{input: `{"loginId":""}`, want: `{"loginId":""}`},
+		{input: `{"loginId":"login-1"}`, want: `{"loginId":"login-1"}`},
+	} {
+		var params CancelLoginAccountParams
+		if err := json.Unmarshal([]byte(tc.input), &params); err != nil {
+			t.Errorf("unmarshal params %s: %v", tc.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(params)
+		if err != nil || string(encoded) != tc.want {
+			t.Errorf("params round trip = %s, %v; want %s", encoded, err, tc.want)
+		}
+	}
+
+	for _, status := range []CancelLoginAccountStatus{
+		CancelLoginAccountStatusCanceled,
+		CancelLoginAccountStatusNotFound,
+	} {
+		encoded, err := json.Marshal(status)
+		if err != nil {
+			t.Errorf("marshal status %q: %v", status, err)
+			continue
+		}
+		var roundTrip CancelLoginAccountStatus
+		if err := json.Unmarshal(encoded, &roundTrip); err != nil || roundTrip != status {
+			t.Errorf("status round trip = %q, %v; want %q", roundTrip, err, status)
+		}
+	}
+
+	for _, status := range []string{"canceled", "notFound"} {
+		input := `{"status":"` + status + `"}`
+		var response CancelLoginAccountResponse
+		if err := json.Unmarshal([]byte(input), &response); err != nil {
+			t.Errorf("unmarshal response %s: %v", input, err)
+			continue
+		}
+		encoded, err := json.Marshal(response)
+		if err != nil || string(encoded) != input {
+			t.Errorf("response round trip = %s, %v; want %s", encoded, err, input)
+		}
+	}
+}
+
+func TestCancelLoginAccountContractsRejectMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `{}`,
+		`{"loginId":null}`, `{"loginId":1}`, `{"loginId":true}`,
+		`{"loginId":{}}`, `{"loginId":[]}`, `{"login_id":"id"}`,
+		`{"loginId":"id","extra":true}`, `{"loginId":"id"} {}`,
+	} {
+		assertJSONRejects[CancelLoginAccountParams](t, input)
+	}
+
+	for _, input := range []string{
+		``, `null`, `""`, `"other"`, `"Canceled"`, `"not_found"`,
+		`1`, `true`, `{}`, `[]`, `"canceled" {}`,
+	} {
+		assertJSONRejects[CancelLoginAccountStatus](t, input)
+	}
+
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `{}`,
+		`{"status":null}`, `{"status":""}`, `{"status":"other"}`,
+		`{"status":"Canceled"}`, `{"status":1}`, `{"Status":"canceled"}`,
+		`{"status":"canceled","extra":true}`, `{"status":"canceled"} {}`,
+	} {
+		assertJSONRejects[CancelLoginAccountResponse](t, input)
+	}
+}
+
+func TestCancelLoginAccountNilReceiversAndInvalidMarshalFailClosed(t *testing.T) {
+	var params *CancelLoginAccountParams
+	if err := params.UnmarshalJSON([]byte(`{"loginId":"id"}`)); err == nil {
+		t.Fatal("nil CancelLoginAccountParams receiver succeeded")
+	}
+	var status *CancelLoginAccountStatus
+	if err := status.UnmarshalJSON([]byte(`"canceled"`)); err == nil {
+		t.Fatal("nil CancelLoginAccountStatus receiver succeeded")
+	}
+	var response *CancelLoginAccountResponse
+	if err := response.UnmarshalJSON([]byte(`{"status":"canceled"}`)); err == nil {
+		t.Fatal("nil CancelLoginAccountResponse receiver succeeded")
+	}
+	if _, err := json.Marshal(CancelLoginAccountStatus("other")); err == nil {
+		t.Fatal("invalid CancelLoginAccountStatus marshaled")
+	}
+	if _, err := json.Marshal(CancelLoginAccountResponse{Status: CancelLoginAccountStatus("other")}); err == nil {
+		t.Fatal("response with invalid status marshaled")
+	}
+}
+
+func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
+	names := []string{
+		"CancelLoginAccountParams",
+		"CancelLoginAccountResponse",
+		"CancelLoginAccountStatus",
+	}
+	for _, binding := range WireTypeBindings() {
+		for _, name := range names {
+			if slices.Contains(binding.Params, name) || slices.Contains(binding.Result, name) {
+				t.Fatalf("%s unexpectedly bound to %s", name, binding.Method)
+			}
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
+		t.Fatalf("definition count = %d, want 364", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestCancelLoginAccountTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	source := string(generated)
+	for _, want := range []string{
+		`export type CancelLoginAccountParams = {`,
+		`"loginId": string;`,
+		`export type CancelLoginAccountResponse = {`,
+		`"status": CancelLoginAccountStatus;`,
+		`export type CancelLoginAccountStatus = "canceled" | "notFound";`,
+	} {
+		if !strings.Contains(source, want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}
+
+var (
+	_ json.Unmarshaler = (*CancelLoginAccountParams)(nil)
+	_ json.Marshaler   = CancelLoginAccountStatus("")
+	_ json.Unmarshaler = (*CancelLoginAccountStatus)(nil)
+	_ json.Unmarshaler = (*CancelLoginAccountResponse)(nil)
+)

--- a/appserver/protocol/cancel_login_account_types.go
+++ b/appserver/protocol/cancel_login_account_types.go
@@ -1,0 +1,102 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// CancelLoginAccountParams is the exact public login-cancellation target. It
+// remains standalone from Gollem account and authentication runtime.
+type CancelLoginAccountParams struct {
+	LoginID string `json:"loginId"`
+}
+
+func (p *CancelLoginAccountParams) UnmarshalJSON(data []byte) error {
+	if p == nil {
+		return errors.New("decode cancel-login account params into nil receiver")
+	}
+	payload, err := decodeExactThreadItemObject(
+		data,
+		"cancel-login account params",
+		"loginId",
+	)
+	if err != nil {
+		return err
+	}
+	loginID, err := decodeRequiredThreadItemValue[string](
+		payload,
+		"cancel-login account params",
+		"loginId",
+	)
+	if err != nil {
+		return err
+	}
+	*p = CancelLoginAccountParams{LoginID: loginID}
+	return nil
+}
+
+// CancelLoginAccountStatus is the exact closed public cancellation outcome.
+type CancelLoginAccountStatus string
+
+const (
+	CancelLoginAccountStatusCanceled CancelLoginAccountStatus = "canceled"
+	CancelLoginAccountStatusNotFound CancelLoginAccountStatus = "notFound"
+)
+
+func (s CancelLoginAccountStatus) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(
+		s,
+		"cancel-login account status",
+		CancelLoginAccountStatus.valid,
+	)
+}
+
+func (s *CancelLoginAccountStatus) UnmarshalJSON(data []byte) error {
+	return unmarshalThreadTurnLeafEnum(
+		data,
+		s,
+		"cancel-login account status",
+		CancelLoginAccountStatus.valid,
+	)
+}
+
+func (s CancelLoginAccountStatus) valid() bool {
+	return s == CancelLoginAccountStatusCanceled || s == CancelLoginAccountStatusNotFound
+}
+
+// CancelLoginAccountResponse is the exact public cancellation outcome. It
+// remains standalone from the deferred account/login/cancel method.
+type CancelLoginAccountResponse struct {
+	Status CancelLoginAccountStatus `json:"status"`
+}
+
+func (r *CancelLoginAccountResponse) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("decode cancel-login account response into nil receiver")
+	}
+	payload, err := decodeExactThreadItemObject(
+		data,
+		"cancel-login account response",
+		"status",
+	)
+	if err != nil {
+		return err
+	}
+	status, err := decodeRequiredThreadItemValue[CancelLoginAccountStatus](
+		payload,
+		"cancel-login account response",
+		"status",
+	)
+	if err != nil {
+		return err
+	}
+	*r = CancelLoginAccountResponse{Status: status}
+	return nil
+}
+
+var (
+	_ json.Unmarshaler = (*CancelLoginAccountParams)(nil)
+	_ json.Marshaler   = CancelLoginAccountStatus("")
+	_ json.Unmarshaler = (*CancelLoginAccountStatus)(nil)
+	_ json.Unmarshaler = (*CancelLoginAccountResponse)(nil)
+)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
-		t.Fatalf("definition count = %d, want 361", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
+		t.Fatalf("definition count = %d, want 364", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
-		t.Fatalf("definition count = %d, want 361", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
+		t.Fatalf("definition count = %d, want 364", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
-		t.Fatalf("definition count = %d, want 361", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
+		t.Fatalf("definition count = %d, want 364", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
-		t.Fatalf("definition count = %d, want 361", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
+		t.Fatalf("definition count = %d, want 364", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
-		t.Fatalf("definition count = %d, want 361", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
+		t.Fatalf("definition count = %d, want 364", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
-		t.Fatalf("definition count = %d, want 361", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
+		t.Fatalf("definition count = %d, want 364", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
-		t.Fatalf("definition count = %d, want 361", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
+		t.Fatalf("definition count = %d, want 364", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
-		t.Fatalf("definition count = %d, want 361", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
+		t.Fatalf("definition count = %d, want 364", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
-		t.Fatalf("definition count = %d, want 361", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
+		t.Fatalf("definition count = %d, want 364", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 361 {
-		t.Fatalf("definition count = %d, want 361", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 364 {
+		t.Fatalf("definition count = %d, want 364", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
-		t.Fatalf("definition count = %d, want 361", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
+		t.Fatalf("definition count = %d, want 364", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
-		t.Fatalf("definition count = %d, want 361", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
+		t.Fatalf("definition count = %d, want 364", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
-		t.Fatalf("definition count = %d, want 361", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
+		t.Fatalf("definition count = %d, want 364", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
-		t.Fatalf("definition count = %d, want 361", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
+		t.Fatalf("definition count = %d, want 364", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
-		t.Fatalf("definition count = %d, want 361", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
+		t.Fatalf("definition count = %d, want 364", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
-		t.Fatalf("definition count = %d, want 361", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
+		t.Fatalf("definition count = %d, want 364", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
-		t.Fatalf("definition count = %d, want 361", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
+		t.Fatalf("definition count = %d, want 364", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
-		t.Fatalf("definition count = %d, want 361", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
+		t.Fatalf("definition count = %d, want 364", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
-		t.Fatalf("definition count = %d, want 361", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
+		t.Fatalf("definition count = %d, want 364", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 361 {
-		t.Fatalf("definition count = %d, want 361", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 364 {
+		t.Fatalf("definition count = %d, want 364", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 361 {
-		t.Fatalf("definition count = %d, want 361", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 364 {
+		t.Fatalf("definition count = %d, want 364", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 361 {
-		t.Fatalf("definition count = %d, want 361", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 364 {
+		t.Fatalf("definition count = %d, want 364", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 361 {
-		t.Fatalf("definition count = %d, want 361", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 364 {
+		t.Fatalf("definition count = %d, want 364", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 361 {
-		t.Fatalf("definition count = %d, want 361", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 364 {
+		t.Fatalf("definition count = %d, want 364", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -102,6 +102,9 @@ func wireSchemaDefinitions() Schema {
 		{Name: "AutoCompactTokenLimitScope", Type: reflect.TypeFor[AutoCompactTokenLimitScope]()},
 		{Name: "AutoReviewDecisionSource", Type: reflect.TypeFor[AutoReviewDecisionSource]()},
 		{Name: "ByteRange", Type: reflect.TypeFor[ByteRange]()},
+		{Name: "CancelLoginAccountParams", Type: reflect.TypeFor[CancelLoginAccountParams]()},
+		{Name: "CancelLoginAccountResponse", Type: reflect.TypeFor[CancelLoginAccountResponse]()},
+		{Name: "CancelLoginAccountStatus", Type: reflect.TypeFor[CancelLoginAccountStatus]()},
 		{Name: "ClientInfo", Type: reflect.TypeFor[ClientInfo]()},
 		{Name: "CodexErrorInfo", Type: reflect.TypeFor[CodexErrorInfo]()},
 		{Name: "CollabAgentState", Type: reflect.TypeFor[CollabAgentState]()},
@@ -484,6 +487,10 @@ func wireSchemaDefinitions() Schema {
 	)
 	schemas["AutoReviewDecisionSource"] = stringEnumSchema(
 		string(AutoReviewDecisionSourceAgent),
+	)
+	schemas["CancelLoginAccountStatus"] = stringEnumSchema(
+		string(CancelLoginAccountStatusCanceled),
+		string(CancelLoginAccountStatusNotFound),
 	)
 	schemas["ReasoningEffort"] = Schema{"type": "string", "minLength": 1}
 	schemas["ResidencyRequirement"] = stringEnumSchema(string(ResidencyRequirementUS))

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -437,6 +437,37 @@
       ],
       "type": "object"
     },
+    "CancelLoginAccountParams": {
+      "additionalProperties": false,
+      "properties": {
+        "loginId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "loginId"
+      ],
+      "type": "object"
+    },
+    "CancelLoginAccountResponse": {
+      "additionalProperties": false,
+      "properties": {
+        "status": {
+          "$ref": "#/$defs/CancelLoginAccountStatus"
+        }
+      },
+      "required": [
+        "status"
+      ],
+      "type": "object"
+    },
+    "CancelLoginAccountStatus": {
+      "enum": [
+        "canceled",
+        "notFound"
+      ],
+      "type": "string"
+    },
     "ClientInfo": {
       "additionalProperties": false,
       "properties": {

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 361 {
-		t.Fatalf("definition count = %d, want 361", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 364 {
+		t.Fatalf("definition count = %d, want 364", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
-		t.Fatalf("definition count = %d, want 361", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
+		t.Fatalf("definition count = %d, want 364", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
-		t.Fatalf("definition count = %d, want 361", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
+		t.Fatalf("definition count = %d, want 364", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
-		t.Fatalf("definition count = %d, want 361", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
+		t.Fatalf("definition count = %d, want 364", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
-		t.Fatalf("definition count = %d, want 361", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
+		t.Fatalf("definition count = %d, want 364", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
-		t.Fatalf("definition count = %d, want 361", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
+		t.Fatalf("definition count = %d, want 364", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 361 {
-		t.Fatalf("definition count = %d, want 361", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 364 {
+		t.Fatalf("definition count = %d, want 364", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 361 {
-		t.Fatalf("definition count = %d, want 361", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 364 {
+		t.Fatalf("definition count = %d, want 364", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
-		t.Fatalf("definition count = %d, want 361", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
+		t.Fatalf("definition count = %d, want 364", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
-		t.Fatalf("definition count = %d, want 361", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
+		t.Fatalf("definition count = %d, want 364", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
-		t.Fatalf("definition count = %d, want 361", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
+		t.Fatalf("definition count = %d, want 364", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
-		t.Fatalf("definition count = %d, want 361", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
+		t.Fatalf("definition count = %d, want 364", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -589,6 +589,16 @@ export type ByteRange = {
   "start": number;
 };
 
+export type CancelLoginAccountParams = {
+  "loginId": string;
+};
+
+export type CancelLoginAccountResponse = {
+  "status": CancelLoginAccountStatus;
+};
+
+export type CancelLoginAccountStatus = "canceled" | "notFound";
+
 export type ClientInfo = {
   "name": string;
   "title"?: string | null;

--- a/appserver/protocol/typescript/testdata/cancel_login_account_contract.ts
+++ b/appserver/protocol/typescript/testdata/cancel_login_account_contract.ts
@@ -1,0 +1,64 @@
+import type {
+  CancelLoginAccountParams,
+  CancelLoginAccountResponse,
+  CancelLoginAccountStatus,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? (<T>() => T extends B ? 1 : 2) extends
+        (<T>() => T extends A ? 1 : 2)
+      ? true
+      : false
+    : false;
+type Expect<T extends true> = T;
+
+type ParamsContract = Expect<Equal<CancelLoginAccountParams, { loginId: string }>>;
+type StatusContract = Expect<Equal<CancelLoginAccountStatus, "canceled" | "notFound">>;
+type ResponseContract = Expect<
+  Equal<CancelLoginAccountResponse, { status: CancelLoginAccountStatus }>
+>;
+
+export const emptyLoginId = { loginId: "" } satisfies CancelLoginAccountParams;
+export const loginId = { loginId: "login-1" } satisfies CancelLoginAccountParams;
+export const canceled = "canceled" satisfies CancelLoginAccountStatus;
+export const notFound = "notFound" satisfies CancelLoginAccountStatus;
+export const response = { status: notFound } satisfies CancelLoginAccountResponse;
+
+// @ts-expect-error loginId is required.
+export const rejectMissingLoginId = {} satisfies CancelLoginAccountParams;
+// @ts-expect-error loginId is non-null.
+export const rejectNullLoginId = { loginId: null } satisfies CancelLoginAccountParams;
+// @ts-expect-error loginId is a string.
+export const rejectNumericLoginId = { loginId: 1 } satisfies CancelLoginAccountParams;
+// @ts-expect-error exact camelCase spelling is required.
+export const rejectLoginIdCase = { login_id: "id" } satisfies CancelLoginAccountParams;
+// @ts-expect-error params are closed.
+export const rejectExtraParam = { loginId: "id", extra: true } satisfies CancelLoginAccountParams;
+
+// @ts-expect-error statuses are closed.
+export const rejectUnknownStatus = "other" satisfies CancelLoginAccountStatus;
+// @ts-expect-error exact casing is required.
+export const rejectStatusCase = "Canceled" satisfies CancelLoginAccountStatus;
+// @ts-expect-error empty strings are not statuses.
+export const rejectEmptyStatus = "" satisfies CancelLoginAccountStatus;
+// @ts-expect-error statuses are non-null.
+export const rejectNullStatus = null satisfies CancelLoginAccountStatus;
+// @ts-expect-error statuses are strings.
+export const rejectNumericStatus = 1 satisfies CancelLoginAccountStatus;
+
+// @ts-expect-error status is required.
+export const rejectMissingStatus = {} satisfies CancelLoginAccountResponse;
+// @ts-expect-error status is non-null.
+export const rejectNullResponseStatus = { status: null } satisfies CancelLoginAccountResponse;
+// @ts-expect-error response status is closed.
+export const rejectUnknownResponseStatus = { status: "other" } satisfies CancelLoginAccountResponse;
+// @ts-expect-error exact response field casing is required.
+export const rejectResponseCase = { Status: "canceled" } satisfies CancelLoginAccountResponse;
+// @ts-expect-error responses are closed.
+export const rejectExtraResponse = { status: "canceled", extra: true } satisfies CancelLoginAccountResponse;
+
+void (null as unknown as ParamsContract);
+void (null as unknown as StatusContract);
+void (null as unknown as ResponseContract);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 361 {
-		t.Fatalf("definition count = %d, want 361", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
+		t.Fatalf("definition count = %d, want 364", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary

- export exact standalone public `CancelLoginAccountParams`, `CancelLoginAccountStatus`, and `CancelLoginAccountResponse`
- preserve required `loginId`, the closed `canceled | notFound` outcomes, and required `status`
- reject missing, null, wrong-type, wrong-case, unknown, malformed/trailing, nil-receiver, and invalid constructed status values
- generate the exact JSON Schema and TypeScript contracts while keeping all method/item bindings unchanged
- raise the deterministic definition count from 361 to 364

This intentionally does not bind the deferred `account/login/cancel` method, implement login cancellation, inspect or mutate account/token state, select providers, add account/auth behavior, or add runtime behavior.

## Verification

- reconciled against Codex `5c19155cbd93bfa099016e7487259f61669823ff`
- deliberate red: absent Go types/constants; three missing generated exports, three false exact identities, and fifteen unused malformed-case directives; Slang reported the corresponding six missing root/protocol exports
- focused tests 30x and focused race
- all five new codec functions at 100% focused statement coverage
- full protocol and every non-Monty package under fresh normal/race suites
- `golangci-lint run ./...` (0 issues), `go vet ./...`, and no-diff `go mod tidy`
- byte-identical deterministic generation and strict TypeScript compile
- configured pre-push and push-time hooks
- all five existing Slang stdio/Unix-socket/WebSocket workflows against the feature binary
- normalized live `config/read` exactly equal to the #161 baseline at SHA-256 `42fb16dc6a328f9ccebcbd7191da2ccec853b1466235b30074625199825ace79` with five values/five entries; only five `updatedAt` fields were removed
- `git diff --check`

Generated hashes:

- schema: `f4f8f71f19ac20c68c9c86b1ab85da3623b3e37435d9e91f8346189d1251a92a`
- TypeScript: `6c696ab160e670ce3f222072bf9f4a6fcd6e80b3b186fcad0e75720907b885a0`
- strict fixture: `ba5c7dfb821bb39c3097c0fb3f26e607aee454d1edb5e537c95b47dab86c2262`
- feature trimpath binary: `41ab931969dd17be1d4e8c81ba0a8d814b964ddedd41e5efd39b9f0c4107be20`

Local `ext/monty` normal/race/coverage tests remain skipped per standing direction with `hooks.skipMontyRace=true`; hosted repository checks are unchanged.