### PR TITLE
Export exact MCP server tool call params

### DIFF
--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 375 {
-		t.Fatalf("definition count = %d, want 375", got)
+	if got := len(defs); got != 376 {
+		t.Fatalf("definition count = %d, want 376", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
-		t.Fatalf("definition count = %d, want 375", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 376 {
+		t.Fatalf("definition count = %d, want 376", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
-		t.Fatalf("definition count = %d, want 375", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 376 {
+		t.Fatalf("definition count = %d, want 376", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
-		t.Fatalf("definition count = %d, want 375", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 376 {
+		t.Fatalf("definition count = %d, want 376", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
-		t.Fatalf("definition count = %d, want 375", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 376 {
+		t.Fatalf("definition count = %d, want 376", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
-		t.Fatalf("definition count = %d, want 375", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 376 {
+		t.Fatalf("definition count = %d, want 376", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
-		t.Fatalf("definition count = %d, want 375", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 376 {
+		t.Fatalf("definition count = %d, want 376", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
-		t.Fatalf("definition count = %d, want 375", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 376 {
+		t.Fatalf("definition count = %d, want 376", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
-		t.Fatalf("definition count = %d, want 375", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 376 {
+		t.Fatalf("definition count = %d, want 376", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
-		t.Fatalf("definition count = %d, want 375", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 376 {
+		t.Fatalf("definition count = %d, want 376", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
-		t.Fatalf("definition count = %d, want 375", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 376 {
+		t.Fatalf("definition count = %d, want 376", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
-		t.Fatalf("definition count = %d, want 375", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 376 {
+		t.Fatalf("definition count = %d, want 376", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
-		t.Fatalf("definition count = %d, want 375", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 376 {
+		t.Fatalf("definition count = %d, want 376", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
-		t.Fatalf("definition count = %d, want 375", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 376 {
+		t.Fatalf("definition count = %d, want 376", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 375 {
-		t.Fatalf("definition count = %d, want 375", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 376 {
+		t.Fatalf("definition count = %d, want 376", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
-		t.Fatalf("definition count = %d, want 375", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 376 {
+		t.Fatalf("definition count = %d, want 376", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
-		t.Fatalf("definition count = %d, want 375", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 376 {
+		t.Fatalf("definition count = %d, want 376", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
-		t.Fatalf("definition count = %d, want 375", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 376 {
+		t.Fatalf("definition count = %d, want 376", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
-		t.Fatalf("definition count = %d, want 375", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 376 {
+		t.Fatalf("definition count = %d, want 376", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
-		t.Fatalf("definition count = %d, want 375", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 376 {
+		t.Fatalf("definition count = %d, want 376", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
-		t.Fatalf("definition count = %d, want 375", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 376 {
+		t.Fatalf("definition count = %d, want 376", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
-		t.Fatalf("definition count = %d, want 375", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 376 {
+		t.Fatalf("definition count = %d, want 376", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
-		t.Fatalf("definition count = %d, want 375", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 376 {
+		t.Fatalf("definition count = %d, want 376", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
-		t.Fatalf("definition count = %d, want 375", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 376 {
+		t.Fatalf("definition count = %d, want 376", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
-		t.Fatalf("definition count = %d, want 375", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 376 {
+		t.Fatalf("definition count = %d, want 376", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -1,0 +1,177 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestMcpServerToolCallParamsSchemaIsExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	params, ok := defs["McpServerToolCallParams"].(Schema)
+	if !ok {
+		t.Fatal("$defs missing McpServerToolCallParams")
+	}
+	if params["type"] != "object" || params["additionalProperties"] != false {
+		t.Fatalf("McpServerToolCallParams is not a closed object: %#v", params)
+	}
+	if got, want := schemaRequiredNames(params), []string{"server", "threadId", "tool"}; !slices.Equal(got, want) {
+		t.Fatalf("McpServerToolCallParams required = %v, want %v", got, want)
+	}
+	wantProperties := Schema{
+		"threadId":  Schema{"type": "string"},
+		"server":    Schema{"type": "string"},
+		"tool":      Schema{"type": "string"},
+		"arguments": Schema{"$ref": "#/$defs/JsonValue"},
+		"_meta":     Schema{"$ref": "#/$defs/JsonValue"},
+	}
+	if got := params["properties"].(Schema); !reflect.DeepEqual(got, wantProperties) {
+		t.Fatalf("McpServerToolCallParams properties = %#v, want %#v", got, wantProperties)
+	}
+}
+
+func TestMcpServerToolCallParamsAcceptsExactWireFormsAndCanonicalizesOptions(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{
+			input: `{"threadId":"","server":"","tool":""}`,
+			want:  `{"threadId":"","server":"","tool":""}`,
+		},
+		{
+			input: `{"threadId":"thread-1","server":"repo","tool":"echo","arguments":null,"_meta":null}`,
+			want:  `{"threadId":"thread-1","server":"repo","tool":"echo"}`,
+		},
+		{
+			input: `{"threadId":"thread-1","server":"repo","tool":"echo","arguments":"value","_meta":false}`,
+			want:  `{"threadId":"thread-1","server":"repo","tool":"echo","arguments":"value","_meta":false}`,
+		},
+		{
+			input: `{"threadId":"thread-1","server":"repo","tool":"echo","arguments":{"big":9007199254740993123456789,"items":[true,null,"x"]},"_meta":[1,{"ok":true}]}`,
+			want:  `{"threadId":"thread-1","server":"repo","tool":"echo","arguments":{"big":9007199254740993123456789,"items":[true,null,"x"]},"_meta":[1,{"ok":true}]}`,
+		},
+	}
+	for _, tc := range cases {
+		var params McpServerToolCallParams
+		if err := json.Unmarshal([]byte(tc.input), &params); err != nil {
+			t.Errorf("Unmarshal(%s): %v", tc.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(params)
+		if err != nil || string(encoded) != tc.want {
+			t.Errorf("canonical = %s, %v; want %s", encoded, err, tc.want)
+		}
+	}
+
+	arguments := JsonValue{raw: json.RawMessage(`{"n":9007199254740993123456789}`)}
+	meta := JsonValue{raw: json.RawMessage(`{"source":"client"}`)}
+	encoded, err := json.Marshal(McpServerToolCallParams{
+		ThreadID:  "thread-1",
+		Server:    "repo",
+		Tool:      "echo",
+		Arguments: &arguments,
+		Meta:      &meta,
+	})
+	want := `{"threadId":"thread-1","server":"repo","tool":"echo","arguments":{"n":9007199254740993123456789},"_meta":{"source":"client"}}`
+	if err != nil || string(encoded) != want {
+		t.Fatalf("marshal populated params = %s, %v; want %s", encoded, err, want)
+	}
+
+	if _, err := json.Marshal(McpServerToolCallParams{
+		ThreadID: "thread-1", Server: "repo", Tool: "echo", Arguments: &JsonValue{},
+	}); err == nil {
+		t.Fatal("marshal invalid constructed arguments succeeded")
+	}
+	if _, err := json.Marshal(McpServerToolCallParams{
+		ThreadID: "thread-1", Server: "repo", Tool: "echo", Meta: &JsonValue{},
+	}); err == nil {
+		t.Fatal("marshal invalid constructed metadata succeeded")
+	}
+}
+
+func TestMcpServerToolCallParamsRejectsMalformedWireForms(t *testing.T) {
+	invalid := []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`,
+		`{}`, `{"threadId":"thread-1"}`, `{"server":"repo"}`, `{"tool":"echo"}`,
+		`{"threadId":"thread-1","server":"repo"}`,
+		`{"threadId":"thread-1","tool":"echo"}`,
+		`{"server":"repo","tool":"echo"}`,
+		`{"threadId":null,"server":"repo","tool":"echo"}`,
+		`{"threadId":1,"server":"repo","tool":"echo"}`,
+		`{"threadId":false,"server":"repo","tool":"echo"}`,
+		`{"threadId":{},"server":"repo","tool":"echo"}`,
+		`{"threadId":"thread-1","server":null,"tool":"echo"}`,
+		`{"threadId":"thread-1","server":1,"tool":"echo"}`,
+		`{"threadId":"thread-1","server":false,"tool":"echo"}`,
+		`{"threadId":"thread-1","server":{},"tool":"echo"}`,
+		`{"threadId":"thread-1","server":"repo","tool":null}`,
+		`{"threadId":"thread-1","server":"repo","tool":1}`,
+		`{"threadId":"thread-1","server":"repo","tool":false}`,
+		`{"threadId":"thread-1","server":"repo","tool":{}}`,
+		`{"thread_id":"thread-1","threadId":"thread-1","server":"repo","tool":"echo"}`,
+		`{"serverName":"repo","threadId":"thread-1","server":"repo","tool":"echo"}`,
+		`{"toolName":"echo","threadId":"thread-1","server":"repo","tool":"echo"}`,
+		`{"args":{},"threadId":"thread-1","server":"repo","tool":"echo"}`,
+		`{"input":{},"threadId":"thread-1","server":"repo","tool":"echo"}`,
+		`{"meta":{},"threadId":"thread-1","server":"repo","tool":"echo"}`,
+		`{"unknown":null,"threadId":"thread-1","server":"repo","tool":"echo"}`,
+		`{"threadId":"thread-1","server":"repo","tool":"echo","arguments":}`,
+		`{"threadId":"thread-1","server":"repo","tool":"echo"} {}`,
+	}
+	for _, input := range invalid {
+		var params McpServerToolCallParams
+		if err := json.Unmarshal([]byte(input), &params); err == nil {
+			t.Errorf("Unmarshal(%s) succeeded", input)
+		}
+	}
+	var params *McpServerToolCallParams
+	if err := params.UnmarshalJSON([]byte(`{"threadId":"thread-1","server":"repo","tool":"echo"}`)); err == nil {
+		t.Fatal("nil McpServerToolCallParams receiver succeeded")
+	}
+}
+
+func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
+	for _, binding := range WireTypeBindings() {
+		if slices.Contains(binding.Params, "McpServerToolCallParams") ||
+			slices.Contains(binding.Result, "McpServerToolCallParams") {
+			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 376 {
+		t.Fatalf("definition count = %d, want 376", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestMcpServerToolCallParamsTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	source := string(generated)
+	for _, want := range []string{
+		`export type McpServerToolCallParams = {`,
+		`"_meta"?: JsonValue;`,
+		`"arguments"?: JsonValue;`,
+		`"server": string;`,
+		`"threadId": string;`,
+		`"tool": string;`,
+	} {
+		if !strings.Contains(source, want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}
+
+var (
+	_ json.Marshaler   = McpServerToolCallParams{}
+	_ json.Unmarshaler = (*McpServerToolCallParams)(nil)
+)

--- a/appserver/protocol/mcp_server_tool_call_params_types.go
+++ b/appserver/protocol/mcp_server_tool_call_params_types.go
@@ -1,0 +1,95 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// McpServerToolCallParams is the exact public MCP tool selector. It remains
+// separate from the alias-compatible live request until an adapter is defined.
+type McpServerToolCallParams struct {
+	ThreadID  string     `json:"threadId"`
+	Server    string     `json:"server"`
+	Tool      string     `json:"tool"`
+	Arguments *JsonValue `json:"arguments,omitempty"`
+	Meta      *JsonValue `json:"_meta,omitempty"`
+}
+
+func (p McpServerToolCallParams) MarshalJSON() ([]byte, error) {
+	type wire struct {
+		ThreadID  string     `json:"threadId"`
+		Server    string     `json:"server"`
+		Tool      string     `json:"tool"`
+		Arguments *JsonValue `json:"arguments,omitempty"`
+		Meta      *JsonValue `json:"_meta,omitempty"`
+	}
+	return json.Marshal(wire(p))
+}
+
+func (p *McpServerToolCallParams) UnmarshalJSON(data []byte) error {
+	if p == nil {
+		return errors.New("decode MCP server tool-call params into nil receiver")
+	}
+	payload, err := decodeExactThreadItemObject(
+		data,
+		"MCP server tool-call params",
+		"threadId",
+		"server",
+		"tool",
+		"arguments",
+		"_meta",
+	)
+	if err != nil {
+		return err
+	}
+	threadID, err := decodeRequiredThreadItemValue[string](
+		payload,
+		"MCP server tool-call params",
+		"threadId",
+	)
+	if err != nil {
+		return err
+	}
+	server, err := decodeRequiredThreadItemValue[string](
+		payload,
+		"MCP server tool-call params",
+		"server",
+	)
+	if err != nil {
+		return err
+	}
+	tool, err := decodeRequiredThreadItemValue[string](
+		payload,
+		"MCP server tool-call params",
+		"tool",
+	)
+	if err != nil {
+		return err
+	}
+	arguments := decodeOptionalMcpServerToolCallJSONValue(payload, "arguments")
+	meta := decodeOptionalMcpServerToolCallJSONValue(payload, "_meta")
+	*p = McpServerToolCallParams{
+		ThreadID:  threadID,
+		Server:    server,
+		Tool:      tool,
+		Arguments: arguments,
+		Meta:      meta,
+	}
+	return nil
+}
+
+func decodeOptionalMcpServerToolCallJSONValue(
+	payload map[string]json.RawMessage,
+	fieldName string,
+) *JsonValue {
+	raw, ok := payload[fieldName]
+	if !ok || isJSONNull(raw) {
+		return nil
+	}
+	return &JsonValue{raw: append(json.RawMessage(nil), raw...)}
+}
+
+var (
+	_ json.Marshaler   = McpServerToolCallParams{}
+	_ json.Unmarshaler = (*McpServerToolCallParams)(nil)
+)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
-		t.Fatalf("definition count = %d, want 375", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 376 {
+		t.Fatalf("definition count = %d, want 376", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
-		t.Fatalf("definition count = %d, want 375", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 376 {
+		t.Fatalf("definition count = %d, want 376", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
-		t.Fatalf("definition count = %d, want 375", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 376 {
+		t.Fatalf("definition count = %d, want 376", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
-		t.Fatalf("definition count = %d, want 375", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 376 {
+		t.Fatalf("definition count = %d, want 376", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
-		t.Fatalf("definition count = %d, want 375", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 376 {
+		t.Fatalf("definition count = %d, want 376", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
-		t.Fatalf("definition count = %d, want 375", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 376 {
+		t.Fatalf("definition count = %d, want 376", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
-		t.Fatalf("definition count = %d, want 375", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 376 {
+		t.Fatalf("definition count = %d, want 376", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
-		t.Fatalf("definition count = %d, want 375", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 376 {
+		t.Fatalf("definition count = %d, want 376", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 375 {
-		t.Fatalf("definition count = %d, want 375", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 376 {
+		t.Fatalf("definition count = %d, want 376", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 375 {
-		t.Fatalf("definition count = %d, want 375", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 376 {
+		t.Fatalf("definition count = %d, want 376", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 375 {
-		t.Fatalf("definition count = %d, want 375", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 376 {
+		t.Fatalf("definition count = %d, want 376", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 375 {
-		t.Fatalf("definition count = %d, want 375", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 376 {
+		t.Fatalf("definition count = %d, want 376", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 375 {
-		t.Fatalf("definition count = %d, want 375", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 376 {
+		t.Fatalf("definition count = %d, want 376", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -236,6 +236,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "MCPToolCallResult", Type: reflect.TypeFor[MCPToolCallResult]()},
 		{Name: "McpAuthStatus", Type: reflect.TypeFor[McpAuthStatus]()},
 		{Name: "McpResourceReadParams", Type: reflect.TypeFor[McpResourceReadParams]()},
+		{Name: "McpServerToolCallParams", Type: reflect.TypeFor[McpServerToolCallParams]()},
 		{Name: "McpServerStartupFailureReason", Type: reflect.TypeFor[McpServerStartupFailureReason]()},
 		{Name: "McpServerStartupState", Type: reflect.TypeFor[McpServerStartupState]()},
 		{Name: "McpServerStatusDetail", Type: reflect.TypeFor[McpServerStatusDetail]()},
@@ -525,6 +526,7 @@ func wireSchemaDefinitions() Schema {
 	)
 	schemas["ListMcpServerStatusParams"] = listMcpServerStatusParamsSchema()
 	schemas["McpResourceReadParams"] = mcpResourceReadParamsSchema()
+	schemas["McpServerToolCallParams"] = mcpServerToolCallParamsSchema()
 	schemas["ReasoningEffort"] = Schema{"type": "string", "minLength": 1}
 	schemas["ResidencyRequirement"] = stringEnumSchema(string(ResidencyRequirementUS))
 	schemas["WebSearchMode"] = stringEnumSchema(
@@ -2026,6 +2028,16 @@ func mcpResourceReadParamsSchema() Schema {
 		"server": Schema{"type": "string"},
 		"uri":    Schema{"type": "string"},
 	}, []string{"server", "uri"})
+}
+
+func mcpServerToolCallParamsSchema() Schema {
+	return closedThreadSessionParamSchema(Schema{
+		"threadId":  Schema{"type": "string"},
+		"server":    Schema{"type": "string"},
+		"tool":      Schema{"type": "string"},
+		"arguments": Schema{"$ref": "#/$defs/JsonValue"},
+		"_meta":     Schema{"$ref": "#/$defs/JsonValue"},
+	}, []string{"server", "threadId", "tool"})
 }
 
 func threadForkParamsSchema() Schema {

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -5917,6 +5917,32 @@
       ],
       "type": "object"
     },
+    "McpServerToolCallParams": {
+      "additionalProperties": false,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/JsonValue"
+        },
+        "arguments": {
+          "$ref": "#/$defs/JsonValue"
+        },
+        "server": {
+          "type": "string"
+        },
+        "threadId": {
+          "type": "string"
+        },
+        "tool": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "server",
+        "threadId",
+        "tool"
+      ],
+      "type": "object"
+    },
     "McpToolCallAppContext": {
       "additionalProperties": false,
       "properties": {

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 375 {
-		t.Fatalf("definition count = %d, want 375", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 376 {
+		t.Fatalf("definition count = %d, want 376", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
-		t.Fatalf("definition count = %d, want 375", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 376 {
+		t.Fatalf("definition count = %d, want 376", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
-		t.Fatalf("definition count = %d, want 375", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 376 {
+		t.Fatalf("definition count = %d, want 376", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
-		t.Fatalf("definition count = %d, want 375", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 376 {
+		t.Fatalf("definition count = %d, want 376", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
-		t.Fatalf("definition count = %d, want 375", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 376 {
+		t.Fatalf("definition count = %d, want 376", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
-		t.Fatalf("definition count = %d, want 375", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 376 {
+		t.Fatalf("definition count = %d, want 376", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 375 {
-		t.Fatalf("definition count = %d, want 375", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 376 {
+		t.Fatalf("definition count = %d, want 376", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 375 {
-		t.Fatalf("definition count = %d, want 375", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 376 {
+		t.Fatalf("definition count = %d, want 376", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
-		t.Fatalf("definition count = %d, want 375", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 376 {
+		t.Fatalf("definition count = %d, want 376", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
-		t.Fatalf("definition count = %d, want 375", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 376 {
+		t.Fatalf("definition count = %d, want 376", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
-		t.Fatalf("definition count = %d, want 375", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 376 {
+		t.Fatalf("definition count = %d, want 376", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
-		t.Fatalf("definition count = %d, want 375", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 376 {
+		t.Fatalf("definition count = %d, want 376", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -1763,6 +1763,14 @@ export type McpServerStatusUpdatedNotification = {
   "threadId": string | null;
 };
 
+export type McpServerToolCallParams = {
+  "_meta"?: JsonValue;
+  "arguments"?: JsonValue;
+  "server": string;
+  "threadId": string;
+  "tool": string;
+};
+
 export type McpToolCallAppContext = {
   "actionName": string | null;
   "appName": string | null;

--- a/appserver/protocol/typescript/testdata/mcp_server_tool_call_params_contract.ts
+++ b/appserver/protocol/typescript/testdata/mcp_server_tool_call_params_contract.ts
@@ -1,0 +1,93 @@
+import type {
+  JsonValue,
+  McpServerToolCallParams,
+  MethodParamsByName,
+  MethodResultsByName,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+
+type Expected = {
+  threadId: string;
+  server: string;
+  tool: string;
+  arguments?: JsonValue;
+  _meta?: JsonValue;
+};
+type Contracts = [
+  Expect<Equal<McpServerToolCallParams, Expected>>,
+  Expect<
+    Equal<
+      "mcpServer/tool/call" extends keyof MethodParamsByName ? true : false,
+      false
+    >
+  >,
+  Expect<
+    Equal<
+      "mcpServer/tool/call" extends keyof MethodResultsByName ? true : false,
+      false
+    >
+  >,
+];
+
+export const emptyStrings = {
+  threadId: "",
+  server: "",
+  tool: "",
+} satisfies McpServerToolCallParams;
+export const nullOptions = {
+  threadId: "thread-1",
+  server: "repo",
+  tool: "echo",
+  arguments: null,
+  _meta: null,
+} satisfies McpServerToolCallParams;
+export const arbitraryJSON = {
+  threadId: "thread-1",
+  server: "repo",
+  tool: "echo",
+  arguments: {
+    nested: [true, null, "value", 9007199254740991],
+  },
+  _meta: [1, { source: "client" }],
+} satisfies McpServerToolCallParams;
+
+// @ts-expect-error threadId is required.
+export const rejectMissingThread = { server: "repo", tool: "echo" } satisfies McpServerToolCallParams;
+// @ts-expect-error server is required.
+export const rejectMissingServer = { threadId: "thread-1", tool: "echo" } satisfies McpServerToolCallParams;
+// @ts-expect-error tool is required.
+export const rejectMissingTool = { threadId: "thread-1", server: "repo" } satisfies McpServerToolCallParams;
+// @ts-expect-error threadId is a non-null string.
+export const rejectNullThread = { threadId: null, server: "repo", tool: "echo" } satisfies McpServerToolCallParams;
+// @ts-expect-error threadId is a string.
+export const rejectNumericThread = { threadId: 1, server: "repo", tool: "echo" } satisfies McpServerToolCallParams;
+// @ts-expect-error server is a non-null string.
+export const rejectNullServer = { threadId: "thread-1", server: null, tool: "echo" } satisfies McpServerToolCallParams;
+// @ts-expect-error server is a string.
+export const rejectNumericServer = { threadId: "thread-1", server: 1, tool: "echo" } satisfies McpServerToolCallParams;
+// @ts-expect-error tool is a non-null string.
+export const rejectNullTool = { threadId: "thread-1", server: "repo", tool: null } satisfies McpServerToolCallParams;
+// @ts-expect-error tool is a string.
+export const rejectNumericTool = { threadId: "thread-1", server: "repo", tool: 1 } satisfies McpServerToolCallParams;
+// @ts-expect-error exact lower-camel wire names are required.
+export const rejectSnakeThread = { thread_id: "thread-1", threadId: "thread-1", server: "repo", tool: "echo" } satisfies McpServerToolCallParams;
+// @ts-expect-error live server aliases are not part of the public contract.
+export const rejectLiveServerAlias = { serverName: "repo", threadId: "thread-1", server: "repo", tool: "echo" } satisfies McpServerToolCallParams;
+// @ts-expect-error live tool aliases are not part of the public contract.
+export const rejectLiveToolAlias = { toolName: "echo", threadId: "thread-1", server: "repo", tool: "echo" } satisfies McpServerToolCallParams;
+// @ts-expect-error live argument aliases are not part of the public contract.
+export const rejectLiveArgumentsAlias = { args: {}, threadId: "thread-1", server: "repo", tool: "echo" } satisfies McpServerToolCallParams;
+// @ts-expect-error the wire metadata name includes the underscore.
+export const rejectMetaAlias = { meta: {}, threadId: "thread-1", server: "repo", tool: "echo" } satisfies McpServerToolCallParams;
+// @ts-expect-error optional arguments may be omitted or JSON null, not explicitly undefined.
+export const rejectUndefinedArguments = { arguments: undefined, threadId: "thread-1", server: "repo", tool: "echo" } satisfies McpServerToolCallParams;
+// @ts-expect-error optional metadata may be omitted or JSON null, not explicitly undefined.
+export const rejectUndefinedMeta = { _meta: undefined, threadId: "thread-1", server: "repo", tool: "echo" } satisfies McpServerToolCallParams;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 375 {
-		t.Fatalf("definition count = %d, want 375", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 376 {
+		t.Fatalf("definition count = %d, want 376", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- export exact standalone public `McpServerToolCallParams`
- preserve precision for arbitrary optional `JsonValue` arguments and `_meta`
- leave alias-compatible live `mcpServer/tool/call` params/result, approvals, and runtime unbound

## Verification
- deliberate red: 8 missing Go references; 1 missing TS export; 1 false identity; 16 unused negative directives
- focused x30, race, and 100% statement coverage for all new codec functions
- full protocol 96.7% coverage
- all 59 non-Monty packages under fresh normal/race suites
- `golangci-lint run ./...`, `go vet ./...`, tidy verification
- deterministic 376-definition generation twice and strict TypeScript
- structural removal restores exact PR #171 schema/TypeScript artifacts
- all five merged Slang transport workflows
- byte-identical legacy-alias and public-shaped live MCP tool-call output against merged baseline

Local Monty normal/race/coverage remain skipped per standing direction; hosted checks are unchanged.