### PR TITLE
Add standalone MCP auth status contract

### DIFF
--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 368 {
-		t.Fatalf("definition count = %d, want 368", got)
+	if got := len(defs); got != 369 {
+		t.Fatalf("definition count = %d, want 369", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 368 {
-		t.Fatalf("definition count = %d, want 368", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
+		t.Fatalf("definition count = %d, want 369", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 368 {
-		t.Fatalf("definition count = %d, want 368", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
+		t.Fatalf("definition count = %d, want 369", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 368 {
-		t.Fatalf("definition count = %d, want 368", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
+		t.Fatalf("definition count = %d, want 369", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 368 {
-		t.Fatalf("definition count = %d, want 368", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
+		t.Fatalf("definition count = %d, want 369", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 368 {
-		t.Fatalf("definition count = %d, want 368", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
+		t.Fatalf("definition count = %d, want 369", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 368 {
-		t.Fatalf("definition count = %d, want 368", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
+		t.Fatalf("definition count = %d, want 369", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 368 {
-		t.Fatalf("definition count = %d, want 368", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
+		t.Fatalf("definition count = %d, want 369", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 368 {
-		t.Fatalf("definition count = %d, want 368", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
+		t.Fatalf("definition count = %d, want 369", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 368 {
-		t.Fatalf("definition count = %d, want 368", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
+		t.Fatalf("definition count = %d, want 369", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 368 {
-		t.Fatalf("definition count = %d, want 368", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
+		t.Fatalf("definition count = %d, want 369", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 368 {
-		t.Fatalf("definition count = %d, want 368", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
+		t.Fatalf("definition count = %d, want 369", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 368 {
-		t.Fatalf("definition count = %d, want 368", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
+		t.Fatalf("definition count = %d, want 369", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 368 {
-		t.Fatalf("definition count = %d, want 368", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
+		t.Fatalf("definition count = %d, want 369", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 368 {
-		t.Fatalf("definition count = %d, want 368", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 369 {
+		t.Fatalf("definition count = %d, want 369", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 368 {
-		t.Fatalf("definition count = %d, want 368", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
+		t.Fatalf("definition count = %d, want 369", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 368 {
-		t.Fatalf("definition count = %d, want 368", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
+		t.Fatalf("definition count = %d, want 369", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 368 {
-		t.Fatalf("definition count = %d, want 368", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
+		t.Fatalf("definition count = %d, want 369", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 368 {
-		t.Fatalf("definition count = %d, want 368", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
+		t.Fatalf("definition count = %d, want 369", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -1,0 +1,102 @@
+package protocol
+
+import (
+	"encoding/json"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestMcpAuthStatusSchemaIsExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	assertStringEnum(
+		t,
+		defs["McpAuthStatus"],
+		"unsupported",
+		"notLoggedIn",
+		"bearerToken",
+		"oAuth",
+	)
+}
+
+func TestMcpAuthStatusAcceptsExactValues(t *testing.T) {
+	tests := map[string]McpAuthStatus{
+		`"unsupported"`: McpAuthStatusUnsupported,
+		`"notLoggedIn"`: McpAuthStatusNotLoggedIn,
+		`"bearerToken"`: McpAuthStatusBearerToken,
+		`"oAuth"`:       McpAuthStatusOAuth,
+	}
+	for input, want := range tests {
+		var status McpAuthStatus
+		if err := json.Unmarshal([]byte(input), &status); err != nil {
+			t.Fatalf("unmarshal McpAuthStatus %s: %v", input, err)
+		}
+		if status != want {
+			t.Fatalf("McpAuthStatus = %q, want %q", status, want)
+		}
+		encoded, err := json.Marshal(status)
+		if err != nil {
+			t.Fatalf("marshal McpAuthStatus %s: %v", input, err)
+		}
+		if got := string(encoded); got != input {
+			t.Fatalf("McpAuthStatus round trip = %s, want %s", got, input)
+		}
+	}
+}
+
+func TestMcpAuthStatusRejectsMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `""`, `"other"`, `"Unsupported"`, `"not_logged_in"`,
+		`"bearer_token"`, `"oauth"`, `"OAuth"`, `1`, `true`, `{}`, `[]`,
+		`"unsupported" {}`, `"oAuth" x`,
+	} {
+		assertJSONRejects[McpAuthStatus](t, input)
+	}
+}
+
+func TestMcpAuthStatusNilReceiverAndInvalidMarshalFailClosed(t *testing.T) {
+	var status *McpAuthStatus
+	if err := status.UnmarshalJSON([]byte(`"unsupported"`)); err == nil {
+		t.Fatal("nil McpAuthStatus receiver succeeded")
+	}
+	if _, err := json.Marshal(McpAuthStatus("")); err == nil {
+		t.Fatal("zero McpAuthStatus marshaled; upstream v2 has no default")
+	}
+	if _, err := json.Marshal(McpAuthStatus("other")); err == nil {
+		t.Fatal("invalid McpAuthStatus marshaled")
+	}
+}
+
+func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
+	for _, binding := range WireTypeBindings() {
+		if slices.Contains(binding.Params, "McpAuthStatus") ||
+			slices.Contains(binding.Result, "McpAuthStatus") {
+			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
+		t.Fatalf("definition count = %d, want 369", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestMcpAuthStatusTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	want := `export type McpAuthStatus = "unsupported" | "notLoggedIn" | "bearerToken" | "oAuth";`
+	if !strings.Contains(string(generated), want) {
+		t.Errorf("generated TypeScript missing %q", want)
+	}
+}
+
+var (
+	_ json.Marshaler   = McpAuthStatus("")
+	_ json.Unmarshaler = (*McpAuthStatus)(nil)
+)

--- a/appserver/protocol/mcp_auth_status_types.go
+++ b/appserver/protocol/mcp_auth_status_types.go
@@ -1,0 +1,34 @@
+package protocol
+
+import "encoding/json"
+
+// McpAuthStatus is the exact closed public MCP authentication status. It is
+// standalone from Gollem's broader MCP status wire and authentication runtime.
+type McpAuthStatus string
+
+const (
+	McpAuthStatusUnsupported McpAuthStatus = "unsupported"
+	McpAuthStatusNotLoggedIn McpAuthStatus = "notLoggedIn"
+	McpAuthStatusBearerToken McpAuthStatus = "bearerToken"
+	McpAuthStatusOAuth       McpAuthStatus = "oAuth"
+)
+
+func (s McpAuthStatus) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(s, "MCP auth status", McpAuthStatus.valid)
+}
+
+func (s *McpAuthStatus) UnmarshalJSON(data []byte) error {
+	return unmarshalThreadTurnLeafEnum(data, s, "MCP auth status", McpAuthStatus.valid)
+}
+
+func (s McpAuthStatus) valid() bool {
+	return s == McpAuthStatusUnsupported ||
+		s == McpAuthStatusNotLoggedIn ||
+		s == McpAuthStatusBearerToken ||
+		s == McpAuthStatusOAuth
+}
+
+var (
+	_ json.Marshaler   = McpAuthStatus("")
+	_ json.Unmarshaler = (*McpAuthStatus)(nil)
+)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 368 {
-		t.Fatalf("definition count = %d, want 368", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
+		t.Fatalf("definition count = %d, want 369", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 368 {
-		t.Fatalf("definition count = %d, want 368", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
+		t.Fatalf("definition count = %d, want 369", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 368 {
-		t.Fatalf("definition count = %d, want 368", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
+		t.Fatalf("definition count = %d, want 369", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 368 {
-		t.Fatalf("definition count = %d, want 368", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
+		t.Fatalf("definition count = %d, want 369", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 368 {
-		t.Fatalf("definition count = %d, want 368", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
+		t.Fatalf("definition count = %d, want 369", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 368 {
-		t.Fatalf("definition count = %d, want 368", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
+		t.Fatalf("definition count = %d, want 369", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 368 {
-		t.Fatalf("definition count = %d, want 368", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
+		t.Fatalf("definition count = %d, want 369", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 368 {
-		t.Fatalf("definition count = %d, want 368", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
+		t.Fatalf("definition count = %d, want 369", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 368 {
-		t.Fatalf("definition count = %d, want 368", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 369 {
+		t.Fatalf("definition count = %d, want 369", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 368 {
-		t.Fatalf("definition count = %d, want 368", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 369 {
+		t.Fatalf("definition count = %d, want 369", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 368 {
-		t.Fatalf("definition count = %d, want 368", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 369 {
+		t.Fatalf("definition count = %d, want 369", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 368 {
-		t.Fatalf("definition count = %d, want 368", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 369 {
+		t.Fatalf("definition count = %d, want 369", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 368 {
-		t.Fatalf("definition count = %d, want 368", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 369 {
+		t.Fatalf("definition count = %d, want 369", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -233,6 +233,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "MCPToolCallItemStartedNotificationParams", Type: reflect.TypeFor[MCPToolCallItemStartedNotificationParams]()},
 		{Name: "MCPToolCallProgressNotificationParams", Type: reflect.TypeFor[MCPToolCallProgressNotificationParams]()},
 		{Name: "MCPToolCallResult", Type: reflect.TypeFor[MCPToolCallResult]()},
+		{Name: "McpAuthStatus", Type: reflect.TypeFor[McpAuthStatus]()},
 		{Name: "McpToolCallAppContext", Type: reflect.TypeFor[McpToolCallAppContext]()},
 		{Name: "McpToolCallResult", Type: reflect.TypeFor[McpToolCallResult]()},
 		{Name: "MemoryCitation", Type: reflect.TypeFor[MemoryCitation]()},
@@ -502,6 +503,10 @@ func wireSchemaDefinitions() Schema {
 	)
 	schemas["LoginAccountParams"] = loginAccountParamsSchema()
 	schemas["LoginAccountResponse"] = loginAccountResponseSchema()
+	schemas["McpAuthStatus"] = stringEnumSchema(
+		string(McpAuthStatusUnsupported), string(McpAuthStatusNotLoggedIn),
+		string(McpAuthStatusBearerToken), string(McpAuthStatusOAuth),
+	)
 	schemas["ReasoningEffort"] = Schema{"type": "string", "minLength": 1}
 	schemas["ResidencyRequirement"] = stringEnumSchema(string(ResidencyRequirementUS))
 	schemas["WebSearchMode"] = stringEnumSchema(

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -5078,6 +5078,15 @@
       ],
       "type": "object"
     },
+    "McpAuthStatus": {
+      "enum": [
+        "unsupported",
+        "notLoggedIn",
+        "bearerToken",
+        "oAuth"
+      ],
+      "type": "string"
+    },
     "McpElicitationArrayType": {
       "enum": [
         "array"

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 368 {
-		t.Fatalf("definition count = %d, want 368", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 369 {
+		t.Fatalf("definition count = %d, want 369", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 368 {
-		t.Fatalf("definition count = %d, want 368", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
+		t.Fatalf("definition count = %d, want 369", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 368 {
-		t.Fatalf("definition count = %d, want 368", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
+		t.Fatalf("definition count = %d, want 369", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 368 {
-		t.Fatalf("definition count = %d, want 368", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
+		t.Fatalf("definition count = %d, want 369", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 368 {
-		t.Fatalf("definition count = %d, want 368", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
+		t.Fatalf("definition count = %d, want 369", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 368 {
-		t.Fatalf("definition count = %d, want 368", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
+		t.Fatalf("definition count = %d, want 369", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 368 {
-		t.Fatalf("definition count = %d, want 368", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 369 {
+		t.Fatalf("definition count = %d, want 369", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 368 {
-		t.Fatalf("definition count = %d, want 368", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 369 {
+		t.Fatalf("definition count = %d, want 369", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 368 {
-		t.Fatalf("definition count = %d, want 368", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
+		t.Fatalf("definition count = %d, want 369", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 368 {
-		t.Fatalf("definition count = %d, want 368", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
+		t.Fatalf("definition count = %d, want 369", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 368 {
-		t.Fatalf("definition count = %d, want 368", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
+		t.Fatalf("definition count = %d, want 369", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 368 {
-		t.Fatalf("definition count = %d, want 368", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
+		t.Fatalf("definition count = %d, want 369", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -1566,6 +1566,8 @@ export type ManagedHooksRequirements = {
   "windowsManagedDir": string | null;
 };
 
+export type McpAuthStatus = "unsupported" | "notLoggedIn" | "bearerToken" | "oAuth";
+
 export type McpElicitationArrayType = "array";
 
 export type McpElicitationBooleanSchema = {

--- a/appserver/protocol/typescript/testdata/mcp_auth_status_contract.ts
+++ b/appserver/protocol/typescript/testdata/mcp_auth_status_contract.ts
@@ -1,0 +1,42 @@
+import type { McpAuthStatus } from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? (<T>() => T extends B ? 1 : 2) extends
+        (<T>() => T extends A ? 1 : 2)
+      ? true
+      : false
+    : false;
+type Expect<T extends true> = T;
+
+type Contract = Expect<
+  Equal<
+    McpAuthStatus,
+    "unsupported" | "notLoggedIn" | "bearerToken" | "oAuth"
+  >
+>;
+
+export const statuses = [
+  "unsupported",
+  "notLoggedIn",
+  "bearerToken",
+  "oAuth",
+] satisfies McpAuthStatus[];
+
+// @ts-expect-error MCP auth statuses are closed.
+export const rejectUnknown = "other" satisfies McpAuthStatus;
+// @ts-expect-error exact lower-camel unsupported spelling is required.
+export const rejectUnsupportedCase = "Unsupported" satisfies McpAuthStatus;
+// @ts-expect-error exact lower-camel not-logged-in spelling is required.
+export const rejectSnakeCase = "not_logged_in" satisfies McpAuthStatus;
+// @ts-expect-error exact mixed-case OAuth spelling is required.
+export const rejectOAuthCase = "oauth" satisfies McpAuthStatus;
+// @ts-expect-error empty strings are not MCP auth statuses.
+export const rejectEmpty = "" satisfies McpAuthStatus;
+// @ts-expect-error MCP auth statuses are non-null.
+export const rejectNull = null satisfies McpAuthStatus;
+// @ts-expect-error MCP auth statuses are strings.
+export const rejectNumber = 1 satisfies McpAuthStatus;
+
+void (null as unknown as Contract);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 368 {
-		t.Fatalf("definition count = %d, want 368", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
+		t.Fatalf("definition count = %d, want 369", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- export exact standalone public `McpAuthStatus` with the four lower-camel wire values
- generate the exact JSON Schema and TypeScript union without adding a default
- keep the broader live MCP status wire, method bindings, OAuth, credentials, and runtime behavior unchanged

## Verification
- deliberate-red Go and strict TypeScript boundaries
- focused tests x30, focused race, and 100% focused coverage for all new enum functions
- full protocol plus all 59 non-Monty packages under normal and race tests
- deterministic generation twice and strict TypeScript
- lint (0 issues), vet, tidy, and configured pre-push
- exact baseline/feature `mcpServerStatus/list` response comparison
- all five Slang real-process transport workflows

Local Monty normal/race/coverage remained skipped per standing direction; hosted checks are unchanged.