### PR TITLE
Export MCP resource-read response

### DIFF
--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 379 {
-		t.Fatalf("definition count = %d, want 379", got)
+	if got := len(defs); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
-		t.Fatalf("definition count = %d, want 379", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
-		t.Fatalf("definition count = %d, want 379", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
-		t.Fatalf("definition count = %d, want 379", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
-		t.Fatalf("definition count = %d, want 379", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
-		t.Fatalf("definition count = %d, want 379", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
-		t.Fatalf("definition count = %d, want 379", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
-		t.Fatalf("definition count = %d, want 379", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
-		t.Fatalf("definition count = %d, want 379", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
-		t.Fatalf("definition count = %d, want 379", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
-		t.Fatalf("definition count = %d, want 379", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
-		t.Fatalf("definition count = %d, want 379", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
-		t.Fatalf("definition count = %d, want 379", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
-		t.Fatalf("definition count = %d, want 379", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 379 {
-		t.Fatalf("definition count = %d, want 379", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 380 {
+		t.Fatalf("definition count = %d, want 380", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
-		t.Fatalf("definition count = %d, want 379", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
-		t.Fatalf("definition count = %d, want 379", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
-		t.Fatalf("definition count = %d, want 379", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
-		t.Fatalf("definition count = %d, want 379", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
-		t.Fatalf("definition count = %d, want 379", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
-		t.Fatalf("definition count = %d, want 379", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
-		t.Fatalf("definition count = %d, want 379", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -1,0 +1,163 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestMcpResourceReadResponseSchemaIsExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	got, ok := defs["McpResourceReadResponse"].(Schema)
+	if !ok {
+		t.Fatal("$defs missing McpResourceReadResponse")
+	}
+	want := closedThreadSessionParamSchema(Schema{
+		"contents": Schema{
+			"type": "array", "items": Schema{"$ref": "#/$defs/ResourceContent"},
+		},
+	}, []string{"contents"})
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("McpResourceReadResponse = %#v, want %#v", got, want)
+	}
+}
+
+func TestMcpResourceReadResponseAcceptsRustWireFormsAndCanonicalizesContents(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{input: `{"contents":[]}`, want: `{"contents":[]}`},
+		{
+			input: `{"contents":[{"uri":"resource://text","text":"hello"}]}`,
+			want:  `{"contents":[{"uri":"resource://text","text":"hello"}]}`,
+		},
+		{
+			input: `{"contents":[{"uri":"resource://text","mimeType":"text/plain","text":"hello","_meta":{"z":1,"a":2}},{"uri":"resource://blob","blob":"AA=="}]}`,
+			want:  `{"contents":[{"uri":"resource://text","mimeType":"text/plain","text":"hello","_meta":{"a":2,"z":1}},{"uri":"resource://blob","blob":"AA=="}]}`,
+		},
+		{
+			input: `{"contents":[{"uri":"resource://crossed","text":"text wins","blob":"ignored"}],"future":{"nested":true}}`,
+			want:  `{"contents":[{"uri":"resource://crossed","text":"text wins"}]}`,
+		},
+	}
+	for _, tc := range cases {
+		var response McpResourceReadResponse
+		if err := json.Unmarshal([]byte(tc.input), &response); err != nil {
+			t.Errorf("Unmarshal(%s): %v", tc.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(response)
+		if err != nil || string(encoded) != tc.want {
+			t.Errorf("canonical = %s, %v; want %s", encoded, err, tc.want)
+		}
+	}
+
+	encoded, err := json.Marshal(McpResourceReadResponse{})
+	if want := `{"contents":[]}`; err != nil || string(encoded) != want {
+		t.Fatalf("marshal nil contents = %s, %v; want %s", encoded, err, want)
+	}
+}
+
+func TestMcpResourceReadResponseRejectsMalformedWireForms(t *testing.T) {
+	invalid := []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{}`,
+		`{"contents":null}`,
+		`{"contents":{}}`,
+		`{"contents":"value"}`,
+		`{"contents":1}`,
+		`{"contents":true}`,
+		`{"contents":[null]}`,
+		`{"contents":[1]}`,
+		`{"contents":[{}]}`,
+		`{"contents":[{"text":"missing uri"}]}`,
+		`{"contents":[{"uri":"resource://missing"}]}`,
+		`{"contents":[{"uri":"resource://text","text":null}]}`,
+		`{"content":[]}`,
+		`{"contents":[],"contents":[]}`,
+		`{"contents":[]`,
+		`{"contents":[]} {}`,
+	}
+	for _, input := range invalid {
+		var response McpResourceReadResponse
+		if err := json.Unmarshal([]byte(input), &response); err == nil {
+			t.Errorf("Unmarshal(%s) succeeded", input)
+		}
+	}
+
+	var response *McpResourceReadResponse
+	if err := response.UnmarshalJSON([]byte(`{"contents":[]}`)); err == nil {
+		t.Fatal("nil McpResourceReadResponse receiver succeeded")
+	}
+	for name, response := range map[string]McpResourceReadResponse{
+		"empty content": {Contents: []ResourceContent{{}}},
+		"invalid content": {
+			Contents: []ResourceContent{{raw: json.RawMessage(`{"uri":"resource://text","text":null}`)}},
+		},
+	} {
+		if _, err := json.Marshal(response); err == nil {
+			t.Errorf("marshal invalid constructed %s succeeded", name)
+		}
+	}
+}
+
+func TestDecodeMcpResourceReadResponseObjectRejectsMalformedJSON(t *testing.T) {
+	invalid := []string{
+		``,
+		`{"unterminated`,
+		`{"contents":`,
+		`{"contents":[]`,
+		`{} {}`,
+		`{} trailing`,
+	}
+	for _, input := range invalid {
+		if _, err := decodeMcpResourceReadResponseObject([]byte(input)); err == nil {
+			t.Errorf("decodeMcpResourceReadResponseObject(%q) succeeded", input)
+		}
+	}
+}
+
+func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
+	for _, binding := range WireTypeBindings() {
+		if slices.Contains(binding.Params, "McpResourceReadResponse") ||
+			slices.Contains(binding.Result, "McpResourceReadResponse") {
+			t.Fatalf("McpResourceReadResponse unexpectedly bound: %#v", binding)
+		}
+	}
+	info, ok := LookupMethod("mcpServer/resource/read")
+	if !ok || info.State != MethodImplemented {
+		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestMcpResourceReadResponseTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	source := string(generated)
+	for _, want := range []string{
+		`export type McpResourceReadResponse = {`,
+		`"contents": Array<ResourceContent>;`,
+	} {
+		if !strings.Contains(source, want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}
+
+var (
+	_ json.Marshaler   = McpResourceReadResponse{}
+	_ json.Unmarshaler = (*McpResourceReadResponse)(nil)
+)

--- a/appserver/protocol/mcp_resource_read_response_types.go
+++ b/appserver/protocol/mcp_resource_read_response_types.go
@@ -1,0 +1,94 @@
+package protocol
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// McpResourceReadResponse is the exact public MCP resource-content envelope.
+// It remains separate from Gollem's broader live result until an adapter exists.
+type McpResourceReadResponse struct {
+	Contents []ResourceContent `json:"contents" jsonschema:"nonnullable=true"`
+}
+
+func (r McpResourceReadResponse) MarshalJSON() ([]byte, error) {
+	contents := r.Contents
+	if contents == nil {
+		contents = []ResourceContent{}
+	}
+	return json.Marshal(struct {
+		Contents []ResourceContent `json:"contents"`
+	}{Contents: contents})
+}
+
+func (r *McpResourceReadResponse) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("decode MCP resource-read response into nil receiver")
+	}
+	payload, err := decodeMcpResourceReadResponseObject(data)
+	if err != nil {
+		return err
+	}
+	contents, err := decodeRequiredThreadItemValue[[]ResourceContent](
+		payload,
+		"MCP resource-read response",
+		"contents",
+	)
+	if err != nil {
+		return err
+	}
+	*r = McpResourceReadResponse{Contents: contents}
+	return nil
+}
+
+func decodeMcpResourceReadResponseObject(data []byte) (map[string]json.RawMessage, error) {
+	const objectName = "MCP resource-read response"
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	opening, err := decoder.Token()
+	if err != nil {
+		return nil, fmt.Errorf("decode %s: %w", objectName, err)
+	}
+	if opening != json.Delim('{') {
+		return nil, fmt.Errorf("%s must be an object", objectName)
+	}
+	payload := make(map[string]json.RawMessage, 1)
+	seenContents := false
+	for decoder.More() {
+		token, err := decoder.Token()
+		if err != nil {
+			return nil, fmt.Errorf("decode %s field name: %w", objectName, err)
+		}
+		name := token.(string)
+		var raw json.RawMessage
+		if err := decoder.Decode(&raw); err != nil {
+			return nil, fmt.Errorf("decode %s field %q: %w", objectName, name, err)
+		}
+		if name != "contents" {
+			continue
+		}
+		if seenContents {
+			return nil, fmt.Errorf("duplicate %s field %q", objectName, name)
+		}
+		seenContents = true
+		payload[name] = append(json.RawMessage(nil), raw...)
+	}
+	if _, err := decoder.Token(); err != nil {
+		return nil, fmt.Errorf("decode %s: %w", objectName, err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return nil, fmt.Errorf("%s must contain one JSON value", objectName)
+		}
+		return nil, fmt.Errorf("decode %s trailing value: %w", objectName, err)
+	}
+	return payload, nil
+}
+
+var (
+	_ json.Marshaler   = McpResourceReadResponse{}
+	_ json.Unmarshaler = (*McpResourceReadResponse)(nil)
+)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
-		t.Fatalf("definition count = %d, want 379", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
-		t.Fatalf("definition count = %d, want 379", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
-		t.Fatalf("definition count = %d, want 379", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
-		t.Fatalf("definition count = %d, want 379", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
-		t.Fatalf("definition count = %d, want 379", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
-		t.Fatalf("definition count = %d, want 379", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
-		t.Fatalf("definition count = %d, want 379", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
-		t.Fatalf("definition count = %d, want 379", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
-		t.Fatalf("definition count = %d, want 379", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
-		t.Fatalf("definition count = %d, want 379", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
-		t.Fatalf("definition count = %d, want 379", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
-		t.Fatalf("definition count = %d, want 379", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
-		t.Fatalf("definition count = %d, want 379", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
-		t.Fatalf("definition count = %d, want 379", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 379 {
-		t.Fatalf("definition count = %d, want 379", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 380 {
+		t.Fatalf("definition count = %d, want 380", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 379 {
-		t.Fatalf("definition count = %d, want 379", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 380 {
+		t.Fatalf("definition count = %d, want 380", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 379 {
-		t.Fatalf("definition count = %d, want 379", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 380 {
+		t.Fatalf("definition count = %d, want 380", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 379 {
-		t.Fatalf("definition count = %d, want 379", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 380 {
+		t.Fatalf("definition count = %d, want 380", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 379 {
-		t.Fatalf("definition count = %d, want 379", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 380 {
+		t.Fatalf("definition count = %d, want 380", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
-		t.Fatalf("definition count = %d, want 379", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -236,6 +236,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "MCPToolCallResult", Type: reflect.TypeFor[MCPToolCallResult]()},
 		{Name: "McpAuthStatus", Type: reflect.TypeFor[McpAuthStatus]()},
 		{Name: "McpResourceReadParams", Type: reflect.TypeFor[McpResourceReadParams]()},
+		{Name: "McpResourceReadResponse", Type: reflect.TypeFor[McpResourceReadResponse]()},
 		{Name: "McpServerRefreshResponse", Type: reflect.TypeFor[McpServerRefreshResponse]()},
 		{Name: "McpServerToolCallParams", Type: reflect.TypeFor[McpServerToolCallParams]()},
 		{Name: "McpServerToolCallResponse", Type: reflect.TypeFor[McpServerToolCallResponse]()},
@@ -529,6 +530,7 @@ func wireSchemaDefinitions() Schema {
 	)
 	schemas["ListMcpServerStatusParams"] = listMcpServerStatusParamsSchema()
 	schemas["McpResourceReadParams"] = mcpResourceReadParamsSchema()
+	schemas["McpResourceReadResponse"] = mcpResourceReadResponseSchema()
 	schemas["McpServerToolCallParams"] = mcpServerToolCallParamsSchema()
 	schemas["McpServerToolCallResponse"] = mcpServerToolCallResponseSchema()
 	schemas["ResourceContent"] = resourceContentSchema()
@@ -2033,6 +2035,14 @@ func mcpResourceReadParamsSchema() Schema {
 		"server": Schema{"type": "string"},
 		"uri":    Schema{"type": "string"},
 	}, []string{"server", "uri"})
+}
+
+func mcpResourceReadResponseSchema() Schema {
+	return closedThreadSessionParamSchema(Schema{
+		"contents": Schema{
+			"type": "array", "items": Schema{"$ref": "#/$defs/ResourceContent"},
+		},
+	}, []string{"contents"})
 }
 
 func mcpServerToolCallParamsSchema() Schema {

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -5573,6 +5573,21 @@
       ],
       "type": "object"
     },
+    "McpResourceReadResponse": {
+      "additionalProperties": false,
+      "properties": {
+        "contents": {
+          "items": {
+            "$ref": "#/$defs/ResourceContent"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "contents"
+      ],
+      "type": "object"
+    },
     "McpServerElicitationAction": {
       "enum": [
         "accept",

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 379 {
-		t.Fatalf("definition count = %d, want 379", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 380 {
+		t.Fatalf("definition count = %d, want 380", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
-		t.Fatalf("definition count = %d, want 379", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
-		t.Fatalf("definition count = %d, want 379", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
-		t.Fatalf("definition count = %d, want 379", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
-		t.Fatalf("definition count = %d, want 379", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
-		t.Fatalf("definition count = %d, want 379", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 379 {
-		t.Fatalf("definition count = %d, want 379", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 380 {
+		t.Fatalf("definition count = %d, want 380", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 379 {
-		t.Fatalf("definition count = %d, want 379", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 380 {
+		t.Fatalf("definition count = %d, want 380", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
-		t.Fatalf("definition count = %d, want 379", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
-		t.Fatalf("definition count = %d, want 379", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
-		t.Fatalf("definition count = %d, want 379", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
-		t.Fatalf("definition count = %d, want 379", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -1693,6 +1693,10 @@ export type McpResourceReadParams = {
   "uri": string;
 };
 
+export type McpResourceReadResponse = {
+  "contents": Array<ResourceContent>;
+};
+
 export type McpServerElicitationAction = "accept" | "decline" | "cancel";
 
 export type McpServerElicitationRequestParams = {

--- a/appserver/protocol/typescript/testdata/mcp_resource_read_response_contract.ts
+++ b/appserver/protocol/typescript/testdata/mcp_resource_read_response_contract.ts
@@ -1,0 +1,57 @@
+import type {
+  McpResourceReadResponse,
+  MethodParamsByName,
+  MethodResultsByName,
+  ResourceContent,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+
+type Expected = { contents: Array<ResourceContent> };
+type Contracts = [
+  Expect<Equal<McpResourceReadResponse, Expected>>,
+  Expect<Equal<"mcpServer/resource/read" extends keyof MethodParamsByName ? true : false, false>>,
+  Expect<Equal<"mcpServer/resource/read" extends keyof MethodResultsByName ? true : false, false>>,
+];
+
+export const empty = { contents: [] } satisfies McpResourceReadResponse;
+export const text = {
+  contents: [{ uri: "resource://text", text: "hello" }],
+} satisfies McpResourceReadResponse;
+export const mixed = {
+  contents: [
+    { uri: "resource://text", mimeType: "text/plain", text: "hello" },
+    { uri: "resource://blob", blob: "AA==", _meta: { source: ["client", null] } },
+  ],
+} satisfies McpResourceReadResponse;
+export const crossed = {
+  contents: [{ uri: "resource://crossed", text: "text", blob: "blob" }],
+} satisfies McpResourceReadResponse;
+
+// @ts-expect-error contents is required.
+export const rejectMissingContents = {} satisfies McpResourceReadResponse;
+// @ts-expect-error contents is a non-null array.
+export const rejectNullContents = { contents: null } satisfies McpResourceReadResponse;
+// @ts-expect-error contents is an array.
+export const rejectObjectContents = { contents: {} } satisfies McpResourceReadResponse;
+// @ts-expect-error contents is an array.
+export const rejectStringContents = { contents: "value" } satisfies McpResourceReadResponse;
+// @ts-expect-error contents cannot be explicitly undefined.
+export const rejectUndefinedContents = { contents: undefined } satisfies McpResourceReadResponse;
+// @ts-expect-error array elements must be resource-content values.
+export const rejectNullElement = { contents: [null] } satisfies McpResourceReadResponse;
+// @ts-expect-error array elements require uri.
+export const rejectMissingElementURI = { contents: [{ text: "value" }] } satisfies McpResourceReadResponse;
+// @ts-expect-error array elements require text or blob.
+export const rejectMissingElementContent = { contents: [{ uri: "resource://missing" }] } satisfies McpResourceReadResponse;
+// @ts-expect-error exact plural wire name is required.
+export const rejectContentAlias = { content: [] } satisfies McpResourceReadResponse;
+// @ts-expect-error fields absent from the public response are rejected.
+export const rejectExtra = { contents: [], extra: true } satisfies McpResourceReadResponse;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 379 {
-		t.Fatalf("definition count = %d, want 379", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
+		t.Fatalf("definition count = %d, want 380", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- export exact standalone `McpResourceReadResponse` with required `ResourceContent[]`
- preserve Rust-compatible unknown-parent input handling and canonical non-null array output
- keep `mcpServer/resource/read` unbound with unchanged live request/result behavior
- advance generated protocol output to 380 definitions without changing method or item bindings

## Verification
- deliberate-red Go and strict TypeScript contracts
- focused tests x30, focused/full race, and 100% coverage for every new function
- full protocol tests at 96.8% coverage
- all 59 non-Monty packages under normal and race tests
- `golangci-lint run ./...` (0 issues), `go vet ./...`, `go mod tidy`
- deterministic schema/TypeScript generation and exact structural removal to PR #175
- byte-identical baseline/feature live resource-read compatibility
- all five Slang real-process workflows
- configured pre-push hook twice with `hooks.skipMontyRace=true`