### PR TITLE
Export exact MCP server refresh response

### DIFF
--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 377 {
-		t.Fatalf("definition count = %d, want 377", got)
+	if got := len(defs); got != 378 {
+		t.Fatalf("definition count = %d, want 378", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 377 {
-		t.Fatalf("definition count = %d, want 377", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
+		t.Fatalf("definition count = %d, want 378", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 377 {
-		t.Fatalf("definition count = %d, want 377", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
+		t.Fatalf("definition count = %d, want 378", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 377 {
-		t.Fatalf("definition count = %d, want 377", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
+		t.Fatalf("definition count = %d, want 378", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 377 {
-		t.Fatalf("definition count = %d, want 377", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
+		t.Fatalf("definition count = %d, want 378", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 377 {
-		t.Fatalf("definition count = %d, want 377", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
+		t.Fatalf("definition count = %d, want 378", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 377 {
-		t.Fatalf("definition count = %d, want 377", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
+		t.Fatalf("definition count = %d, want 378", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 377 {
-		t.Fatalf("definition count = %d, want 377", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
+		t.Fatalf("definition count = %d, want 378", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 377 {
-		t.Fatalf("definition count = %d, want 377", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
+		t.Fatalf("definition count = %d, want 378", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 377 {
-		t.Fatalf("definition count = %d, want 377", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
+		t.Fatalf("definition count = %d, want 378", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 377 {
-		t.Fatalf("definition count = %d, want 377", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
+		t.Fatalf("definition count = %d, want 378", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 377 {
-		t.Fatalf("definition count = %d, want 377", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
+		t.Fatalf("definition count = %d, want 378", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 377 {
-		t.Fatalf("definition count = %d, want 377", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
+		t.Fatalf("definition count = %d, want 378", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 377 {
-		t.Fatalf("definition count = %d, want 377", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
+		t.Fatalf("definition count = %d, want 378", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 377 {
-		t.Fatalf("definition count = %d, want 377", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 378 {
+		t.Fatalf("definition count = %d, want 378", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 377 {
-		t.Fatalf("definition count = %d, want 377", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
+		t.Fatalf("definition count = %d, want 378", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 377 {
-		t.Fatalf("definition count = %d, want 377", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
+		t.Fatalf("definition count = %d, want 378", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 377 {
-		t.Fatalf("definition count = %d, want 377", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
+		t.Fatalf("definition count = %d, want 378", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 377 {
-		t.Fatalf("definition count = %d, want 377", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
+		t.Fatalf("definition count = %d, want 378", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 377 {
-		t.Fatalf("definition count = %d, want 377", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
+		t.Fatalf("definition count = %d, want 378", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 377 {
-		t.Fatalf("definition count = %d, want 377", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
+		t.Fatalf("definition count = %d, want 378", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -8,29 +8,29 @@ import (
 	"testing"
 )
 
-func TestLogoutAccountResponseSchemaIsExact(t *testing.T) {
+func TestMcpServerRefreshResponseSchemaIsExact(t *testing.T) {
 	defs := JSONSchema()["$defs"].(Schema)
-	got, ok := defs["LogoutAccountResponse"].(Schema)
+	got, ok := defs["McpServerRefreshResponse"].(Schema)
 	if !ok {
-		t.Fatal("$defs missing LogoutAccountResponse")
+		t.Fatal("$defs missing McpServerRefreshResponse")
 	}
 	want := Schema{
 		"type":                 "object",
 		"additionalProperties": false,
 	}
 	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("LogoutAccountResponse = %#v, want %#v", got, want)
+		t.Fatalf("McpServerRefreshResponse = %#v, want %#v", got, want)
 	}
 }
 
-func TestLogoutAccountResponseAcceptsAndCanonicalizesObjects(t *testing.T) {
+func TestMcpServerRefreshResponseAcceptsAndCanonicalizesObjects(t *testing.T) {
 	for _, input := range []string{
 		`{}`,
 		`{"future":true}`,
 		`{"nested":{"value":[1,null,"two"]}}`,
 		`{"future":1,"future":2}`,
 	} {
-		var response LogoutAccountResponse
+		var response McpServerRefreshResponse
 		if err := json.Unmarshal([]byte(input), &response); err != nil {
 			t.Errorf("Unmarshal(%s): %v", input, err)
 			continue
@@ -46,29 +46,29 @@ func TestLogoutAccountResponseAcceptsAndCanonicalizesObjects(t *testing.T) {
 	}
 }
 
-func TestLogoutAccountResponseRejectsMalformedWireForms(t *testing.T) {
+func TestMcpServerRefreshResponseRejectsMalformedWireForms(t *testing.T) {
 	for _, input := range []string{
 		`null`, `[]`, `"value"`, `1`, `true`, `{`, `{} {}`,
 	} {
-		assertJSONRejects[LogoutAccountResponse](t, input)
+		assertJSONRejects[McpServerRefreshResponse](t, input)
 	}
 
-	var response *LogoutAccountResponse
+	var response *McpServerRefreshResponse
 	if err := response.UnmarshalJSON([]byte(`{}`)); err == nil {
-		t.Fatal("nil LogoutAccountResponse receiver succeeded")
+		t.Fatal("nil McpServerRefreshResponse receiver succeeded")
 	}
 }
 
-func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
+func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	for _, binding := range WireTypeBindings() {
-		if slices.Contains(binding.Params, "LogoutAccountResponse") ||
-			slices.Contains(binding.Result, "LogoutAccountResponse") {
-			t.Fatalf("LogoutAccountResponse unexpectedly bound to %s", binding.Method)
+		if slices.Contains(binding.Params, "McpServerRefreshResponse") ||
+			slices.Contains(binding.Result, "McpServerRefreshResponse") {
+			t.Fatalf("McpServerRefreshResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	info, ok := LookupMethod("account/logout")
-	if !ok || info.State != MethodDeferredStub {
-		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
+	info, ok := LookupMethod("config/mcpServer/reload")
+	if !ok || info.State != MethodImplemented {
+		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
 		t.Fatalf("definition count = %d, want 378", got)
@@ -81,15 +81,15 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	}
 }
 
-func TestLogoutAccountResponseTypeScriptIsExact(t *testing.T) {
+func TestMcpServerRefreshResponseTypeScriptIsExact(t *testing.T) {
 	generated, err := MarshalTypeScript()
 	if err != nil {
 		t.Fatalf("MarshalTypeScript: %v", err)
 	}
-	want := `export type LogoutAccountResponse = Record<string, never>;`
+	want := `export type McpServerRefreshResponse = Record<string, never>;`
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing %q", want)
 	}
 }
 
-var _ json.Unmarshaler = (*LogoutAccountResponse)(nil)
+var _ json.Unmarshaler = (*McpServerRefreshResponse)(nil)

--- a/appserver/protocol/mcp_server_refresh_response_types.go
+++ b/appserver/protocol/mcp_server_refresh_response_types.go
@@ -1,0 +1,32 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// McpServerRefreshResponse is the exact empty public MCP refresh response. It
+// remains standalone from Gollem's broader live registry reload result.
+type McpServerRefreshResponse struct{}
+
+func (r *McpServerRefreshResponse) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("decode MCP server refresh response into nil receiver")
+	}
+
+	// Serde ignores unknown fields for this empty struct. Decode through a map
+	// to preserve that input compatibility while still requiring one object.
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(data, &object); err != nil {
+		return fmt.Errorf("decode MCP server refresh response: %w", err)
+	}
+	if object == nil {
+		return errors.New("MCP server refresh response must be an object")
+	}
+
+	*r = McpServerRefreshResponse{}
+	return nil
+}
+
+var _ json.Unmarshaler = (*McpServerRefreshResponse)(nil)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 377 {
-		t.Fatalf("definition count = %d, want 377", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
+		t.Fatalf("definition count = %d, want 378", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 377 {
-		t.Fatalf("definition count = %d, want 377", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
+		t.Fatalf("definition count = %d, want 378", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 377 {
-		t.Fatalf("definition count = %d, want 377", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
+		t.Fatalf("definition count = %d, want 378", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 377 {
-		t.Fatalf("definition count = %d, want 377", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
+		t.Fatalf("definition count = %d, want 378", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 377 {
-		t.Fatalf("definition count = %d, want 377", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
+		t.Fatalf("definition count = %d, want 378", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 377 {
-		t.Fatalf("definition count = %d, want 377", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
+		t.Fatalf("definition count = %d, want 378", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 377 {
-		t.Fatalf("definition count = %d, want 377", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
+		t.Fatalf("definition count = %d, want 378", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 377 {
-		t.Fatalf("definition count = %d, want 377", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
+		t.Fatalf("definition count = %d, want 378", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 377 {
-		t.Fatalf("definition count = %d, want 377", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
+		t.Fatalf("definition count = %d, want 378", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 377 {
-		t.Fatalf("definition count = %d, want 377", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
+		t.Fatalf("definition count = %d, want 378", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 377 {
-		t.Fatalf("definition count = %d, want 377", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
+		t.Fatalf("definition count = %d, want 378", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 377 {
-		t.Fatalf("definition count = %d, want 377", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
+		t.Fatalf("definition count = %d, want 378", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 377 {
-		t.Fatalf("definition count = %d, want 377", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
+		t.Fatalf("definition count = %d, want 378", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 377 {
-		t.Fatalf("definition count = %d, want 377", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 378 {
+		t.Fatalf("definition count = %d, want 378", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 377 {
-		t.Fatalf("definition count = %d, want 377", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 378 {
+		t.Fatalf("definition count = %d, want 378", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 377 {
-		t.Fatalf("definition count = %d, want 377", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 378 {
+		t.Fatalf("definition count = %d, want 378", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 377 {
-		t.Fatalf("definition count = %d, want 377", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 378 {
+		t.Fatalf("definition count = %d, want 378", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 377 {
-		t.Fatalf("definition count = %d, want 377", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 378 {
+		t.Fatalf("definition count = %d, want 378", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -236,6 +236,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "MCPToolCallResult", Type: reflect.TypeFor[MCPToolCallResult]()},
 		{Name: "McpAuthStatus", Type: reflect.TypeFor[McpAuthStatus]()},
 		{Name: "McpResourceReadParams", Type: reflect.TypeFor[McpResourceReadParams]()},
+		{Name: "McpServerRefreshResponse", Type: reflect.TypeFor[McpServerRefreshResponse]()},
 		{Name: "McpServerToolCallParams", Type: reflect.TypeFor[McpServerToolCallParams]()},
 		{Name: "McpServerToolCallResponse", Type: reflect.TypeFor[McpServerToolCallResponse]()},
 		{Name: "McpServerStartupFailureReason", Type: reflect.TypeFor[McpServerStartupFailureReason]()},

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -5846,6 +5846,10 @@
       ],
       "type": "object"
     },
+    "McpServerRefreshResponse": {
+      "additionalProperties": false,
+      "type": "object"
+    },
     "McpServerStartupFailureReason": {
       "enum": [
         "reauthenticationRequired"

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 377 {
-		t.Fatalf("definition count = %d, want 377", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 378 {
+		t.Fatalf("definition count = %d, want 378", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 377 {
-		t.Fatalf("definition count = %d, want 377", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
+		t.Fatalf("definition count = %d, want 378", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 377 {
-		t.Fatalf("definition count = %d, want 377", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
+		t.Fatalf("definition count = %d, want 378", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 377 {
-		t.Fatalf("definition count = %d, want 377", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
+		t.Fatalf("definition count = %d, want 378", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 377 {
-		t.Fatalf("definition count = %d, want 377", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
+		t.Fatalf("definition count = %d, want 378", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 377 {
-		t.Fatalf("definition count = %d, want 377", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
+		t.Fatalf("definition count = %d, want 378", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 377 {
-		t.Fatalf("definition count = %d, want 377", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 378 {
+		t.Fatalf("definition count = %d, want 378", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 377 {
-		t.Fatalf("definition count = %d, want 377", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 378 {
+		t.Fatalf("definition count = %d, want 378", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 377 {
-		t.Fatalf("definition count = %d, want 377", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
+		t.Fatalf("definition count = %d, want 378", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 377 {
-		t.Fatalf("definition count = %d, want 377", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
+		t.Fatalf("definition count = %d, want 378", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 377 {
-		t.Fatalf("definition count = %d, want 377", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
+		t.Fatalf("definition count = %d, want 378", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 377 {
-		t.Fatalf("definition count = %d, want 377", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
+		t.Fatalf("definition count = %d, want 378", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -1749,6 +1749,8 @@ export type McpServerElicitationRequestResponse = {
   "content": unknown;
 };
 
+export type McpServerRefreshResponse = Record<string, never>;
+
 export type McpServerStartupFailureReason = "reauthenticationRequired";
 
 export type McpServerStartupState = "starting" | "ready" | "failed" | "cancelled";

--- a/appserver/protocol/typescript/testdata/mcp_server_refresh_response_contract.ts
+++ b/appserver/protocol/typescript/testdata/mcp_server_refresh_response_contract.ts
@@ -1,0 +1,48 @@
+import type {
+  McpServerRefreshResponse,
+  MethodParamsByName,
+  MethodResultsByName,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+
+type ResponseContract = Expect<Equal<McpServerRefreshResponse, Record<string, never>>>;
+type ParamsRemainUnbound = Expect<Equal<
+  "config/mcpServer/reload" extends keyof MethodParamsByName ? true : false,
+  false
+>>;
+type ResultRemainsUnbound = Expect<Equal<
+  "config/mcpServer/reload" extends keyof MethodResultsByName ? true : false,
+  false
+>>;
+
+const response: McpServerRefreshResponse = {};
+void response;
+
+// @ts-expect-error refresh responses have no known fields.
+const extra: McpServerRefreshResponse = { reloaded: false };
+// @ts-expect-error refresh responses are objects.
+const nilResponse: McpServerRefreshResponse = null;
+// @ts-expect-error refresh responses are not arrays.
+const arrayResponse: McpServerRefreshResponse = [];
+// @ts-expect-error refresh responses are not strings.
+const stringResponse: McpServerRefreshResponse = "";
+// @ts-expect-error refresh responses are not numbers.
+const numberResponse: McpServerRefreshResponse = 0;
+// @ts-expect-error refresh responses are not booleans.
+const booleanResponse: McpServerRefreshResponse = false;
+
+void (null as unknown as ResponseContract);
+void (null as unknown as ParamsRemainUnbound);
+void (null as unknown as ResultRemainsUnbound);
+void extra;
+void nilResponse;
+void arrayResponse;
+void stringResponse;
+void numberResponse;
+void booleanResponse;

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 377 {
-		t.Fatalf("definition count = %d, want 377", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
+		t.Fatalf("definition count = %d, want 378", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary

- export exact standalone public `McpServerRefreshResponse` as a closed empty object
- preserve Rust empty-struct input compatibility by discarding unknown object fields and canonicalizing output to `{}`
- keep `config/mcpServer/reload` unbound from the broader live reload result, with method maps and runtime unchanged
- advance deterministic generation to 378 definitions with unchanged 224 methods, 59 wire bindings, and five item bindings

## Verification

- deliberate red: four missing Go references, one missing generated export, one false exact identity, six unused malformed-boundary directives
- focused tests x30, focused race, and 100% statement coverage for the new codec
- full protocol coverage: 96.7%
- fresh normal and race gates across all 59 non-Monty packages
- `golangci-lint run ./...` (0 issues), `go vet ./...`, and unchanged `go mod tidy`
- configured pre-push passed twice; `hooks.skipMontyRace=true` explicitly skipped local `ext/monty` race tests
- deterministic schema/TypeScript generation twice and strict TypeScript compile
- structural removal restores exact PR #173 schema/TypeScript artifacts and unchanged method/item metadata
- baseline/feature reload output is byte-identical with no registry and with one registered server
- all five Slang stdio/Unix-socket/WebSocket workflows pass against the feature binary

Local Monty normal/race/coverage tests were intentionally omitted per standing direction; hosted checks are unchanged.
