### PR TITLE
feat(protocol): export session migration

### DIFF
--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(defs); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 384 {
-		t.Fatalf("definition count = %d, want 384", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 385 {
+		t.Fatalf("definition count = %d, want 385", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 384 {
-		t.Fatalf("definition count = %d, want 384", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 385 {
+		t.Fatalf("definition count = %d, want 385", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 384 {
-		t.Fatalf("definition count = %d, want 384", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 385 {
+		t.Fatalf("definition count = %d, want 385", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 384 {
-		t.Fatalf("definition count = %d, want 384", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 385 {
+		t.Fatalf("definition count = %d, want 385", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 384 {
-		t.Fatalf("definition count = %d, want 384", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 385 {
+		t.Fatalf("definition count = %d, want 385", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 384 {
-		t.Fatalf("definition count = %d, want 384", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 385 {
+		t.Fatalf("definition count = %d, want 385", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -308,6 +308,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "PlanDeltaNotification", Type: reflect.TypeFor[PlanDeltaNotification]()},
 		{Name: "PluginsMigration", Type: reflect.TypeFor[PluginsMigration]()},
 		{Name: "SkillMigration", Type: reflect.TypeFor[SkillMigration]()},
+		{Name: "SessionMigration", Type: reflect.TypeFor[SessionMigration]()},
 		{Name: "PermissionGrantScope", Type: reflect.TypeFor[PermissionGrantScope]()},
 		{Name: "PermissionsApprovalRequestParams", Type: reflect.TypeFor[PermissionsApprovalRequestParams]()},
 		{Name: "PermissionsRequestApprovalParams", Type: reflect.TypeFor[PermissionsRequestApprovalParams]()},
@@ -539,6 +540,7 @@ func wireSchemaDefinitions() Schema {
 	schemas["McpServerMigration"] = mcpServerMigrationSchema()
 	schemas["PluginsMigration"] = pluginsMigrationSchema()
 	schemas["SkillMigration"] = skillMigrationSchema()
+	schemas["SessionMigration"] = sessionMigrationSchema()
 	schemas["McpServerToolCallParams"] = mcpServerToolCallParamsSchema()
 	schemas["McpServerToolCallResponse"] = mcpServerToolCallResponseSchema()
 	schemas["ResourceContent"] = resourceContentSchema()
@@ -2096,6 +2098,16 @@ func skillMigrationSchema() Schema {
 	return closedThreadSessionParamSchema(Schema{
 		"name": Schema{"type": "string"},
 	}, []string{"name"})
+}
+
+func sessionMigrationSchema() Schema {
+	return closedThreadSessionParamSchema(Schema{
+		"path": Schema{"type": "string"},
+		"cwd":  Schema{"type": "string"},
+		"title": Schema{
+			"anyOf": []any{Schema{"type": "string"}, Schema{"type": "null"}},
+		},
+	}, []string{"path", "cwd", "title"})
 }
 
 func mcpServerToolCallParamsSchema() Schema {

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -8680,6 +8680,33 @@
     "ServerRequestResolvedNotificationParams": {
       "$ref": "#/$defs/ServerRequestResolvedNotification"
     },
+    "SessionMigration": {
+      "additionalProperties": false,
+      "properties": {
+        "cwd": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "path",
+        "cwd",
+        "title"
+      ],
+      "type": "object"
+    },
     "SessionSource": {
       "oneOf": [
         {

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -1,0 +1,154 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestSessionMigrationSchemaIsExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	got, ok := defs["SessionMigration"].(Schema)
+	if !ok {
+		t.Fatal("$defs missing SessionMigration")
+	}
+	want := closedThreadSessionParamSchema(Schema{
+		"path": Schema{"type": "string"},
+		"cwd":  Schema{"type": "string"},
+		"title": Schema{
+			"anyOf": []any{Schema{"type": "string"}, Schema{"type": "null"}},
+		},
+	}, []string{"path", "cwd", "title"})
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("SessionMigration = %#v, want %#v", got, want)
+	}
+}
+
+func TestSessionMigrationAcceptsRustWireFormsAndCanonicalizesTitle(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{
+			input: `{"path":"","cwd":""}`,
+			want:  `{"path":"","cwd":"","title":null}`,
+		},
+		{
+			input: `{"path":"sessions/session.jsonl","cwd":"repo/../repo","title":null}`,
+			want:  `{"path":"sessions/session.jsonl","cwd":"repo/../repo","title":null}`,
+		},
+		{
+			input: `{"path":"/tmp/session.jsonl","cwd":"/tmp/repo","title":""}`,
+			want:  `{"path":"/tmp/session.jsonl","cwd":"/tmp/repo","title":""}`,
+		},
+		{
+			input: `{"path":"./session","cwd":".","title":"Title","session_path":"ignored","future":{"nested":true}}`,
+			want:  `{"path":"./session","cwd":".","title":"Title"}`,
+		},
+	}
+	for _, tc := range cases {
+		var migration SessionMigration
+		if err := json.Unmarshal([]byte(tc.input), &migration); err != nil {
+			t.Errorf("Unmarshal(%s): %v", tc.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(migration)
+		if err != nil || string(encoded) != tc.want {
+			t.Errorf("canonical = %s, %v; want %s", encoded, err, tc.want)
+		}
+	}
+}
+
+func TestSessionMigrationRejectsMalformedWireForms(t *testing.T) {
+	invalid := []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{}`,
+		`{"path":"session"}`,
+		`{"cwd":"repo"}`,
+		`{"path":null,"cwd":"repo"}`,
+		`{"path":1,"cwd":"repo"}`,
+		`{"path":true,"cwd":"repo"}`,
+		`{"path":{},"cwd":"repo"}`,
+		`{"path":[],"cwd":"repo"}`,
+		`{"path":"session","cwd":null}`,
+		`{"path":"session","cwd":1}`,
+		`{"path":"session","cwd":true}`,
+		`{"path":"session","cwd":{}}`,
+		`{"path":"session","cwd":[]}`,
+		`{"path":"session","cwd":"repo","title":1}`,
+		`{"path":"session","cwd":"repo","title":true}`,
+		`{"path":"session","cwd":"repo","title":{}}`,
+		`{"path":"session","cwd":"repo","title":[]}`,
+		`{"path":"one","path":"two","cwd":"repo"}`,
+		`{"path":"session","cwd":"one","cwd":"two"}`,
+		`{"path":"session","cwd":"repo","title":null,"title":"two"}`,
+		`{"path":"session","cwd":"repo"`,
+		`{"path":"session","cwd":"repo"} {}`,
+	}
+	for _, input := range invalid {
+		var migration SessionMigration
+		if err := json.Unmarshal([]byte(input), &migration); err == nil {
+			t.Errorf("Unmarshal(%s) succeeded", input)
+		}
+	}
+
+	var migration *SessionMigration
+	if err := migration.UnmarshalJSON([]byte(`{"path":"session","cwd":"repo"}`)); err == nil {
+		t.Fatal("nil SessionMigration receiver succeeded")
+	}
+}
+
+func TestDecodeSessionMigrationObjectRejectsMalformedJSON(t *testing.T) {
+	invalid := []string{
+		``,
+		`{"unterminated`,
+		`{"path":`,
+		`{"path":"session","cwd":"repo"`,
+		`{} {}`,
+		`{} trailing`,
+	}
+	for _, input := range invalid {
+		if _, err := decodeSessionMigrationObject([]byte(input)); err == nil {
+			t.Errorf("decodeSessionMigrationObject(%q) succeeded", input)
+		}
+	}
+}
+
+func TestSessionMigrationRemainsStandalone(t *testing.T) {
+	for _, binding := range WireTypeBindings() {
+		if slices.Contains(binding.Params, "SessionMigration") ||
+			slices.Contains(binding.Result, "SessionMigration") {
+			t.Fatalf("SessionMigration unexpectedly bound: %#v", binding)
+		}
+	}
+	for _, method := range []string{"externalAgentConfig/detect", "externalAgentConfig/import"} {
+		info, ok := LookupMethod(method)
+		if !ok || info.State != MethodDeferredStub {
+			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestSessionMigrationTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	source := string(generated)
+	want := "export type SessionMigration = {\n  \"cwd\": string;\n  \"path\": string;\n  \"title\": string | null;\n};"
+	if !strings.Contains(source, want) {
+		t.Errorf("generated TypeScript missing %q", want)
+	}
+}
+
+var _ json.Unmarshaler = (*SessionMigration)(nil)

--- a/appserver/protocol/session_migration_types.go
+++ b/appserver/protocol/session_migration_types.go
@@ -1,0 +1,100 @@
+package protocol
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// SessionMigration describes one external session file and its working path.
+// It remains standalone until the external-agent migration contracts land.
+type SessionMigration struct {
+	Path  string  `json:"path"`
+	CWD   string  `json:"cwd"`
+	Title *string `json:"title"`
+}
+
+func (m *SessionMigration) UnmarshalJSON(data []byte) error {
+	if m == nil {
+		return errors.New("decode session migration into nil receiver")
+	}
+	payload, err := decodeSessionMigrationObject(data)
+	if err != nil {
+		return err
+	}
+	path, err := decodeRequiredThreadItemValue[string](payload, "session migration", "path")
+	if err != nil {
+		return err
+	}
+	cwd, err := decodeRequiredThreadItemValue[string](payload, "session migration", "cwd")
+	if err != nil {
+		return err
+	}
+	title, err := decodeOptionalNullableSessionMigrationTitle(payload)
+	if err != nil {
+		return err
+	}
+	*m = SessionMigration{Path: path, CWD: cwd, Title: title}
+	return nil
+}
+
+func decodeSessionMigrationObject(data []byte) (map[string]json.RawMessage, error) {
+	const objectName = "session migration"
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	opening, err := decoder.Token()
+	if err != nil {
+		return nil, fmt.Errorf("decode %s: %w", objectName, err)
+	}
+	if opening != json.Delim('{') {
+		return nil, fmt.Errorf("%s must be an object", objectName)
+	}
+	known := map[string]struct{}{"path": {}, "cwd": {}, "title": {}}
+	payload := make(map[string]json.RawMessage, len(known))
+	seen := make(map[string]bool, len(known))
+	for decoder.More() {
+		token, err := decoder.Token()
+		if err != nil {
+			return nil, fmt.Errorf("decode %s field name: %w", objectName, err)
+		}
+		name := token.(string)
+		var raw json.RawMessage
+		if err := decoder.Decode(&raw); err != nil {
+			return nil, fmt.Errorf("decode %s field %q: %w", objectName, name, err)
+		}
+		if _, ok := known[name]; !ok {
+			continue
+		}
+		if seen[name] {
+			return nil, fmt.Errorf("duplicate %s field %q", objectName, name)
+		}
+		seen[name] = true
+		payload[name] = append(json.RawMessage(nil), raw...)
+	}
+	if _, err := decoder.Token(); err != nil {
+		return nil, fmt.Errorf("decode %s: %w", objectName, err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return nil, fmt.Errorf("%s must contain one JSON value", objectName)
+		}
+		return nil, fmt.Errorf("decode %s trailing value: %w", objectName, err)
+	}
+	return payload, nil
+}
+
+func decodeOptionalNullableSessionMigrationTitle(payload map[string]json.RawMessage) (*string, error) {
+	raw, ok := payload["title"]
+	if !ok || isJSONNull(raw) {
+		return nil, nil
+	}
+	var title string
+	if err := json.Unmarshal(raw, &title); err != nil {
+		return nil, fmt.Errorf("decode session migration title: %w", err)
+	}
+	return &title, nil
+}
+
+var _ json.Unmarshaler = (*SessionMigration)(nil)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 384 {
-		t.Fatalf("definition count = %d, want 384", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 385 {
+		t.Fatalf("definition count = %d, want 385", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 384 {
-		t.Fatalf("definition count = %d, want 384", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 385 {
+		t.Fatalf("definition count = %d, want 385", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 384 {
-		t.Fatalf("definition count = %d, want 384", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 385 {
+		t.Fatalf("definition count = %d, want 385", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -2292,6 +2292,12 @@ export type ServerRequestResolvedNotification = {
 
 export type ServerRequestResolvedNotificationParams = ServerRequestResolvedNotification;
 
+export type SessionMigration = {
+  "cwd": string;
+  "path": string;
+  "title": string | null;
+};
+
 export type SessionSource = "cli" | "vscode" | "exec" | "appServer" | "unknown" | {
   "custom": string;
 } | {

--- a/appserver/protocol/typescript/testdata/session_migration_contract.ts
+++ b/appserver/protocol/typescript/testdata/session_migration_contract.ts
@@ -1,0 +1,56 @@
+import type {
+  MethodParamsByName,
+  MethodResultsByName,
+  SessionMigration,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+
+type Expected = {
+  cwd: string;
+  path: string;
+  title: string | null;
+};
+type Contracts = [
+  Expect<Equal<SessionMigration, Expected>>,
+  Expect<Equal<"externalAgentConfig/detect" extends keyof MethodParamsByName ? true : false, false>>,
+  Expect<Equal<"externalAgentConfig/detect" extends keyof MethodResultsByName ? true : false, false>>,
+  Expect<Equal<"externalAgentConfig/import" extends keyof MethodParamsByName ? true : false, false>>,
+  Expect<Equal<"externalAgentConfig/import" extends keyof MethodResultsByName ? true : false, false>>,
+];
+
+export const empty = { path: "", cwd: "", title: null } satisfies SessionMigration;
+export const relative = { path: "sessions/session.jsonl", cwd: "repo/../repo", title: "" } satisfies SessionMigration;
+export const absolute = { path: "/tmp/session.jsonl", cwd: "/tmp/repo", title: "Title" } satisfies SessionMigration;
+
+// @ts-expect-error all canonical fields are required.
+export const rejectMissingAll = {} satisfies SessionMigration;
+// @ts-expect-error path is required.
+export const rejectMissingPath = { cwd: "repo", title: null } satisfies SessionMigration;
+// @ts-expect-error cwd is required.
+export const rejectMissingCwd = { path: "session", title: null } satisfies SessionMigration;
+// @ts-expect-error canonical TypeScript requires explicit nullable title.
+export const rejectMissingTitle = { path: "session", cwd: "repo" } satisfies SessionMigration;
+// @ts-expect-error path is non-null.
+export const rejectNullPath = { path: null, cwd: "repo", title: null } satisfies SessionMigration;
+// @ts-expect-error path must be a string.
+export const rejectNumberPath = { path: 1, cwd: "repo", title: null } satisfies SessionMigration;
+// @ts-expect-error cwd is non-null.
+export const rejectNullCwd = { path: "session", cwd: null, title: null } satisfies SessionMigration;
+// @ts-expect-error cwd must be a string.
+export const rejectNumberCwd = { path: "session", cwd: 1, title: null } satisfies SessionMigration;
+// @ts-expect-error title must be string or null.
+export const rejectNumberTitle = { path: "session", cwd: "repo", title: 1 } satisfies SessionMigration;
+// @ts-expect-error title must be string or null.
+export const rejectObjectTitle = { path: "session", cwd: "repo", title: {} } satisfies SessionMigration;
+// @ts-expect-error aliases do not replace canonical fields.
+export const rejectAliases = { sessionPath: "session", workingDirectory: "repo", title: null } satisfies SessionMigration;
+// @ts-expect-error fields absent from the public record are rejected.
+export const rejectExtra = { path: "session", cwd: "repo", title: null, extra: true } satisfies SessionMigration;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 384 {
-		t.Fatalf("definition count = %d, want 384", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 385 {
+		t.Fatalf("definition count = %d, want 385", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- export exact standalone `SessionMigration` with generic path strings and canonical nullable title
- generate the closed three-field JSON Schema and exact TypeScript record
- keep `MigrationDetails`, external-agent methods, filesystem behavior, and runtime bindings absent or unchanged

## Verification
- deliberate-red Go and strict TypeScript boundaries
- 30 focused repetitions, focused race, and 100% coverage for all three decoder functions
- full protocol and all 59 non-Monty packages under normal and race tests
- `golangci-lint`, `go vet`, `go mod tidy`, deterministic generation, and configured pre-push twice
- structural reverse restores PR #180 tree; baseline/feature initialize + MCP status output is byte-identical

Local Monty tests were skipped per project direction; hosted checks are unchanged.