### PR TITLE
Export exact MCP startup status notification

### DIFF
--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 371 {
-		t.Fatalf("definition count = %d, want 371", got)
+	if got := len(defs); got != 372 {
+		t.Fatalf("definition count = %d, want 372", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
-		t.Fatalf("definition count = %d, want 371", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
+		t.Fatalf("definition count = %d, want 372", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
-		t.Fatalf("definition count = %d, want 371", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
+		t.Fatalf("definition count = %d, want 372", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
-		t.Fatalf("definition count = %d, want 371", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
+		t.Fatalf("definition count = %d, want 372", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
-		t.Fatalf("definition count = %d, want 371", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
+		t.Fatalf("definition count = %d, want 372", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
-		t.Fatalf("definition count = %d, want 371", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
+		t.Fatalf("definition count = %d, want 372", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
-		t.Fatalf("definition count = %d, want 371", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
+		t.Fatalf("definition count = %d, want 372", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
-		t.Fatalf("definition count = %d, want 371", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
+		t.Fatalf("definition count = %d, want 372", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
-		t.Fatalf("definition count = %d, want 371", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
+		t.Fatalf("definition count = %d, want 372", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
-		t.Fatalf("definition count = %d, want 371", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
+		t.Fatalf("definition count = %d, want 372", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
-		t.Fatalf("definition count = %d, want 371", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
+		t.Fatalf("definition count = %d, want 372", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
-		t.Fatalf("definition count = %d, want 371", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
+		t.Fatalf("definition count = %d, want 372", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
-		t.Fatalf("definition count = %d, want 371", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
+		t.Fatalf("definition count = %d, want 372", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
-		t.Fatalf("definition count = %d, want 371", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
+		t.Fatalf("definition count = %d, want 372", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 371 {
-		t.Fatalf("definition count = %d, want 371", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 372 {
+		t.Fatalf("definition count = %d, want 372", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
-		t.Fatalf("definition count = %d, want 371", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
+		t.Fatalf("definition count = %d, want 372", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
-		t.Fatalf("definition count = %d, want 371", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
+		t.Fatalf("definition count = %d, want 372", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
-		t.Fatalf("definition count = %d, want 371", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
+		t.Fatalf("definition count = %d, want 372", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
-		t.Fatalf("definition count = %d, want 371", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
+		t.Fatalf("definition count = %d, want 372", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
-		t.Fatalf("definition count = %d, want 371", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
+		t.Fatalf("definition count = %d, want 372", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
-		t.Fatalf("definition count = %d, want 371", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
+		t.Fatalf("definition count = %d, want 372", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -1,0 +1,161 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestMcpServerStatusUpdatedNotificationSchemaIsExact(t *testing.T) {
+	definition, ok := JSONSchema()["$defs"].(Schema)["McpServerStatusUpdatedNotification"].(Schema)
+	if !ok {
+		t.Fatal("$defs missing McpServerStatusUpdatedNotification")
+	}
+	if definition["type"] != "object" || definition["additionalProperties"] != false {
+		t.Fatalf("McpServerStatusUpdatedNotification is not a closed object: %#v", definition)
+	}
+	if got := schemaRequiredNames(definition); !slices.Equal(got, []string{
+		"threadId", "name", "status", "error", "failureReason",
+	}) {
+		t.Fatalf("McpServerStatusUpdatedNotification required = %v", got)
+	}
+	wantProperties := Schema{
+		"threadId": Schema{"anyOf": []any{Schema{"type": "string"}, Schema{"type": "null"}}},
+		"name":     Schema{"type": "string"},
+		"status":   Schema{"$ref": "#/$defs/McpServerStartupState"},
+		"error":    Schema{"anyOf": []any{Schema{"type": "string"}, Schema{"type": "null"}}},
+		"failureReason": Schema{"anyOf": []any{
+			Schema{"$ref": "#/$defs/McpServerStartupFailureReason"},
+			Schema{"type": "null"},
+		}},
+	}
+	if got := definition["properties"].(Schema); !reflect.DeepEqual(got, wantProperties) {
+		t.Fatalf("McpServerStatusUpdatedNotification properties = %#v, want %#v", got, wantProperties)
+	}
+}
+
+func TestMcpServerStatusUpdatedNotificationAcceptsCanonicalAndCompatibleForms(t *testing.T) {
+	valid := []struct {
+		input string
+		want  string
+	}{
+		{
+			input: `{"name":"","status":"starting"}`,
+			want:  `{"threadId":null,"name":"","status":"starting","error":null,"failureReason":null}`,
+		},
+		{
+			input: `{"threadId":null,"name":"server","status":"ready","error":null,"failureReason":null}`,
+			want:  `{"threadId":null,"name":"server","status":"ready","error":null,"failureReason":null}`,
+		},
+		{
+			input: `{"threadId":"","name":"server","status":"failed",` +
+				`"error":"","failureReason":"reauthenticationRequired"}`,
+			want: `{"threadId":"","name":"server","status":"failed",` +
+				`"error":"","failureReason":"reauthenticationRequired"}`,
+		},
+		{
+			input: `{"name":"server","status":"cancelled","error":"cancelled"}`,
+			want:  `{"threadId":null,"name":"server","status":"cancelled","error":"cancelled","failureReason":null}`,
+		},
+	}
+	for _, tc := range valid {
+		var notification McpServerStatusUpdatedNotification
+		if err := json.Unmarshal([]byte(tc.input), &notification); err != nil {
+			t.Errorf("Unmarshal(%s): %v", tc.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(notification)
+		if err != nil || string(encoded) != tc.want {
+			t.Errorf("canonical = %s, %v; want %s", encoded, err, tc.want)
+		}
+	}
+}
+
+func TestMcpServerStatusUpdatedNotificationRejectsMalformedForms(t *testing.T) {
+	invalid := []string{
+		``, `null`, `[]`, `"value"`, `1`, `{}`,
+		`{"status":"starting"}`,
+		`{"name":"server"}`,
+		`{"name":null,"status":"starting"}`,
+		`{"name":1,"status":"starting"}`,
+		`{"name":"server","status":null}`,
+		`{"name":"server","status":"other"}`,
+		`{"threadId":1,"name":"server","status":"starting"}`,
+		`{"threadId":{},"name":"server","status":"starting"}`,
+		`{"name":"server","status":"starting","error":1}`,
+		`{"name":"server","status":"starting","error":{}}`,
+		`{"name":"server","status":"starting","failureReason":"other"}`,
+		`{"name":"server","status":"starting","failureReason":1}`,
+		`{"name":"server","status":"starting","failure_reason":"reauthenticationRequired"}`,
+		`{"name":"server","status":"starting","extra":true}`,
+		`{"name":"server","status":"starting"} {}`,
+	}
+	for _, input := range invalid {
+		var notification McpServerStatusUpdatedNotification
+		if err := json.Unmarshal([]byte(input), &notification); err == nil {
+			t.Errorf("Unmarshal(%s) succeeded", input)
+		}
+	}
+
+	if _, err := json.Marshal(McpServerStatusUpdatedNotification{Name: "server"}); err == nil {
+		t.Fatal("notification with zero startup status marshaled")
+	}
+	badReason := McpServerStartupFailureReason("other")
+	if _, err := json.Marshal(McpServerStatusUpdatedNotification{
+		Name: "server", Status: McpServerStartupStateFailed, FailureReason: &badReason,
+	}); err == nil {
+		t.Fatal("notification with invalid failure reason marshaled")
+	}
+	var nilNotification *McpServerStatusUpdatedNotification
+	if err := nilNotification.UnmarshalJSON([]byte(`{"name":"server","status":"ready"}`)); err == nil {
+		t.Fatal("nil McpServerStatusUpdatedNotification receiver succeeded")
+	}
+}
+
+func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
+	for _, binding := range WireTypeBindings() {
+		if slices.Contains(binding.Params, "McpServerStatusUpdatedNotification") ||
+			slices.Contains(binding.Result, "McpServerStatusUpdatedNotification") {
+			t.Fatalf("McpServerStatusUpdatedNotification unexpectedly bound to %s", binding.Method)
+		}
+	}
+	info, ok := LookupMethod("mcpServer/startupStatus/updated")
+	if !ok || info.State != MethodBlocked {
+		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
+		t.Fatalf("definition count = %d, want 372", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestMcpServerStatusUpdatedNotificationTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	for _, want := range []string{
+		`export type McpServerStatusUpdatedNotification = {`,
+		`"error": string | null;`,
+		`"failureReason": McpServerStartupFailureReason | null;`,
+		`"name": string;`,
+		`"status": McpServerStartupState;`,
+		`"threadId": string | null;`,
+	} {
+		if !strings.Contains(string(generated), want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}
+
+var (
+	_ json.Marshaler   = McpServerStatusUpdatedNotification{}
+	_ json.Unmarshaler = (*McpServerStatusUpdatedNotification)(nil)
+)

--- a/appserver/protocol/mcp_server_status_updated_notification_types.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_types.go
@@ -1,0 +1,103 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// McpServerStatusUpdatedNotification is the exact public MCP startup-status
+// value. It remains standalone until Gollem has a startup producer.
+type McpServerStatusUpdatedNotification struct {
+	ThreadID      *string                        `json:"threadId"`
+	Name          string                         `json:"name"`
+	Status        McpServerStartupState          `json:"status"`
+	Error         *string                        `json:"error"`
+	FailureReason *McpServerStartupFailureReason `json:"failureReason"`
+}
+
+func (n McpServerStatusUpdatedNotification) MarshalJSON() ([]byte, error) {
+	type wire McpServerStatusUpdatedNotification
+	encoded, err := json.Marshal(wire(n))
+	if err != nil {
+		return nil, fmt.Errorf("encode MCP server status-updated notification: %w", err)
+	}
+	return encoded, nil
+}
+
+func (n *McpServerStatusUpdatedNotification) UnmarshalJSON(data []byte) error {
+	if n == nil {
+		return errors.New("decode MCP server status-updated notification into nil receiver")
+	}
+	payload, err := decodeExactThreadItemObject(
+		data,
+		"MCP server status-updated notification",
+		"threadId",
+		"name",
+		"status",
+		"error",
+		"failureReason",
+	)
+	if err != nil {
+		return err
+	}
+	name, err := decodeRequiredThreadItemValue[string](
+		payload,
+		"MCP server status-updated notification",
+		"name",
+	)
+	if err != nil {
+		return err
+	}
+	status, err := decodeRequiredThreadItemValue[McpServerStartupState](
+		payload,
+		"MCP server status-updated notification",
+		"status",
+	)
+	if err != nil {
+		return err
+	}
+	threadID, err := decodeOptionalNullableMcpServerStatusUpdatedValue[string](payload, "threadId")
+	if err != nil {
+		return err
+	}
+	errorMessage, err := decodeOptionalNullableMcpServerStatusUpdatedValue[string](payload, "error")
+	if err != nil {
+		return err
+	}
+	failureReason, err := decodeOptionalNullableMcpServerStatusUpdatedValue[McpServerStartupFailureReason](
+		payload,
+		"failureReason",
+	)
+	if err != nil {
+		return err
+	}
+	*n = McpServerStatusUpdatedNotification{
+		ThreadID:      threadID,
+		Name:          name,
+		Status:        status,
+		Error:         errorMessage,
+		FailureReason: failureReason,
+	}
+	return nil
+}
+
+func decodeOptionalNullableMcpServerStatusUpdatedValue[T any](
+	payload map[string]json.RawMessage,
+	fieldName string,
+) (*T, error) {
+	raw, ok := payload[fieldName]
+	if !ok || isJSONNull(raw) {
+		return nil, nil
+	}
+	var value T
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return nil, fmt.Errorf("decode MCP server status-updated notification %s: %w", fieldName, err)
+	}
+	return &value, nil
+}
+
+var (
+	_ json.Marshaler   = McpServerStatusUpdatedNotification{}
+	_ json.Unmarshaler = (*McpServerStatusUpdatedNotification)(nil)
+)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
-		t.Fatalf("definition count = %d, want 371", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
+		t.Fatalf("definition count = %d, want 372", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
-		t.Fatalf("definition count = %d, want 371", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
+		t.Fatalf("definition count = %d, want 372", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
-		t.Fatalf("definition count = %d, want 371", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
+		t.Fatalf("definition count = %d, want 372", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
-		t.Fatalf("definition count = %d, want 371", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
+		t.Fatalf("definition count = %d, want 372", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
-		t.Fatalf("definition count = %d, want 371", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
+		t.Fatalf("definition count = %d, want 372", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
-		t.Fatalf("definition count = %d, want 371", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
+		t.Fatalf("definition count = %d, want 372", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
-		t.Fatalf("definition count = %d, want 371", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
+		t.Fatalf("definition count = %d, want 372", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
-		t.Fatalf("definition count = %d, want 371", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
+		t.Fatalf("definition count = %d, want 372", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 371 {
-		t.Fatalf("definition count = %d, want 371", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 372 {
+		t.Fatalf("definition count = %d, want 372", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 371 {
-		t.Fatalf("definition count = %d, want 371", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 372 {
+		t.Fatalf("definition count = %d, want 372", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 371 {
-		t.Fatalf("definition count = %d, want 371", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 372 {
+		t.Fatalf("definition count = %d, want 372", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 371 {
-		t.Fatalf("definition count = %d, want 371", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 372 {
+		t.Fatalf("definition count = %d, want 372", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 371 {
-		t.Fatalf("definition count = %d, want 371", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 372 {
+		t.Fatalf("definition count = %d, want 372", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -236,6 +236,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "McpAuthStatus", Type: reflect.TypeFor[McpAuthStatus]()},
 		{Name: "McpServerStartupFailureReason", Type: reflect.TypeFor[McpServerStartupFailureReason]()},
 		{Name: "McpServerStartupState", Type: reflect.TypeFor[McpServerStartupState]()},
+		{Name: "McpServerStatusUpdatedNotification", Type: reflect.TypeFor[McpServerStatusUpdatedNotification]()},
 		{Name: "McpToolCallAppContext", Type: reflect.TypeFor[McpToolCallAppContext]()},
 		{Name: "McpToolCallResult", Type: reflect.TypeFor[McpToolCallResult]()},
 		{Name: "MemoryCitation", Type: reflect.TypeFor[MemoryCitation]()},

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -5784,6 +5784,55 @@
       ],
       "type": "string"
     },
+    "McpServerStatusUpdatedNotification": {
+      "additionalProperties": false,
+      "properties": {
+        "error": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "failureReason": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/McpServerStartupFailureReason"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "status": {
+          "$ref": "#/$defs/McpServerStartupState"
+        },
+        "threadId": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "threadId",
+        "name",
+        "status",
+        "error",
+        "failureReason"
+      ],
+      "type": "object"
+    },
     "McpToolCallAppContext": {
       "additionalProperties": false,
       "properties": {

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 371 {
-		t.Fatalf("definition count = %d, want 371", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 372 {
+		t.Fatalf("definition count = %d, want 372", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
-		t.Fatalf("definition count = %d, want 371", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
+		t.Fatalf("definition count = %d, want 372", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
-		t.Fatalf("definition count = %d, want 371", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
+		t.Fatalf("definition count = %d, want 372", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
-		t.Fatalf("definition count = %d, want 371", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
+		t.Fatalf("definition count = %d, want 372", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
-		t.Fatalf("definition count = %d, want 371", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
+		t.Fatalf("definition count = %d, want 372", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
-		t.Fatalf("definition count = %d, want 371", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
+		t.Fatalf("definition count = %d, want 372", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 371 {
-		t.Fatalf("definition count = %d, want 371", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 372 {
+		t.Fatalf("definition count = %d, want 372", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 371 {
-		t.Fatalf("definition count = %d, want 371", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 372 {
+		t.Fatalf("definition count = %d, want 372", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
-		t.Fatalf("definition count = %d, want 371", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
+		t.Fatalf("definition count = %d, want 372", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
-		t.Fatalf("definition count = %d, want 371", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
+		t.Fatalf("definition count = %d, want 372", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
-		t.Fatalf("definition count = %d, want 371", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
+		t.Fatalf("definition count = %d, want 372", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
-		t.Fatalf("definition count = %d, want 371", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
+		t.Fatalf("definition count = %d, want 372", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -1740,6 +1740,14 @@ export type McpServerStartupFailureReason = "reauthenticationRequired";
 
 export type McpServerStartupState = "starting" | "ready" | "failed" | "cancelled";
 
+export type McpServerStatusUpdatedNotification = {
+  "error": string | null;
+  "failureReason": McpServerStartupFailureReason | null;
+  "name": string;
+  "status": McpServerStartupState;
+  "threadId": string | null;
+};
+
 export type McpToolCallAppContext = {
   "actionName": string | null;
   "appName": string | null;

--- a/appserver/protocol/typescript/testdata/mcp_server_status_updated_notification_contract.ts
+++ b/appserver/protocol/typescript/testdata/mcp_server_status_updated_notification_contract.ts
@@ -1,0 +1,131 @@
+import type {
+  McpServerStartupFailureReason,
+  McpServerStartupState,
+  McpServerStatusUpdatedNotification,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? (<T>() => T extends B ? 1 : 2) extends
+        (<T>() => T extends A ? 1 : 2)
+      ? true
+      : false
+    : false;
+type Expect<T extends true> = T;
+
+type NotificationContract = Expect<
+  Equal<
+    McpServerStatusUpdatedNotification,
+    {
+      error: string | null;
+      failureReason: McpServerStartupFailureReason | null;
+      name: string;
+      status: McpServerStartupState;
+      threadId: string | null;
+    }
+  >
+>;
+
+export const starting: McpServerStatusUpdatedNotification = {
+  error: null,
+  failureReason: null,
+  name: "server",
+  status: "starting",
+  threadId: null,
+};
+
+export const failed: McpServerStatusUpdatedNotification = {
+  error: "login required",
+  failureReason: "reauthenticationRequired",
+  name: "server",
+  status: "failed",
+  threadId: "thread",
+};
+
+// @ts-expect-error name is required.
+export const rejectMissingName: McpServerStatusUpdatedNotification = {
+  error: null,
+  failureReason: null,
+  status: "ready",
+  threadId: null,
+};
+// @ts-expect-error status is required.
+export const rejectMissingStatus: McpServerStatusUpdatedNotification = {
+  error: null,
+  failureReason: null,
+  name: "server",
+  threadId: null,
+};
+// @ts-expect-error canonical generated values require threadId.
+export const rejectMissingThreadId: McpServerStatusUpdatedNotification = {
+  error: null,
+  failureReason: null,
+  name: "server",
+  status: "ready",
+};
+// @ts-expect-error canonical generated values require error.
+export const rejectMissingError: McpServerStatusUpdatedNotification = {
+  failureReason: null,
+  name: "server",
+  status: "ready",
+  threadId: null,
+};
+// @ts-expect-error canonical generated values require failureReason.
+export const rejectMissingFailureReason: McpServerStatusUpdatedNotification = {
+  error: null,
+  name: "server",
+  status: "ready",
+  threadId: null,
+};
+export const rejectNullName: McpServerStatusUpdatedNotification = {
+  error: null,
+  failureReason: null,
+  // @ts-expect-error name is non-null.
+  name: null,
+  status: "ready",
+  threadId: null,
+};
+export const rejectUnknownStatus: McpServerStatusUpdatedNotification = {
+  error: null,
+  failureReason: null,
+  name: "server",
+  // @ts-expect-error startup states are closed.
+  status: "other",
+  threadId: null,
+};
+export const rejectUnknownReason: McpServerStatusUpdatedNotification = {
+  error: null,
+  // @ts-expect-error startup failure reasons are closed.
+  failureReason: "other",
+  name: "server",
+  status: "failed",
+  threadId: null,
+};
+export const rejectNumberThreadId: McpServerStatusUpdatedNotification = {
+  error: null,
+  failureReason: null,
+  name: "server",
+  status: "ready",
+  // @ts-expect-error threadId is nullable string.
+  threadId: 1,
+};
+export const rejectNumberError: McpServerStatusUpdatedNotification = {
+  // @ts-expect-error error is nullable string.
+  error: 1,
+  failureReason: null,
+  name: "server",
+  status: "failed",
+  threadId: null,
+};
+export const rejectExtra: McpServerStatusUpdatedNotification = {
+  error: null,
+  failureReason: null,
+  name: "server",
+  status: "ready",
+  threadId: null,
+  // @ts-expect-error generated object is closed.
+  extra: true,
+};
+
+void (null as unknown as NotificationContract);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 371 {
-		t.Fatalf("definition count = %d, want 371", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
+		t.Fatalf("definition count = %d, want 372", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- export strict standalone `McpServerStatusUpdatedNotification` with exact startup enum dependencies
- accept omitted/null optional Rust inputs and canonicalize nullable fields to explicit null
- keep `mcpServer/startupStatus/updated` blocked and unbound with no startup, OAuth, credential, or capability behavior
- update deterministic schema/TypeScript output to 372 definitions with unchanged 224 methods and 59/5 bindings

## Verification
- deliberate red Go and strict TypeScript boundaries
- focused tests x30, focused race, and 100% coverage for all three new functions
- full protocol tests at 96.6% coverage
- all 59 non-Monty packages under fresh normal/race suites
- `golangci-lint run` (0 issues), `go vet`, tidy unchanged
- deterministic generation twice and strict TypeScript
- all five existing Slang real-binary workflows
- exact baseline/feature initialized MCP status output and AST-guided generated-artifact comparison
- configured pre-push hook passed with `hooks.skipMontyRace=true`

Local `ext/monty` normal/race/coverage was intentionally skipped per standing direction; hosted checks remain unchanged.