### PR TITLE
Export exact MCP startup status enums

### DIFF
--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 369 {
-		t.Fatalf("definition count = %d, want 369", got)
+	if got := len(defs); got != 371 {
+		t.Fatalf("definition count = %d, want 371", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
-		t.Fatalf("definition count = %d, want 369", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
+		t.Fatalf("definition count = %d, want 371", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
-		t.Fatalf("definition count = %d, want 369", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
+		t.Fatalf("definition count = %d, want 371", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
-		t.Fatalf("definition count = %d, want 369", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
+		t.Fatalf("definition count = %d, want 371", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
-		t.Fatalf("definition count = %d, want 369", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
+		t.Fatalf("definition count = %d, want 371", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
-		t.Fatalf("definition count = %d, want 369", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
+		t.Fatalf("definition count = %d, want 371", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
-		t.Fatalf("definition count = %d, want 369", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
+		t.Fatalf("definition count = %d, want 371", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
-		t.Fatalf("definition count = %d, want 369", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
+		t.Fatalf("definition count = %d, want 371", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
-		t.Fatalf("definition count = %d, want 369", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
+		t.Fatalf("definition count = %d, want 371", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
-		t.Fatalf("definition count = %d, want 369", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
+		t.Fatalf("definition count = %d, want 371", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
-		t.Fatalf("definition count = %d, want 369", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
+		t.Fatalf("definition count = %d, want 371", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
-		t.Fatalf("definition count = %d, want 369", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
+		t.Fatalf("definition count = %d, want 371", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
-		t.Fatalf("definition count = %d, want 369", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
+		t.Fatalf("definition count = %d, want 371", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
-		t.Fatalf("definition count = %d, want 369", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
+		t.Fatalf("definition count = %d, want 371", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 369 {
-		t.Fatalf("definition count = %d, want 369", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 371 {
+		t.Fatalf("definition count = %d, want 371", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
-		t.Fatalf("definition count = %d, want 369", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
+		t.Fatalf("definition count = %d, want 371", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
-		t.Fatalf("definition count = %d, want 369", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
+		t.Fatalf("definition count = %d, want 371", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
-		t.Fatalf("definition count = %d, want 369", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
+		t.Fatalf("definition count = %d, want 371", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
-		t.Fatalf("definition count = %d, want 369", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
+		t.Fatalf("definition count = %d, want 371", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
-		t.Fatalf("definition count = %d, want 369", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
+		t.Fatalf("definition count = %d, want 371", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -1,0 +1,150 @@
+package protocol
+
+import (
+	"encoding/json"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestMcpServerStartupStatusSchemasAreExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	assertStringEnum(
+		t,
+		defs["McpServerStartupFailureReason"],
+		"reauthenticationRequired",
+	)
+	assertStringEnum(
+		t,
+		defs["McpServerStartupState"],
+		"starting",
+		"ready",
+		"failed",
+		"cancelled",
+	)
+}
+
+func TestMcpServerStartupFailureReasonAcceptsExactValue(t *testing.T) {
+	const input = `"reauthenticationRequired"`
+	var reason McpServerStartupFailureReason
+	if err := json.Unmarshal([]byte(input), &reason); err != nil {
+		t.Fatalf("unmarshal McpServerStartupFailureReason: %v", err)
+	}
+	if reason != McpServerStartupFailureReasonReauthenticationRequired {
+		t.Fatalf("McpServerStartupFailureReason = %q", reason)
+	}
+	encoded, err := json.Marshal(reason)
+	if err != nil {
+		t.Fatalf("marshal McpServerStartupFailureReason: %v", err)
+	}
+	if got := string(encoded); got != input {
+		t.Fatalf("McpServerStartupFailureReason round trip = %s, want %s", got, input)
+	}
+}
+
+func TestMcpServerStartupStateAcceptsExactValues(t *testing.T) {
+	tests := map[string]McpServerStartupState{
+		`"starting"`:  McpServerStartupStateStarting,
+		`"ready"`:     McpServerStartupStateReady,
+		`"failed"`:    McpServerStartupStateFailed,
+		`"cancelled"`: McpServerStartupStateCancelled,
+	}
+	for input, want := range tests {
+		var state McpServerStartupState
+		if err := json.Unmarshal([]byte(input), &state); err != nil {
+			t.Fatalf("unmarshal McpServerStartupState %s: %v", input, err)
+		}
+		if state != want {
+			t.Fatalf("McpServerStartupState = %q, want %q", state, want)
+		}
+		encoded, err := json.Marshal(state)
+		if err != nil {
+			t.Fatalf("marshal McpServerStartupState %s: %v", input, err)
+		}
+		if got := string(encoded); got != input {
+			t.Fatalf("McpServerStartupState round trip = %s, want %s", got, input)
+		}
+	}
+}
+
+func TestMcpServerStartupStatusRejectsMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `""`, `"other"`, `"ReauthenticationRequired"`,
+		`"reauthentication_required"`, `1`, `true`, `{}`, `[]`,
+		`"reauthenticationRequired" {}`, `"reauthenticationRequired" x`,
+	} {
+		assertJSONRejects[McpServerStartupFailureReason](t, input)
+	}
+
+	for _, input := range []string{
+		``, `null`, `""`, `"other"`, `"Starting"`, `"inProgress"`,
+		`"canceled"`, `"CANCELLED"`, `1`, `true`, `{}`, `[]`,
+		`"starting" {}`, `"cancelled" x`,
+	} {
+		assertJSONRejects[McpServerStartupState](t, input)
+	}
+}
+
+func TestMcpServerStartupStatusNilReceiversAndInvalidMarshalFailClosed(t *testing.T) {
+	var reason *McpServerStartupFailureReason
+	if err := reason.UnmarshalJSON([]byte(`"reauthenticationRequired"`)); err == nil {
+		t.Fatal("nil McpServerStartupFailureReason receiver succeeded")
+	}
+	for _, value := range []McpServerStartupFailureReason{"", "other"} {
+		if _, err := json.Marshal(value); err == nil {
+			t.Fatalf("invalid McpServerStartupFailureReason %q marshaled", value)
+		}
+	}
+
+	var state *McpServerStartupState
+	if err := state.UnmarshalJSON([]byte(`"starting"`)); err == nil {
+		t.Fatal("nil McpServerStartupState receiver succeeded")
+	}
+	for _, value := range []McpServerStartupState{"", "other"} {
+		if _, err := json.Marshal(value); err == nil {
+			t.Fatalf("invalid McpServerStartupState %q marshaled", value)
+		}
+	}
+}
+
+func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
+	names := []string{"McpServerStartupFailureReason", "McpServerStartupState"}
+	for _, binding := range WireTypeBindings() {
+		for _, name := range names {
+			if slices.Contains(binding.Params, name) || slices.Contains(binding.Result, name) {
+				t.Fatalf("%s unexpectedly bound to %s", name, binding.Method)
+			}
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
+		t.Fatalf("definition count = %d, want 371", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestMcpServerStartupStatusTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	for _, want := range []string{
+		`export type McpServerStartupFailureReason = "reauthenticationRequired";`,
+		`export type McpServerStartupState = "starting" | "ready" | "failed" | "cancelled";`,
+	} {
+		if !strings.Contains(string(generated), want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}
+
+var (
+	_ json.Marshaler   = McpServerStartupFailureReason("")
+	_ json.Unmarshaler = (*McpServerStartupFailureReason)(nil)
+	_ json.Marshaler   = McpServerStartupState("")
+	_ json.Unmarshaler = (*McpServerStartupState)(nil)
+)

--- a/appserver/protocol/mcp_server_startup_status_types.go
+++ b/appserver/protocol/mcp_server_startup_status_types.go
@@ -1,0 +1,56 @@
+package protocol
+
+import "encoding/json"
+
+// McpServerStartupFailureReason is the exact closed public MCP startup failure
+// reason. It does not imply that Gollem performs reauthentication.
+type McpServerStartupFailureReason string
+
+const (
+	McpServerStartupFailureReasonReauthenticationRequired McpServerStartupFailureReason = "reauthenticationRequired"
+)
+
+func (r McpServerStartupFailureReason) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(r, "MCP server startup failure reason", McpServerStartupFailureReason.valid)
+}
+
+func (r *McpServerStartupFailureReason) UnmarshalJSON(data []byte) error {
+	return unmarshalThreadTurnLeafEnum(data, r, "MCP server startup failure reason", McpServerStartupFailureReason.valid)
+}
+
+func (r McpServerStartupFailureReason) valid() bool {
+	return r == McpServerStartupFailureReasonReauthenticationRequired
+}
+
+// McpServerStartupState is the exact closed public MCP startup lifecycle. It
+// remains standalone from Gollem's MCP registration and runtime state.
+type McpServerStartupState string
+
+const (
+	McpServerStartupStateStarting  McpServerStartupState = "starting"
+	McpServerStartupStateReady     McpServerStartupState = "ready"
+	McpServerStartupStateFailed    McpServerStartupState = "failed"
+	McpServerStartupStateCancelled McpServerStartupState = "cancelled"
+)
+
+func (s McpServerStartupState) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(s, "MCP server startup state", McpServerStartupState.valid)
+}
+
+func (s *McpServerStartupState) UnmarshalJSON(data []byte) error {
+	return unmarshalThreadTurnLeafEnum(data, s, "MCP server startup state", McpServerStartupState.valid)
+}
+
+func (s McpServerStartupState) valid() bool {
+	return s == McpServerStartupStateStarting ||
+		s == McpServerStartupStateReady ||
+		s == McpServerStartupStateFailed ||
+		s == McpServerStartupStateCancelled
+}
+
+var (
+	_ json.Marshaler   = McpServerStartupFailureReason("")
+	_ json.Unmarshaler = (*McpServerStartupFailureReason)(nil)
+	_ json.Marshaler   = McpServerStartupState("")
+	_ json.Unmarshaler = (*McpServerStartupState)(nil)
+)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
-		t.Fatalf("definition count = %d, want 369", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
+		t.Fatalf("definition count = %d, want 371", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
-		t.Fatalf("definition count = %d, want 369", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
+		t.Fatalf("definition count = %d, want 371", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
-		t.Fatalf("definition count = %d, want 369", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
+		t.Fatalf("definition count = %d, want 371", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
-		t.Fatalf("definition count = %d, want 369", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
+		t.Fatalf("definition count = %d, want 371", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
-		t.Fatalf("definition count = %d, want 369", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
+		t.Fatalf("definition count = %d, want 371", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
-		t.Fatalf("definition count = %d, want 369", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
+		t.Fatalf("definition count = %d, want 371", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
-		t.Fatalf("definition count = %d, want 369", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
+		t.Fatalf("definition count = %d, want 371", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
-		t.Fatalf("definition count = %d, want 369", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
+		t.Fatalf("definition count = %d, want 371", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 369 {
-		t.Fatalf("definition count = %d, want 369", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 371 {
+		t.Fatalf("definition count = %d, want 371", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 369 {
-		t.Fatalf("definition count = %d, want 369", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 371 {
+		t.Fatalf("definition count = %d, want 371", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 369 {
-		t.Fatalf("definition count = %d, want 369", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 371 {
+		t.Fatalf("definition count = %d, want 371", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 369 {
-		t.Fatalf("definition count = %d, want 369", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 371 {
+		t.Fatalf("definition count = %d, want 371", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 369 {
-		t.Fatalf("definition count = %d, want 369", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 371 {
+		t.Fatalf("definition count = %d, want 371", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -234,6 +234,8 @@ func wireSchemaDefinitions() Schema {
 		{Name: "MCPToolCallProgressNotificationParams", Type: reflect.TypeFor[MCPToolCallProgressNotificationParams]()},
 		{Name: "MCPToolCallResult", Type: reflect.TypeFor[MCPToolCallResult]()},
 		{Name: "McpAuthStatus", Type: reflect.TypeFor[McpAuthStatus]()},
+		{Name: "McpServerStartupFailureReason", Type: reflect.TypeFor[McpServerStartupFailureReason]()},
+		{Name: "McpServerStartupState", Type: reflect.TypeFor[McpServerStartupState]()},
 		{Name: "McpToolCallAppContext", Type: reflect.TypeFor[McpToolCallAppContext]()},
 		{Name: "McpToolCallResult", Type: reflect.TypeFor[McpToolCallResult]()},
 		{Name: "MemoryCitation", Type: reflect.TypeFor[MemoryCitation]()},
@@ -506,6 +508,13 @@ func wireSchemaDefinitions() Schema {
 	schemas["McpAuthStatus"] = stringEnumSchema(
 		string(McpAuthStatusUnsupported), string(McpAuthStatusNotLoggedIn),
 		string(McpAuthStatusBearerToken), string(McpAuthStatusOAuth),
+	)
+	schemas["McpServerStartupFailureReason"] = stringEnumSchema(
+		string(McpServerStartupFailureReasonReauthenticationRequired),
+	)
+	schemas["McpServerStartupState"] = stringEnumSchema(
+		string(McpServerStartupStateStarting), string(McpServerStartupStateReady),
+		string(McpServerStartupStateFailed), string(McpServerStartupStateCancelled),
 	)
 	schemas["ReasoningEffort"] = Schema{"type": "string", "minLength": 1}
 	schemas["ResidencyRequirement"] = stringEnumSchema(string(ResidencyRequirementUS))

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -5769,6 +5769,21 @@
       ],
       "type": "object"
     },
+    "McpServerStartupFailureReason": {
+      "enum": [
+        "reauthenticationRequired"
+      ],
+      "type": "string"
+    },
+    "McpServerStartupState": {
+      "enum": [
+        "starting",
+        "ready",
+        "failed",
+        "cancelled"
+      ],
+      "type": "string"
+    },
     "McpToolCallAppContext": {
       "additionalProperties": false,
       "properties": {

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 369 {
-		t.Fatalf("definition count = %d, want 369", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 371 {
+		t.Fatalf("definition count = %d, want 371", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
-		t.Fatalf("definition count = %d, want 369", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
+		t.Fatalf("definition count = %d, want 371", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
-		t.Fatalf("definition count = %d, want 369", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
+		t.Fatalf("definition count = %d, want 371", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
-		t.Fatalf("definition count = %d, want 369", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
+		t.Fatalf("definition count = %d, want 371", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
-		t.Fatalf("definition count = %d, want 369", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
+		t.Fatalf("definition count = %d, want 371", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
-		t.Fatalf("definition count = %d, want 369", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
+		t.Fatalf("definition count = %d, want 371", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 369 {
-		t.Fatalf("definition count = %d, want 369", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 371 {
+		t.Fatalf("definition count = %d, want 371", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 369 {
-		t.Fatalf("definition count = %d, want 369", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 371 {
+		t.Fatalf("definition count = %d, want 371", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
-		t.Fatalf("definition count = %d, want 369", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
+		t.Fatalf("definition count = %d, want 371", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
-		t.Fatalf("definition count = %d, want 369", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
+		t.Fatalf("definition count = %d, want 371", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
-		t.Fatalf("definition count = %d, want 369", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
+		t.Fatalf("definition count = %d, want 371", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
-		t.Fatalf("definition count = %d, want 369", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
+		t.Fatalf("definition count = %d, want 371", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -1736,6 +1736,10 @@ export type McpServerElicitationRequestResponse = {
   "content": unknown;
 };
 
+export type McpServerStartupFailureReason = "reauthenticationRequired";
+
+export type McpServerStartupState = "starting" | "ready" | "failed" | "cancelled";
+
 export type McpToolCallAppContext = {
   "actionName": string | null;
   "appName": string | null;

--- a/appserver/protocol/typescript/testdata/mcp_server_startup_status_contract.ts
+++ b/appserver/protocol/typescript/testdata/mcp_server_startup_status_contract.ts
@@ -1,0 +1,65 @@
+import type {
+  McpServerStartupFailureReason,
+  McpServerStartupState,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? (<T>() => T extends B ? 1 : 2) extends
+        (<T>() => T extends A ? 1 : 2)
+      ? true
+      : false
+    : false;
+type Expect<T extends true> = T;
+
+type FailureReasonContract = Expect<
+  Equal<McpServerStartupFailureReason, "reauthenticationRequired">
+>;
+type StateContract = Expect<
+  Equal<
+    McpServerStartupState,
+    "starting" | "ready" | "failed" | "cancelled"
+  >
+>;
+
+export const failureReasons = [
+  "reauthenticationRequired",
+] satisfies McpServerStartupFailureReason[];
+export const states = [
+  "starting",
+  "ready",
+  "failed",
+  "cancelled",
+] satisfies McpServerStartupState[];
+
+// @ts-expect-error startup failure reasons are closed.
+export const rejectUnknownReason = "other" satisfies McpServerStartupFailureReason;
+// @ts-expect-error exact lower-camel spelling is required.
+export const rejectReasonCase = "ReauthenticationRequired" satisfies McpServerStartupFailureReason;
+// @ts-expect-error snake-case failure reasons are not accepted.
+export const rejectSnakeReason = "reauthentication_required" satisfies McpServerStartupFailureReason;
+// @ts-expect-error empty strings are not startup failure reasons.
+export const rejectEmptyReason = "" satisfies McpServerStartupFailureReason;
+// @ts-expect-error startup failure reasons are non-null.
+export const rejectNullReason = null satisfies McpServerStartupFailureReason;
+// @ts-expect-error startup failure reasons are strings.
+export const rejectNumberReason = 1 satisfies McpServerStartupFailureReason;
+
+// @ts-expect-error startup states are closed.
+export const rejectUnknownState = "other" satisfies McpServerStartupState;
+// @ts-expect-error exact lowercase spelling is required.
+export const rejectStateCase = "Starting" satisfies McpServerStartupState;
+// @ts-expect-error American spelling is not the public wire value.
+export const rejectCanceledState = "canceled" satisfies McpServerStartupState;
+// @ts-expect-error failure reasons and startup states are distinct.
+export const rejectFailureAsState = "reauthenticationRequired" satisfies McpServerStartupState;
+// @ts-expect-error empty strings are not startup states.
+export const rejectEmptyState = "" satisfies McpServerStartupState;
+// @ts-expect-error startup states are non-null.
+export const rejectNullState = null satisfies McpServerStartupState;
+// @ts-expect-error startup states are strings.
+export const rejectNumberState = 1 satisfies McpServerStartupState;
+
+void (null as unknown as FailureReasonContract);
+void (null as unknown as StateContract);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 369 {
-		t.Fatalf("definition count = %d, want 369", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
+		t.Fatalf("definition count = %d, want 371", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- export exact standalone McpServerStartupFailureReason = reauthenticationRequired and McpServerStartupState = starting | ready | failed | cancelled
- reject invalid, wrong-case, empty, null, non-string, malformed/trailing, nil-receiver, zero, and invalid constructed values with no invented defaults
- preserve all 224 methods, 59 wire bindings, five item bindings, live mcpServerStatus/list JSON, MCP registration, OAuth, credentials, capabilities, startup behavior, and runtime

## Verification
- deliberate-red Go and strict TypeScript boundaries
- focused tests x30, focused race, and 100% focused statement coverage for all six new codec functions
- full protocol suite
- all 59 non-Monty packages under normal and race suites; ext/monty intentionally skipped per standing direction
- deterministic generation twice: 371 definitions / 224 methods / 59 wire bindings / 5 item bindings
- generated schema and TypeScript reduce exactly to PR #166 artifacts when the two definitions/exports are removed
- strict TypeScript, golangci-lint (0 issues), go vet, tidy invariance, configured pre-push
- all five Slang real-transport workflows against the reviewed trimpath binary
- byte-identical baseline/feature live mcpServerStatus/list response; no stderr