### PR TITLE
Export exact standalone login app brand

### DIFF
--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 364 {
-		t.Fatalf("definition count = %d, want 364", got)
+	if got := len(defs); got != 365 {
+		t.Fatalf("definition count = %d, want 365", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
-		t.Fatalf("definition count = %d, want 364", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
+		t.Fatalf("definition count = %d, want 365", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
-		t.Fatalf("definition count = %d, want 364", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
+		t.Fatalf("definition count = %d, want 365", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
-		t.Fatalf("definition count = %d, want 364", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
+		t.Fatalf("definition count = %d, want 365", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
-		t.Fatalf("definition count = %d, want 364", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
+		t.Fatalf("definition count = %d, want 365", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
-		t.Fatalf("definition count = %d, want 364", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
+		t.Fatalf("definition count = %d, want 365", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
-		t.Fatalf("definition count = %d, want 364", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
+		t.Fatalf("definition count = %d, want 365", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
-		t.Fatalf("definition count = %d, want 364", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
+		t.Fatalf("definition count = %d, want 365", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
-		t.Fatalf("definition count = %d, want 364", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
+		t.Fatalf("definition count = %d, want 365", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
-		t.Fatalf("definition count = %d, want 364", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
+		t.Fatalf("definition count = %d, want 365", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
-		t.Fatalf("definition count = %d, want 364", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
+		t.Fatalf("definition count = %d, want 365", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
-		t.Fatalf("definition count = %d, want 364", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
+		t.Fatalf("definition count = %d, want 365", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
-		t.Fatalf("definition count = %d, want 364", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
+		t.Fatalf("definition count = %d, want 365", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
-		t.Fatalf("definition count = %d, want 364", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
+		t.Fatalf("definition count = %d, want 365", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 364 {
-		t.Fatalf("definition count = %d, want 364", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 365 {
+		t.Fatalf("definition count = %d, want 365", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -1,0 +1,85 @@
+package protocol
+
+import (
+	"encoding/json"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestLoginAppBrandSchemaIsExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	assertStringEnum(t, defs["LoginAppBrand"], "codex", "chatgpt")
+}
+
+func TestLoginAppBrandAcceptsExactValuesAndDefault(t *testing.T) {
+	for _, input := range []string{`"codex"`, `"chatgpt"`} {
+		var brand LoginAppBrand
+		if err := json.Unmarshal([]byte(input), &brand); err != nil {
+			t.Fatalf("unmarshal LoginAppBrand %s: %v", input, err)
+		}
+		encoded, err := json.Marshal(brand)
+		if err != nil {
+			t.Fatalf("marshal LoginAppBrand %s: %v", input, err)
+		}
+		if got := string(encoded); got != input {
+			t.Fatalf("LoginAppBrand round trip = %s, want %s", got, input)
+		}
+	}
+	if LoginAppBrandDefault != LoginAppBrandCodex {
+		t.Fatalf("LoginAppBrandDefault = %q, want %q", LoginAppBrandDefault, LoginAppBrandCodex)
+	}
+}
+
+func TestLoginAppBrandRejectsMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `""`, `"other"`, `"Codex"`, `"ChatGPT"`,
+		`1`, `true`, `{}`, `[]`, `"codex" {}`, `"chatgpt" x`,
+	} {
+		assertJSONRejects[LoginAppBrand](t, input)
+	}
+}
+
+func TestLoginAppBrandNilReceiverAndInvalidMarshalFailClosed(t *testing.T) {
+	var brand *LoginAppBrand
+	if err := brand.UnmarshalJSON([]byte(`"codex"`)); err == nil {
+		t.Fatal("nil LoginAppBrand receiver succeeded")
+	}
+	if _, err := json.Marshal(LoginAppBrand("other")); err == nil {
+		t.Fatal("invalid LoginAppBrand marshaled")
+	}
+}
+
+func TestLoginAppBrandRemainsStandalone(t *testing.T) {
+	for _, binding := range WireTypeBindings() {
+		if slices.Contains(binding.Params, "LoginAppBrand") ||
+			slices.Contains(binding.Result, "LoginAppBrand") {
+			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
+		t.Fatalf("definition count = %d, want 365", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestLoginAppBrandTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	want := `export type LoginAppBrand = "codex" | "chatgpt";`
+	if !strings.Contains(string(generated), want) {
+		t.Errorf("generated TypeScript missing %q", want)
+	}
+}
+
+var (
+	_ json.Marshaler   = LoginAppBrand("")
+	_ json.Unmarshaler = (*LoginAppBrand)(nil)
+)

--- a/appserver/protocol/login_app_brand_types.go
+++ b/appserver/protocol/login_app_brand_types.go
@@ -1,0 +1,31 @@
+package protocol
+
+import "encoding/json"
+
+// LoginAppBrand is the exact closed public brand for ChatGPT login UI. It is
+// standalone from Gollem's account, credential, provider, and browser runtime.
+type LoginAppBrand string
+
+const (
+	LoginAppBrandCodex   LoginAppBrand = "codex"
+	LoginAppBrandChatGPT LoginAppBrand = "chatgpt"
+
+	LoginAppBrandDefault = LoginAppBrandCodex
+)
+
+func (b LoginAppBrand) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(b, "login app brand", LoginAppBrand.valid)
+}
+
+func (b *LoginAppBrand) UnmarshalJSON(data []byte) error {
+	return unmarshalThreadTurnLeafEnum(data, b, "login app brand", LoginAppBrand.valid)
+}
+
+func (b LoginAppBrand) valid() bool {
+	return b == LoginAppBrandCodex || b == LoginAppBrandChatGPT
+}
+
+var (
+	_ json.Marshaler   = LoginAppBrand("")
+	_ json.Unmarshaler = (*LoginAppBrand)(nil)
+)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
-		t.Fatalf("definition count = %d, want 364", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
+		t.Fatalf("definition count = %d, want 365", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
-		t.Fatalf("definition count = %d, want 364", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
+		t.Fatalf("definition count = %d, want 365", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
-		t.Fatalf("definition count = %d, want 364", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
+		t.Fatalf("definition count = %d, want 365", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
-		t.Fatalf("definition count = %d, want 364", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
+		t.Fatalf("definition count = %d, want 365", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
-		t.Fatalf("definition count = %d, want 364", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
+		t.Fatalf("definition count = %d, want 365", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
-		t.Fatalf("definition count = %d, want 364", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
+		t.Fatalf("definition count = %d, want 365", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
-		t.Fatalf("definition count = %d, want 364", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
+		t.Fatalf("definition count = %d, want 365", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
-		t.Fatalf("definition count = %d, want 364", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
+		t.Fatalf("definition count = %d, want 365", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
-		t.Fatalf("definition count = %d, want 364", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
+		t.Fatalf("definition count = %d, want 365", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 364 {
-		t.Fatalf("definition count = %d, want 364", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 365 {
+		t.Fatalf("definition count = %d, want 365", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 364 {
-		t.Fatalf("definition count = %d, want 364", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 365 {
+		t.Fatalf("definition count = %d, want 365", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 364 {
-		t.Fatalf("definition count = %d, want 364", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 365 {
+		t.Fatalf("definition count = %d, want 365", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 364 {
-		t.Fatalf("definition count = %d, want 364", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 365 {
+		t.Fatalf("definition count = %d, want 365", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 364 {
-		t.Fatalf("definition count = %d, want 364", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 365 {
+		t.Fatalf("definition count = %d, want 365", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -219,6 +219,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "ItemLifecycleNotificationParams", Type: reflect.TypeFor[ItemLifecycleNotificationParams]()},
 		{Name: "ItemStartedNotification", Type: reflect.TypeFor[ItemStartedNotification]()},
 		{Name: "LegacyAppPathString", Type: reflect.TypeFor[LegacyAppPathString]()},
+		{Name: "LoginAppBrand", Type: reflect.TypeFor[LoginAppBrand]()},
 		{Name: "LocalShellAction", Type: reflect.TypeFor[LocalShellAction]()},
 		{Name: "LocalShellStatus", Type: reflect.TypeFor[LocalShellStatus]()},
 		{Name: "ManagedHooksRequirements", Type: reflect.TypeFor[ManagedHooksRequirements]()},
@@ -491,6 +492,10 @@ func wireSchemaDefinitions() Schema {
 	schemas["CancelLoginAccountStatus"] = stringEnumSchema(
 		string(CancelLoginAccountStatusCanceled),
 		string(CancelLoginAccountStatusNotFound),
+	)
+	schemas["LoginAppBrand"] = stringEnumSchema(
+		string(LoginAppBrandCodex),
+		string(LoginAppBrandChatGPT),
 	)
 	schemas["ReasoningEffort"] = Schema{"type": "string", "minLength": 1}
 	schemas["ResidencyRequirement"] = stringEnumSchema(string(ResidencyRequirementUS))

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -4550,6 +4550,13 @@
       ],
       "type": "string"
     },
+    "LoginAppBrand": {
+      "enum": [
+        "codex",
+        "chatgpt"
+      ],
+      "type": "string"
+    },
     "MCPContent": {
       "additionalProperties": false,
       "properties": {

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 364 {
-		t.Fatalf("definition count = %d, want 364", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 365 {
+		t.Fatalf("definition count = %d, want 365", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
-		t.Fatalf("definition count = %d, want 364", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
+		t.Fatalf("definition count = %d, want 365", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
-		t.Fatalf("definition count = %d, want 364", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
+		t.Fatalf("definition count = %d, want 365", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
-		t.Fatalf("definition count = %d, want 364", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
+		t.Fatalf("definition count = %d, want 365", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
-		t.Fatalf("definition count = %d, want 364", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
+		t.Fatalf("definition count = %d, want 365", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
-		t.Fatalf("definition count = %d, want 364", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
+		t.Fatalf("definition count = %d, want 365", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 364 {
-		t.Fatalf("definition count = %d, want 364", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 365 {
+		t.Fatalf("definition count = %d, want 365", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 364 {
-		t.Fatalf("definition count = %d, want 364", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 365 {
+		t.Fatalf("definition count = %d, want 365", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
-		t.Fatalf("definition count = %d, want 364", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
+		t.Fatalf("definition count = %d, want 365", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
-		t.Fatalf("definition count = %d, want 364", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
+		t.Fatalf("definition count = %d, want 365", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
-		t.Fatalf("definition count = %d, want 364", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
+		t.Fatalf("definition count = %d, want 365", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
-		t.Fatalf("definition count = %d, want 364", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
+		t.Fatalf("definition count = %d, want 365", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -1465,6 +1465,8 @@ export type LocalShellAction = {
 
 export type LocalShellStatus = "completed" | "in_progress" | "incomplete";
 
+export type LoginAppBrand = "codex" | "chatgpt";
+
 export type MCPContent = {
   "text"?: string;
   "type": string;

--- a/appserver/protocol/typescript/testdata/login_app_brand_contract.ts
+++ b/appserver/protocol/typescript/testdata/login_app_brand_contract.ts
@@ -1,0 +1,30 @@
+import type { LoginAppBrand } from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? (<T>() => T extends B ? 1 : 2) extends
+        (<T>() => T extends A ? 1 : 2)
+      ? true
+      : false
+    : false;
+type Expect<T extends true> = T;
+
+type Contract = Expect<Equal<LoginAppBrand, "codex" | "chatgpt">>;
+
+export const brands = ["codex", "chatgpt"] satisfies LoginAppBrand[];
+
+// @ts-expect-error login app brands are closed.
+export const rejectUnknown = "other" satisfies LoginAppBrand;
+// @ts-expect-error exact lowercase Codex spelling is required.
+export const rejectCodexCase = "Codex" satisfies LoginAppBrand;
+// @ts-expect-error exact lowercase ChatGPT spelling is required.
+export const rejectChatGPTCase = "ChatGPT" satisfies LoginAppBrand;
+// @ts-expect-error empty strings are not login app brands.
+export const rejectEmpty = "" satisfies LoginAppBrand;
+// @ts-expect-error login app brands are non-null.
+export const rejectNull = null satisfies LoginAppBrand;
+// @ts-expect-error login app brands are strings.
+export const rejectNumber = 1 satisfies LoginAppBrand;
+
+void (null as unknown as Contract);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 364 {
-		t.Fatalf("definition count = %d, want 364", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
+		t.Fatalf("definition count = %d, want 365", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- export exact standalone `LoginAppBrand = "codex" | "chatgpt"` from public Codex `5c19155c`
- preserve `codex` as the Go default identity and reject malformed/unknown constructed values
- regenerate the v1 schema and framework-neutral TypeScript at 365 definitions, with 59 method and 5 item bindings unchanged

This deliberately does not add `LoginAccountParams`, `LoginAccountResponse`, `account/login/start`, browser/OAuth/device-code behavior, account/token state, provider selection, authentication grants, or runtime behavior.

## Verification
- deliberate-red Go and strict TypeScript gates
- 30 focused repetitions; focused race; 100% coverage for all 3 new codec functions
- full protocol and all-package non-Monty normal/race suites
- `golangci-lint run ./...` (0 issues), `go vet ./...`, `go mod tidy`
- deterministic generation twice; strict TypeScript
- all 5 existing Slang real-process workflows against the feature binary
- normalized fixed-workspace `config/read` baseline/feature equality
- configured pre-push hook passed with `hooks.skipMontyRace=true`

Local Monty tests remain skipped per standing direction; hosted CI is unchanged.