### PR TITLE
feat(protocol): add command migration contract

### DIFF
--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(defs); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -8,34 +8,34 @@ import (
 	"testing"
 )
 
-func TestSubagentMigrationSchemaIsExact(t *testing.T) {
+func TestCommandMigrationSchemaIsExact(t *testing.T) {
 	defs := JSONSchema()["$defs"].(Schema)
-	got, ok := defs["SubagentMigration"].(Schema)
+	got, ok := defs["CommandMigration"].(Schema)
 	if !ok {
-		t.Fatal("$defs missing SubagentMigration")
+		t.Fatal("$defs missing CommandMigration")
 	}
 	want := closedThreadSessionParamSchema(Schema{
 		"name": Schema{"type": "string"},
 	}, []string{"name"})
 	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("SubagentMigration = %#v, want %#v", got, want)
+		t.Fatalf("CommandMigration = %#v, want %#v", got, want)
 	}
 }
 
-func TestSubagentMigrationAcceptsRustWireForms(t *testing.T) {
+func TestCommandMigrationAcceptsRustWireForms(t *testing.T) {
 	cases := []struct {
 		input string
 		want  string
 	}{
 		{input: `{"name":""}`, want: `{"name":""}`},
-		{input: `{"name":"subagent"}`, want: `{"name":"subagent"}`},
+		{input: `{"name":"command"}`, want: `{"name":"command"}`},
 		{
-			input: `{"name":"subagent","agent_name":"ignored","future":{"nested":true}}`,
-			want:  `{"name":"subagent"}`,
+			input: `{"name":"command","command_name":"ignored","future":{"nested":true}}`,
+			want:  `{"name":"command"}`,
 		},
 	}
 	for _, tc := range cases {
-		var migration SubagentMigration
+		var migration CommandMigration
 		if err := json.Unmarshal([]byte(tc.input), &migration); err != nil {
 			t.Errorf("Unmarshal(%s): %v", tc.input, err)
 			continue
@@ -47,7 +47,7 @@ func TestSubagentMigrationAcceptsRustWireForms(t *testing.T) {
 	}
 }
 
-func TestSubagentMigrationRejectsMalformedWireForms(t *testing.T) {
+func TestCommandMigrationRejectsMalformedWireForms(t *testing.T) {
 	invalid := []string{
 		``, `null`, `[]`, `"value"`, `1`, `true`, `{}`,
 		`{"future":true}`,
@@ -57,43 +57,43 @@ func TestSubagentMigrationRejectsMalformedWireForms(t *testing.T) {
 		`{"name":{}}`,
 		`{"name":[]}`,
 		`{"name":"first","name":"second"}`,
-		`{"name":"subagent"`,
-		`{"name":"subagent"} {}`,
+		`{"name":"command"`,
+		`{"name":"command"} {}`,
 	}
 	for _, input := range invalid {
-		var migration SubagentMigration
+		var migration CommandMigration
 		if err := json.Unmarshal([]byte(input), &migration); err == nil {
 			t.Errorf("Unmarshal(%s) succeeded", input)
 		}
 	}
 
-	var migration *SubagentMigration
-	if err := migration.UnmarshalJSON([]byte(`{"name":"subagent"}`)); err == nil {
-		t.Fatal("nil SubagentMigration receiver succeeded")
+	var migration *CommandMigration
+	if err := migration.UnmarshalJSON([]byte(`{"name":"command"}`)); err == nil {
+		t.Fatal("nil CommandMigration receiver succeeded")
 	}
 }
 
-func TestDecodeSubagentMigrationObjectRejectsMalformedJSON(t *testing.T) {
+func TestDecodeCommandMigrationObjectRejectsMalformedJSON(t *testing.T) {
 	invalid := []string{
 		``,
 		`{"unterminated`,
 		`{"name":`,
-		`{"name":"subagent"`,
+		`{"name":"command"`,
 		`{} {}`,
 		`{} trailing`,
 	}
 	for _, input := range invalid {
-		if _, err := decodeSubagentMigrationObject([]byte(input)); err == nil {
-			t.Errorf("decodeSubagentMigrationObject(%q) succeeded", input)
+		if _, err := decodeCommandMigrationObject([]byte(input)); err == nil {
+			t.Errorf("decodeCommandMigrationObject(%q) succeeded", input)
 		}
 	}
 }
 
-func TestSubagentMigrationRemainsStandalone(t *testing.T) {
+func TestCommandMigrationRemainsStandalone(t *testing.T) {
 	for _, binding := range WireTypeBindings() {
-		if slices.Contains(binding.Params, "SubagentMigration") ||
-			slices.Contains(binding.Result, "SubagentMigration") {
-			t.Fatalf("SubagentMigration unexpectedly bound: %#v", binding)
+		if slices.Contains(binding.Params, "CommandMigration") ||
+			slices.Contains(binding.Result, "CommandMigration") {
+			t.Fatalf("CommandMigration unexpectedly bound: %#v", binding)
 		}
 	}
 	for _, method := range []string{"externalAgentConfig/detect", "externalAgentConfig/import"} {
@@ -113,16 +113,16 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 	}
 }
 
-func TestSubagentMigrationTypeScriptIsExact(t *testing.T) {
+func TestCommandMigrationTypeScriptIsExact(t *testing.T) {
 	generated, err := MarshalTypeScript()
 	if err != nil {
 		t.Fatalf("MarshalTypeScript: %v", err)
 	}
 	source := string(generated)
-	want := "export type SubagentMigration = {\n  \"name\": string;\n};"
+	want := "export type CommandMigration = {\n  \"name\": string;\n};"
 	if !strings.Contains(source, want) {
 		t.Errorf("generated TypeScript missing %q", want)
 	}
 }
 
-var _ json.Unmarshaler = (*SubagentMigration)(nil)
+var _ json.Unmarshaler = (*CommandMigration)(nil)

--- a/appserver/protocol/command_migration_types.go
+++ b/appserver/protocol/command_migration_types.go
@@ -1,0 +1,77 @@
+package protocol
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// CommandMigration identifies one command configuration migration.
+// It remains standalone until the external-agent migration contracts land.
+type CommandMigration struct {
+	Name string `json:"name"`
+}
+
+func (m *CommandMigration) UnmarshalJSON(data []byte) error {
+	if m == nil {
+		return errors.New("decode command migration into nil receiver")
+	}
+	payload, err := decodeCommandMigrationObject(data)
+	if err != nil {
+		return err
+	}
+	name, err := decodeRequiredThreadItemValue[string](payload, "command migration", "name")
+	if err != nil {
+		return err
+	}
+	*m = CommandMigration{Name: name}
+	return nil
+}
+
+func decodeCommandMigrationObject(data []byte) (map[string]json.RawMessage, error) {
+	const objectName = "command migration"
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	opening, err := decoder.Token()
+	if err != nil {
+		return nil, fmt.Errorf("decode %s: %w", objectName, err)
+	}
+	if opening != json.Delim('{') {
+		return nil, fmt.Errorf("%s must be an object", objectName)
+	}
+	payload := make(map[string]json.RawMessage, 1)
+	seenName := false
+	for decoder.More() {
+		token, err := decoder.Token()
+		if err != nil {
+			return nil, fmt.Errorf("decode %s field name: %w", objectName, err)
+		}
+		name := token.(string)
+		var raw json.RawMessage
+		if err := decoder.Decode(&raw); err != nil {
+			return nil, fmt.Errorf("decode %s field %q: %w", objectName, name, err)
+		}
+		if name != "name" {
+			continue
+		}
+		if seenName {
+			return nil, fmt.Errorf("duplicate %s field %q", objectName, name)
+		}
+		seenName = true
+		payload[name] = append(json.RawMessage(nil), raw...)
+	}
+	if _, err := decoder.Token(); err != nil {
+		return nil, fmt.Errorf("decode %s: %w", objectName, err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return nil, fmt.Errorf("%s must contain one JSON value", objectName)
+		}
+		return nil, fmt.Errorf("decode %s trailing value: %w", objectName, err)
+	}
+	return payload, nil
+}
+
+var _ json.Unmarshaler = (*CommandMigration)(nil)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 387 {
-		t.Fatalf("definition count = %d, want 387", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 388 {
+		t.Fatalf("definition count = %d, want 388", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 387 {
-		t.Fatalf("definition count = %d, want 387", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 388 {
+		t.Fatalf("definition count = %d, want 388", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 387 {
-		t.Fatalf("definition count = %d, want 387", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 388 {
+		t.Fatalf("definition count = %d, want 388", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 387 {
-		t.Fatalf("definition count = %d, want 387", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 388 {
+		t.Fatalf("definition count = %d, want 388", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 387 {
-		t.Fatalf("definition count = %d, want 387", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 388 {
+		t.Fatalf("definition count = %d, want 388", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 387 {
-		t.Fatalf("definition count = %d, want 387", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 388 {
+		t.Fatalf("definition count = %d, want 388", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -311,6 +311,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "SessionMigration", Type: reflect.TypeFor[SessionMigration]()},
 		{Name: "HookMigration", Type: reflect.TypeFor[HookMigration]()},
 		{Name: "SubagentMigration", Type: reflect.TypeFor[SubagentMigration]()},
+		{Name: "CommandMigration", Type: reflect.TypeFor[CommandMigration]()},
 		{Name: "PermissionGrantScope", Type: reflect.TypeFor[PermissionGrantScope]()},
 		{Name: "PermissionsApprovalRequestParams", Type: reflect.TypeFor[PermissionsApprovalRequestParams]()},
 		{Name: "PermissionsRequestApprovalParams", Type: reflect.TypeFor[PermissionsRequestApprovalParams]()},
@@ -545,6 +546,7 @@ func wireSchemaDefinitions() Schema {
 	schemas["SessionMigration"] = sessionMigrationSchema()
 	schemas["HookMigration"] = hookMigrationSchema()
 	schemas["SubagentMigration"] = subagentMigrationSchema()
+	schemas["CommandMigration"] = commandMigrationSchema()
 	schemas["McpServerToolCallParams"] = mcpServerToolCallParamsSchema()
 	schemas["McpServerToolCallResponse"] = mcpServerToolCallResponseSchema()
 	schemas["ResourceContent"] = resourceContentSchema()
@@ -2111,6 +2113,12 @@ func hookMigrationSchema() Schema {
 }
 
 func subagentMigrationSchema() Schema {
+	return closedThreadSessionParamSchema(Schema{
+		"name": Schema{"type": "string"},
+	}, []string{"name"})
+}
+
+func commandMigrationSchema() Schema {
 	return closedThreadSessionParamSchema(Schema{
 		"name": Schema{"type": "string"},
 	}, []string{"name"})

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -1486,6 +1486,18 @@
       ],
       "type": "string"
     },
+    "CommandMigration": {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
     "ComputerUseRequirements": {
       "additionalProperties": false,
       "properties": {

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 387 {
-		t.Fatalf("definition count = %d, want 387", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 388 {
+		t.Fatalf("definition count = %d, want 388", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 387 {
-		t.Fatalf("definition count = %d, want 387", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 388 {
+		t.Fatalf("definition count = %d, want 388", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 387 {
-		t.Fatalf("definition count = %d, want 387", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 388 {
+		t.Fatalf("definition count = %d, want 388", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -811,6 +811,10 @@ export type CommandExecutionSource = "agent" | "userShell" | "unifiedExecStartup
 
 export type CommandExecutionStatus = "inProgress" | "completed" | "failed" | "declined";
 
+export type CommandMigration = {
+  "name": string;
+};
+
 export type ComputerUseRequirements = {
   "allowLockedComputerUse": boolean | null;
 };

--- a/appserver/protocol/typescript/testdata/command_migration_contract.ts
+++ b/appserver/protocol/typescript/testdata/command_migration_contract.ts
@@ -1,0 +1,47 @@
+import type {
+  MethodParamsByName,
+  MethodResultsByName,
+  CommandMigration,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+
+type Expected = {
+  name: string;
+};
+type Contracts = [
+  Expect<Equal<CommandMigration, Expected>>,
+  Expect<Equal<"externalAgentConfig/detect" extends keyof MethodParamsByName ? true : false, false>>,
+  Expect<Equal<"externalAgentConfig/detect" extends keyof MethodResultsByName ? true : false, false>>,
+  Expect<Equal<"externalAgentConfig/import" extends keyof MethodParamsByName ? true : false, false>>,
+  Expect<Equal<"externalAgentConfig/import" extends keyof MethodResultsByName ? true : false, false>>,
+];
+
+export const empty = { name: "" } satisfies CommandMigration;
+export const named = { name: "command" } satisfies CommandMigration;
+
+// @ts-expect-error name is required.
+export const rejectMissingName = {} satisfies CommandMigration;
+// @ts-expect-error name is non-null.
+export const rejectNullName = { name: null } satisfies CommandMigration;
+// @ts-expect-error name must be a string.
+export const rejectNumberName = { name: 1 } satisfies CommandMigration;
+// @ts-expect-error name must be a string.
+export const rejectBooleanName = { name: true } satisfies CommandMigration;
+// @ts-expect-error name must be a string.
+export const rejectObjectName = { name: {} } satisfies CommandMigration;
+// @ts-expect-error name must be a string.
+export const rejectArrayName = { name: [] } satisfies CommandMigration;
+// @ts-expect-error aliases do not replace the canonical name field.
+export const rejectCamelAlias = { commandName: "command" } satisfies CommandMigration;
+// @ts-expect-error snake-case aliases do not replace the canonical name field.
+export const rejectSnakeAlias = { command_name: "command" } satisfies CommandMigration;
+// @ts-expect-error fields absent from the public record are rejected.
+export const rejectExtra = { name: "command", extra: true } satisfies CommandMigration;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 387 {
-		t.Fatalf("definition count = %d, want 387", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
+		t.Fatalf("definition count = %d, want 388", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- export the exact standalone public `CommandMigration` record
- reject missing, null, duplicate, malformed, and wrong-type names while preserving Rust-compatible unknown-field discard
- generate the exact closed JSON Schema and TypeScript record without adding method, item, or runtime bindings

## Validation
- deliberate-red Go boundary: 5 missing references
- deliberate-red TypeScript boundary: 1 missing export, 1 false exact identity, 9 unused malformed-shape directives
- 30 focused repetitions and focused race
- 100% statement coverage for both new decoder functions
- full protocol normal and race suites
- all 59 non-Monty packages under serialized normal and race suites
- `golangci-lint run ./...`, `go vet ./...`, tidy verification
- deterministic 388-definition / 59-method-binding / 5-item-binding generation
- strict TypeScript fixture
- configured pre-push twice with `hooks.skipMontyRace=true`
- all five existing Slang real-binary workflows
- baseline/feature fixed-workspace transcript byte-identical
- structural reversal restores exact PR #183 tree

Local Monty normal/race/coverage tests remain skipped per project direction; hosted CI is unchanged.
