### PR TITLE
Add standalone login account contracts

### DIFF
--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 365 {
-		t.Fatalf("definition count = %d, want 365", got)
+	if got := len(defs); got != 367 {
+		t.Fatalf("definition count = %d, want 367", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
-		t.Fatalf("definition count = %d, want 365", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 367 {
+		t.Fatalf("definition count = %d, want 367", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
-		t.Fatalf("definition count = %d, want 365", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 367 {
+		t.Fatalf("definition count = %d, want 367", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
-		t.Fatalf("definition count = %d, want 365", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 367 {
+		t.Fatalf("definition count = %d, want 367", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
-		t.Fatalf("definition count = %d, want 365", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 367 {
+		t.Fatalf("definition count = %d, want 367", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
-		t.Fatalf("definition count = %d, want 365", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 367 {
+		t.Fatalf("definition count = %d, want 367", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
-		t.Fatalf("definition count = %d, want 365", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 367 {
+		t.Fatalf("definition count = %d, want 367", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
-		t.Fatalf("definition count = %d, want 365", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 367 {
+		t.Fatalf("definition count = %d, want 367", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
-		t.Fatalf("definition count = %d, want 365", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 367 {
+		t.Fatalf("definition count = %d, want 367", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
-		t.Fatalf("definition count = %d, want 365", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 367 {
+		t.Fatalf("definition count = %d, want 367", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
-		t.Fatalf("definition count = %d, want 365", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 367 {
+		t.Fatalf("definition count = %d, want 367", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
-		t.Fatalf("definition count = %d, want 365", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 367 {
+		t.Fatalf("definition count = %d, want 367", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
-		t.Fatalf("definition count = %d, want 365", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 367 {
+		t.Fatalf("definition count = %d, want 367", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
-		t.Fatalf("definition count = %d, want 365", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 367 {
+		t.Fatalf("definition count = %d, want 367", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 365 {
-		t.Fatalf("definition count = %d, want 365", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 367 {
+		t.Fatalf("definition count = %d, want 367", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -1,0 +1,386 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestLoginAccountSchemasAreExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	params := loginAccountSchemaVariants(t, defs["LoginAccountParams"], 5)
+	response := loginAccountSchemaVariants(t, defs["LoginAccountResponse"], 5)
+
+	wantParamsRequired := map[string][]string{
+		"apiKey":            {"apiKey", "type"},
+		"chatgpt":           {"type"},
+		"chatgptDeviceCode": {"type"},
+		"chatgptAuthTokens": {"accessToken", "chatgptAccountId", "type"},
+		"amazonBedrock":     {"apiKey", "region", "type"},
+	}
+	wantResponseRequired := map[string][]string{
+		"apiKey":            {"type"},
+		"chatgpt":           {"authUrl", "loginId", "type"},
+		"chatgptDeviceCode": {"loginId", "type", "userCode", "verificationUrl"},
+		"chatgptAuthTokens": {"type"},
+		"amazonBedrock":     {"type"},
+	}
+	assertLoginAccountVariantRequired(t, params, wantParamsRequired)
+	assertLoginAccountVariantRequired(t, response, wantResponseRequired)
+
+	chatgptProperties := params["chatgpt"]["properties"].(Schema)
+	for _, name := range []string{"codexStreamlinedLogin", "useHostedLoginSuccessPage"} {
+		if got := chatgptProperties[name]; !reflect.DeepEqual(got, Schema{"type": "boolean"}) {
+			t.Errorf("LoginAccountParams.chatgpt.%s = %#v", name, got)
+		}
+	}
+	assertLoginAccountNullableSchema(
+		t,
+		chatgptProperties["appBrand"],
+		Schema{"$ref": "#/$defs/LoginAppBrand"},
+	)
+	if _, ok := chatgptProperties["appBrand"].(Schema)["default"]; !ok {
+		t.Error("LoginAccountParams.chatgpt.appBrand has no null default")
+	}
+
+	tokenProperties := params["chatgptAuthTokens"]["properties"].(Schema)
+	assertLoginAccountNullableSchema(
+		t,
+		tokenProperties["chatgptPlanType"],
+		Schema{"type": "string"},
+	)
+}
+
+func TestLoginAccountParamsAcceptAndCanonicalizeExactWireForms(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		input     string
+		canonical string
+		kind      string
+	}{
+		{
+			name:      "API key empty and unknown input discarded",
+			input:     `{"type":"apiKey","apiKey":"","future":{"ok":true}}`,
+			canonical: `{"type":"apiKey","apiKey":""}`,
+			kind:      "apiKey",
+		},
+		{
+			name:      "ChatGPT defaults",
+			input:     `{"type":"chatgpt"}`,
+			canonical: `{"type":"chatgpt","appBrand":null}`,
+			kind:      "chatgpt",
+		},
+		{
+			name:      "ChatGPT explicit false and null canonicalize",
+			input:     `{"type":"chatgpt","codexStreamlinedLogin":false,"useHostedLoginSuccessPage":false,"appBrand":null}`,
+			canonical: `{"type":"chatgpt","appBrand":null}`,
+			kind:      "chatgpt",
+		},
+		{
+			name:      "ChatGPT full Codex brand",
+			input:     `{"type":"chatgpt","codexStreamlinedLogin":true,"useHostedLoginSuccessPage":true,"appBrand":"codex"}`,
+			canonical: `{"type":"chatgpt","codexStreamlinedLogin":true,"useHostedLoginSuccessPage":true,"appBrand":"codex"}`,
+			kind:      "chatgpt",
+		},
+		{
+			name:      "ChatGPT ChatGPT brand",
+			input:     `{"type":"chatgpt","appBrand":"chatgpt"}`,
+			canonical: `{"type":"chatgpt","appBrand":"chatgpt"}`,
+			kind:      "chatgpt",
+		},
+		{
+			name:      "device code",
+			input:     `{"type":"chatgptDeviceCode"}`,
+			canonical: `{"type":"chatgptDeviceCode"}`,
+			kind:      "chatgptDeviceCode",
+		},
+		{
+			name:      "auth tokens omitted plan",
+			input:     `{"type":"chatgptAuthTokens","accessToken":"","chatgptAccountId":""}`,
+			canonical: `{"type":"chatgptAuthTokens","accessToken":"","chatgptAccountId":"","chatgptPlanType":null}`,
+			kind:      "chatgptAuthTokens",
+		},
+		{
+			name:      "auth tokens explicit plan",
+			input:     `{"type":"chatgptAuthTokens","accessToken":"token","chatgptAccountId":"account","chatgptPlanType":"pro"}`,
+			canonical: `{"type":"chatgptAuthTokens","accessToken":"token","chatgptAccountId":"account","chatgptPlanType":"pro"}`,
+			kind:      "chatgptAuthTokens",
+		},
+		{
+			name:      "Bedrock empty strings",
+			input:     `{"type":"amazonBedrock","apiKey":"","region":""}`,
+			canonical: `{"type":"amazonBedrock","apiKey":"","region":""}`,
+			kind:      "amazonBedrock",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var value LoginAccountParams
+			if err := json.Unmarshal([]byte(tc.input), &value); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if got := value.Type(); got != tc.kind {
+				t.Errorf("Type() = %q, want %q", got, tc.kind)
+			}
+			encoded, err := json.Marshal(value)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if got := string(encoded); got != tc.canonical {
+				t.Errorf("canonical = %s, want %s", got, tc.canonical)
+			}
+		})
+	}
+}
+
+func TestLoginAccountResponseAcceptsAndCanonicalizesExactWireForms(t *testing.T) {
+	for _, tc := range []struct {
+		input     string
+		canonical string
+		kind      string
+	}{
+		{`{"type":"apiKey","future":true}`, `{"type":"apiKey"}`, "apiKey"},
+		{`{"type":"chatgpt","loginId":"","authUrl":""}`, `{"type":"chatgpt","loginId":"","authUrl":""}`, "chatgpt"},
+		{`{"type":"chatgptDeviceCode","loginId":"id","verificationUrl":"url","userCode":"code"}`, `{"type":"chatgptDeviceCode","loginId":"id","verificationUrl":"url","userCode":"code"}`, "chatgptDeviceCode"},
+		{`{"type":"chatgptAuthTokens"}`, `{"type":"chatgptAuthTokens"}`, "chatgptAuthTokens"},
+		{`{"type":"amazonBedrock"}`, `{"type":"amazonBedrock"}`, "amazonBedrock"},
+	} {
+		var value LoginAccountResponse
+		if err := json.Unmarshal([]byte(tc.input), &value); err != nil {
+			t.Errorf("unmarshal %s: %v", tc.input, err)
+			continue
+		}
+		if got := value.Type(); got != tc.kind {
+			t.Errorf("Type(%s) = %q, want %q", tc.input, got, tc.kind)
+		}
+		encoded, err := json.Marshal(value)
+		if err != nil || string(encoded) != tc.canonical {
+			t.Errorf("round trip %s = %s, %v; want %s", tc.input, encoded, err, tc.canonical)
+		}
+	}
+}
+
+func TestLoginAccountParamsRejectMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `{}`, `{} {}`,
+		`{"type":null}`, `{"type":1}`, `{"type":""}`, `{"type":"other"}`,
+		`{"type":"ApiKey","apiKey":"key"}`,
+		`{"type":"apiKey"}`, `{"type":"apiKey","apiKey":null}`,
+		`{"type":"apiKey","apiKey":1}`, `{"type":"apiKey","apiKey":"key","region":"us-east-1"}`,
+		`{"type":"chatgpt","codexStreamlinedLogin":null}`,
+		`{"type":"chatgpt","codexStreamlinedLogin":"true"}`,
+		`{"type":"chatgpt","useHostedLoginSuccessPage":null}`,
+		`{"type":"chatgpt","appBrand":"Codex"}`,
+		`{"type":"chatgpt","appBrand":1}`,
+		`{"type":"chatgpt","apiKey":"key"}`,
+		`{"type":"chatgptDeviceCode","appBrand":"codex"}`,
+		`{"type":"chatgptAuthTokens","accessToken":"token"}`,
+		`{"type":"chatgptAuthTokens","accessToken":null,"chatgptAccountId":"account"}`,
+		`{"type":"chatgptAuthTokens","accessToken":"token","chatgptAccountId":null}`,
+		`{"type":"chatgptAuthTokens","accessToken":"token","chatgptAccountId":"account","chatgptPlanType":1}`,
+		`{"type":"chatgptAuthTokens","accessToken":"token","chatgptAccountId":"account","region":"us-east-1"}`,
+		`{"type":"amazonBedrock","apiKey":"key"}`,
+		`{"type":"amazonBedrock","apiKey":null,"region":"us-east-1"}`,
+		`{"type":"amazonBedrock","apiKey":"key","region":null}`,
+		`{"type":"amazonBedrock","apiKey":"key","region":"us-east-1","accessToken":"token"}`,
+		`{"type":"apiKey","type":"apiKey","apiKey":"key"}`,
+		`{"type":"apiKey","apiKey":"one","apiKey":"two"}`,
+		`{"type":"chatgpt"} {}`,
+	} {
+		assertJSONRejects[LoginAccountParams](t, input)
+	}
+}
+
+func TestLoginAccountResponseRejectMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `{}`, `{} {}`,
+		`{"type":null}`, `{"type":1}`, `{"type":""}`, `{"type":"other"}`,
+		`{"type":"Chatgpt"}`,
+		`{"type":"apiKey","loginId":"id"}`,
+		`{"type":"chatgpt"}`, `{"type":"chatgpt","loginId":"id"}`,
+		`{"type":"chatgpt","loginId":null,"authUrl":"url"}`,
+		`{"type":"chatgpt","loginId":"id","authUrl":null}`,
+		`{"type":"chatgpt","loginId":"id","authUrl":"url","userCode":"code"}`,
+		`{"type":"chatgptDeviceCode","loginId":"id","verificationUrl":"url"}`,
+		`{"type":"chatgptDeviceCode","loginId":null,"verificationUrl":"url","userCode":"code"}`,
+		`{"type":"chatgptDeviceCode","loginId":"id","verificationUrl":1,"userCode":"code"}`,
+		`{"type":"chatgptDeviceCode","loginId":"id","verificationUrl":"url","userCode":null}`,
+		`{"type":"chatgptDeviceCode","loginId":"id","verificationUrl":"url","userCode":"code","apiKey":"key"}`,
+		`{"type":"chatgptAuthTokens","authUrl":"url"}`,
+		`{"type":"amazonBedrock","loginId":"id"}`,
+		`{"type":"chatgpt","type":"chatgpt","loginId":"id","authUrl":"url"}`,
+		`{"type":"chatgpt","loginId":"one","loginId":"two","authUrl":"url"}`,
+		`{"type":"apiKey"} {}`,
+	} {
+		assertJSONRejects[LoginAccountResponse](t, input)
+	}
+}
+
+func TestLoginAccountDirectDecoderRejectsMalformedJSON(t *testing.T) {
+	for _, input := range []string{
+		``,
+		`{`,
+		`{1`,
+		`{"type":`,
+		`{"type":"apiKey"`,
+		`{"type":"apiKey","apiKey":"key"} {}`,
+		`{"type":"apiKey","apiKey":"key"} trailing`,
+	} {
+		var value LoginAccountParams
+		if err := value.UnmarshalJSON([]byte(input)); err == nil {
+			t.Errorf("direct UnmarshalJSON from %q succeeded", input)
+		}
+	}
+}
+
+func TestLoginAccountContractsNilReceiversAndInvalidMarshalFailClosed(t *testing.T) {
+	var params *LoginAccountParams
+	if err := params.UnmarshalJSON([]byte(`{"type":"chatgpt"}`)); err == nil {
+		t.Fatal("nil LoginAccountParams receiver succeeded")
+	}
+	var response *LoginAccountResponse
+	if err := response.UnmarshalJSON([]byte(`{"type":"apiKey"}`)); err == nil {
+		t.Fatal("nil LoginAccountResponse receiver succeeded")
+	}
+	for _, value := range []any{
+		LoginAccountParams{},
+		LoginAccountParams{raw: json.RawMessage(`{"type":"apiKey"}`)},
+		LoginAccountParams{raw: json.RawMessage(`{"type":"unknown"}`)},
+		LoginAccountResponse{},
+		LoginAccountResponse{raw: json.RawMessage(`{"type":"chatgpt"}`)},
+		LoginAccountResponse{raw: json.RawMessage(`{"type":"unknown"}`)},
+	} {
+		if _, err := json.Marshal(value); err == nil {
+			t.Errorf("invalid %T marshaled", value)
+		}
+	}
+	for _, value := range []interface{ Type() string }{
+		LoginAccountParams{},
+		LoginAccountParams{raw: json.RawMessage(`not-json`)},
+		LoginAccountResponse{},
+		LoginAccountResponse{raw: json.RawMessage(`not-json`)},
+	} {
+		if got := value.Type(); got != "" {
+			t.Errorf("invalid %T Type() = %q", value, got)
+		}
+	}
+}
+
+func TestLoginAccountContractsRemainStandalone(t *testing.T) {
+	names := []string{"LoginAccountParams", "LoginAccountResponse"}
+	for _, binding := range WireTypeBindings() {
+		for _, name := range names {
+			if slices.Contains(binding.Params, name) || slices.Contains(binding.Result, name) {
+				t.Fatalf("%s unexpectedly bound to %s", name, binding.Method)
+			}
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 367 {
+		t.Fatalf("definition count = %d, want 367", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestLoginAccountTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	source := string(generated)
+	for _, want := range []string{
+		`export type LoginAccountParams = {`,
+		`"type": "apiKey";`,
+		`"type": "chatgpt";`,
+		`"codexStreamlinedLogin"?: boolean;`,
+		`"useHostedLoginSuccessPage"?: boolean;`,
+		`"appBrand"?: LoginAppBrand | null;`,
+		`"type": "chatgptDeviceCode";`,
+		`"type": "chatgptAuthTokens";`,
+		`"chatgptPlanType"?: string | null;`,
+		`"type": "amazonBedrock";`,
+		`export type LoginAccountResponse = {`,
+		`"authUrl": string;`,
+		`"verificationUrl": string;`,
+		`"userCode": string;`,
+	} {
+		if !strings.Contains(source, want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}
+
+func loginAccountSchemaVariants(t *testing.T, definition any, wantCount int) map[string]Schema {
+	t.Helper()
+	schema, ok := definition.(Schema)
+	if !ok {
+		t.Fatalf("definition type = %T", definition)
+	}
+	oneOf, ok := schema["oneOf"].([]any)
+	if !ok || len(oneOf) != wantCount {
+		t.Fatalf("oneOf = %#v, want %d variants", schema["oneOf"], wantCount)
+	}
+	variants := make(map[string]Schema, wantCount)
+	for _, raw := range oneOf {
+		variant := raw.(Schema)
+		if variant["type"] != "object" || variant["additionalProperties"] != false {
+			t.Fatalf("variant is not a closed object: %#v", variant)
+		}
+		properties := variant["properties"].(Schema)
+		typeSchema := properties["type"].(Schema)
+		values := typeSchema["enum"].([]any)
+		if len(values) != 1 {
+			t.Fatalf("variant type = %#v", typeSchema)
+		}
+		kind := values[0].(string)
+		if _, exists := variants[kind]; exists {
+			t.Fatalf("duplicate schema variant %q", kind)
+		}
+		variants[kind] = variant
+	}
+	return variants
+}
+
+func assertLoginAccountVariantRequired(t *testing.T, variants map[string]Schema, want map[string][]string) {
+	t.Helper()
+	if len(variants) != len(want) {
+		t.Fatalf("variants = %v, want %v", variants, want)
+	}
+	for kind, required := range want {
+		variant, ok := variants[kind]
+		if !ok {
+			t.Errorf("missing variant %q", kind)
+			continue
+		}
+		got := schemaRequiredNames(variant)
+		slices.Sort(got)
+		wantRequired := append([]string(nil), required...)
+		slices.Sort(wantRequired)
+		if !slices.Equal(got, wantRequired) {
+			t.Errorf("%s required = %v, want %v", kind, got, wantRequired)
+		}
+	}
+}
+
+func assertLoginAccountNullableSchema(t *testing.T, raw any, wantValue Schema) {
+	t.Helper()
+	schema := raw.(Schema)
+	variants := schema["anyOf"].([]any)
+	if len(variants) != 2 ||
+		!reflect.DeepEqual(variants[0], wantValue) ||
+		!reflect.DeepEqual(variants[1], Schema{"type": "null"}) {
+		t.Fatalf("nullable schema = %#v, want %#v or null", schema, wantValue)
+	}
+}
+
+var (
+	_ json.Marshaler   = LoginAccountParams{}
+	_ json.Unmarshaler = (*LoginAccountParams)(nil)
+	_ json.Marshaler   = LoginAccountResponse{}
+	_ json.Unmarshaler = (*LoginAccountResponse)(nil)
+)

--- a/appserver/protocol/login_account_types.go
+++ b/appserver/protocol/login_account_types.go
@@ -1,0 +1,429 @@
+package protocol
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// LoginAccountParams is the exact public login-start request union. It remains
+// standalone until Gollem implements the account/login/start method itself.
+type LoginAccountParams struct{ raw json.RawMessage }
+
+// LoginAccountResponse is the exact public login-start response union. It
+// remains standalone from Gollem's account and credential runtime.
+type LoginAccountResponse struct{ raw json.RawMessage }
+
+func (p LoginAccountParams) MarshalJSON() ([]byte, error) {
+	if len(p.raw) == 0 {
+		return nil, errors.New("login account params are empty")
+	}
+	return validateLoginAccountParamsJSON(p.raw)
+}
+
+func (p *LoginAccountParams) UnmarshalJSON(data []byte) error {
+	if p == nil {
+		return errors.New("decode login account params into nil receiver")
+	}
+	canonical, err := validateLoginAccountParamsJSON(data)
+	if err != nil {
+		return err
+	}
+	p.raw = canonical
+	return nil
+}
+
+// Type returns the request union's public discriminant, or an empty string for
+// an uninitialized or invalid internal value.
+func (p LoginAccountParams) Type() string {
+	return loginAccountDiscriminant(p.raw)
+}
+
+func (r LoginAccountResponse) MarshalJSON() ([]byte, error) {
+	if len(r.raw) == 0 {
+		return nil, errors.New("login account response is empty")
+	}
+	return validateLoginAccountResponseJSON(r.raw)
+}
+
+func (r *LoginAccountResponse) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("decode login account response into nil receiver")
+	}
+	canonical, err := validateLoginAccountResponseJSON(data)
+	if err != nil {
+		return err
+	}
+	r.raw = canonical
+	return nil
+}
+
+// Type returns the response union's public discriminant, or an empty string
+// for an uninitialized or invalid internal value.
+func (r LoginAccountResponse) Type() string {
+	return loginAccountDiscriminant(r.raw)
+}
+
+func validateLoginAccountParamsJSON(data []byte) ([]byte, error) {
+	payload, err := decodeLoginAccountObject(data, "login account params")
+	if err != nil {
+		return nil, err
+	}
+	typeName, err := decodeRequiredThreadItemValue[string](payload, "login account params", "type")
+	if err != nil {
+		return nil, err
+	}
+
+	switch typeName {
+	case "apiKey":
+		if err := requireLoginAccountVariantFields(payload, typeName, "type", "apiKey"); err != nil {
+			return nil, err
+		}
+		apiKey, err := decodeRequiredThreadItemValue[string](payload, "apiKey login account params", "apiKey")
+		if err != nil {
+			return nil, err
+		}
+		return json.Marshal(struct {
+			Type string `json:"type"`
+			//nolint:gosec // APIKey is the required public wire field name.
+			APIKey string `json:"apiKey"`
+		}{Type: typeName, APIKey: apiKey})
+	case "chatgpt":
+		if err := requireLoginAccountVariantFields(
+			payload,
+			typeName,
+			"type",
+			"codexStreamlinedLogin",
+			"useHostedLoginSuccessPage",
+			"appBrand",
+		); err != nil {
+			return nil, err
+		}
+		streamlined, err := decodeOptionalLoginAccountBool(
+			payload, "chatgpt login account params", "codexStreamlinedLogin",
+		)
+		if err != nil {
+			return nil, err
+		}
+		hostedSuccessPage, err := decodeOptionalLoginAccountBool(
+			payload, "chatgpt login account params", "useHostedLoginSuccessPage",
+		)
+		if err != nil {
+			return nil, err
+		}
+		appBrand, err := decodeNullableLoginAccountValue[LoginAppBrand](
+			payload, "chatgpt login account params", "appBrand",
+		)
+		if err != nil {
+			return nil, err
+		}
+		return json.Marshal(struct {
+			Type                      string         `json:"type"`
+			CodexStreamlinedLogin     bool           `json:"codexStreamlinedLogin,omitempty"`
+			UseHostedLoginSuccessPage bool           `json:"useHostedLoginSuccessPage,omitempty"`
+			AppBrand                  *LoginAppBrand `json:"appBrand"`
+		}{
+			Type:                      typeName,
+			CodexStreamlinedLogin:     streamlined,
+			UseHostedLoginSuccessPage: hostedSuccessPage,
+			AppBrand:                  appBrand,
+		})
+	case "chatgptDeviceCode":
+		if err := requireLoginAccountVariantFields(payload, typeName, "type"); err != nil {
+			return nil, err
+		}
+		return marshalLoginAccountType(typeName)
+	case "chatgptAuthTokens":
+		if err := requireLoginAccountVariantFields(
+			payload,
+			typeName,
+			"type",
+			"accessToken",
+			"chatgptAccountId",
+			"chatgptPlanType",
+		); err != nil {
+			return nil, err
+		}
+		accessToken, err := decodeRequiredThreadItemValue[string](
+			payload, "chatgptAuthTokens login account params", "accessToken",
+		)
+		if err != nil {
+			return nil, err
+		}
+		accountID, err := decodeRequiredThreadItemValue[string](
+			payload, "chatgptAuthTokens login account params", "chatgptAccountId",
+		)
+		if err != nil {
+			return nil, err
+		}
+		planType, err := decodeNullableLoginAccountValue[string](
+			payload, "chatgptAuthTokens login account params", "chatgptPlanType",
+		)
+		if err != nil {
+			return nil, err
+		}
+		return json.Marshal(struct {
+			Type string `json:"type"`
+			//nolint:gosec // AccessToken is the required public wire field name.
+			AccessToken      string  `json:"accessToken"`
+			ChatGPTAccountID string  `json:"chatgptAccountId"`
+			ChatGPTPlanType  *string `json:"chatgptPlanType"`
+		}{
+			Type:             typeName,
+			AccessToken:      accessToken,
+			ChatGPTAccountID: accountID,
+			ChatGPTPlanType:  planType,
+		})
+	case "amazonBedrock":
+		if err := requireLoginAccountVariantFields(payload, typeName, "type", "apiKey", "region"); err != nil {
+			return nil, err
+		}
+		apiKey, err := decodeRequiredThreadItemValue[string](
+			payload, "amazonBedrock login account params", "apiKey",
+		)
+		if err != nil {
+			return nil, err
+		}
+		region, err := decodeRequiredThreadItemValue[string](
+			payload, "amazonBedrock login account params", "region",
+		)
+		if err != nil {
+			return nil, err
+		}
+		return json.Marshal(struct {
+			Type string `json:"type"`
+			//nolint:gosec // APIKey is the required public wire field name.
+			APIKey string `json:"apiKey"`
+			Region string `json:"region"`
+		}{Type: typeName, APIKey: apiKey, Region: region})
+	default:
+		return nil, fmt.Errorf("unsupported login account params type %q", typeName)
+	}
+}
+
+func validateLoginAccountResponseJSON(data []byte) ([]byte, error) {
+	payload, err := decodeLoginAccountObject(data, "login account response")
+	if err != nil {
+		return nil, err
+	}
+	typeName, err := decodeRequiredThreadItemValue[string](payload, "login account response", "type")
+	if err != nil {
+		return nil, err
+	}
+
+	switch typeName {
+	case "apiKey", "chatgptAuthTokens", "amazonBedrock":
+		if err := requireLoginAccountVariantFields(payload, typeName, "type"); err != nil {
+			return nil, err
+		}
+		return marshalLoginAccountType(typeName)
+	case "chatgpt":
+		if err := requireLoginAccountVariantFields(payload, typeName, "type", "loginId", "authUrl"); err != nil {
+			return nil, err
+		}
+		loginID, err := decodeRequiredThreadItemValue[string](
+			payload, "chatgpt login account response", "loginId",
+		)
+		if err != nil {
+			return nil, err
+		}
+		authURL, err := decodeRequiredThreadItemValue[string](
+			payload, "chatgpt login account response", "authUrl",
+		)
+		if err != nil {
+			return nil, err
+		}
+		return json.Marshal(struct {
+			Type    string `json:"type"`
+			LoginID string `json:"loginId"`
+			AuthURL string `json:"authUrl"`
+		}{Type: typeName, LoginID: loginID, AuthURL: authURL})
+	case "chatgptDeviceCode":
+		if err := requireLoginAccountVariantFields(
+			payload,
+			typeName,
+			"type",
+			"loginId",
+			"verificationUrl",
+			"userCode",
+		); err != nil {
+			return nil, err
+		}
+		loginID, err := decodeRequiredThreadItemValue[string](
+			payload, "chatgptDeviceCode login account response", "loginId",
+		)
+		if err != nil {
+			return nil, err
+		}
+		verificationURL, err := decodeRequiredThreadItemValue[string](
+			payload, "chatgptDeviceCode login account response", "verificationUrl",
+		)
+		if err != nil {
+			return nil, err
+		}
+		userCode, err := decodeRequiredThreadItemValue[string](
+			payload, "chatgptDeviceCode login account response", "userCode",
+		)
+		if err != nil {
+			return nil, err
+		}
+		return json.Marshal(struct {
+			Type            string `json:"type"`
+			LoginID         string `json:"loginId"`
+			VerificationURL string `json:"verificationUrl"`
+			UserCode        string `json:"userCode"`
+		}{
+			Type:            typeName,
+			LoginID:         loginID,
+			VerificationURL: verificationURL,
+			UserCode:        userCode,
+		})
+	default:
+		return nil, fmt.Errorf("unsupported login account response type %q", typeName)
+	}
+}
+
+func decodeLoginAccountObject(data []byte, objectName string) (map[string]json.RawMessage, error) {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	opening, err := decoder.Token()
+	if err != nil {
+		return nil, fmt.Errorf("decode %s: %w", objectName, err)
+	}
+	if opening != json.Delim('{') {
+		return nil, fmt.Errorf("%s must be an object", objectName)
+	}
+
+	payload := make(map[string]json.RawMessage, 9)
+	seen := make(map[string]bool, 9)
+	for decoder.More() {
+		token, err := decoder.Token()
+		if err != nil {
+			return nil, fmt.Errorf("decode %s field name: %w", objectName, err)
+		}
+		name := token.(string)
+		var raw json.RawMessage
+		if err := decoder.Decode(&raw); err != nil {
+			return nil, fmt.Errorf("decode %s field %q: %w", objectName, name, err)
+		}
+		if !isLoginAccountKnownField(name) {
+			continue
+		}
+		if seen[name] {
+			return nil, fmt.Errorf("duplicate %s field %q", objectName, name)
+		}
+		seen[name] = true
+		payload[name] = append(json.RawMessage(nil), raw...)
+	}
+	if _, err := decoder.Token(); err != nil {
+		return nil, fmt.Errorf("decode %s: %w", objectName, err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return nil, fmt.Errorf("%s must contain one JSON value", objectName)
+		}
+		return nil, fmt.Errorf("decode %s trailing value: %w", objectName, err)
+	}
+	return payload, nil
+}
+
+func isLoginAccountKnownField(name string) bool {
+	switch name {
+	case "type",
+		"apiKey",
+		"codexStreamlinedLogin",
+		"useHostedLoginSuccessPage",
+		"appBrand",
+		"accessToken",
+		"chatgptAccountId",
+		"chatgptPlanType",
+		"region",
+		"loginId",
+		"authUrl",
+		"verificationUrl",
+		"userCode":
+		return true
+	default:
+		return false
+	}
+}
+
+func requireLoginAccountVariantFields(
+	payload map[string]json.RawMessage,
+	typeName string,
+	allowed ...string,
+) error {
+	for name := range payload {
+		accepted := false
+		for _, candidate := range allowed {
+			if name == candidate {
+				accepted = true
+				break
+			}
+		}
+		if !accepted {
+			return fmt.Errorf("login account %s variant does not accept field %q", typeName, name)
+		}
+	}
+	return nil
+}
+
+func decodeOptionalLoginAccountBool(
+	payload map[string]json.RawMessage,
+	objectName string,
+	fieldName string,
+) (bool, error) {
+	raw, ok := payload[fieldName]
+	if !ok {
+		return false, nil
+	}
+	if isJSONNull(raw) {
+		return false, fmt.Errorf("%s %s must be a boolean", objectName, fieldName)
+	}
+	var value bool
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return false, fmt.Errorf("decode %s %s: %w", objectName, fieldName, err)
+	}
+	return value, nil
+}
+
+func decodeNullableLoginAccountValue[T any](
+	payload map[string]json.RawMessage,
+	objectName string,
+	fieldName string,
+) (*T, error) {
+	raw, ok := payload[fieldName]
+	if !ok || isJSONNull(raw) {
+		return nil, nil
+	}
+	var value T
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return nil, fmt.Errorf("decode %s %s: %w", objectName, fieldName, err)
+	}
+	return &value, nil
+}
+
+func marshalLoginAccountType(typeName string) ([]byte, error) {
+	return json.Marshal(struct {
+		Type string `json:"type"`
+	}{Type: typeName})
+}
+
+func loginAccountDiscriminant(data json.RawMessage) string {
+	var value struct {
+		Type string `json:"type"`
+	}
+	if json.Unmarshal(data, &value) != nil {
+		return ""
+	}
+	return value.Type
+}
+
+var (
+	_ json.Marshaler   = LoginAccountParams{}
+	_ json.Unmarshaler = (*LoginAccountParams)(nil)
+	_ json.Marshaler   = LoginAccountResponse{}
+	_ json.Unmarshaler = (*LoginAccountResponse)(nil)
+)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
-		t.Fatalf("definition count = %d, want 365", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 367 {
+		t.Fatalf("definition count = %d, want 367", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
-		t.Fatalf("definition count = %d, want 365", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 367 {
+		t.Fatalf("definition count = %d, want 367", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
-		t.Fatalf("definition count = %d, want 365", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 367 {
+		t.Fatalf("definition count = %d, want 367", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
-		t.Fatalf("definition count = %d, want 365", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 367 {
+		t.Fatalf("definition count = %d, want 367", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
-		t.Fatalf("definition count = %d, want 365", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 367 {
+		t.Fatalf("definition count = %d, want 367", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
-		t.Fatalf("definition count = %d, want 365", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 367 {
+		t.Fatalf("definition count = %d, want 367", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
-		t.Fatalf("definition count = %d, want 365", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 367 {
+		t.Fatalf("definition count = %d, want 367", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
-		t.Fatalf("definition count = %d, want 365", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 367 {
+		t.Fatalf("definition count = %d, want 367", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
-		t.Fatalf("definition count = %d, want 365", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 367 {
+		t.Fatalf("definition count = %d, want 367", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
-		t.Fatalf("definition count = %d, want 365", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 367 {
+		t.Fatalf("definition count = %d, want 367", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 365 {
-		t.Fatalf("definition count = %d, want 365", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 367 {
+		t.Fatalf("definition count = %d, want 367", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 365 {
-		t.Fatalf("definition count = %d, want 365", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 367 {
+		t.Fatalf("definition count = %d, want 367", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 365 {
-		t.Fatalf("definition count = %d, want 365", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 367 {
+		t.Fatalf("definition count = %d, want 367", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 365 {
-		t.Fatalf("definition count = %d, want 365", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 367 {
+		t.Fatalf("definition count = %d, want 367", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 365 {
-		t.Fatalf("definition count = %d, want 365", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 367 {
+		t.Fatalf("definition count = %d, want 367", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -219,6 +219,8 @@ func wireSchemaDefinitions() Schema {
 		{Name: "ItemLifecycleNotificationParams", Type: reflect.TypeFor[ItemLifecycleNotificationParams]()},
 		{Name: "ItemStartedNotification", Type: reflect.TypeFor[ItemStartedNotification]()},
 		{Name: "LegacyAppPathString", Type: reflect.TypeFor[LegacyAppPathString]()},
+		{Name: "LoginAccountParams", Type: reflect.TypeFor[LoginAccountParams]()},
+		{Name: "LoginAccountResponse", Type: reflect.TypeFor[LoginAccountResponse]()},
 		{Name: "LoginAppBrand", Type: reflect.TypeFor[LoginAppBrand]()},
 		{Name: "LocalShellAction", Type: reflect.TypeFor[LocalShellAction]()},
 		{Name: "LocalShellStatus", Type: reflect.TypeFor[LocalShellStatus]()},
@@ -497,6 +499,8 @@ func wireSchemaDefinitions() Schema {
 		string(LoginAppBrandCodex),
 		string(LoginAppBrandChatGPT),
 	)
+	schemas["LoginAccountParams"] = loginAccountParamsSchema()
+	schemas["LoginAccountResponse"] = loginAccountResponseSchema()
 	schemas["ReasoningEffort"] = Schema{"type": "string", "minLength": 1}
 	schemas["ResidencyRequirement"] = stringEnumSchema(string(ResidencyRequirementUS))
 	schemas["WebSearchMode"] = stringEnumSchema(
@@ -827,6 +831,123 @@ func wireSchemaDefinitions() Schema {
 		string(TurnLifecycleFailed), string(TurnLifecycleInterrupted),
 	)
 	return schemas
+}
+
+func loginAccountParamsSchema() Schema {
+	return Schema{"oneOf": []any{
+		loginAccountVariantSchema(
+			"apiKey",
+			[]string{"apiKey", "type"},
+			Schema{"apiKey": Schema{"type": "string"}},
+		),
+		loginAccountVariantSchema(
+			"chatgpt",
+			[]string{"type"},
+			Schema{
+				"codexStreamlinedLogin":     Schema{"type": "boolean"},
+				"useHostedLoginSuccessPage": Schema{"type": "boolean"},
+				"appBrand": Schema{
+					"anyOf": []any{
+						Schema{"$ref": "#/$defs/LoginAppBrand"},
+						Schema{"type": "null"},
+					},
+					"default": nil,
+				},
+			},
+		),
+		loginAccountVariantSchema("chatgptDeviceCode", []string{"type"}, nil),
+		loginAccountVariantSchema(
+			"chatgptAuthTokens",
+			[]string{"accessToken", "chatgptAccountId", "type"},
+			Schema{
+				"accessToken": Schema{
+					"type": "string",
+					"description": "Access token (JWT) supplied by the client. " +
+						"This token is used for backend API requests and email extraction.",
+				},
+				"chatgptAccountId": Schema{
+					"type":        "string",
+					"description": "Workspace/account identifier supplied by the client.",
+				},
+				"chatgptPlanType": Schema{
+					"anyOf": []any{Schema{"type": "string"}, Schema{"type": "null"}},
+					"description": "Optional plan type supplied by the client.\n\n" +
+						"When `null`, Codex attempts to derive the plan type from access-token " +
+						"claims. If unavailable, the plan defaults to `unknown`.",
+				},
+			},
+			"[UNSTABLE] FOR OPENAI INTERNAL USE ONLY - DO NOT USE. "+
+				"The access token must contain the same scopes that Codex-managed ChatGPT auth tokens have.",
+		),
+		loginAccountVariantSchema(
+			"amazonBedrock",
+			[]string{"apiKey", "region", "type"},
+			Schema{
+				"apiKey": Schema{"type": "string"},
+				"region": Schema{"type": "string"},
+			},
+			"[UNSTABLE] Managed Amazon Bedrock login is experimental.",
+		),
+	}}
+}
+
+func loginAccountResponseSchema() Schema {
+	return Schema{"oneOf": []any{
+		loginAccountVariantSchema("apiKey", []string{"type"}, nil),
+		loginAccountVariantSchema(
+			"chatgpt",
+			[]string{"authUrl", "loginId", "type"},
+			Schema{
+				"loginId": Schema{"type": "string"},
+				"authUrl": Schema{
+					"type":        "string",
+					"description": "URL the client should open in a browser to initiate the OAuth flow.",
+				},
+			},
+		),
+		loginAccountVariantSchema(
+			"chatgptDeviceCode",
+			[]string{"loginId", "type", "userCode", "verificationUrl"},
+			Schema{
+				"loginId": Schema{"type": "string"},
+				"verificationUrl": Schema{
+					"type": "string",
+					"description": "URL the client should open in a browser to complete " +
+						"device code authorization.",
+				},
+				"userCode": Schema{
+					"type":        "string",
+					"description": "One-time code the user must enter after signing in.",
+				},
+			},
+		),
+		loginAccountVariantSchema("chatgptAuthTokens", []string{"type"}, nil),
+		loginAccountVariantSchema("amazonBedrock", []string{"type"}, nil),
+	}}
+}
+
+func loginAccountVariantSchema(
+	typeName string,
+	required []string,
+	fields Schema,
+	description ...string,
+) Schema {
+	properties := Schema{
+		"type": Schema{"type": "string", "enum": []any{typeName}},
+	}
+	for name, schema := range fields {
+		properties[name] = schema
+	}
+	variant := Schema{
+		"type":                 "object",
+		"properties":           properties,
+		"required":             required,
+		"additionalProperties": false,
+	}
+	if len(description) > 0 {
+		variant["description"] = description[0]
+	}
+	return variant
 }
 
 func codexErrorInfoSchema() Schema {

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -4550,6 +4550,239 @@
       ],
       "type": "string"
     },
+    "LoginAccountParams": {
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "apiKey": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "apiKey"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "apiKey",
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "appBrand": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LoginAppBrand"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null
+            },
+            "codexStreamlinedLogin": {
+              "type": "boolean"
+            },
+            "type": {
+              "enum": [
+                "chatgpt"
+              ],
+              "type": "string"
+            },
+            "useHostedLoginSuccessPage": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "enum": [
+                "chatgptDeviceCode"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "[UNSTABLE] FOR OPENAI INTERNAL USE ONLY - DO NOT USE. The access token must contain the same scopes that Codex-managed ChatGPT auth tokens have.",
+          "properties": {
+            "accessToken": {
+              "description": "Access token (JWT) supplied by the client. This token is used for backend API requests and email extraction.",
+              "type": "string"
+            },
+            "chatgptAccountId": {
+              "description": "Workspace/account identifier supplied by the client.",
+              "type": "string"
+            },
+            "chatgptPlanType": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Optional plan type supplied by the client.\n\nWhen `null`, Codex attempts to derive the plan type from access-token claims. If unavailable, the plan defaults to `unknown`."
+            },
+            "type": {
+              "enum": [
+                "chatgptAuthTokens"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "accessToken",
+            "chatgptAccountId",
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "[UNSTABLE] Managed Amazon Bedrock login is experimental.",
+          "properties": {
+            "apiKey": {
+              "type": "string"
+            },
+            "region": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "amazonBedrock"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "apiKey",
+            "region",
+            "type"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "LoginAccountResponse": {
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "enum": [
+                "apiKey"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "authUrl": {
+              "description": "URL the client should open in a browser to initiate the OAuth flow.",
+              "type": "string"
+            },
+            "loginId": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "chatgpt"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "authUrl",
+            "loginId",
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "loginId": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "chatgptDeviceCode"
+              ],
+              "type": "string"
+            },
+            "userCode": {
+              "description": "One-time code the user must enter after signing in.",
+              "type": "string"
+            },
+            "verificationUrl": {
+              "description": "URL the client should open in a browser to complete device code authorization.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "loginId",
+            "type",
+            "userCode",
+            "verificationUrl"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "enum": [
+                "chatgptAuthTokens"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "enum": [
+                "amazonBedrock"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        }
+      ]
+    },
     "LoginAppBrand": {
       "enum": [
         "codex",

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 365 {
-		t.Fatalf("definition count = %d, want 365", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 367 {
+		t.Fatalf("definition count = %d, want 367", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
-		t.Fatalf("definition count = %d, want 365", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 367 {
+		t.Fatalf("definition count = %d, want 367", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
-		t.Fatalf("definition count = %d, want 365", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 367 {
+		t.Fatalf("definition count = %d, want 367", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
-		t.Fatalf("definition count = %d, want 365", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 367 {
+		t.Fatalf("definition count = %d, want 367", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
-		t.Fatalf("definition count = %d, want 365", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 367 {
+		t.Fatalf("definition count = %d, want 367", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
-		t.Fatalf("definition count = %d, want 365", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 367 {
+		t.Fatalf("definition count = %d, want 367", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 365 {
-		t.Fatalf("definition count = %d, want 365", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 367 {
+		t.Fatalf("definition count = %d, want 367", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 365 {
-		t.Fatalf("definition count = %d, want 365", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 367 {
+		t.Fatalf("definition count = %d, want 367", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
-		t.Fatalf("definition count = %d, want 365", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 367 {
+		t.Fatalf("definition count = %d, want 367", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
-		t.Fatalf("definition count = %d, want 365", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 367 {
+		t.Fatalf("definition count = %d, want 367", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
-		t.Fatalf("definition count = %d, want 365", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 367 {
+		t.Fatalf("definition count = %d, want 367", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
-		t.Fatalf("definition count = %d, want 365", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 367 {
+		t.Fatalf("definition count = %d, want 367", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -1465,6 +1465,44 @@ export type LocalShellAction = {
 
 export type LocalShellStatus = "completed" | "in_progress" | "incomplete";
 
+export type LoginAccountParams = {
+  "apiKey": string;
+  "type": "apiKey";
+} | {
+  "appBrand"?: LoginAppBrand | null;
+  "codexStreamlinedLogin"?: boolean;
+  "type": "chatgpt";
+  "useHostedLoginSuccessPage"?: boolean;
+} | {
+  "type": "chatgptDeviceCode";
+} | {
+  "accessToken": string;
+  "chatgptAccountId": string;
+  "chatgptPlanType"?: string | null;
+  "type": "chatgptAuthTokens";
+} | {
+  "apiKey": string;
+  "region": string;
+  "type": "amazonBedrock";
+};
+
+export type LoginAccountResponse = {
+  "type": "apiKey";
+} | {
+  "authUrl": string;
+  "loginId": string;
+  "type": "chatgpt";
+} | {
+  "loginId": string;
+  "type": "chatgptDeviceCode";
+  "userCode": string;
+  "verificationUrl": string;
+} | {
+  "type": "chatgptAuthTokens";
+} | {
+  "type": "amazonBedrock";
+};
+
 export type LoginAppBrand = "codex" | "chatgpt";
 
 export type MCPContent = {

--- a/appserver/protocol/typescript/testdata/login_account_contract.ts
+++ b/appserver/protocol/typescript/testdata/login_account_contract.ts
@@ -1,0 +1,124 @@
+import type {
+  LoginAccountParams,
+  LoginAccountResponse,
+  LoginAppBrand,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? (<T>() => T extends B ? 1 : 2) extends
+        (<T>() => T extends A ? 1 : 2)
+      ? true
+      : false
+    : false;
+type Expect<T extends true> = T;
+
+type ExpectedParams =
+  | { type: "apiKey"; apiKey: string }
+  | {
+      type: "chatgpt";
+      codexStreamlinedLogin?: boolean;
+      useHostedLoginSuccessPage?: boolean;
+      appBrand?: LoginAppBrand | null;
+    }
+  | { type: "chatgptDeviceCode" }
+  | {
+      type: "chatgptAuthTokens";
+      accessToken: string;
+      chatgptAccountId: string;
+      chatgptPlanType?: string | null;
+    }
+  | { type: "amazonBedrock"; apiKey: string; region: string };
+
+type ExpectedResponse =
+  | { type: "apiKey" }
+  | { type: "chatgpt"; loginId: string; authUrl: string }
+  | {
+      type: "chatgptDeviceCode";
+      loginId: string;
+      verificationUrl: string;
+      userCode: string;
+    }
+  | { type: "chatgptAuthTokens" }
+  | { type: "amazonBedrock" };
+
+type ParamsContract = Expect<Equal<LoginAccountParams, ExpectedParams>>;
+type ResponseContract = Expect<Equal<LoginAccountResponse, ExpectedResponse>>;
+
+export const apiKey = { type: "apiKey", apiKey: "" } satisfies LoginAccountParams;
+export const chatgpt = { type: "chatgpt" } satisfies LoginAccountParams;
+export const chatgptFull = {
+  type: "chatgpt",
+  codexStreamlinedLogin: false,
+  useHostedLoginSuccessPage: true,
+  appBrand: null,
+} satisfies LoginAccountParams;
+export const deviceCode = { type: "chatgptDeviceCode" } satisfies LoginAccountParams;
+export const authTokens = {
+  type: "chatgptAuthTokens",
+  accessToken: "",
+  chatgptAccountId: "",
+  chatgptPlanType: null,
+} satisfies LoginAccountParams;
+export const bedrock = {
+  type: "amazonBedrock",
+  apiKey: "",
+  region: "",
+} satisfies LoginAccountParams;
+
+export const apiKeyResponse = { type: "apiKey" } satisfies LoginAccountResponse;
+export const chatgptResponse = {
+  type: "chatgpt",
+  loginId: "",
+  authUrl: "",
+} satisfies LoginAccountResponse;
+export const deviceCodeResponse = {
+  type: "chatgptDeviceCode",
+  loginId: "",
+  verificationUrl: "",
+  userCode: "",
+} satisfies LoginAccountResponse;
+export const authTokensResponse = { type: "chatgptAuthTokens" } satisfies LoginAccountResponse;
+export const bedrockResponse = { type: "amazonBedrock" } satisfies LoginAccountResponse;
+
+// @ts-expect-error request discriminants are closed and case-sensitive.
+export const rejectRequestType = { type: "chatGPT" } satisfies LoginAccountParams;
+// @ts-expect-error API key requests require apiKey.
+export const rejectMissingApiKey = { type: "apiKey" } satisfies LoginAccountParams;
+// @ts-expect-error API keys are non-null strings.
+export const rejectNullApiKey = { type: "apiKey", apiKey: null } satisfies LoginAccountParams;
+// @ts-expect-error ChatGPT booleans are non-null.
+export const rejectNullBoolean = { type: "chatgpt", codexStreamlinedLogin: null } satisfies LoginAccountParams;
+// @ts-expect-error appBrand is a closed enum.
+export const rejectAppBrand = { type: "chatgpt", appBrand: "Codex" } satisfies LoginAccountParams;
+// @ts-expect-error variant fields cannot cross into ChatGPT requests.
+export const rejectCrossedChatgpt = { type: "chatgpt", apiKey: "key" } satisfies LoginAccountParams;
+// @ts-expect-error device-code requests are closed.
+export const rejectDeviceExtension = { type: "chatgptDeviceCode", appBrand: "codex" } satisfies LoginAccountParams;
+// @ts-expect-error auth-token requests require an access token.
+export const rejectMissingAccessToken = { type: "chatgptAuthTokens", chatgptAccountId: "account" } satisfies LoginAccountParams;
+// @ts-expect-error account ids are non-null strings.
+export const rejectNullAccountId = { type: "chatgptAuthTokens", accessToken: "token", chatgptAccountId: null } satisfies LoginAccountParams;
+// @ts-expect-error plan type is a nullable string.
+export const rejectNumericPlan = { type: "chatgptAuthTokens", accessToken: "token", chatgptAccountId: "account", chatgptPlanType: 1 } satisfies LoginAccountParams;
+// @ts-expect-error Bedrock requests require region.
+export const rejectMissingRegion = { type: "amazonBedrock", apiKey: "key" } satisfies LoginAccountParams;
+// @ts-expect-error request variants are closed.
+export const rejectRequestExtension = { type: "amazonBedrock", apiKey: "key", region: "region", extra: true } satisfies LoginAccountParams;
+
+// @ts-expect-error response discriminants are closed and case-sensitive.
+export const rejectResponseType = { type: "chatGPT" } satisfies LoginAccountResponse;
+// @ts-expect-error ChatGPT responses require loginId.
+export const rejectMissingLoginId = { type: "chatgpt", authUrl: "url" } satisfies LoginAccountResponse;
+// @ts-expect-error authUrl is a non-null string.
+export const rejectNullAuthUrl = { type: "chatgpt", loginId: "id", authUrl: null } satisfies LoginAccountResponse;
+// @ts-expect-error device-code responses require userCode.
+export const rejectMissingUserCode = { type: "chatgptDeviceCode", loginId: "id", verificationUrl: "url" } satisfies LoginAccountResponse;
+// @ts-expect-error verificationUrl is a string.
+export const rejectNumericVerificationUrl = { type: "chatgptDeviceCode", loginId: "id", verificationUrl: 1, userCode: "code" } satisfies LoginAccountResponse;
+// @ts-expect-error empty response variants are closed.
+export const rejectResponseExtension = { type: "chatgptAuthTokens", loginId: "id" } satisfies LoginAccountResponse;
+
+void (null as unknown as ParamsContract);
+void (null as unknown as ResponseContract);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 365 {
-		t.Fatalf("definition count = %d, want 365", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 367 {
+		t.Fatalf("definition count = %d, want 367", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary

- add exact standalone `LoginAccountParams` and `LoginAccountResponse` tagged unions
- preserve Rust-compatible decoding defaults, nullable canonicalization, unknown-field tolerance, and duplicate known-field rejection
- generate closed JSON Schema and TypeScript unions without binding `account/login/start`
- add strict Go and TypeScript contract coverage for all variants and malformed wire forms

## Validation

- `go test ./appserver/protocol -run "^TestLoginAccount" -count=30`
- `go test -race ./appserver/protocol -run "^TestLoginAccount" -count=1`
- focused coverage: 100% for all functions in `login_account_types.go`
- full non-Monty normal and race test matrices
- deterministic generation across two consecutive runs
- `golangci-lint run ./...`
- `go vet ./...`
- `go mod tidy && go mod verify`
- `.githooks/pre-push` with `hooks.skipMontyRace=true`

Local Monty tests were intentionally skipped per project workflow.