### PR TITLE
feat(protocol): export MCP server info

### DIFF
--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(defs); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 380 {
-		t.Fatalf("definition count = %d, want 380", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 381 {
+		t.Fatalf("definition count = %d, want 381", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -1,0 +1,183 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestMcpServerInfoSchemaIsExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	got, ok := defs["McpServerInfo"].(Schema)
+	if !ok {
+		t.Fatal("$defs missing McpServerInfo")
+	}
+	want := closedThreadSessionParamSchema(Schema{
+		"name": Schema{"type": "string"},
+		"title": Schema{
+			"anyOf": []any{Schema{"type": "string"}, Schema{"type": "null"}},
+		},
+		"version": Schema{"type": "string"},
+		"description": Schema{
+			"anyOf": []any{Schema{"type": "string"}, Schema{"type": "null"}},
+		},
+		"icons": Schema{
+			"anyOf": []any{
+				Schema{"type": "array", "items": Schema{"$ref": "#/$defs/JsonValue"}},
+				Schema{"type": "null"},
+			},
+		},
+		"websiteUrl": Schema{
+			"anyOf": []any{Schema{"type": "string"}, Schema{"type": "null"}},
+		},
+	}, []string{"name", "title", "version", "description", "icons", "websiteUrl"})
+	want["description"] = "Presentation metadata advertised by an initialized MCP server."
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("McpServerInfo = %#v, want %#v", got, want)
+	}
+}
+
+func TestMcpServerInfoAcceptsRustWireFormsAndCanonicalizesOptions(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{
+			input: `{"name":"","version":""}`,
+			want:  `{"name":"","title":null,"version":"","description":null,"icons":null,"websiteUrl":null}`,
+		},
+		{
+			input: `{"name":"server","title":null,"version":"1.0.0","description":null,"icons":null,"websiteUrl":null}`,
+			want:  `{"name":"server","title":null,"version":"1.0.0","description":null,"icons":null,"websiteUrl":null}`,
+		},
+		{
+			input: `{"name":"server","title":"Title","version":"1.0.0","description":"Description",` +
+				`"icons":[null,true,"icon",9007199254740993,{"z":2,"a":[false,null]}],` +
+				`"websiteUrl":"https://example.com"}`,
+			want: `{"name":"server","title":"Title","version":"1.0.0","description":"Description",` +
+				`"icons":[null,true,"icon",9007199254740993,{"a":[false,null],"z":2}],` +
+				`"websiteUrl":"https://example.com"}`,
+		},
+		{
+			input: `{"name":"server","version":"1.0.0","icons":[],` +
+				`"website_url":"https://ignored.example","future":{"nested":true}}`,
+			want: `{"name":"server","title":null,"version":"1.0.0",` +
+				`"description":null,"icons":[],"websiteUrl":null}`,
+		},
+	}
+	for _, tc := range cases {
+		var info McpServerInfo
+		if err := json.Unmarshal([]byte(tc.input), &info); err != nil {
+			t.Errorf("Unmarshal(%s): %v", tc.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(info)
+		if err != nil || string(encoded) != tc.want {
+			t.Errorf("canonical = %s, %v; want %s", encoded, err, tc.want)
+		}
+	}
+}
+
+func TestMcpServerInfoRejectsMalformedWireForms(t *testing.T) {
+	invalid := []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{}`,
+		`{"version":"1.0.0"}`,
+		`{"name":"server"}`,
+		`{"name":null,"version":"1.0.0"}`,
+		`{"name":1,"version":"1.0.0"}`,
+		`{"name":"server","version":null}`,
+		`{"name":"server","version":1}`,
+		`{"name":"server","version":"1.0.0","title":1}`,
+		`{"name":"server","version":"1.0.0","description":{}}`,
+		`{"name":"server","version":"1.0.0","icons":{}}`,
+		`{"name":"server","version":"1.0.0","icons":"value"}`,
+		`{"name":"server","version":"1.0.0","websiteUrl":1}`,
+		`{"name":"first","name":"second","version":"1.0.0"}`,
+		`{"name":"server","version":"1","version":"2"}`,
+		`{"name":"server","title":null,"title":null,"version":"1.0.0"}`,
+		`{"name":"server","version":"1.0.0","description":null,"description":null}`,
+		`{"name":"server","version":"1.0.0","icons":null,"icons":[]}`,
+		`{"name":"server","version":"1.0.0","websiteUrl":null,"websiteUrl":""}`,
+		`{"name":"server","version":"1.0.0"`,
+		`{"name":"server","version":"1.0.0"} {}`,
+	}
+	for _, input := range invalid {
+		var info McpServerInfo
+		if err := json.Unmarshal([]byte(input), &info); err == nil {
+			t.Errorf("Unmarshal(%s) succeeded", input)
+		}
+	}
+
+	var info *McpServerInfo
+	if err := info.UnmarshalJSON([]byte(`{"name":"server","version":"1.0.0"}`)); err == nil {
+		t.Fatal("nil McpServerInfo receiver succeeded")
+	}
+	if _, err := json.Marshal(McpServerInfo{
+		Name: "server", Version: "1.0.0", Icons: []JsonValue{{}},
+	}); err == nil {
+		t.Fatal("McpServerInfo with invalid constructed icon JSON marshaled")
+	}
+}
+
+func TestDecodeMcpServerInfoObjectRejectsMalformedJSON(t *testing.T) {
+	invalid := []string{
+		``,
+		`{"unterminated`,
+		`{"name":`,
+		`{"name":"server"`,
+		`{} {}`,
+		`{} trailing`,
+	}
+	for _, input := range invalid {
+		if _, err := decodeMcpServerInfoObject([]byte(input)); err == nil {
+			t.Errorf("decodeMcpServerInfoObject(%q) succeeded", input)
+		}
+	}
+}
+
+func TestMcpServerInfoRemainsStandalone(t *testing.T) {
+	for _, binding := range WireTypeBindings() {
+		if slices.Contains(binding.Params, "McpServerInfo") ||
+			slices.Contains(binding.Result, "McpServerInfo") {
+			t.Fatalf("McpServerInfo unexpectedly bound: %#v", binding)
+		}
+	}
+	info, ok := LookupMethod("mcpServerStatus/list")
+	if !ok || info.State != MethodImplemented {
+		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestMcpServerInfoTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	source := string(generated)
+	for _, want := range []string{
+		`export type McpServerInfo = {`,
+		`"description": string | null;`,
+		`"icons": Array<JsonValue> | null;`,
+		`"name": string;`,
+		`"title": string | null;`,
+		`"version": string;`,
+		`"websiteUrl": string | null;`,
+	} {
+		if !strings.Contains(source, want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}
+
+var _ json.Unmarshaler = (*McpServerInfo)(nil)

--- a/appserver/protocol/mcp_server_info_types.go
+++ b/appserver/protocol/mcp_server_info_types.go
@@ -1,0 +1,131 @@
+package protocol
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// McpServerInfo is the exact public presentation metadata advertised by an
+// initialized MCP server. It remains standalone until status projection exists.
+type McpServerInfo struct {
+	Name        string      `json:"name"`
+	Title       *string     `json:"title"`
+	Version     string      `json:"version"`
+	Description *string     `json:"description"`
+	Icons       []JsonValue `json:"icons"`
+	WebsiteURL  *string     `json:"websiteUrl"`
+}
+
+func (i *McpServerInfo) UnmarshalJSON(data []byte) error {
+	if i == nil {
+		return errors.New("decode MCP server info into nil receiver")
+	}
+	payload, err := decodeMcpServerInfoObject(data)
+	if err != nil {
+		return err
+	}
+	name, err := decodeRequiredThreadItemValue[string](payload, "MCP server info", "name")
+	if err != nil {
+		return err
+	}
+	version, err := decodeRequiredThreadItemValue[string](payload, "MCP server info", "version")
+	if err != nil {
+		return err
+	}
+	title, err := decodeOptionalNullableMcpServerInfoValue[string](payload, "title")
+	if err != nil {
+		return err
+	}
+	description, err := decodeOptionalNullableMcpServerInfoValue[string](payload, "description")
+	if err != nil {
+		return err
+	}
+	iconsValue, err := decodeOptionalNullableMcpServerInfoValue[[]JsonValue](payload, "icons")
+	if err != nil {
+		return err
+	}
+	var icons []JsonValue
+	if iconsValue != nil {
+		icons = *iconsValue
+	}
+	websiteURL, err := decodeOptionalNullableMcpServerInfoValue[string](payload, "websiteUrl")
+	if err != nil {
+		return err
+	}
+	*i = McpServerInfo{
+		Name:        name,
+		Title:       title,
+		Version:     version,
+		Description: description,
+		Icons:       icons,
+		WebsiteURL:  websiteURL,
+	}
+	return nil
+}
+
+func decodeMcpServerInfoObject(data []byte) (map[string]json.RawMessage, error) {
+	const objectName = "MCP server info"
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	opening, err := decoder.Token()
+	if err != nil {
+		return nil, fmt.Errorf("decode %s: %w", objectName, err)
+	}
+	if opening != json.Delim('{') {
+		return nil, fmt.Errorf("%s must be an object", objectName)
+	}
+	known := map[string]struct{}{
+		"name": {}, "title": {}, "version": {}, "description": {}, "icons": {}, "websiteUrl": {},
+	}
+	payload := make(map[string]json.RawMessage, len(known))
+	seen := make(map[string]bool, len(known))
+	for decoder.More() {
+		token, err := decoder.Token()
+		if err != nil {
+			return nil, fmt.Errorf("decode %s field name: %w", objectName, err)
+		}
+		name := token.(string)
+		var raw json.RawMessage
+		if err := decoder.Decode(&raw); err != nil {
+			return nil, fmt.Errorf("decode %s field %q: %w", objectName, name, err)
+		}
+		if _, ok := known[name]; !ok {
+			continue
+		}
+		if seen[name] {
+			return nil, fmt.Errorf("duplicate %s field %q", objectName, name)
+		}
+		seen[name] = true
+		payload[name] = append(json.RawMessage(nil), raw...)
+	}
+	if _, err := decoder.Token(); err != nil {
+		return nil, fmt.Errorf("decode %s: %w", objectName, err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return nil, fmt.Errorf("%s must contain one JSON value", objectName)
+		}
+		return nil, fmt.Errorf("decode %s trailing value: %w", objectName, err)
+	}
+	return payload, nil
+}
+
+func decodeOptionalNullableMcpServerInfoValue[T any](
+	payload map[string]json.RawMessage,
+	fieldName string,
+) (*T, error) {
+	raw, ok := payload[fieldName]
+	if !ok || isJSONNull(raw) {
+		return nil, nil
+	}
+	var value T
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return nil, fmt.Errorf("decode MCP server info %s: %w", fieldName, err)
+	}
+	return &value, nil
+}
+
+var _ json.Unmarshaler = (*McpServerInfo)(nil)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 380 {
-		t.Fatalf("definition count = %d, want 380", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 381 {
+		t.Fatalf("definition count = %d, want 381", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 380 {
-		t.Fatalf("definition count = %d, want 380", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 381 {
+		t.Fatalf("definition count = %d, want 381", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 380 {
-		t.Fatalf("definition count = %d, want 380", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 381 {
+		t.Fatalf("definition count = %d, want 381", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 380 {
-		t.Fatalf("definition count = %d, want 380", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 381 {
+		t.Fatalf("definition count = %d, want 381", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 380 {
-		t.Fatalf("definition count = %d, want 380", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 381 {
+		t.Fatalf("definition count = %d, want 381", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -237,6 +237,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "McpAuthStatus", Type: reflect.TypeFor[McpAuthStatus]()},
 		{Name: "McpResourceReadParams", Type: reflect.TypeFor[McpResourceReadParams]()},
 		{Name: "McpResourceReadResponse", Type: reflect.TypeFor[McpResourceReadResponse]()},
+		{Name: "McpServerInfo", Type: reflect.TypeFor[McpServerInfo]()},
 		{Name: "McpServerRefreshResponse", Type: reflect.TypeFor[McpServerRefreshResponse]()},
 		{Name: "McpServerToolCallParams", Type: reflect.TypeFor[McpServerToolCallParams]()},
 		{Name: "McpServerToolCallResponse", Type: reflect.TypeFor[McpServerToolCallResponse]()},
@@ -531,6 +532,7 @@ func wireSchemaDefinitions() Schema {
 	schemas["ListMcpServerStatusParams"] = listMcpServerStatusParamsSchema()
 	schemas["McpResourceReadParams"] = mcpResourceReadParamsSchema()
 	schemas["McpResourceReadResponse"] = mcpResourceReadResponseSchema()
+	schemas["McpServerInfo"] = mcpServerInfoSchema()
 	schemas["McpServerToolCallParams"] = mcpServerToolCallParamsSchema()
 	schemas["McpServerToolCallResponse"] = mcpServerToolCallResponseSchema()
 	schemas["ResourceContent"] = resourceContentSchema()
@@ -2043,6 +2045,30 @@ func mcpResourceReadResponseSchema() Schema {
 			"type": "array", "items": Schema{"$ref": "#/$defs/ResourceContent"},
 		},
 	}, []string{"contents"})
+}
+
+func mcpServerInfoSchema() Schema {
+	schema := closedThreadSessionParamSchema(Schema{
+		"name": Schema{"type": "string"},
+		"title": Schema{
+			"anyOf": []any{Schema{"type": "string"}, Schema{"type": "null"}},
+		},
+		"version": Schema{"type": "string"},
+		"description": Schema{
+			"anyOf": []any{Schema{"type": "string"}, Schema{"type": "null"}},
+		},
+		"icons": Schema{
+			"anyOf": []any{
+				Schema{"type": "array", "items": Schema{"$ref": "#/$defs/JsonValue"}},
+				Schema{"type": "null"},
+			},
+		},
+		"websiteUrl": Schema{
+			"anyOf": []any{Schema{"type": "string"}, Schema{"type": "null"}},
+		},
+	}, []string{"name", "title", "version", "description", "icons", "websiteUrl"})
+	schema["description"] = "Presentation metadata advertised by an initialized MCP server."
+	return schema
 }
 
 func mcpServerToolCallParamsSchema() Schema {

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -5861,6 +5861,70 @@
       ],
       "type": "object"
     },
+    "McpServerInfo": {
+      "additionalProperties": false,
+      "description": "Presentation metadata advertised by an initialized MCP server.",
+      "properties": {
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "icons": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/JsonValue"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "version": {
+          "type": "string"
+        },
+        "websiteUrl": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "title",
+        "version",
+        "description",
+        "icons",
+        "websiteUrl"
+      ],
+      "type": "object"
+    },
     "McpServerRefreshResponse": {
       "additionalProperties": false,
       "type": "object"

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 380 {
-		t.Fatalf("definition count = %d, want 380", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 381 {
+		t.Fatalf("definition count = %d, want 381", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 380 {
-		t.Fatalf("definition count = %d, want 380", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 381 {
+		t.Fatalf("definition count = %d, want 381", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 380 {
-		t.Fatalf("definition count = %d, want 380", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 381 {
+		t.Fatalf("definition count = %d, want 381", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -1753,6 +1753,15 @@ export type McpServerElicitationRequestResponse = {
   "content": unknown;
 };
 
+export type McpServerInfo = {
+  "description": string | null;
+  "icons": Array<JsonValue> | null;
+  "name": string;
+  "title": string | null;
+  "version": string;
+  "websiteUrl": string | null;
+};
+
 export type McpServerRefreshResponse = Record<string, never>;
 
 export type McpServerStartupFailureReason = "reauthenticationRequired";

--- a/appserver/protocol/typescript/testdata/mcp_server_info_contract.ts
+++ b/appserver/protocol/typescript/testdata/mcp_server_info_contract.ts
@@ -1,0 +1,77 @@
+import type {
+  JsonValue,
+  McpServerInfo,
+  MethodParamsByName,
+  MethodResultsByName,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+
+type Expected = {
+  name: string;
+  title: string | null;
+  version: string;
+  description: string | null;
+  icons: Array<JsonValue> | null;
+  websiteUrl: string | null;
+};
+type Contracts = [
+  Expect<Equal<McpServerInfo, Expected>>,
+  Expect<Equal<"mcpServerStatus/list" extends keyof MethodParamsByName ? true : false, false>>,
+  Expect<Equal<"mcpServerStatus/list" extends keyof MethodResultsByName ? true : false, false>>,
+];
+
+export const empty = {
+  name: "",
+  title: null,
+  version: "",
+  description: null,
+  icons: null,
+  websiteUrl: null,
+} satisfies McpServerInfo;
+export const full = {
+  name: "server",
+  title: "Server",
+  version: "1.0.0",
+  description: "Description",
+  icons: [null, true, "icon", 9007199254740993, { source: ["client", null] }],
+  websiteUrl: "https://example.com",
+} satisfies McpServerInfo;
+export const emptyIcons = {
+  name: "server",
+  title: "",
+  version: "1.0.0",
+  description: "",
+  icons: [],
+  websiteUrl: "",
+} satisfies McpServerInfo;
+
+// @ts-expect-error name is required.
+export const rejectMissingName = { title: null, version: "1", description: null, icons: null, websiteUrl: null } satisfies McpServerInfo;
+// @ts-expect-error name is non-null.
+export const rejectNullName = { name: null, title: null, version: "1", description: null, icons: null, websiteUrl: null } satisfies McpServerInfo;
+// @ts-expect-error canonical title is required nullable.
+export const rejectMissingTitle = { name: "server", version: "1", description: null, icons: null, websiteUrl: null } satisfies McpServerInfo;
+// @ts-expect-error title cannot be explicitly undefined.
+export const rejectUndefinedTitle = { name: "server", title: undefined, version: "1", description: null, icons: null, websiteUrl: null } satisfies McpServerInfo;
+// @ts-expect-error version is required.
+export const rejectMissingVersion = { name: "server", title: null, description: null, icons: null, websiteUrl: null } satisfies McpServerInfo;
+// @ts-expect-error version is non-null.
+export const rejectNullVersion = { name: "server", title: null, version: null, description: null, icons: null, websiteUrl: null } satisfies McpServerInfo;
+// @ts-expect-error description is string or null.
+export const rejectDescriptionObject = { name: "server", title: null, version: "1", description: {}, icons: null, websiteUrl: null } satisfies McpServerInfo;
+// @ts-expect-error icons is an array or null.
+export const rejectIconsObject = { name: "server", title: null, version: "1", description: null, icons: {}, websiteUrl: null } satisfies McpServerInfo;
+// @ts-expect-error functions are not JSON icon values.
+export const rejectIconFunction = { name: "server", title: null, version: "1", description: null, icons: [() => true], websiteUrl: null } satisfies McpServerInfo;
+// @ts-expect-error exact camel-case website field is required.
+export const rejectWebsiteAlias = { name: "server", title: null, version: "1", description: null, icons: null, website_url: null } satisfies McpServerInfo;
+// @ts-expect-error fields absent from the public record are rejected.
+export const rejectExtra = { name: "server", title: null, version: "1", description: null, icons: null, websiteUrl: null, extra: true } satisfies McpServerInfo;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 380 {
-		t.Fatalf("definition count = %d, want 380", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 381 {
+		t.Fatalf("definition count = %d, want 381", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary

- export the exact pinned Codex `McpServerInfo` protocol shape as a standalone Go type
- preserve omitted/null optionals as canonical nulls while distinguishing an empty `icons` array
- preserve arbitrary precision-safe JSON icon values, reject duplicate known fields, and discard unknown input fields
- generate the closed JSON Schema and TypeScript contract without changing MCP status-list runtime bindings

## Verification

- `go test ./appserver/protocol`
- strict generated-TypeScript fixture compilation
- focused contract tests repeated 30 times
- focused race tests
- 100% statement coverage for each new decoding function; full protocol package coverage 96.8%
- all 59 non-Monty packages under normal and race tests
- `golangci-lint run`
- non-Monty `go vet`
- `go mod tidy` produced no diff
- configured pre-push hook passed (Monty race skipped via `hooks.skipMontyRace=true`)
- generated artifacts are deterministic
- removing only the new schema definition and TypeScript block exactly reproduces the prior merged artifacts
- reviewed, committed, and feature binaries are byte-identical with `-buildvcs=false -trimpath`
- merged-baseline and feature MCP status-list output are byte-identical
- all five Slang interoperability workflows pass against the feature binary

Per standing instruction, local Monty normal/race/coverage tests were not run because of their cost; hosted checks are unchanged.