### PR TITLE
Export exact MCP resource read params

### DIFF
--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 374 {
-		t.Fatalf("definition count = %d, want 374", got)
+	if got := len(defs); got != 375 {
+		t.Fatalf("definition count = %d, want 375", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
-		t.Fatalf("definition count = %d, want 374", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
+		t.Fatalf("definition count = %d, want 375", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
-		t.Fatalf("definition count = %d, want 374", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
+		t.Fatalf("definition count = %d, want 375", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
-		t.Fatalf("definition count = %d, want 374", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
+		t.Fatalf("definition count = %d, want 375", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
-		t.Fatalf("definition count = %d, want 374", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
+		t.Fatalf("definition count = %d, want 375", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
-		t.Fatalf("definition count = %d, want 374", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
+		t.Fatalf("definition count = %d, want 375", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
-		t.Fatalf("definition count = %d, want 374", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
+		t.Fatalf("definition count = %d, want 375", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
-		t.Fatalf("definition count = %d, want 374", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
+		t.Fatalf("definition count = %d, want 375", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
-		t.Fatalf("definition count = %d, want 374", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
+		t.Fatalf("definition count = %d, want 375", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
-		t.Fatalf("definition count = %d, want 374", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
+		t.Fatalf("definition count = %d, want 375", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
-		t.Fatalf("definition count = %d, want 374", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
+		t.Fatalf("definition count = %d, want 375", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
-		t.Fatalf("definition count = %d, want 374", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
+		t.Fatalf("definition count = %d, want 375", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
-		t.Fatalf("definition count = %d, want 374", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
+		t.Fatalf("definition count = %d, want 375", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
-		t.Fatalf("definition count = %d, want 374", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
+		t.Fatalf("definition count = %d, want 375", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 374 {
-		t.Fatalf("definition count = %d, want 374", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 375 {
+		t.Fatalf("definition count = %d, want 375", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
-		t.Fatalf("definition count = %d, want 374", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
+		t.Fatalf("definition count = %d, want 375", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
-		t.Fatalf("definition count = %d, want 374", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
+		t.Fatalf("definition count = %d, want 375", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
-		t.Fatalf("definition count = %d, want 374", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
+		t.Fatalf("definition count = %d, want 375", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
-		t.Fatalf("definition count = %d, want 374", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
+		t.Fatalf("definition count = %d, want 375", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
-		t.Fatalf("definition count = %d, want 374", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
+		t.Fatalf("definition count = %d, want 375", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
-		t.Fatalf("definition count = %d, want 374", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
+		t.Fatalf("definition count = %d, want 375", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -1,0 +1,149 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestMcpResourceReadParamsSchemaIsExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	params, ok := defs["McpResourceReadParams"].(Schema)
+	if !ok {
+		t.Fatal("$defs missing McpResourceReadParams")
+	}
+	if params["type"] != "object" || params["additionalProperties"] != false {
+		t.Fatalf("McpResourceReadParams is not a closed object: %#v", params)
+	}
+	if got, want := schemaRequiredNames(params), []string{"server", "uri"}; !slices.Equal(got, want) {
+		t.Fatalf("McpResourceReadParams required = %v, want %v", got, want)
+	}
+	wantProperties := Schema{
+		"threadId": Schema{
+			"anyOf": []any{Schema{"type": "string"}, Schema{"type": "null"}},
+		},
+		"server": Schema{"type": "string"},
+		"uri":    Schema{"type": "string"},
+	}
+	if got := params["properties"].(Schema); !reflect.DeepEqual(got, wantProperties) {
+		t.Fatalf("McpResourceReadParams properties = %#v, want %#v", got, wantProperties)
+	}
+}
+
+func TestMcpResourceReadParamsAcceptsExactWireFormsAndCanonicalizesThread(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{
+			input: `{"server":"","uri":""}`,
+			want:  `{"threadId":null,"server":"","uri":""}`,
+		},
+		{
+			input: `{"threadId":null,"server":"repo","uri":"file:///workspace/README.md"}`,
+			want:  `{"threadId":null,"server":"repo","uri":"file:///workspace/README.md"}`,
+		},
+		{
+			input: `{"threadId":"thread-1","server":"repo","uri":"file:///workspace/README.md"}`,
+			want:  `{"threadId":"thread-1","server":"repo","uri":"file:///workspace/README.md"}`,
+		},
+	}
+	for _, tc := range cases {
+		var params McpResourceReadParams
+		if err := json.Unmarshal([]byte(tc.input), &params); err != nil {
+			t.Errorf("Unmarshal(%s): %v", tc.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(params)
+		if err != nil || string(encoded) != tc.want {
+			t.Errorf("canonical = %s, %v; want %s", encoded, err, tc.want)
+		}
+	}
+
+	threadID := "thread-1"
+	encoded, err := json.Marshal(McpResourceReadParams{
+		ThreadID: &threadID,
+		Server:   "repo",
+		URI:      "file:///workspace/README.md",
+	})
+	want := `{"threadId":"thread-1","server":"repo","uri":"file:///workspace/README.md"}`
+	if err != nil || string(encoded) != want {
+		t.Fatalf("marshal populated params = %s, %v; want %s", encoded, err, want)
+	}
+}
+
+func TestMcpResourceReadParamsRejectsMalformedWireForms(t *testing.T) {
+	invalid := []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`,
+		`{}`, `{"threadId":null}`, `{"server":"repo"}`, `{"uri":"resource"}`,
+		`{"server":null,"uri":"resource"}`, `{"server":1,"uri":"resource"}`,
+		`{"server":false,"uri":"resource"}`, `{"server":{},"uri":"resource"}`,
+		`{"server":"repo","uri":null}`, `{"server":"repo","uri":1}`,
+		`{"server":"repo","uri":false}`, `{"server":"repo","uri":{}}`,
+		`{"threadId":1,"server":"repo","uri":"resource"}`,
+		`{"threadId":false,"server":"repo","uri":"resource"}`,
+		`{"thread_id":"thread-1","server":"repo","uri":"resource"}`,
+		`{"serverId":"repo","server":"repo","uri":"resource"}`,
+		`{"serverName":"repo","server":"repo","uri":"resource"}`,
+		`{"name":"repo","server":"repo","uri":"resource"}`,
+		`{"mcpServerId":"repo","server":"repo","uri":"resource"}`,
+		`{"mcpServer":"repo","server":"repo","uri":"resource"}`,
+		`{"resourceUri":"resource","server":"repo","uri":"resource"}`,
+		`{"resourceURI":"resource","server":"repo","uri":"resource"}`,
+		`{"unknown":null,"server":"repo","uri":"resource"}`,
+		`{"server":"repo","uri":"resource"} {}`,
+	}
+	for _, input := range invalid {
+		var params McpResourceReadParams
+		if err := json.Unmarshal([]byte(input), &params); err == nil {
+			t.Errorf("Unmarshal(%s) succeeded", input)
+		}
+	}
+	var params *McpResourceReadParams
+	if err := params.UnmarshalJSON([]byte(`{"server":"repo","uri":"resource"}`)); err == nil {
+		t.Fatal("nil McpResourceReadParams receiver succeeded")
+	}
+}
+
+func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
+	for _, binding := range WireTypeBindings() {
+		if slices.Contains(binding.Params, "McpResourceReadParams") ||
+			slices.Contains(binding.Result, "McpResourceReadParams") {
+			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
+		t.Fatalf("definition count = %d, want 375", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestMcpResourceReadParamsTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	source := string(generated)
+	for _, want := range []string{
+		`export type McpResourceReadParams = {`,
+		`"server": string;`,
+		`"threadId"?: string | null;`,
+		`"uri": string;`,
+	} {
+		if !strings.Contains(source, want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}
+
+var (
+	_ json.Marshaler   = McpResourceReadParams{}
+	_ json.Unmarshaler = (*McpResourceReadParams)(nil)
+)

--- a/appserver/protocol/mcp_resource_read_params_types.go
+++ b/appserver/protocol/mcp_resource_read_params_types.go
@@ -1,0 +1,82 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// McpResourceReadParams is the exact public MCP resource selector. It remains
+// separate from the alias-compatible live request until an adapter is defined.
+type McpResourceReadParams struct {
+	ThreadID *string `json:"threadId,omitempty"`
+	Server   string  `json:"server"`
+	URI      string  `json:"uri"`
+}
+
+func (p McpResourceReadParams) MarshalJSON() ([]byte, error) {
+	type wire struct {
+		ThreadID *string `json:"threadId"`
+		Server   string  `json:"server"`
+		URI      string  `json:"uri"`
+	}
+	return json.Marshal(wire(p))
+}
+
+func (p *McpResourceReadParams) UnmarshalJSON(data []byte) error {
+	if p == nil {
+		return errors.New("decode MCP resource-read params into nil receiver")
+	}
+	payload, err := decodeExactThreadItemObject(
+		data,
+		"MCP resource-read params",
+		"threadId",
+		"server",
+		"uri",
+	)
+	if err != nil {
+		return err
+	}
+	server, err := decodeRequiredThreadItemValue[string](
+		payload,
+		"MCP resource-read params",
+		"server",
+	)
+	if err != nil {
+		return err
+	}
+	uri, err := decodeRequiredThreadItemValue[string](
+		payload,
+		"MCP resource-read params",
+		"uri",
+	)
+	if err != nil {
+		return err
+	}
+	threadID, err := decodeOptionalNullableMcpResourceReadValue[string](payload, "threadId")
+	if err != nil {
+		return err
+	}
+	*p = McpResourceReadParams{ThreadID: threadID, Server: server, URI: uri}
+	return nil
+}
+
+func decodeOptionalNullableMcpResourceReadValue[T any](
+	payload map[string]json.RawMessage,
+	fieldName string,
+) (*T, error) {
+	raw, ok := payload[fieldName]
+	if !ok || isJSONNull(raw) {
+		return nil, nil
+	}
+	var value T
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return nil, fmt.Errorf("decode MCP resource-read %s: %w", fieldName, err)
+	}
+	return &value, nil
+}
+
+var (
+	_ json.Marshaler   = McpResourceReadParams{}
+	_ json.Unmarshaler = (*McpResourceReadParams)(nil)
+)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
-		t.Fatalf("definition count = %d, want 374", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
+		t.Fatalf("definition count = %d, want 375", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
-		t.Fatalf("definition count = %d, want 374", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
+		t.Fatalf("definition count = %d, want 375", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
-		t.Fatalf("definition count = %d, want 374", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
+		t.Fatalf("definition count = %d, want 375", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
-		t.Fatalf("definition count = %d, want 374", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
+		t.Fatalf("definition count = %d, want 375", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
-		t.Fatalf("definition count = %d, want 374", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
+		t.Fatalf("definition count = %d, want 375", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
-		t.Fatalf("definition count = %d, want 374", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
+		t.Fatalf("definition count = %d, want 375", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
-		t.Fatalf("definition count = %d, want 374", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
+		t.Fatalf("definition count = %d, want 375", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
-		t.Fatalf("definition count = %d, want 374", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
+		t.Fatalf("definition count = %d, want 375", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
-		t.Fatalf("definition count = %d, want 374", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
+		t.Fatalf("definition count = %d, want 375", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
-		t.Fatalf("definition count = %d, want 374", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
+		t.Fatalf("definition count = %d, want 375", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
-		t.Fatalf("definition count = %d, want 374", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
+		t.Fatalf("definition count = %d, want 375", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 374 {
-		t.Fatalf("definition count = %d, want 374", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 375 {
+		t.Fatalf("definition count = %d, want 375", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 374 {
-		t.Fatalf("definition count = %d, want 374", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 375 {
+		t.Fatalf("definition count = %d, want 375", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 374 {
-		t.Fatalf("definition count = %d, want 374", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 375 {
+		t.Fatalf("definition count = %d, want 375", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 374 {
-		t.Fatalf("definition count = %d, want 374", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 375 {
+		t.Fatalf("definition count = %d, want 375", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 374 {
-		t.Fatalf("definition count = %d, want 374", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 375 {
+		t.Fatalf("definition count = %d, want 375", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -235,6 +235,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "MCPToolCallProgressNotificationParams", Type: reflect.TypeFor[MCPToolCallProgressNotificationParams]()},
 		{Name: "MCPToolCallResult", Type: reflect.TypeFor[MCPToolCallResult]()},
 		{Name: "McpAuthStatus", Type: reflect.TypeFor[McpAuthStatus]()},
+		{Name: "McpResourceReadParams", Type: reflect.TypeFor[McpResourceReadParams]()},
 		{Name: "McpServerStartupFailureReason", Type: reflect.TypeFor[McpServerStartupFailureReason]()},
 		{Name: "McpServerStartupState", Type: reflect.TypeFor[McpServerStartupState]()},
 		{Name: "McpServerStatusDetail", Type: reflect.TypeFor[McpServerStatusDetail]()},
@@ -523,6 +524,7 @@ func wireSchemaDefinitions() Schema {
 		string(McpServerStatusDetailFull), string(McpServerStatusDetailToolsAndAuthOnly),
 	)
 	schemas["ListMcpServerStatusParams"] = listMcpServerStatusParamsSchema()
+	schemas["McpResourceReadParams"] = mcpResourceReadParamsSchema()
 	schemas["ReasoningEffort"] = Schema{"type": "string", "minLength": 1}
 	schemas["ResidencyRequirement"] = stringEnumSchema(string(ResidencyRequirementUS))
 	schemas["WebSearchMode"] = stringEnumSchema(
@@ -2014,6 +2016,16 @@ func listMcpServerStatusParamsSchema() Schema {
 			"anyOf": []any{Schema{"type": "string"}, Schema{"type": "null"}},
 		},
 	}, nil)
+}
+
+func mcpResourceReadParamsSchema() Schema {
+	return closedThreadSessionParamSchema(Schema{
+		"threadId": Schema{
+			"anyOf": []any{Schema{"type": "string"}, Schema{"type": "null"}},
+		},
+		"server": Schema{"type": "string"},
+		"uri":    Schema{"type": "string"},
+	}, []string{"server", "uri"})
 }
 
 func threadForkParamsSchema() Schema {

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -5547,6 +5547,32 @@
       ],
       "type": "object"
     },
+    "McpResourceReadParams": {
+      "additionalProperties": false,
+      "properties": {
+        "server": {
+          "type": "string"
+        },
+        "threadId": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "server",
+        "uri"
+      ],
+      "type": "object"
+    },
     "McpServerElicitationAction": {
       "enum": [
         "accept",

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 374 {
-		t.Fatalf("definition count = %d, want 374", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 375 {
+		t.Fatalf("definition count = %d, want 375", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
-		t.Fatalf("definition count = %d, want 374", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
+		t.Fatalf("definition count = %d, want 375", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
-		t.Fatalf("definition count = %d, want 374", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
+		t.Fatalf("definition count = %d, want 375", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
-		t.Fatalf("definition count = %d, want 374", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
+		t.Fatalf("definition count = %d, want 375", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
-		t.Fatalf("definition count = %d, want 374", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
+		t.Fatalf("definition count = %d, want 375", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
-		t.Fatalf("definition count = %d, want 374", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
+		t.Fatalf("definition count = %d, want 375", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 374 {
-		t.Fatalf("definition count = %d, want 374", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 375 {
+		t.Fatalf("definition count = %d, want 375", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 374 {
-		t.Fatalf("definition count = %d, want 374", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 375 {
+		t.Fatalf("definition count = %d, want 375", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
-		t.Fatalf("definition count = %d, want 374", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
+		t.Fatalf("definition count = %d, want 375", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
-		t.Fatalf("definition count = %d, want 374", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
+		t.Fatalf("definition count = %d, want 375", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
-		t.Fatalf("definition count = %d, want 374", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
+		t.Fatalf("definition count = %d, want 375", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
-		t.Fatalf("definition count = %d, want 374", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
+		t.Fatalf("definition count = %d, want 375", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -1687,6 +1687,12 @@ export type McpElicitationUntitledSingleSelectEnumSchema = {
   "type": McpElicitationStringType;
 };
 
+export type McpResourceReadParams = {
+  "server": string;
+  "threadId"?: string | null;
+  "uri": string;
+};
+
 export type McpServerElicitationAction = "accept" | "decline" | "cancel";
 
 export type McpServerElicitationRequestParams = {

--- a/appserver/protocol/typescript/testdata/mcp_resource_read_params_contract.ts
+++ b/appserver/protocol/typescript/testdata/mcp_resource_read_params_contract.ts
@@ -1,0 +1,73 @@
+import type {
+  McpResourceReadParams,
+  MethodParamsByName,
+  MethodResultsByName,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+
+type Expected = {
+  threadId?: string | null;
+  server: string;
+  uri: string;
+};
+type Contracts = [
+  Expect<Equal<McpResourceReadParams, Expected>>,
+  Expect<
+    Equal<
+      "mcpServer/resource/read" extends keyof MethodParamsByName ? true : false,
+      false
+    >
+  >,
+  Expect<
+    Equal<
+      "mcpServer/resource/read" extends keyof MethodResultsByName ? true : false,
+      false
+    >
+  >,
+];
+
+export const emptyStrings = {
+  server: "",
+  uri: "",
+} satisfies McpResourceReadParams;
+export const nullableThread = {
+  threadId: null,
+  server: "repo",
+  uri: "file:///workspace/README.md",
+} satisfies McpResourceReadParams;
+export const populated = {
+  threadId: "thread-1",
+  server: "repo",
+  uri: "file:///workspace/README.md",
+} satisfies McpResourceReadParams;
+
+// @ts-expect-error server is required.
+export const rejectMissingServer = { uri: "resource" } satisfies McpResourceReadParams;
+// @ts-expect-error URI is required.
+export const rejectMissingURI = { server: "repo" } satisfies McpResourceReadParams;
+// @ts-expect-error server is a non-null string.
+export const rejectNullServer = { server: null, uri: "resource" } satisfies McpResourceReadParams;
+// @ts-expect-error server is a string.
+export const rejectNumericServer = { server: 1, uri: "resource" } satisfies McpResourceReadParams;
+// @ts-expect-error URI is a non-null string.
+export const rejectNullURI = { server: "repo", uri: null } satisfies McpResourceReadParams;
+// @ts-expect-error URI is a string.
+export const rejectNumericURI = { server: "repo", uri: 1 } satisfies McpResourceReadParams;
+// @ts-expect-error thread ids are nullable strings only.
+export const rejectNumericThread = { threadId: 1, server: "repo", uri: "resource" } satisfies McpResourceReadParams;
+// @ts-expect-error exact lower-camel wire names are required.
+export const rejectSnakeThread = { thread_id: "thread-1", server: "repo", uri: "resource" } satisfies McpResourceReadParams;
+// @ts-expect-error live server aliases are not part of the public contract.
+export const rejectLiveServerAlias = { serverName: "repo", server: "repo", uri: "resource" } satisfies McpResourceReadParams;
+// @ts-expect-error live resource aliases are not part of the public contract.
+export const rejectLiveResourceAlias = { resourceUri: "resource", server: "repo", uri: "resource" } satisfies McpResourceReadParams;
+// @ts-expect-error exact optional properties may be omitted or null, not explicitly undefined.
+export const rejectUndefinedThread = { threadId: undefined, server: "repo", uri: "resource" } satisfies McpResourceReadParams;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 374 {
-		t.Fatalf("definition count = %d, want 374", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
+		t.Fatalf("definition count = %d, want 375", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- export exact standalone `McpResourceReadParams` from the pinned public contract
- preserve required `server`/`uri` and optional nullable `threadId` semantics
- leave the alias-compatible live resource-read method and all runtime behavior unchanged

## Verification
- deliberate-red Go and strict TypeScript boundaries
- focused x30, focused race, and 100% new codec/helper coverage
- full protocol coverage (96.7%)
- all 59 non-Monty packages under fresh normal and race suites
- lint, vet, tidy, deterministic generation, and configured pre-push
- structural artifact comparison and byte-identical baseline/feature live resource behavior
- five Slang stdio, Unix-socket, and WebSocket workflows