### PR TITLE
Export exact MCP status list params

### DIFF
--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 373 {
-		t.Fatalf("definition count = %d, want 373", got)
+	if got := len(defs); got != 374 {
+		t.Fatalf("definition count = %d, want 374", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
-		t.Fatalf("definition count = %d, want 373", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
+		t.Fatalf("definition count = %d, want 374", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
-		t.Fatalf("definition count = %d, want 373", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
+		t.Fatalf("definition count = %d, want 374", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
-		t.Fatalf("definition count = %d, want 373", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
+		t.Fatalf("definition count = %d, want 374", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
-		t.Fatalf("definition count = %d, want 373", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
+		t.Fatalf("definition count = %d, want 374", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
-		t.Fatalf("definition count = %d, want 373", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
+		t.Fatalf("definition count = %d, want 374", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
-		t.Fatalf("definition count = %d, want 373", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
+		t.Fatalf("definition count = %d, want 374", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
-		t.Fatalf("definition count = %d, want 373", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
+		t.Fatalf("definition count = %d, want 374", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
-		t.Fatalf("definition count = %d, want 373", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
+		t.Fatalf("definition count = %d, want 374", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
-		t.Fatalf("definition count = %d, want 373", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
+		t.Fatalf("definition count = %d, want 374", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
-		t.Fatalf("definition count = %d, want 373", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
+		t.Fatalf("definition count = %d, want 374", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
-		t.Fatalf("definition count = %d, want 373", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
+		t.Fatalf("definition count = %d, want 374", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
-		t.Fatalf("definition count = %d, want 373", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
+		t.Fatalf("definition count = %d, want 374", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
-		t.Fatalf("definition count = %d, want 373", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
+		t.Fatalf("definition count = %d, want 374", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 373 {
-		t.Fatalf("definition count = %d, want 373", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 374 {
+		t.Fatalf("definition count = %d, want 374", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -1,0 +1,163 @@
+package protocol
+
+import (
+	"encoding/json"
+	"math"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestListMcpServerStatusParamsSchemaIsExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	params, ok := defs["ListMcpServerStatusParams"].(Schema)
+	if !ok {
+		t.Fatal("$defs missing ListMcpServerStatusParams")
+	}
+	if params["type"] != "object" || params["additionalProperties"] != false {
+		t.Fatalf("ListMcpServerStatusParams is not a closed object: %#v", params)
+	}
+	if got := schemaRequiredNames(params); len(got) != 0 {
+		t.Fatalf("ListMcpServerStatusParams required = %v, want none", got)
+	}
+	wantProperties := Schema{
+		"cursor": Schema{
+			"description": "Opaque pagination cursor returned by a previous call.",
+			"anyOf":       []any{Schema{"type": "string"}, Schema{"type": "null"}},
+		},
+		"limit": Schema{
+			"description": "Optional page size; defaults to a server-defined value.",
+			"anyOf": []any{
+				Schema{"type": "integer", "minimum": 0, "maximum": 4294967295},
+				Schema{"type": "null"},
+			},
+		},
+		"detail": Schema{
+			"description": "Controls how much MCP inventory data to fetch for each server. Defaults to `Full` when omitted.",
+			"anyOf": []any{
+				Schema{"$ref": "#/$defs/McpServerStatusDetail"},
+				Schema{"type": "null"},
+			},
+		},
+		"threadId": Schema{
+			"anyOf": []any{Schema{"type": "string"}, Schema{"type": "null"}},
+		},
+	}
+	if got := params["properties"].(Schema); !reflect.DeepEqual(got, wantProperties) {
+		t.Fatalf("ListMcpServerStatusParams properties = %#v, want %#v", got, wantProperties)
+	}
+}
+
+func TestListMcpServerStatusParamsAcceptsExactWireFormsAndCanonicalizesOptions(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{
+			input: `{}`,
+			want:  `{"cursor":null,"limit":null,"detail":null,"threadId":null}`,
+		},
+		{
+			input: `{"cursor":null,"limit":null,"detail":null,"threadId":null}`,
+			want:  `{"cursor":null,"limit":null,"detail":null,"threadId":null}`,
+		},
+		{
+			input: `{"cursor":"","limit":0,"detail":"full","threadId":""}`,
+			want:  `{"cursor":"","limit":0,"detail":"full","threadId":""}`,
+		},
+		{
+			input: `{"cursor":"next","limit":4294967295,"detail":"toolsAndAuthOnly","threadId":"thread-1"}`,
+			want:  `{"cursor":"next","limit":4294967295,"detail":"toolsAndAuthOnly","threadId":"thread-1"}`,
+		},
+	}
+	for _, tc := range cases {
+		var params ListMcpServerStatusParams
+		if err := json.Unmarshal([]byte(tc.input), &params); err != nil {
+			t.Errorf("Unmarshal(%s): %v", tc.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(params)
+		if err != nil || string(encoded) != tc.want {
+			t.Errorf("canonical = %s, %v; want %s", encoded, err, tc.want)
+		}
+	}
+
+	cursor := "next"
+	limit := uint32(math.MaxUint32)
+	detail := McpServerStatusDetailToolsAndAuthOnly
+	threadID := "thread-1"
+	encoded, err := json.Marshal(ListMcpServerStatusParams{
+		Cursor: &cursor, Limit: &limit, Detail: &detail, ThreadID: &threadID,
+	})
+	want := `{"cursor":"next","limit":4294967295,"detail":"toolsAndAuthOnly","threadId":"thread-1"}`
+	if err != nil || string(encoded) != want {
+		t.Fatalf("marshal populated params = %s, %v; want %s", encoded, err, want)
+	}
+}
+
+func TestListMcpServerStatusParamsRejectsMalformedWireForms(t *testing.T) {
+	invalid := []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`,
+		`{"cursor":1}`, `{"cursor":false}`,
+		`{"limit":-1}`, `{"limit":1.5}`, `{"limit":4294967296}`, `{"limit":"1"}`,
+		`{"detail":""}`, `{"detail":"Full"}`, `{"detail":"tools_and_auth_only"}`,
+		`{"detail":"other"}`, `{"detail":1}`, `{"detail":false}`, `{"detail":{}}`,
+		`{"threadId":1}`, `{"threadId":false}`,
+		`{"thread_id":"thread-1"}`, `{"serverId":"server-1"}`, `{"serverName":"server"}`,
+		`{"name":"server"}`, `{"servers":[]}`, `{"unknown":null}`,
+		`{"limit":1} {}`,
+	}
+	for _, input := range invalid {
+		var params ListMcpServerStatusParams
+		if err := json.Unmarshal([]byte(input), &params); err == nil {
+			t.Errorf("Unmarshal(%s) succeeded", input)
+		}
+	}
+	var params *ListMcpServerStatusParams
+	if err := params.UnmarshalJSON([]byte(`{}`)); err == nil {
+		t.Fatal("nil ListMcpServerStatusParams receiver succeeded")
+	}
+}
+
+func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
+	for _, binding := range WireTypeBindings() {
+		if slices.Contains(binding.Params, "ListMcpServerStatusParams") ||
+			slices.Contains(binding.Result, "ListMcpServerStatusParams") {
+			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
+		t.Fatalf("definition count = %d, want 374", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestListMcpServerStatusParamsTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	source := string(generated)
+	for _, want := range []string{
+		`export type ListMcpServerStatusParams = {`,
+		`"cursor"?: string | null;`,
+		`"detail"?: McpServerStatusDetail | null;`,
+		`"limit"?: number | null;`,
+		`"threadId"?: string | null;`,
+	} {
+		if !strings.Contains(source, want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}
+
+var (
+	_ json.Marshaler   = ListMcpServerStatusParams{}
+	_ json.Unmarshaler = (*ListMcpServerStatusParams)(nil)
+)

--- a/appserver/protocol/list_mcp_server_status_params_types.go
+++ b/appserver/protocol/list_mcp_server_status_params_types.go
@@ -1,0 +1,83 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// ListMcpServerStatusParams is the exact public MCP inventory page selector.
+// It remains separate from the live server-filter request until an adapter is defined.
+type ListMcpServerStatusParams struct {
+	Cursor   *string                `json:"cursor,omitempty"`
+	Limit    *uint32                `json:"limit,omitempty"`
+	Detail   *McpServerStatusDetail `json:"detail,omitempty"`
+	ThreadID *string                `json:"threadId,omitempty"`
+}
+
+func (p ListMcpServerStatusParams) MarshalJSON() ([]byte, error) {
+	type wire struct {
+		Cursor   *string                `json:"cursor"`
+		Limit    *uint32                `json:"limit"`
+		Detail   *McpServerStatusDetail `json:"detail"`
+		ThreadID *string                `json:"threadId"`
+	}
+	return json.Marshal(wire(p))
+}
+
+func (p *ListMcpServerStatusParams) UnmarshalJSON(data []byte) error {
+	if p == nil {
+		return errors.New("decode MCP server status-list params into nil receiver")
+	}
+	payload, err := decodeExactThreadItemObject(
+		data,
+		"MCP server status-list params",
+		"cursor",
+		"limit",
+		"detail",
+		"threadId",
+	)
+	if err != nil {
+		return err
+	}
+	cursor, err := decodeOptionalNullableMcpStatusListValue[string](payload, "cursor")
+	if err != nil {
+		return err
+	}
+	limit, err := decodeOptionalNullableMcpStatusListValue[uint32](payload, "limit")
+	if err != nil {
+		return err
+	}
+	detail, err := decodeOptionalNullableMcpStatusListValue[McpServerStatusDetail](payload, "detail")
+	if err != nil {
+		return err
+	}
+	threadID, err := decodeOptionalNullableMcpStatusListValue[string](payload, "threadId")
+	if err != nil {
+		return err
+	}
+	*p = ListMcpServerStatusParams{
+		Cursor: cursor, Limit: limit, Detail: detail, ThreadID: threadID,
+	}
+	return nil
+}
+
+func decodeOptionalNullableMcpStatusListValue[T any](
+	payload map[string]json.RawMessage,
+	fieldName string,
+) (*T, error) {
+	raw, ok := payload[fieldName]
+	if !ok || isJSONNull(raw) {
+		return nil, nil
+	}
+	var value T
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return nil, fmt.Errorf("decode MCP server status-list %s: %w", fieldName, err)
+	}
+	return &value, nil
+}
+
+var (
+	_ json.Marshaler   = ListMcpServerStatusParams{}
+	_ json.Unmarshaler = (*ListMcpServerStatusParams)(nil)
+)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
-		t.Fatalf("definition count = %d, want 373", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
+		t.Fatalf("definition count = %d, want 374", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
-		t.Fatalf("definition count = %d, want 373", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
+		t.Fatalf("definition count = %d, want 374", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
-		t.Fatalf("definition count = %d, want 373", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
+		t.Fatalf("definition count = %d, want 374", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
-		t.Fatalf("definition count = %d, want 373", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
+		t.Fatalf("definition count = %d, want 374", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
-		t.Fatalf("definition count = %d, want 373", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
+		t.Fatalf("definition count = %d, want 374", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
-		t.Fatalf("definition count = %d, want 373", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
+		t.Fatalf("definition count = %d, want 374", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
-		t.Fatalf("definition count = %d, want 373", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
+		t.Fatalf("definition count = %d, want 374", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
-		t.Fatalf("definition count = %d, want 373", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
+		t.Fatalf("definition count = %d, want 374", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
-		t.Fatalf("definition count = %d, want 373", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
+		t.Fatalf("definition count = %d, want 374", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
-		t.Fatalf("definition count = %d, want 373", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
+		t.Fatalf("definition count = %d, want 374", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
-		t.Fatalf("definition count = %d, want 373", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
+		t.Fatalf("definition count = %d, want 374", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
-		t.Fatalf("definition count = %d, want 373", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
+		t.Fatalf("definition count = %d, want 374", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
-		t.Fatalf("definition count = %d, want 373", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
+		t.Fatalf("definition count = %d, want 374", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
-		t.Fatalf("definition count = %d, want 373", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
+		t.Fatalf("definition count = %d, want 374", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
-		t.Fatalf("definition count = %d, want 373", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
+		t.Fatalf("definition count = %d, want 374", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
-		t.Fatalf("definition count = %d, want 373", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
+		t.Fatalf("definition count = %d, want 374", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 373 {
-		t.Fatalf("definition count = %d, want 373", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 374 {
+		t.Fatalf("definition count = %d, want 374", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 373 {
-		t.Fatalf("definition count = %d, want 373", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 374 {
+		t.Fatalf("definition count = %d, want 374", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 373 {
-		t.Fatalf("definition count = %d, want 373", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 374 {
+		t.Fatalf("definition count = %d, want 374", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 373 {
-		t.Fatalf("definition count = %d, want 373", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 374 {
+		t.Fatalf("definition count = %d, want 374", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 373 {
-		t.Fatalf("definition count = %d, want 373", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 374 {
+		t.Fatalf("definition count = %d, want 374", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -219,6 +219,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "ItemLifecycleNotificationParams", Type: reflect.TypeFor[ItemLifecycleNotificationParams]()},
 		{Name: "ItemStartedNotification", Type: reflect.TypeFor[ItemStartedNotification]()},
 		{Name: "LegacyAppPathString", Type: reflect.TypeFor[LegacyAppPathString]()},
+		{Name: "ListMcpServerStatusParams", Type: reflect.TypeFor[ListMcpServerStatusParams]()},
 		{Name: "LoginAccountParams", Type: reflect.TypeFor[LoginAccountParams]()},
 		{Name: "LoginAccountResponse", Type: reflect.TypeFor[LoginAccountResponse]()},
 		{Name: "LoginAppBrand", Type: reflect.TypeFor[LoginAppBrand]()},
@@ -521,6 +522,7 @@ func wireSchemaDefinitions() Schema {
 	schemas["McpServerStatusDetail"] = stringEnumSchema(
 		string(McpServerStatusDetailFull), string(McpServerStatusDetailToolsAndAuthOnly),
 	)
+	schemas["ListMcpServerStatusParams"] = listMcpServerStatusParamsSchema()
 	schemas["ReasoningEffort"] = Schema{"type": "string", "minLength": 1}
 	schemas["ResidencyRequirement"] = stringEnumSchema(string(ResidencyRequirementUS))
 	schemas["WebSearchMode"] = stringEnumSchema(
@@ -1984,6 +1986,32 @@ func modelListParamsSchema() Schema {
 		"includeHidden": Schema{
 			"description": "When true, include models that are hidden from the default picker list.",
 			"anyOf":       []any{Schema{"type": "boolean"}, Schema{"type": "null"}},
+		},
+	}, nil)
+}
+
+func listMcpServerStatusParamsSchema() Schema {
+	return closedThreadSessionParamSchema(Schema{
+		"cursor": Schema{
+			"description": "Opaque pagination cursor returned by a previous call.",
+			"anyOf":       []any{Schema{"type": "string"}, Schema{"type": "null"}},
+		},
+		"limit": Schema{
+			"description": "Optional page size; defaults to a server-defined value.",
+			"anyOf": []any{
+				Schema{"type": "integer", "minimum": 0, "maximum": 4294967295},
+				Schema{"type": "null"},
+			},
+		},
+		"detail": Schema{
+			"description": "Controls how much MCP inventory data to fetch for each server. Defaults to `Full` when omitted.",
+			"anyOf": []any{
+				Schema{"$ref": "#/$defs/McpServerStatusDetail"},
+				Schema{"type": "null"},
+			},
+		},
+		"threadId": Schema{
+			"anyOf": []any{Schema{"type": "string"}, Schema{"type": "null"}},
 		},
 	}, nil)
 }

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -4468,6 +4468,57 @@
     "LegacyAppPathString": {
       "type": "string"
     },
+    "ListMcpServerStatusParams": {
+      "additionalProperties": false,
+      "properties": {
+        "cursor": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Opaque pagination cursor returned by a previous call."
+        },
+        "detail": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/McpServerStatusDetail"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Controls how much MCP inventory data to fetch for each server. Defaults to `Full` when omitted."
+        },
+        "limit": {
+          "anyOf": [
+            {
+              "maximum": 4294967295,
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional page size; defaults to a server-defined value."
+        },
+        "threadId": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
     "LocalShellAction": {
       "oneOf": [
         {

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 373 {
-		t.Fatalf("definition count = %d, want 373", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 374 {
+		t.Fatalf("definition count = %d, want 374", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
-		t.Fatalf("definition count = %d, want 373", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
+		t.Fatalf("definition count = %d, want 374", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
-		t.Fatalf("definition count = %d, want 373", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
+		t.Fatalf("definition count = %d, want 374", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
-		t.Fatalf("definition count = %d, want 373", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
+		t.Fatalf("definition count = %d, want 374", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
-		t.Fatalf("definition count = %d, want 373", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
+		t.Fatalf("definition count = %d, want 374", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
-		t.Fatalf("definition count = %d, want 373", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
+		t.Fatalf("definition count = %d, want 374", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 373 {
-		t.Fatalf("definition count = %d, want 373", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 374 {
+		t.Fatalf("definition count = %d, want 374", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 373 {
-		t.Fatalf("definition count = %d, want 373", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 374 {
+		t.Fatalf("definition count = %d, want 374", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
-		t.Fatalf("definition count = %d, want 373", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
+		t.Fatalf("definition count = %d, want 374", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
-		t.Fatalf("definition count = %d, want 373", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
+		t.Fatalf("definition count = %d, want 374", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
-		t.Fatalf("definition count = %d, want 373", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
+		t.Fatalf("definition count = %d, want 374", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
-		t.Fatalf("definition count = %d, want 373", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
+		t.Fatalf("definition count = %d, want 374", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -1454,6 +1454,13 @@ export type JsonValue = number | string | boolean | Array<JsonValue> | { [key: s
 
 export type LegacyAppPathString = string;
 
+export type ListMcpServerStatusParams = {
+  "cursor"?: string | null;
+  "detail"?: McpServerStatusDetail | null;
+  "limit"?: number | null;
+  "threadId"?: string | null;
+};
+
 export type LocalShellAction = {
   "command": Array<string>;
   "env": Record<string, string> | null;

--- a/appserver/protocol/typescript/testdata/list_mcp_server_status_params_contract.ts
+++ b/appserver/protocol/typescript/testdata/list_mcp_server_status_params_contract.ts
@@ -1,0 +1,75 @@
+import type {
+  ListMcpServerStatusParams,
+  McpServerStatusDetail,
+  MethodParamsByName,
+  MethodResultsByName,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? (<T>() => T extends B ? 1 : 2) extends
+        (<T>() => T extends A ? 1 : 2)
+      ? true
+      : false
+    : false;
+type Expect<T extends true> = T;
+
+type Expected = {
+  cursor?: string | null;
+  limit?: number | null;
+  detail?: McpServerStatusDetail | null;
+  threadId?: string | null;
+};
+type Contracts = [
+  Expect<Equal<ListMcpServerStatusParams, Expected>>,
+  Expect<
+    Equal<
+      "mcpServerStatus/list" extends keyof MethodParamsByName ? true : false,
+      false
+    >
+  >,
+  Expect<
+    Equal<
+      "mcpServerStatus/list" extends keyof MethodResultsByName ? true : false,
+      false
+    >
+  >,
+];
+
+export const empty = {} satisfies ListMcpServerStatusParams;
+export const nullable = {
+  cursor: null,
+  limit: null,
+  detail: null,
+  threadId: null,
+} satisfies ListMcpServerStatusParams;
+export const lowerBoundary = {
+  cursor: "",
+  limit: 0,
+  detail: "full",
+  threadId: "",
+} satisfies ListMcpServerStatusParams;
+export const upperBoundary = {
+  cursor: "next",
+  limit: 4294967295,
+  detail: "toolsAndAuthOnly",
+  threadId: "thread-1",
+} satisfies ListMcpServerStatusParams;
+
+// @ts-expect-error cursors are nullable strings only.
+export const rejectNumericCursor = { cursor: 1 } satisfies ListMcpServerStatusParams;
+// @ts-expect-error limits are nullable numbers only.
+export const rejectStringLimit = { limit: "1" } satisfies ListMcpServerStatusParams;
+// @ts-expect-error status detail values are closed.
+export const rejectUnknownDetail = { detail: "other" } satisfies ListMcpServerStatusParams;
+// @ts-expect-error thread ids are nullable strings only.
+export const rejectNumericThread = { threadId: 1 } satisfies ListMcpServerStatusParams;
+// @ts-expect-error exact lower-camel wire names are required.
+export const rejectSnakeThread = { thread_id: "thread-1" } satisfies ListMcpServerStatusParams;
+// @ts-expect-error live server filters are not part of the public contract.
+export const rejectLiveFilter = { serverId: "server-1" } satisfies ListMcpServerStatusParams;
+// @ts-expect-error exact optional properties may be omitted or null, not explicitly undefined.
+export const rejectUndefinedDetail = { detail: undefined } satisfies ListMcpServerStatusParams;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 373 {
-		t.Fatalf("definition count = %d, want 373", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
+		t.Fatalf("definition count = %d, want 374", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- export exact standalone `ListMcpServerStatusParams` with optional nullable cursor, uint32 limit, detail, and thread id
- preserve Rust option serialization with explicit null canonical output and strict malformed/alias rejection
- keep `mcpServerStatus/list` live params/results and all method/item bindings unchanged

## Verification
- deliberate-red Go and strict TypeScript contracts
- focused x30, focused race, 100% new-code coverage, full protocol at 96.6%
- all 59 non-Monty packages normal/race; lint, vet, tidy, configured pre-push
- deterministic 374-definition generation and strict TypeScript
- all five Slang stdio/Unix-socket/WebSocket workflows
- byte-identical baseline/feature initialized plus status-list output

Local Monty normal/race/coverage was intentionally skipped per project direction; hosted checks are unchanged.