### PR TITLE
feat(protocol): export resource content

### DIFF
--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 378 {
-		t.Fatalf("definition count = %d, want 378", got)
+	if got := len(defs); got != 379 {
+		t.Fatalf("definition count = %d, want 379", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
-		t.Fatalf("definition count = %d, want 378", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
+		t.Fatalf("definition count = %d, want 379", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
-		t.Fatalf("definition count = %d, want 378", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
+		t.Fatalf("definition count = %d, want 379", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
-		t.Fatalf("definition count = %d, want 378", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
+		t.Fatalf("definition count = %d, want 379", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
-		t.Fatalf("definition count = %d, want 378", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
+		t.Fatalf("definition count = %d, want 379", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
-		t.Fatalf("definition count = %d, want 378", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
+		t.Fatalf("definition count = %d, want 379", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
-		t.Fatalf("definition count = %d, want 378", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
+		t.Fatalf("definition count = %d, want 379", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
-		t.Fatalf("definition count = %d, want 378", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
+		t.Fatalf("definition count = %d, want 379", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
-		t.Fatalf("definition count = %d, want 378", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
+		t.Fatalf("definition count = %d, want 379", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
-		t.Fatalf("definition count = %d, want 378", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
+		t.Fatalf("definition count = %d, want 379", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
-		t.Fatalf("definition count = %d, want 378", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
+		t.Fatalf("definition count = %d, want 379", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
-		t.Fatalf("definition count = %d, want 378", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
+		t.Fatalf("definition count = %d, want 379", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
-		t.Fatalf("definition count = %d, want 378", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
+		t.Fatalf("definition count = %d, want 379", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
-		t.Fatalf("definition count = %d, want 378", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
+		t.Fatalf("definition count = %d, want 379", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 378 {
-		t.Fatalf("definition count = %d, want 378", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 379 {
+		t.Fatalf("definition count = %d, want 379", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
-		t.Fatalf("definition count = %d, want 378", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
+		t.Fatalf("definition count = %d, want 379", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
-		t.Fatalf("definition count = %d, want 378", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
+		t.Fatalf("definition count = %d, want 379", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
-		t.Fatalf("definition count = %d, want 378", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
+		t.Fatalf("definition count = %d, want 379", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
-		t.Fatalf("definition count = %d, want 378", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
+		t.Fatalf("definition count = %d, want 379", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
-		t.Fatalf("definition count = %d, want 378", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
+		t.Fatalf("definition count = %d, want 379", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
-		t.Fatalf("definition count = %d, want 378", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
+		t.Fatalf("definition count = %d, want 379", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
-		t.Fatalf("definition count = %d, want 378", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
+		t.Fatalf("definition count = %d, want 379", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
-		t.Fatalf("definition count = %d, want 378", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
+		t.Fatalf("definition count = %d, want 379", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
-		t.Fatalf("definition count = %d, want 378", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
+		t.Fatalf("definition count = %d, want 379", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
-		t.Fatalf("definition count = %d, want 378", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
+		t.Fatalf("definition count = %d, want 379", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
-		t.Fatalf("definition count = %d, want 378", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
+		t.Fatalf("definition count = %d, want 379", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
-		t.Fatalf("definition count = %d, want 378", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
+		t.Fatalf("definition count = %d, want 379", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
-		t.Fatalf("definition count = %d, want 378", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
+		t.Fatalf("definition count = %d, want 379", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
-		t.Fatalf("definition count = %d, want 378", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
+		t.Fatalf("definition count = %d, want 379", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
-		t.Fatalf("definition count = %d, want 378", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
+		t.Fatalf("definition count = %d, want 379", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
-		t.Fatalf("definition count = %d, want 378", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
+		t.Fatalf("definition count = %d, want 379", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
-		t.Fatalf("definition count = %d, want 378", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
+		t.Fatalf("definition count = %d, want 379", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
-		t.Fatalf("definition count = %d, want 378", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
+		t.Fatalf("definition count = %d, want 379", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
-		t.Fatalf("definition count = %d, want 378", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
+		t.Fatalf("definition count = %d, want 379", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
-		t.Fatalf("definition count = %d, want 378", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
+		t.Fatalf("definition count = %d, want 379", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
-		t.Fatalf("definition count = %d, want 378", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
+		t.Fatalf("definition count = %d, want 379", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 378 {
-		t.Fatalf("definition count = %d, want 378", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 379 {
+		t.Fatalf("definition count = %d, want 379", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 378 {
-		t.Fatalf("definition count = %d, want 378", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 379 {
+		t.Fatalf("definition count = %d, want 379", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 378 {
-		t.Fatalf("definition count = %d, want 378", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 379 {
+		t.Fatalf("definition count = %d, want 379", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 378 {
-		t.Fatalf("definition count = %d, want 378", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 379 {
+		t.Fatalf("definition count = %d, want 379", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 378 {
-		t.Fatalf("definition count = %d, want 378", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 379 {
+		t.Fatalf("definition count = %d, want 379", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -1,0 +1,196 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestResourceContentSchemaIsExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	got, ok := defs["ResourceContent"].(Schema)
+	if !ok {
+		t.Fatal("$defs missing ResourceContent")
+	}
+	optionalString := Schema{
+		"anyOf":                                []any{Schema{"type": "string"}, Schema{"type": "null"}},
+		"x-gollem-typescript-optional-nonnull": true,
+	}
+	want := Schema{"oneOf": []any{
+		closedThreadSessionParamSchema(Schema{
+			"uri": Schema{"type": "string"}, "mimeType": optionalString,
+			"text": Schema{"type": "string"}, "_meta": Schema{"$ref": "#/$defs/JsonValue"},
+		}, []string{"text", "uri"}),
+		closedThreadSessionParamSchema(Schema{
+			"uri": Schema{"type": "string"}, "mimeType": optionalString,
+			"blob": Schema{"type": "string"}, "_meta": Schema{"$ref": "#/$defs/JsonValue"},
+		}, []string{"blob", "uri"}),
+	}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ResourceContent = %#v, want %#v", got, want)
+	}
+}
+
+func TestResourceContentAcceptsRustWireFormsAndCanonicalizesVariants(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{input: `{"uri":"","text":""}`, want: `{"uri":"","text":""}`},
+		{input: `{"uri":"resource://blob","blob":"AA=="}`, want: `{"uri":"resource://blob","blob":"AA=="}`},
+		{
+			input: `{"uri":"resource://text","mimeType":"text/plain","text":"hello","_meta":{"z":1,"a":[true,null]}}`,
+			want:  `{"uri":"resource://text","mimeType":"text/plain","text":"hello","_meta":{"a":[true,null],"z":1}}`,
+		},
+		{
+			input: `{"uri":"resource://blob","mimeType":"application/octet-stream","blob":"AA==","_meta":["source",9007199254740993123456789]}`,
+			want:  `{"uri":"resource://blob","mimeType":"application/octet-stream","blob":"AA==","_meta":["source",9007199254740993123456789]}`,
+		},
+		{
+			input: `{"uri":"resource://nulls","mimeType":null,"text":"value","_meta":null}`,
+			want:  `{"uri":"resource://nulls","text":"value"}`,
+		},
+		{
+			input: `{"uri":"resource://future","text":"value","future":{"nested":true},"mime_type":"ignored"}`,
+			want:  `{"uri":"resource://future","text":"value"}`,
+		},
+		{
+			input: `{"uri":"resource://crossed","text":"text wins","blob":"ignored"}`,
+			want:  `{"uri":"resource://crossed","text":"text wins"}`,
+		},
+		{
+			input: `{"uri":"resource://fallback","text":1,"blob":"blob wins"}`,
+			want:  `{"uri":"resource://fallback","blob":"blob wins"}`,
+		},
+		{
+			input: `{"uri":"resource://text","text":"text wins","blob":1}`,
+			want:  `{"uri":"resource://text","text":"text wins"}`,
+		},
+		{
+			input: `{"uri":"resource://duplicates","text":"text wins","blob":"one","blob":"two"}`,
+			want:  `{"uri":"resource://duplicates","text":"text wins"}`,
+		},
+		{
+			input: `{"uri":"resource://fallback","text":"one","text":"two","blob":"blob wins"}`,
+			want:  `{"uri":"resource://fallback","blob":"blob wins"}`,
+		},
+	}
+	for _, tc := range cases {
+		var content ResourceContent
+		if err := json.Unmarshal([]byte(tc.input), &content); err != nil {
+			t.Errorf("Unmarshal(%s): %v", tc.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(content)
+		if err != nil || string(encoded) != tc.want {
+			t.Errorf("canonical = %s, %v; want %s", encoded, err, tc.want)
+		}
+	}
+}
+
+func TestResourceContentRejectsMalformedWireForms(t *testing.T) {
+	invalid := []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{}`,
+		`{"text":"value"}`,
+		`{"blob":"AA=="}`,
+		`{"uri":"resource://only"}`,
+		`{"uri":null,"text":"value"}`,
+		`{"uri":1,"text":"value"}`,
+		`{"uri":"resource://text","text":null}`,
+		`{"uri":"resource://text","text":1}`,
+		`{"uri":"resource://blob","blob":null}`,
+		`{"uri":"resource://blob","blob":1}`,
+		`{"uri":"resource://mime","mimeType":1,"text":"value"}`,
+		`{"uri":"resource://meta","text":"value","_meta":undefined}`,
+		`{"uri":"resource://duplicate","uri":"other","text":"value"}`,
+		`{"uri":"resource://duplicate","mimeType":"a","mimeType":"b","text":"value"}`,
+		`{"uri":"resource://duplicate","_meta":1,"_meta":2,"text":"value"}`,
+		`{"uri":"resource://both","text":1,"blob":2}`,
+		`{"uri":"resource://text","text":"value"`,
+		`{"uri":"resource://text","text":"value"} {}`,
+	}
+	for _, input := range invalid {
+		var content ResourceContent
+		if err := json.Unmarshal([]byte(input), &content); err == nil {
+			t.Errorf("Unmarshal(%s) succeeded", input)
+		}
+	}
+
+	var content *ResourceContent
+	if err := content.UnmarshalJSON([]byte(`{"uri":"resource://text","text":"value"}`)); err == nil {
+		t.Fatal("nil ResourceContent receiver succeeded")
+	}
+	for name, content := range map[string]ResourceContent{
+		"empty":        {},
+		"missing uri":  {raw: json.RawMessage(`{"text":"value"}`)},
+		"invalid meta": {raw: json.RawMessage(`{"uri":"resource://text","text":"value","_meta":undefined}`)},
+	} {
+		if _, err := json.Marshal(content); err == nil {
+			t.Errorf("marshal invalid constructed %s succeeded", name)
+		}
+	}
+}
+
+func TestDecodeResourceContentVariantObjectRejectsMalformedJSON(t *testing.T) {
+	invalid := []string{
+		``,
+		`{"unterminated`,
+		`{"uri":"resource://text"`,
+		`{} {}`,
+		`{} trailing`,
+	}
+	for _, input := range invalid {
+		if _, err := decodeResourceContentVariantObject([]byte(input), "resource content", "uri"); err == nil {
+			t.Errorf("decodeResourceContentVariantObject(%q) succeeded", input)
+		}
+	}
+}
+
+func TestResourceContentRemainsStandalone(t *testing.T) {
+	for _, binding := range WireTypeBindings() {
+		if slices.Contains(binding.Params, "ResourceContent") ||
+			slices.Contains(binding.Result, "ResourceContent") {
+			t.Fatalf("ResourceContent unexpectedly bound: %#v", binding)
+		}
+	}
+	info, ok := LookupMethod("mcpServer/resource/read")
+	if !ok || info.State != MethodImplemented {
+		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
+		t.Fatalf("definition count = %d, want 379", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestResourceContentTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	source := string(generated)
+	for _, want := range []string{
+		`export type ResourceContent = {`,
+		`"_meta"?: JsonValue;`,
+		`"blob": string;`,
+		`"mimeType"?: string;`,
+		`"text": string;`,
+		`"uri": string;`,
+	} {
+		if !strings.Contains(source, want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}
+
+var (
+	_ json.Marshaler   = ResourceContent{}
+	_ json.Unmarshaler = (*ResourceContent)(nil)
+)

--- a/appserver/protocol/resource_content_types.go
+++ b/appserver/protocol/resource_content_types.go
@@ -1,0 +1,183 @@
+package protocol
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// ResourceContent retains one exact public MCP resource value. It remains
+// standalone until the public resource-read response and live adapter exist.
+type ResourceContent struct {
+	raw json.RawMessage
+}
+
+func (c ResourceContent) MarshalJSON() ([]byte, error) {
+	if len(c.raw) == 0 {
+		return nil, errors.New("resource content has no value")
+	}
+	return validateResourceContentJSON(c.raw)
+}
+
+func (c *ResourceContent) UnmarshalJSON(data []byte) error {
+	if c == nil {
+		return errors.New("decode resource content into nil receiver")
+	}
+	canonical, err := validateResourceContentJSON(data)
+	if err != nil {
+		return err
+	}
+	c.raw = canonical
+	return nil
+}
+
+func validateResourceContentJSON(data []byte) (json.RawMessage, error) {
+	text, textErr := validateTextResourceContentJSON(data)
+	if textErr == nil {
+		return text, nil
+	}
+	blob, blobErr := validateBlobResourceContentJSON(data)
+	if blobErr == nil {
+		return blob, nil
+	}
+	return nil, fmt.Errorf("decode resource content: text variant: %w; blob variant: %w", textErr, blobErr)
+}
+
+func validateTextResourceContentJSON(data []byte) (json.RawMessage, error) {
+	const objectName = "text resource content"
+	payload, err := decodeResourceContentVariantObject(data, objectName, "uri", "mimeType", "text", "_meta")
+	if err != nil {
+		return nil, err
+	}
+	uri, err := decodeRequiredThreadItemValue[string](payload, objectName, "uri")
+	if err != nil {
+		return nil, err
+	}
+	mimeType, err := decodeOptionalResourceContentString(payload, objectName, "mimeType")
+	if err != nil {
+		return nil, err
+	}
+	text, err := decodeRequiredThreadItemValue[string](payload, objectName, "text")
+	if err != nil {
+		return nil, err
+	}
+	meta := decodeOptionalResourceContentJSONValue(payload, "_meta")
+	return json.Marshal(struct {
+		URI      string     `json:"uri"`
+		MimeType *string    `json:"mimeType,omitempty"`
+		Text     string     `json:"text"`
+		Meta     *JsonValue `json:"_meta,omitempty"`
+	}{URI: uri, MimeType: mimeType, Text: text, Meta: meta})
+}
+
+func validateBlobResourceContentJSON(data []byte) (json.RawMessage, error) {
+	const objectName = "blob resource content"
+	payload, err := decodeResourceContentVariantObject(data, objectName, "uri", "mimeType", "blob", "_meta")
+	if err != nil {
+		return nil, err
+	}
+	uri, err := decodeRequiredThreadItemValue[string](payload, objectName, "uri")
+	if err != nil {
+		return nil, err
+	}
+	mimeType, err := decodeOptionalResourceContentString(payload, objectName, "mimeType")
+	if err != nil {
+		return nil, err
+	}
+	blob, err := decodeRequiredThreadItemValue[string](payload, objectName, "blob")
+	if err != nil {
+		return nil, err
+	}
+	meta := decodeOptionalResourceContentJSONValue(payload, "_meta")
+	return json.Marshal(struct {
+		URI      string     `json:"uri"`
+		MimeType *string    `json:"mimeType,omitempty"`
+		Blob     string     `json:"blob"`
+		Meta     *JsonValue `json:"_meta,omitempty"`
+	}{URI: uri, MimeType: mimeType, Blob: blob, Meta: meta})
+}
+
+func decodeResourceContentVariantObject(
+	data []byte,
+	objectName string,
+	fields ...string,
+) (map[string]json.RawMessage, error) {
+	known := make(map[string]bool, len(fields))
+	for _, field := range fields {
+		known[field] = true
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	opening, err := decoder.Token()
+	if err != nil {
+		return nil, fmt.Errorf("decode %s: %w", objectName, err)
+	}
+	if opening != json.Delim('{') {
+		return nil, fmt.Errorf("%s must be an object", objectName)
+	}
+	payload := make(map[string]json.RawMessage, len(fields))
+	seen := make(map[string]bool, len(fields))
+	for decoder.More() {
+		token, err := decoder.Token()
+		if err != nil {
+			return nil, fmt.Errorf("decode %s field name: %w", objectName, err)
+		}
+		name := token.(string)
+		var raw json.RawMessage
+		if err := decoder.Decode(&raw); err != nil {
+			return nil, fmt.Errorf("decode %s field %q: %w", objectName, name, err)
+		}
+		if !known[name] {
+			continue
+		}
+		if seen[name] {
+			return nil, fmt.Errorf("duplicate %s field %q", objectName, name)
+		}
+		seen[name] = true
+		payload[name] = append(json.RawMessage(nil), raw...)
+	}
+	if _, err := decoder.Token(); err != nil {
+		return nil, fmt.Errorf("decode %s: %w", objectName, err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return nil, fmt.Errorf("%s must contain one JSON value", objectName)
+		}
+		return nil, fmt.Errorf("decode %s trailing value: %w", objectName, err)
+	}
+	return payload, nil
+}
+
+func decodeOptionalResourceContentString(
+	payload map[string]json.RawMessage,
+	objectName string,
+	fieldName string,
+) (*string, error) {
+	raw, ok := payload[fieldName]
+	if !ok || isJSONNull(raw) {
+		return nil, nil
+	}
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return nil, fmt.Errorf("decode %s %s: %w", objectName, fieldName, err)
+	}
+	return &value, nil
+}
+
+func decodeOptionalResourceContentJSONValue(
+	payload map[string]json.RawMessage,
+	fieldName string,
+) *JsonValue {
+	raw, ok := payload[fieldName]
+	if !ok || isJSONNull(raw) {
+		return nil
+	}
+	return &JsonValue{raw: append(json.RawMessage(nil), raw...)}
+}
+
+var (
+	_ json.Marshaler   = ResourceContent{}
+	_ json.Unmarshaler = (*ResourceContent)(nil)
+)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -318,6 +318,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "ReasoningItemReasoningSummary", Type: reflect.TypeFor[ReasoningItemReasoningSummary]()},
 		{Name: "ResidencyRequirement", Type: reflect.TypeFor[ResidencyRequirement]()},
 		{Name: "RawResponseItemCompletedNotification", Type: reflect.TypeFor[RawResponseItemCompletedNotification]()},
+		{Name: "ResourceContent", Type: reflect.TypeFor[ResourceContent]()},
 		{Name: "ResponseItem", Type: reflect.TypeFor[ResponseItem]()},
 		{Name: "ResponsesApiWebSearchAction", Type: reflect.TypeFor[ResponsesApiWebSearchAction]()},
 		{Name: "SandboxMode", Type: reflect.TypeFor[SandboxMode]()},
@@ -530,6 +531,7 @@ func wireSchemaDefinitions() Schema {
 	schemas["McpResourceReadParams"] = mcpResourceReadParamsSchema()
 	schemas["McpServerToolCallParams"] = mcpServerToolCallParamsSchema()
 	schemas["McpServerToolCallResponse"] = mcpServerToolCallResponseSchema()
+	schemas["ResourceContent"] = resourceContentSchema()
 	schemas["ReasoningEffort"] = Schema{"type": "string", "minLength": 1}
 	schemas["ResidencyRequirement"] = stringEnumSchema(string(ResidencyRequirementUS))
 	schemas["WebSearchMode"] = stringEnumSchema(
@@ -2055,6 +2057,26 @@ func mcpServerToolCallResponseSchema() Schema {
 		},
 		"_meta": Schema{"$ref": "#/$defs/JsonValue"},
 	}, []string{"content"})
+}
+
+func resourceContentSchema() Schema {
+	return Schema{"oneOf": []any{
+		resourceContentVariantSchema("text"),
+		resourceContentVariantSchema("blob"),
+	}}
+}
+
+func resourceContentVariantSchema(contentField string) Schema {
+	properties := Schema{
+		"uri": Schema{"type": "string"},
+		"mimeType": Schema{
+			"anyOf":                          []any{Schema{"type": "string"}, Schema{"type": "null"}},
+			typeScriptOptionalNonNullKeyword: true,
+		},
+		"_meta": Schema{"$ref": "#/$defs/JsonValue"},
+	}
+	properties[contentField] = Schema{"type": "string"}
+	return closedThreadSessionParamSchema(properties, []string{contentField, "uri"})
 }
 
 func threadForkParamsSchema() Schema {

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -7709,6 +7709,70 @@
       ],
       "type": "string"
     },
+    "ResourceContent": {
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "_meta": {
+              "$ref": "#/$defs/JsonValue"
+            },
+            "mimeType": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "x-gollem-typescript-optional-nonnull": true
+            },
+            "text": {
+              "type": "string"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "text",
+            "uri"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "_meta": {
+              "$ref": "#/$defs/JsonValue"
+            },
+            "blob": {
+              "type": "string"
+            },
+            "mimeType": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "x-gollem-typescript-optional-nonnull": true
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "blob",
+            "uri"
+          ],
+          "type": "object"
+        }
+      ]
+    },
     "Response": {
       "additionalProperties": false,
       "properties": {

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 378 {
-		t.Fatalf("definition count = %d, want 378", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 379 {
+		t.Fatalf("definition count = %d, want 379", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
-		t.Fatalf("definition count = %d, want 378", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
+		t.Fatalf("definition count = %d, want 379", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
-		t.Fatalf("definition count = %d, want 378", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
+		t.Fatalf("definition count = %d, want 379", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
-		t.Fatalf("definition count = %d, want 378", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
+		t.Fatalf("definition count = %d, want 379", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
-		t.Fatalf("definition count = %d, want 378", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
+		t.Fatalf("definition count = %d, want 379", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
-		t.Fatalf("definition count = %d, want 378", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
+		t.Fatalf("definition count = %d, want 379", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 378 {
-		t.Fatalf("definition count = %d, want 378", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 379 {
+		t.Fatalf("definition count = %d, want 379", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 378 {
-		t.Fatalf("definition count = %d, want 378", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 379 {
+		t.Fatalf("definition count = %d, want 379", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
-		t.Fatalf("definition count = %d, want 378", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
+		t.Fatalf("definition count = %d, want 379", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
-		t.Fatalf("definition count = %d, want 378", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
+		t.Fatalf("definition count = %d, want 379", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
-		t.Fatalf("definition count = %d, want 378", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
+		t.Fatalf("definition count = %d, want 379", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
-		t.Fatalf("definition count = %d, want 378", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
+		t.Fatalf("definition count = %d, want 379", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -2096,6 +2096,18 @@ export type RequestPermissionProfile = {
 
 export type ResidencyRequirement = "us";
 
+export type ResourceContent = {
+  "_meta"?: JsonValue;
+  "mimeType"?: string;
+  "text": string;
+  "uri": string;
+} | {
+  "_meta"?: JsonValue;
+  "blob": string;
+  "mimeType"?: string;
+  "uri": string;
+};
+
 export type Response = {
   "error"?: Error;
   "id": RequestID;

--- a/appserver/protocol/typescript/testdata/resource_content_contract.ts
+++ b/appserver/protocol/typescript/testdata/resource_content_contract.ts
@@ -1,0 +1,70 @@
+import type {
+  JsonValue,
+  MethodParamsByName,
+  MethodResultsByName,
+  ResourceContent,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+
+type Expected =
+  | { uri: string; mimeType?: string; text: string; _meta?: JsonValue }
+  | { uri: string; mimeType?: string; blob: string; _meta?: JsonValue };
+type Contracts = [
+  Expect<Equal<ResourceContent, Expected>>,
+  Expect<Equal<"mcpServer/resource/read" extends keyof MethodParamsByName ? true : false, false>>,
+  Expect<Equal<"mcpServer/resource/read" extends keyof MethodResultsByName ? true : false, false>>,
+];
+
+export const text = { uri: "", text: "" } satisfies ResourceContent;
+export const blob = { uri: "resource://blob", blob: "AA==" } satisfies ResourceContent;
+export const fullText = {
+  uri: "resource://text",
+  mimeType: "text/plain",
+  text: "hello",
+  _meta: { source: ["client", null] },
+} satisfies ResourceContent;
+export const nullMeta = {
+  uri: "resource://blob",
+  blob: "AA==",
+  _meta: null,
+} satisfies ResourceContent;
+
+// The exact public structural union accepts fields known by either variant.
+export const crossed = {
+  uri: "resource://crossed",
+  text: "text",
+  blob: "blob",
+} satisfies ResourceContent;
+
+// @ts-expect-error uri is required by both variants.
+export const rejectMissingURI = { text: "value" } satisfies ResourceContent;
+// @ts-expect-error one content field is required.
+export const rejectMissingContent = { uri: "resource://missing" } satisfies ResourceContent;
+// @ts-expect-error uri is non-null.
+export const rejectNullURI = { uri: null, text: "value" } satisfies ResourceContent;
+// @ts-expect-error text is non-null.
+export const rejectNullText = { uri: "resource://text", text: null } satisfies ResourceContent;
+// @ts-expect-error blob is non-null.
+export const rejectNullBlob = { uri: "resource://blob", blob: null } satisfies ResourceContent;
+// @ts-expect-error mimeType may be omitted but is non-null when present.
+export const rejectNullMime = { uri: "resource://text", mimeType: null, text: "value" } satisfies ResourceContent;
+// @ts-expect-error exact camelCase spelling is required.
+export const rejectMimeAlias = { uri: "resource://text", mime_type: "text/plain", text: "value" } satisfies ResourceContent;
+// @ts-expect-error fields absent from both public variants are rejected.
+export const rejectExtra = { uri: "resource://text", text: "value", extra: true } satisfies ResourceContent;
+// @ts-expect-error optional mimeType cannot be explicitly undefined.
+export const rejectUndefinedMime = { uri: "resource://text", mimeType: undefined, text: "value" } satisfies ResourceContent;
+// @ts-expect-error optional metadata cannot be explicitly undefined.
+export const rejectUndefinedMeta = { uri: "resource://text", text: "value", _meta: undefined } satisfies ResourceContent;
+// @ts-expect-error bigint is not a JSON value.
+export const rejectBigIntMeta = { uri: "resource://text", text: "value", _meta: 1n } satisfies ResourceContent;
+// @ts-expect-error functions are not JSON values.
+export const rejectFunctionMeta = { uri: "resource://text", text: "value", _meta: () => true } satisfies ResourceContent;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 378 {
-		t.Fatalf("definition count = %d, want 378", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
+		t.Fatalf("definition count = %d, want 379", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary

- export the exact standalone public `ResourceContent` text/blob union
- match Rust untagged variant ordering, fallback, unknown-field, duplicate-field, null-option, and precision-preserving metadata behavior
- generate the 379-definition schema and strict TypeScript contract without binding or changing live `mcpServer/resource/read` behavior

## Validation

- `go test ./appserver/protocol -run ResourceContent -count=30`
- focused race and 100% statement coverage for every new wire-type function
- full protocol package: 96.7% statement coverage
- all 59 non-Monty normal and race package suites
- `golangci-lint run`, `go vet`, deterministic generation, strict `tsc`, tidy, and configured pre-push
- generated-artifact structural removal reproduces PR #174 exactly
- baseline/feature live resource-read compatibility output is byte-identical
- all five real Slang stdio, Unix-socket, and WebSocket workflows against the committed feature binary

Local Monty tests are intentionally skipped per project direction; hosted checks remain unchanged.
