### PR TITLE
feat(protocol): export plugins migration

### DIFF
--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(defs); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 382 {
-		t.Fatalf("definition count = %d, want 382", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 383 {
+		t.Fatalf("definition count = %d, want 383", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -1,0 +1,156 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestPluginsMigrationSchemaIsExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	got, ok := defs["PluginsMigration"].(Schema)
+	if !ok {
+		t.Fatal("$defs missing PluginsMigration")
+	}
+	want := closedThreadSessionParamSchema(Schema{
+		"marketplaceName": Schema{"type": "string"},
+		"pluginNames": Schema{
+			"type":  "array",
+			"items": Schema{"type": "string"},
+		},
+	}, []string{"marketplaceName", "pluginNames"})
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("PluginsMigration = %#v, want %#v", got, want)
+	}
+}
+
+func TestPluginsMigrationAcceptsRustWireForms(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{
+			input: `{"marketplaceName":"","pluginNames":[]}`,
+			want:  `{"marketplaceName":"","pluginNames":[]}`,
+		},
+		{
+			input: `{"marketplaceName":"market","pluginNames":["one","","one"]}`,
+			want:  `{"marketplaceName":"market","pluginNames":["one","","one"]}`,
+		},
+		{
+			input: `{"marketplaceName":"market","pluginNames":["one"],"marketplace_name":"ignored","future":{"nested":true}}`,
+			want:  `{"marketplaceName":"market","pluginNames":["one"]}`,
+		},
+	}
+	for _, tc := range cases {
+		var migration PluginsMigration
+		if err := json.Unmarshal([]byte(tc.input), &migration); err != nil {
+			t.Errorf("Unmarshal(%s): %v", tc.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(migration)
+		if err != nil || string(encoded) != tc.want {
+			t.Errorf("canonical = %s, %v; want %s", encoded, err, tc.want)
+		}
+	}
+
+	encoded, err := json.Marshal(PluginsMigration{})
+	if err != nil || string(encoded) != `{"marketplaceName":"","pluginNames":[]}` {
+		t.Errorf("zero-value canonical = %s, %v", encoded, err)
+	}
+}
+
+func TestPluginsMigrationRejectsMalformedWireForms(t *testing.T) {
+	invalid := []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{}`,
+		`{"marketplaceName":"market"}`,
+		`{"pluginNames":[]}`,
+		`{"marketplaceName":null,"pluginNames":[]}`,
+		`{"marketplaceName":1,"pluginNames":[]}`,
+		`{"marketplaceName":true,"pluginNames":[]}`,
+		`{"marketplaceName":{},"pluginNames":[]}`,
+		`{"marketplaceName":[],"pluginNames":[]}`,
+		`{"marketplaceName":"market","pluginNames":null}`,
+		`{"marketplaceName":"market","pluginNames":"plugin"}`,
+		`{"marketplaceName":"market","pluginNames":{}}`,
+		`{"marketplaceName":"market","pluginNames":[null]}`,
+		`{"marketplaceName":"market","pluginNames":[1]}`,
+		`{"marketplaceName":"market","pluginNames":[true]}`,
+		`{"marketplaceName":"market","pluginNames":[{}]}`,
+		`{"marketplaceName":"market","pluginNames":[[]]}`,
+		`{"marketplaceName":"first","marketplaceName":"second","pluginNames":[]}`,
+		`{"marketplaceName":"market","pluginNames":[],"pluginNames":[]}`,
+		`{"marketplaceName":"market","pluginNames":[]`,
+		`{"marketplaceName":"market","pluginNames":[]} {}`,
+	}
+	for _, input := range invalid {
+		var migration PluginsMigration
+		if err := json.Unmarshal([]byte(input), &migration); err == nil {
+			t.Errorf("Unmarshal(%s) succeeded", input)
+		}
+	}
+
+	var migration *PluginsMigration
+	if err := migration.UnmarshalJSON([]byte(`{"marketplaceName":"market","pluginNames":[]}`)); err == nil {
+		t.Fatal("nil PluginsMigration receiver succeeded")
+	}
+}
+
+func TestDecodePluginsMigrationObjectRejectsMalformedJSON(t *testing.T) {
+	invalid := []string{
+		``,
+		`{"unterminated`,
+		`{"marketplaceName":`,
+		`{"marketplaceName":"market","pluginNames":[]`,
+		`{} {}`,
+		`{} trailing`,
+	}
+	for _, input := range invalid {
+		if _, err := decodePluginsMigrationObject([]byte(input)); err == nil {
+			t.Errorf("decodePluginsMigrationObject(%q) succeeded", input)
+		}
+	}
+}
+
+func TestPluginsMigrationRemainsStandalone(t *testing.T) {
+	for _, binding := range WireTypeBindings() {
+		if slices.Contains(binding.Params, "PluginsMigration") ||
+			slices.Contains(binding.Result, "PluginsMigration") {
+			t.Fatalf("PluginsMigration unexpectedly bound: %#v", binding)
+		}
+	}
+	for _, method := range []string{"externalAgentConfig/detect", "externalAgentConfig/import"} {
+		info, ok := LookupMethod(method)
+		if !ok || info.State != MethodDeferredStub {
+			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestPluginsMigrationTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	source := string(generated)
+	want := "export type PluginsMigration = {\n  \"marketplaceName\": string;\n  \"pluginNames\": Array<string>;\n};"
+	if !strings.Contains(source, want) {
+		t.Errorf("generated TypeScript missing %q", want)
+	}
+}
+
+var (
+	_ json.Marshaler   = PluginsMigration{}
+	_ json.Unmarshaler = (*PluginsMigration)(nil)
+)

--- a/appserver/protocol/plugins_migration_types.go
+++ b/appserver/protocol/plugins_migration_types.go
@@ -1,0 +1,99 @@
+package protocol
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// PluginsMigration identifies plugin names from one marketplace migration.
+// It remains standalone until the external-agent migration contracts land.
+type PluginsMigration struct {
+	MarketplaceName string   `json:"marketplaceName"`
+	PluginNames     []string `json:"pluginNames" jsonschema:"nonnullable=true"`
+}
+
+func (m PluginsMigration) MarshalJSON() ([]byte, error) {
+	pluginNames := m.PluginNames
+	if pluginNames == nil {
+		pluginNames = []string{}
+	}
+	return json.Marshal(struct {
+		MarketplaceName string   `json:"marketplaceName"`
+		PluginNames     []string `json:"pluginNames"`
+	}{
+		MarketplaceName: m.MarketplaceName,
+		PluginNames:     pluginNames,
+	})
+}
+
+func (m *PluginsMigration) UnmarshalJSON(data []byte) error {
+	if m == nil {
+		return errors.New("decode plugins migration into nil receiver")
+	}
+	payload, err := decodePluginsMigrationObject(data)
+	if err != nil {
+		return err
+	}
+	marketplaceName, err := decodeRequiredThreadItemValue[string](payload, "plugins migration", "marketplaceName")
+	if err != nil {
+		return err
+	}
+	pluginNames, err := decodeRequiredNonNullStringArray(payload, "plugins migration", "pluginNames")
+	if err != nil {
+		return err
+	}
+	*m = PluginsMigration{MarketplaceName: marketplaceName, PluginNames: pluginNames}
+	return nil
+}
+
+func decodePluginsMigrationObject(data []byte) (map[string]json.RawMessage, error) {
+	const objectName = "plugins migration"
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	opening, err := decoder.Token()
+	if err != nil {
+		return nil, fmt.Errorf("decode %s: %w", objectName, err)
+	}
+	if opening != json.Delim('{') {
+		return nil, fmt.Errorf("%s must be an object", objectName)
+	}
+	payload := make(map[string]json.RawMessage, 2)
+	seen := make(map[string]struct{}, 2)
+	for decoder.More() {
+		token, err := decoder.Token()
+		if err != nil {
+			return nil, fmt.Errorf("decode %s field name: %w", objectName, err)
+		}
+		name := token.(string)
+		var raw json.RawMessage
+		if err := decoder.Decode(&raw); err != nil {
+			return nil, fmt.Errorf("decode %s field %q: %w", objectName, name, err)
+		}
+		if name != "marketplaceName" && name != "pluginNames" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			return nil, fmt.Errorf("duplicate %s field %q", objectName, name)
+		}
+		seen[name] = struct{}{}
+		payload[name] = append(json.RawMessage(nil), raw...)
+	}
+	if _, err := decoder.Token(); err != nil {
+		return nil, fmt.Errorf("decode %s: %w", objectName, err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return nil, fmt.Errorf("%s must contain one JSON value", objectName)
+		}
+		return nil, fmt.Errorf("decode %s trailing value: %w", objectName, err)
+	}
+	return payload, nil
+}
+
+var (
+	_ json.Marshaler   = PluginsMigration{}
+	_ json.Unmarshaler = (*PluginsMigration)(nil)
+)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 382 {
-		t.Fatalf("definition count = %d, want 382", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 383 {
+		t.Fatalf("definition count = %d, want 383", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 382 {
-		t.Fatalf("definition count = %d, want 382", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 383 {
+		t.Fatalf("definition count = %d, want 383", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 382 {
-		t.Fatalf("definition count = %d, want 382", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 383 {
+		t.Fatalf("definition count = %d, want 383", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 382 {
-		t.Fatalf("definition count = %d, want 382", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 383 {
+		t.Fatalf("definition count = %d, want 383", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 382 {
-		t.Fatalf("definition count = %d, want 382", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 383 {
+		t.Fatalf("definition count = %d, want 383", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -306,6 +306,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "PatchChangeKind", Type: reflect.TypeFor[PatchChangeKind]()},
 		{Name: "Personality", Type: reflect.TypeFor[Personality]()},
 		{Name: "PlanDeltaNotification", Type: reflect.TypeFor[PlanDeltaNotification]()},
+		{Name: "PluginsMigration", Type: reflect.TypeFor[PluginsMigration]()},
 		{Name: "PermissionGrantScope", Type: reflect.TypeFor[PermissionGrantScope]()},
 		{Name: "PermissionsApprovalRequestParams", Type: reflect.TypeFor[PermissionsApprovalRequestParams]()},
 		{Name: "PermissionsRequestApprovalParams", Type: reflect.TypeFor[PermissionsRequestApprovalParams]()},
@@ -535,6 +536,7 @@ func wireSchemaDefinitions() Schema {
 	schemas["McpResourceReadResponse"] = mcpResourceReadResponseSchema()
 	schemas["McpServerInfo"] = mcpServerInfoSchema()
 	schemas["McpServerMigration"] = mcpServerMigrationSchema()
+	schemas["PluginsMigration"] = pluginsMigrationSchema()
 	schemas["McpServerToolCallParams"] = mcpServerToolCallParamsSchema()
 	schemas["McpServerToolCallResponse"] = mcpServerToolCallResponseSchema()
 	schemas["ResourceContent"] = resourceContentSchema()
@@ -2077,6 +2079,15 @@ func mcpServerMigrationSchema() Schema {
 	return closedThreadSessionParamSchema(Schema{
 		"name": Schema{"type": "string"},
 	}, []string{"name"})
+}
+
+func pluginsMigrationSchema() Schema {
+	return closedThreadSessionParamSchema(Schema{
+		"marketplaceName": Schema{"type": "string"},
+		"pluginNames": Schema{
+			"type": "array", "items": Schema{"type": "string"},
+		},
+	}, []string{"marketplaceName", "pluginNames"})
 }
 
 func mcpServerToolCallParamsSchema() Schema {

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -7396,6 +7396,25 @@
       ],
       "type": "object"
     },
+    "PluginsMigration": {
+      "additionalProperties": false,
+      "properties": {
+        "marketplaceName": {
+          "type": "string"
+        },
+        "pluginNames": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "marketplaceName",
+        "pluginNames"
+      ],
+      "type": "object"
+    },
     "RawResponseItemCompletedNotification": {
       "additionalProperties": false,
       "properties": {

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 382 {
-		t.Fatalf("definition count = %d, want 382", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 383 {
+		t.Fatalf("definition count = %d, want 383", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 382 {
-		t.Fatalf("definition count = %d, want 382", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 383 {
+		t.Fatalf("definition count = %d, want 383", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 382 {
-		t.Fatalf("definition count = %d, want 382", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 383 {
+		t.Fatalf("definition count = %d, want 383", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -2045,6 +2045,11 @@ export type PlanDeltaNotification = {
   "turnId": string;
 };
 
+export type PluginsMigration = {
+  "marketplaceName": string;
+  "pluginNames": Array<string>;
+};
+
 export type RawResponseItemCompletedNotification = {
   "item": ResponseItem;
   "threadId": string;

--- a/appserver/protocol/typescript/testdata/plugins_migration_contract.ts
+++ b/appserver/protocol/typescript/testdata/plugins_migration_contract.ts
@@ -1,0 +1,53 @@
+import type {
+  MethodParamsByName,
+  MethodResultsByName,
+  PluginsMigration,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+
+type Expected = {
+  marketplaceName: string;
+  pluginNames: Array<string>;
+};
+type Contracts = [
+  Expect<Equal<PluginsMigration, Expected>>,
+  Expect<Equal<"externalAgentConfig/detect" extends keyof MethodParamsByName ? true : false, false>>,
+  Expect<Equal<"externalAgentConfig/detect" extends keyof MethodResultsByName ? true : false, false>>,
+  Expect<Equal<"externalAgentConfig/import" extends keyof MethodParamsByName ? true : false, false>>,
+  Expect<Equal<"externalAgentConfig/import" extends keyof MethodResultsByName ? true : false, false>>,
+];
+
+export const empty = { marketplaceName: "", pluginNames: [] } satisfies PluginsMigration;
+export const named = {
+  marketplaceName: "market",
+  pluginNames: ["one", "", "one"],
+} satisfies PluginsMigration;
+
+// @ts-expect-error both fields are required.
+export const rejectMissing = {} satisfies PluginsMigration;
+// @ts-expect-error marketplaceName is required.
+export const rejectMissingMarketplace = { pluginNames: [] } satisfies PluginsMigration;
+// @ts-expect-error pluginNames is required.
+export const rejectMissingPlugins = { marketplaceName: "market" } satisfies PluginsMigration;
+// @ts-expect-error marketplaceName is non-null.
+export const rejectNullMarketplace = { marketplaceName: null, pluginNames: [] } satisfies PluginsMigration;
+// @ts-expect-error marketplaceName must be a string.
+export const rejectNumberMarketplace = { marketplaceName: 1, pluginNames: [] } satisfies PluginsMigration;
+// @ts-expect-error pluginNames is non-null.
+export const rejectNullPlugins = { marketplaceName: "market", pluginNames: null } satisfies PluginsMigration;
+// @ts-expect-error pluginNames must be an array.
+export const rejectStringPlugins = { marketplaceName: "market", pluginNames: "one" } satisfies PluginsMigration;
+// @ts-expect-error plugin names must be strings.
+export const rejectNumberPlugin = { marketplaceName: "market", pluginNames: [1] } satisfies PluginsMigration;
+// @ts-expect-error snake-case aliases do not replace canonical fields.
+export const rejectAliases = { marketplace_name: "market", plugin_names: [] } satisfies PluginsMigration;
+// @ts-expect-error fields absent from the public record are rejected.
+export const rejectExtra = { marketplaceName: "market", pluginNames: [], extra: true } satisfies PluginsMigration;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 382 {
-		t.Fatalf("definition count = %d, want 382", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 383 {
+		t.Fatalf("definition count = %d, want 383", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- export exact standalone public `PluginsMigration` from Codex `5c19155cbd93bfa099016e7487259f61669823ff`
- preserve Rust-compatible required camel-case fields, non-null ordered string-array semantics, unknown-input discard, duplicate-known-field rejection, and canonical empty-array output
- keep `MigrationDetails`, external-agent config methods, plugin discovery/install/mutation, and all method/item/runtime behavior unbound and unchanged

## Contract
- exact generated shape: `{ marketplaceName: string; pluginNames: string[] }`
- both fields are required and non-null; empty marketplace/plugin names and an empty array are valid
- input order and duplicates are preserved
- malformed, missing, null, wrong-type, duplicate-known, trailing, and nil-receiver inputs are rejected
- generated schema is closed while Rust-compatible decoding discards unknown fields
- generated totals are 383 definitions, 59 method bindings, five item bindings, and 224 unchanged method classifications

## Verification
- deliberate-red Go and strict TypeScript boundaries before implementation
- focused test repeated 30 times
- focused race test
- 100% statement coverage for all new decoder/marshaler functions; full protocol coverage 96.8%
- full protocol suite and strict TypeScript compile
- all non-Monty package tests and race tests
- `golangci-lint run ./...`
- `go vet ./...`
- `go mod tidy` with no diff
- deterministic generation
- configured pre-push hook twice; local Monty tests skipped via standing direction and `hooks.skipMontyRace=true`
