### PR TITLE
Export exact MCP server status detail

### DIFF
--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 372 {
-		t.Fatalf("definition count = %d, want 372", got)
+	if got := len(defs); got != 373 {
+		t.Fatalf("definition count = %d, want 373", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
-		t.Fatalf("definition count = %d, want 372", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
+		t.Fatalf("definition count = %d, want 373", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
-		t.Fatalf("definition count = %d, want 372", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
+		t.Fatalf("definition count = %d, want 373", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
-		t.Fatalf("definition count = %d, want 372", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
+		t.Fatalf("definition count = %d, want 373", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
-		t.Fatalf("definition count = %d, want 372", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
+		t.Fatalf("definition count = %d, want 373", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
-		t.Fatalf("definition count = %d, want 372", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
+		t.Fatalf("definition count = %d, want 373", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
-		t.Fatalf("definition count = %d, want 372", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
+		t.Fatalf("definition count = %d, want 373", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
-		t.Fatalf("definition count = %d, want 372", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
+		t.Fatalf("definition count = %d, want 373", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
-		t.Fatalf("definition count = %d, want 372", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
+		t.Fatalf("definition count = %d, want 373", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
-		t.Fatalf("definition count = %d, want 372", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
+		t.Fatalf("definition count = %d, want 373", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
-		t.Fatalf("definition count = %d, want 372", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
+		t.Fatalf("definition count = %d, want 373", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
-		t.Fatalf("definition count = %d, want 372", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
+		t.Fatalf("definition count = %d, want 373", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
-		t.Fatalf("definition count = %d, want 372", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
+		t.Fatalf("definition count = %d, want 373", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
-		t.Fatalf("definition count = %d, want 372", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
+		t.Fatalf("definition count = %d, want 373", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 372 {
-		t.Fatalf("definition count = %d, want 372", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 373 {
+		t.Fatalf("definition count = %d, want 373", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
-		t.Fatalf("definition count = %d, want 372", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
+		t.Fatalf("definition count = %d, want 373", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
-		t.Fatalf("definition count = %d, want 372", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
+		t.Fatalf("definition count = %d, want 373", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
-		t.Fatalf("definition count = %d, want 372", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
+		t.Fatalf("definition count = %d, want 373", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
-		t.Fatalf("definition count = %d, want 372", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
+		t.Fatalf("definition count = %d, want 373", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
-		t.Fatalf("definition count = %d, want 372", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
+		t.Fatalf("definition count = %d, want 373", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
-		t.Fatalf("definition count = %d, want 372", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
+		t.Fatalf("definition count = %d, want 373", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -1,0 +1,97 @@
+package protocol
+
+import (
+	"encoding/json"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestMcpServerStatusDetailSchemaIsExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	assertStringEnum(
+		t,
+		defs["McpServerStatusDetail"],
+		"full",
+		"toolsAndAuthOnly",
+	)
+}
+
+func TestMcpServerStatusDetailAcceptsExactValues(t *testing.T) {
+	tests := map[string]McpServerStatusDetail{
+		`"full"`:             McpServerStatusDetailFull,
+		`"toolsAndAuthOnly"`: McpServerStatusDetailToolsAndAuthOnly,
+	}
+	for input, want := range tests {
+		var detail McpServerStatusDetail
+		if err := json.Unmarshal([]byte(input), &detail); err != nil {
+			t.Fatalf("unmarshal McpServerStatusDetail %s: %v", input, err)
+		}
+		if detail != want {
+			t.Fatalf("McpServerStatusDetail = %q, want %q", detail, want)
+		}
+		encoded, err := json.Marshal(detail)
+		if err != nil {
+			t.Fatalf("marshal McpServerStatusDetail %s: %v", input, err)
+		}
+		if got := string(encoded); got != input {
+			t.Fatalf("McpServerStatusDetail round trip = %s, want %s", got, input)
+		}
+	}
+}
+
+func TestMcpServerStatusDetailRejectsMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `""`, `"other"`, `"Full"`, `"ToolsAndAuthOnly"`,
+		`"tools_and_auth_only"`, `"toolsOnly"`, `1`, `true`, `{}`, `[]`,
+		`"full" {}`, `"toolsAndAuthOnly" x`,
+	} {
+		assertJSONRejects[McpServerStatusDetail](t, input)
+	}
+}
+
+func TestMcpServerStatusDetailNilReceiverAndInvalidMarshalFailClosed(t *testing.T) {
+	var detail *McpServerStatusDetail
+	if err := detail.UnmarshalJSON([]byte(`"full"`)); err == nil {
+		t.Fatal("nil McpServerStatusDetail receiver succeeded")
+	}
+	for _, value := range []McpServerStatusDetail{"", "other"} {
+		if _, err := json.Marshal(value); err == nil {
+			t.Fatalf("invalid McpServerStatusDetail %q marshaled", value)
+		}
+	}
+}
+
+func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
+	for _, binding := range WireTypeBindings() {
+		if slices.Contains(binding.Params, "McpServerStatusDetail") ||
+			slices.Contains(binding.Result, "McpServerStatusDetail") {
+			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
+		t.Fatalf("definition count = %d, want 373", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestMcpServerStatusDetailTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	want := `export type McpServerStatusDetail = "full" | "toolsAndAuthOnly";`
+	if !strings.Contains(string(generated), want) {
+		t.Errorf("generated TypeScript missing %q", want)
+	}
+}
+
+var (
+	_ json.Marshaler   = McpServerStatusDetail("")
+	_ json.Unmarshaler = (*McpServerStatusDetail)(nil)
+)

--- a/appserver/protocol/mcp_server_status_detail_types.go
+++ b/appserver/protocol/mcp_server_status_detail_types.go
@@ -1,0 +1,30 @@
+package protocol
+
+import "encoding/json"
+
+// McpServerStatusDetail is the exact closed public MCP status detail selector.
+// It remains standalone from Gollem's broader status request and runtime.
+type McpServerStatusDetail string
+
+const (
+	McpServerStatusDetailFull             McpServerStatusDetail = "full"
+	McpServerStatusDetailToolsAndAuthOnly McpServerStatusDetail = "toolsAndAuthOnly"
+)
+
+func (d McpServerStatusDetail) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(d, "MCP server status detail", McpServerStatusDetail.valid)
+}
+
+func (d *McpServerStatusDetail) UnmarshalJSON(data []byte) error {
+	return unmarshalThreadTurnLeafEnum(data, d, "MCP server status detail", McpServerStatusDetail.valid)
+}
+
+func (d McpServerStatusDetail) valid() bool {
+	return d == McpServerStatusDetailFull ||
+		d == McpServerStatusDetailToolsAndAuthOnly
+}
+
+var (
+	_ json.Marshaler   = McpServerStatusDetail("")
+	_ json.Unmarshaler = (*McpServerStatusDetail)(nil)
+)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
-		t.Fatalf("definition count = %d, want 372", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
+		t.Fatalf("definition count = %d, want 373", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
-		t.Fatalf("definition count = %d, want 372", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
+		t.Fatalf("definition count = %d, want 373", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
-		t.Fatalf("definition count = %d, want 372", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
+		t.Fatalf("definition count = %d, want 373", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
-		t.Fatalf("definition count = %d, want 372", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
+		t.Fatalf("definition count = %d, want 373", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
-		t.Fatalf("definition count = %d, want 372", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
+		t.Fatalf("definition count = %d, want 373", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
-		t.Fatalf("definition count = %d, want 372", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
+		t.Fatalf("definition count = %d, want 373", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
-		t.Fatalf("definition count = %d, want 372", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
+		t.Fatalf("definition count = %d, want 373", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
-		t.Fatalf("definition count = %d, want 372", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
+		t.Fatalf("definition count = %d, want 373", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
-		t.Fatalf("definition count = %d, want 372", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
+		t.Fatalf("definition count = %d, want 373", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 372 {
-		t.Fatalf("definition count = %d, want 372", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 373 {
+		t.Fatalf("definition count = %d, want 373", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 372 {
-		t.Fatalf("definition count = %d, want 372", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 373 {
+		t.Fatalf("definition count = %d, want 373", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 372 {
-		t.Fatalf("definition count = %d, want 372", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 373 {
+		t.Fatalf("definition count = %d, want 373", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 372 {
-		t.Fatalf("definition count = %d, want 372", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 373 {
+		t.Fatalf("definition count = %d, want 373", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 372 {
-		t.Fatalf("definition count = %d, want 372", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 373 {
+		t.Fatalf("definition count = %d, want 373", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -236,6 +236,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "McpAuthStatus", Type: reflect.TypeFor[McpAuthStatus]()},
 		{Name: "McpServerStartupFailureReason", Type: reflect.TypeFor[McpServerStartupFailureReason]()},
 		{Name: "McpServerStartupState", Type: reflect.TypeFor[McpServerStartupState]()},
+		{Name: "McpServerStatusDetail", Type: reflect.TypeFor[McpServerStatusDetail]()},
 		{Name: "McpServerStatusUpdatedNotification", Type: reflect.TypeFor[McpServerStatusUpdatedNotification]()},
 		{Name: "McpToolCallAppContext", Type: reflect.TypeFor[McpToolCallAppContext]()},
 		{Name: "McpToolCallResult", Type: reflect.TypeFor[McpToolCallResult]()},
@@ -516,6 +517,9 @@ func wireSchemaDefinitions() Schema {
 	schemas["McpServerStartupState"] = stringEnumSchema(
 		string(McpServerStartupStateStarting), string(McpServerStartupStateReady),
 		string(McpServerStartupStateFailed), string(McpServerStartupStateCancelled),
+	)
+	schemas["McpServerStatusDetail"] = stringEnumSchema(
+		string(McpServerStatusDetailFull), string(McpServerStatusDetailToolsAndAuthOnly),
 	)
 	schemas["ReasoningEffort"] = Schema{"type": "string", "minLength": 1}
 	schemas["ResidencyRequirement"] = stringEnumSchema(string(ResidencyRequirementUS))

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -5784,6 +5784,13 @@
       ],
       "type": "string"
     },
+    "McpServerStatusDetail": {
+      "enum": [
+        "full",
+        "toolsAndAuthOnly"
+      ],
+      "type": "string"
+    },
     "McpServerStatusUpdatedNotification": {
       "additionalProperties": false,
       "properties": {

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 372 {
-		t.Fatalf("definition count = %d, want 372", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 373 {
+		t.Fatalf("definition count = %d, want 373", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
-		t.Fatalf("definition count = %d, want 372", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
+		t.Fatalf("definition count = %d, want 373", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
-		t.Fatalf("definition count = %d, want 372", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
+		t.Fatalf("definition count = %d, want 373", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
-		t.Fatalf("definition count = %d, want 372", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
+		t.Fatalf("definition count = %d, want 373", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
-		t.Fatalf("definition count = %d, want 372", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
+		t.Fatalf("definition count = %d, want 373", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
-		t.Fatalf("definition count = %d, want 372", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
+		t.Fatalf("definition count = %d, want 373", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 372 {
-		t.Fatalf("definition count = %d, want 372", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 373 {
+		t.Fatalf("definition count = %d, want 373", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 372 {
-		t.Fatalf("definition count = %d, want 372", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 373 {
+		t.Fatalf("definition count = %d, want 373", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
-		t.Fatalf("definition count = %d, want 372", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
+		t.Fatalf("definition count = %d, want 373", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
-		t.Fatalf("definition count = %d, want 372", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
+		t.Fatalf("definition count = %d, want 373", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
-		t.Fatalf("definition count = %d, want 372", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
+		t.Fatalf("definition count = %d, want 373", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
-		t.Fatalf("definition count = %d, want 372", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
+		t.Fatalf("definition count = %d, want 373", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -1740,6 +1740,8 @@ export type McpServerStartupFailureReason = "reauthenticationRequired";
 
 export type McpServerStartupState = "starting" | "ready" | "failed" | "cancelled";
 
+export type McpServerStatusDetail = "full" | "toolsAndAuthOnly";
+
 export type McpServerStatusUpdatedNotification = {
   "error": string | null;
   "failureReason": McpServerStartupFailureReason | null;

--- a/appserver/protocol/typescript/testdata/mcp_server_status_detail_contract.ts
+++ b/appserver/protocol/typescript/testdata/mcp_server_status_detail_contract.ts
@@ -1,0 +1,37 @@
+import type { McpServerStatusDetail } from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? (<T>() => T extends B ? 1 : 2) extends
+        (<T>() => T extends A ? 1 : 2)
+      ? true
+      : false
+    : false;
+type Expect<T extends true> = T;
+
+type Contract = Expect<
+  Equal<McpServerStatusDetail, "full" | "toolsAndAuthOnly">
+>;
+
+export const details = [
+  "full",
+  "toolsAndAuthOnly",
+] satisfies McpServerStatusDetail[];
+
+// @ts-expect-error status detail values are closed.
+export const rejectUnknown = "other" satisfies McpServerStatusDetail;
+// @ts-expect-error exact lower-camel spelling is required.
+export const rejectFullCase = "Full" satisfies McpServerStatusDetail;
+// @ts-expect-error exact lower-camel spelling is required.
+export const rejectToolsCase = "ToolsAndAuthOnly" satisfies McpServerStatusDetail;
+// @ts-expect-error snake-case detail values are not accepted.
+export const rejectSnakeCase = "tools_and_auth_only" satisfies McpServerStatusDetail;
+// @ts-expect-error empty strings are not status detail values.
+export const rejectEmpty = "" satisfies McpServerStatusDetail;
+// @ts-expect-error status detail values are non-null.
+export const rejectNull = null satisfies McpServerStatusDetail;
+// @ts-expect-error status detail values are strings.
+export const rejectNumber = 1 satisfies McpServerStatusDetail;
+
+void (null as unknown as Contract);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 372 {
-		t.Fatalf("definition count = %d, want 372", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
+		t.Fatalf("definition count = %d, want 373", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- export the exact public `McpServerStatusDetail` string enum
- include it in generated JSON Schema and TypeScript output
- enforce exact literals and strict invalid-input behavior with Go and TypeScript contract tests

## Scope
This is a standalone protocol-leaf export. It deliberately does not bind `mcpServerStatus/list` or add list parameters, result projection, authentication inference, or runtime behavior.

## Verification
- focused contract tests, 30 repeated runs, race, and coverage
- full `appserver/protocol` tests
- all 59 non-Monty packages under normal and race tests
- `golangci-lint run ./...`
- `go vet ./...`
- `go mod tidy` stability
- deterministic schema/TypeScript generation
- all five canonical Slang workflows against the exact feature binary
- baseline/feature startup and `mcpServerStatus/list` output byte identity

Local Monty normal/race/coverage tests were intentionally omitted. The configured pre-push gate explicitly skipped only Monty race via `hooks.skipMontyRace=true`; all other configured checks passed.