### PR TITLE
feat(protocol): add migration details contract

### DIFF
--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(defs); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 388 {
-		t.Fatalf("definition count = %d, want 388", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 389 {
+		t.Fatalf("definition count = %d, want 389", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -1,0 +1,220 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+const emptyMigrationDetailsJSON = `{"plugins":[],"skills":[],"sessions":[],"mcpServers":[],"hooks":[],"subagents":[],"commands":[]}`
+
+func TestMigrationDetailsSchemaIsExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	got, ok := defs["MigrationDetails"].(Schema)
+	if !ok {
+		t.Fatal("$defs missing MigrationDetails")
+	}
+	want := closedThreadSessionParamSchema(Schema{
+		"plugins":    migrationDetailsArraySchema("PluginsMigration"),
+		"skills":     migrationDetailsArraySchema("SkillMigration"),
+		"sessions":   migrationDetailsArraySchema("SessionMigration"),
+		"mcpServers": migrationDetailsArraySchema("McpServerMigration"),
+		"hooks":      migrationDetailsArraySchema("HookMigration"),
+		"subagents":  migrationDetailsArraySchema("SubagentMigration"),
+		"commands":   migrationDetailsArraySchema("CommandMigration"),
+	}, nil)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("MigrationDetails = %#v, want %#v", got, want)
+	}
+	if _, ok := got["required"]; ok {
+		t.Fatal("MigrationDetails schema unexpectedly requires serde-defaulted fields")
+	}
+}
+
+func TestMigrationDetailsAcceptsRustWireForms(t *testing.T) {
+	title := "thread"
+	cases := []struct {
+		name  string
+		input string
+		want  MigrationDetails
+	}{
+		{name: "all omitted", input: `{}`, want: MigrationDetails{}},
+		{
+			name:  "partial and unknown",
+			input: `{"skills":[{"name":""}],"future":{"nested":true}}`,
+			want:  MigrationDetails{Skills: []SkillMigration{{Name: ""}}},
+		},
+		{
+			name: "full",
+			input: `{"plugins":[{"marketplaceName":"market","pluginNames":["one","one"]}],` +
+				`"skills":[{"name":"skill"}],` +
+				`"sessions":[{"path":"session","cwd":"repo","title":"thread"}],` +
+				`"mcpServers":[{"name":"mcp"}],"hooks":[{"name":"hook"}],` +
+				`"subagents":[{"name":"agent"}],"commands":[{"name":"command"},{"name":"command"}]}`,
+			want: MigrationDetails{
+				Plugins:    []PluginsMigration{{MarketplaceName: "market", PluginNames: []string{"one", "one"}}},
+				Skills:     []SkillMigration{{Name: "skill"}},
+				Sessions:   []SessionMigration{{Path: "session", CWD: "repo", Title: &title}},
+				MCPServers: []McpServerMigration{{Name: "mcp"}},
+				Hooks:      []HookMigration{{Name: "hook"}},
+				Subagents:  []SubagentMigration{{Name: "agent"}},
+				Commands:   []CommandMigration{{Name: "command"}, {Name: "command"}},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var details MigrationDetails
+			if err := json.Unmarshal([]byte(tc.input), &details); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			if !reflect.DeepEqual(details, canonicalMigrationDetails(tc.want)) {
+				t.Fatalf("details = %#v, want %#v", details, canonicalMigrationDetails(tc.want))
+			}
+			encoded, err := json.Marshal(details)
+			if err != nil {
+				t.Fatalf("Marshal: %v", err)
+			}
+			var roundTrip MigrationDetails
+			if err := json.Unmarshal(encoded, &roundTrip); err != nil || !reflect.DeepEqual(roundTrip, details) {
+				t.Fatalf("round trip = %#v, %v; want %#v", roundTrip, err, details)
+			}
+		})
+	}
+
+	encoded, err := json.Marshal(MigrationDetails{})
+	if err != nil || string(encoded) != emptyMigrationDetailsJSON {
+		t.Fatalf("zero-value canonical = %s, %v; want %s", encoded, err, emptyMigrationDetailsJSON)
+	}
+}
+
+func TestMigrationDetailsRejectsMalformedWireForms(t *testing.T) {
+	invalid := []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`,
+		`{"plugins":null}`,
+		`{"skills":null}`,
+		`{"sessions":null}`,
+		`{"mcpServers":null}`,
+		`{"hooks":null}`,
+		`{"subagents":null}`,
+		`{"commands":null}`,
+		`{"plugins":{}}`,
+		`{"skills":"skill"}`,
+		`{"sessions":[null]}`,
+		`{"mcpServers":[{"name":1}]}`,
+		`{"hooks":[{"name":null}]}`,
+		`{"subagents":[{}]}`,
+		`{"commands":[{"name":"first","name":"second"}]}`,
+		`{"commands":[],"commands":[]}`,
+		`{"commands":[]`,
+		`{"commands":[]} {}`,
+	}
+	for _, input := range invalid {
+		var details MigrationDetails
+		if err := json.Unmarshal([]byte(input), &details); err == nil {
+			t.Errorf("Unmarshal(%s) succeeded", input)
+		}
+	}
+
+	var details *MigrationDetails
+	if err := details.UnmarshalJSON([]byte(`{}`)); err == nil {
+		t.Fatal("nil MigrationDetails receiver succeeded")
+	}
+}
+
+func TestDecodeMigrationDetailsObjectRejectsMalformedJSON(t *testing.T) {
+	invalid := []string{
+		``,
+		`{"unterminated`,
+		`{"commands":`,
+		`{"commands":[]`,
+		`{} {}`,
+		`{} trailing`,
+	}
+	for _, input := range invalid {
+		if _, err := decodeMigrationDetailsObject([]byte(input)); err == nil {
+			t.Errorf("decodeMigrationDetailsObject(%q) succeeded", input)
+		}
+	}
+}
+
+func TestMigrationDetailsPreservesArrayOrderAndDuplicates(t *testing.T) {
+	input := `{"skills":[{"name":"second"},{"name":"first"},{"name":"second"}],` +
+		`"commands":[{"name":"two"},{"name":"one"},{"name":"two"}]}`
+	var details MigrationDetails
+	if err := json.Unmarshal([]byte(input), &details); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got := []string{details.Skills[0].Name, details.Skills[1].Name, details.Skills[2].Name}; !reflect.DeepEqual(got, []string{"second", "first", "second"}) {
+		t.Errorf("skill order = %v", got)
+	}
+	if got := []string{details.Commands[0].Name, details.Commands[1].Name, details.Commands[2].Name}; !reflect.DeepEqual(got, []string{"two", "one", "two"}) {
+		t.Errorf("command order = %v", got)
+	}
+}
+
+func TestMigrationDetailsRemainsStandalone(t *testing.T) {
+	for _, binding := range WireTypeBindings() {
+		if slices.Contains(binding.Params, "MigrationDetails") ||
+			slices.Contains(binding.Result, "MigrationDetails") {
+			t.Fatalf("MigrationDetails unexpectedly bound: %#v", binding)
+		}
+	}
+	for _, method := range []string{"externalAgentConfig/detect", "externalAgentConfig/import"} {
+		info, ok := LookupMethod(method)
+		if !ok || info.State != MethodDeferredStub {
+			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestMigrationDetailsTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	source := string(generated)
+	want := "export type MigrationDetails = {\n" +
+		"  \"commands\": Array<CommandMigration>;\n" +
+		"  \"hooks\": Array<HookMigration>;\n" +
+		"  \"mcpServers\": Array<McpServerMigration>;\n" +
+		"  \"plugins\": Array<PluginsMigration>;\n" +
+		"  \"sessions\": Array<SessionMigration>;\n" +
+		"  \"skills\": Array<SkillMigration>;\n" +
+		"  \"subagents\": Array<SubagentMigration>;\n" +
+		"};"
+	if !strings.Contains(source, want) {
+		t.Errorf("generated TypeScript missing %q", want)
+	}
+	if !strings.Contains(source, `"appBrand"?: LoginAppBrand | null;`) {
+		t.Error("MigrationDetails override made unrelated defaulted fields required")
+	}
+}
+
+func canonicalMigrationDetails(details MigrationDetails) MigrationDetails {
+	encoded, err := json.Marshal(details)
+	if err != nil {
+		panic(err)
+	}
+	var canonical MigrationDetails
+	if err := json.Unmarshal(encoded, &canonical); err != nil {
+		panic(err)
+	}
+	return canonical
+}
+
+var (
+	_ json.Marshaler   = MigrationDetails{}
+	_ json.Unmarshaler = (*MigrationDetails)(nil)
+)

--- a/appserver/protocol/migration_details_types.go
+++ b/appserver/protocol/migration_details_types.go
@@ -1,0 +1,159 @@
+package protocol
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// MigrationDetails groups the standalone external-agent migration leaves.
+// It remains unbound until the external-agent request and runtime contracts land.
+type MigrationDetails struct {
+	Plugins    []PluginsMigration   `json:"plugins"`
+	Skills     []SkillMigration     `json:"skills"`
+	Sessions   []SessionMigration   `json:"sessions"`
+	MCPServers []McpServerMigration `json:"mcpServers"`
+	Hooks      []HookMigration      `json:"hooks"`
+	Subagents  []SubagentMigration  `json:"subagents"`
+	Commands   []CommandMigration   `json:"commands"`
+}
+
+func (d MigrationDetails) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Plugins    []PluginsMigration   `json:"plugins"`
+		Skills     []SkillMigration     `json:"skills"`
+		Sessions   []SessionMigration   `json:"sessions"`
+		MCPServers []McpServerMigration `json:"mcpServers"`
+		Hooks      []HookMigration      `json:"hooks"`
+		Subagents  []SubagentMigration  `json:"subagents"`
+		Commands   []CommandMigration   `json:"commands"`
+	}{
+		Plugins:    nonNilMigrationDetailsSlice(d.Plugins),
+		Skills:     nonNilMigrationDetailsSlice(d.Skills),
+		Sessions:   nonNilMigrationDetailsSlice(d.Sessions),
+		MCPServers: nonNilMigrationDetailsSlice(d.MCPServers),
+		Hooks:      nonNilMigrationDetailsSlice(d.Hooks),
+		Subagents:  nonNilMigrationDetailsSlice(d.Subagents),
+		Commands:   nonNilMigrationDetailsSlice(d.Commands),
+	})
+}
+
+func (d *MigrationDetails) UnmarshalJSON(data []byte) error {
+	if d == nil {
+		return errors.New("decode migration details into nil receiver")
+	}
+	payload, err := decodeMigrationDetailsObject(data)
+	if err != nil {
+		return err
+	}
+	plugins, err := decodeMigrationDetailsArray[PluginsMigration](payload, "plugins")
+	if err != nil {
+		return err
+	}
+	skills, err := decodeMigrationDetailsArray[SkillMigration](payload, "skills")
+	if err != nil {
+		return err
+	}
+	sessions, err := decodeMigrationDetailsArray[SessionMigration](payload, "sessions")
+	if err != nil {
+		return err
+	}
+	mcpServers, err := decodeMigrationDetailsArray[McpServerMigration](payload, "mcpServers")
+	if err != nil {
+		return err
+	}
+	hooks, err := decodeMigrationDetailsArray[HookMigration](payload, "hooks")
+	if err != nil {
+		return err
+	}
+	subagents, err := decodeMigrationDetailsArray[SubagentMigration](payload, "subagents")
+	if err != nil {
+		return err
+	}
+	commands, err := decodeMigrationDetailsArray[CommandMigration](payload, "commands")
+	if err != nil {
+		return err
+	}
+	*d = MigrationDetails{
+		Plugins: plugins, Skills: skills, Sessions: sessions, MCPServers: mcpServers,
+		Hooks: hooks, Subagents: subagents, Commands: commands,
+	}
+	return nil
+}
+
+func decodeMigrationDetailsObject(data []byte) (map[string]json.RawMessage, error) {
+	const objectName = "migration details"
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	opening, err := decoder.Token()
+	if err != nil {
+		return nil, fmt.Errorf("decode %s: %w", objectName, err)
+	}
+	if opening != json.Delim('{') {
+		return nil, fmt.Errorf("%s must be an object", objectName)
+	}
+	known := map[string]struct{}{
+		"plugins": {}, "skills": {}, "sessions": {}, "mcpServers": {},
+		"hooks": {}, "subagents": {}, "commands": {},
+	}
+	payload := make(map[string]json.RawMessage, len(known))
+	seen := make(map[string]bool, len(known))
+	for decoder.More() {
+		token, err := decoder.Token()
+		if err != nil {
+			return nil, fmt.Errorf("decode %s field name: %w", objectName, err)
+		}
+		name := token.(string)
+		var raw json.RawMessage
+		if err := decoder.Decode(&raw); err != nil {
+			return nil, fmt.Errorf("decode %s field %q: %w", objectName, name, err)
+		}
+		if _, ok := known[name]; !ok {
+			continue
+		}
+		if seen[name] {
+			return nil, fmt.Errorf("duplicate %s field %q", objectName, name)
+		}
+		seen[name] = true
+		payload[name] = append(json.RawMessage(nil), raw...)
+	}
+	if _, err := decoder.Token(); err != nil {
+		return nil, fmt.Errorf("decode %s: %w", objectName, err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return nil, fmt.Errorf("%s must contain one JSON value", objectName)
+		}
+		return nil, fmt.Errorf("decode %s trailing value: %w", objectName, err)
+	}
+	return payload, nil
+}
+
+func decodeMigrationDetailsArray[T any](payload map[string]json.RawMessage, fieldName string) ([]T, error) {
+	raw, ok := payload[fieldName]
+	if !ok {
+		return []T{}, nil
+	}
+	if isJSONNull(raw) {
+		return nil, fmt.Errorf("migration details field %q must be a non-null array", fieldName)
+	}
+	var values []T
+	if err := json.Unmarshal(raw, &values); err != nil {
+		return nil, fmt.Errorf("decode migration details field %q: %w", fieldName, err)
+	}
+	return nonNilMigrationDetailsSlice(values), nil
+}
+
+func nonNilMigrationDetailsSlice[T any](values []T) []T {
+	if values == nil {
+		return []T{}
+	}
+	return values
+}
+
+var (
+	_ json.Marshaler   = MigrationDetails{}
+	_ json.Unmarshaler = (*MigrationDetails)(nil)
+)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 388 {
-		t.Fatalf("definition count = %d, want 388", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 389 {
+		t.Fatalf("definition count = %d, want 389", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 388 {
-		t.Fatalf("definition count = %d, want 388", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 389 {
+		t.Fatalf("definition count = %d, want 389", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 388 {
-		t.Fatalf("definition count = %d, want 388", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 389 {
+		t.Fatalf("definition count = %d, want 389", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 388 {
-		t.Fatalf("definition count = %d, want 388", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 389 {
+		t.Fatalf("definition count = %d, want 389", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 388 {
-		t.Fatalf("definition count = %d, want 388", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 389 {
+		t.Fatalf("definition count = %d, want 389", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -312,6 +312,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "HookMigration", Type: reflect.TypeFor[HookMigration]()},
 		{Name: "SubagentMigration", Type: reflect.TypeFor[SubagentMigration]()},
 		{Name: "CommandMigration", Type: reflect.TypeFor[CommandMigration]()},
+		{Name: "MigrationDetails", Type: reflect.TypeFor[MigrationDetails]()},
 		{Name: "PermissionGrantScope", Type: reflect.TypeFor[PermissionGrantScope]()},
 		{Name: "PermissionsApprovalRequestParams", Type: reflect.TypeFor[PermissionsApprovalRequestParams]()},
 		{Name: "PermissionsRequestApprovalParams", Type: reflect.TypeFor[PermissionsRequestApprovalParams]()},
@@ -547,6 +548,7 @@ func wireSchemaDefinitions() Schema {
 	schemas["HookMigration"] = hookMigrationSchema()
 	schemas["SubagentMigration"] = subagentMigrationSchema()
 	schemas["CommandMigration"] = commandMigrationSchema()
+	schemas["MigrationDetails"] = migrationDetailsSchema()
 	schemas["McpServerToolCallParams"] = mcpServerToolCallParamsSchema()
 	schemas["McpServerToolCallResponse"] = mcpServerToolCallResponseSchema()
 	schemas["ResourceContent"] = resourceContentSchema()
@@ -2122,6 +2124,26 @@ func commandMigrationSchema() Schema {
 	return closedThreadSessionParamSchema(Schema{
 		"name": Schema{"type": "string"},
 	}, []string{"name"})
+}
+
+func migrationDetailsSchema() Schema {
+	return closedThreadSessionParamSchema(Schema{
+		"plugins":    migrationDetailsArraySchema("PluginsMigration"),
+		"skills":     migrationDetailsArraySchema("SkillMigration"),
+		"sessions":   migrationDetailsArraySchema("SessionMigration"),
+		"mcpServers": migrationDetailsArraySchema("McpServerMigration"),
+		"hooks":      migrationDetailsArraySchema("HookMigration"),
+		"subagents":  migrationDetailsArraySchema("SubagentMigration"),
+		"commands":   migrationDetailsArraySchema("CommandMigration"),
+	}, nil)
+}
+
+func migrationDetailsArraySchema(typeName string) Schema {
+	return Schema{
+		"type":    "array",
+		"items":   Schema{"$ref": "#/$defs/" + typeName},
+		"default": []any{},
+	}
 }
 
 func sessionMigrationSchema() Schema {

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -6337,6 +6337,61 @@
       ],
       "type": "string"
     },
+    "MigrationDetails": {
+      "additionalProperties": false,
+      "properties": {
+        "commands": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/CommandMigration"
+          },
+          "type": "array"
+        },
+        "hooks": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/HookMigration"
+          },
+          "type": "array"
+        },
+        "mcpServers": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/McpServerMigration"
+          },
+          "type": "array"
+        },
+        "plugins": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/PluginsMigration"
+          },
+          "type": "array"
+        },
+        "sessions": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/SessionMigration"
+          },
+          "type": "array"
+        },
+        "skills": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/SkillMigration"
+          },
+          "type": "array"
+        },
+        "subagents": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/SubagentMigration"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
     "Model": {
       "additionalProperties": false,
       "properties": {

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 388 {
-		t.Fatalf("definition count = %d, want 388", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 389 {
+		t.Fatalf("definition count = %d, want 389", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 388 {
-		t.Fatalf("definition count = %d, want 388", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 389 {
+		t.Fatalf("definition count = %d, want 389", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 388 {
-		t.Fatalf("definition count = %d, want 388", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 389 {
+		t.Fatalf("definition count = %d, want 389", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -36,7 +36,22 @@ func MarshalTypeScript() ([]byte, error) {
 	}
 	sort.Strings(names)
 	for _, name := range names {
-		typeName, err := typeScriptType(defs[name], 0)
+		definition := defs[name]
+		if name == "MigrationDetails" {
+			// Rust accepts omitted serde-defaulted arrays while its generated
+			// TypeScript record requires callers to provide every field.
+			schema, _ := typeScriptSchema(definition)
+			renderSchema := make(Schema, len(schema)+1)
+			for key, value := range schema {
+				renderSchema[key] = value
+			}
+			schema = renderSchema
+			schema["required"] = []string{
+				"plugins", "skills", "sessions", "mcpServers", "hooks", "subagents", "commands",
+			}
+			definition = schema
+		}
+		typeName, err := typeScriptType(definition, 0)
 		if err != nil {
 			return nil, fmt.Errorf("generate TypeScript definition %s: %w", name, err)
 		}

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -1858,6 +1858,16 @@ export type MethodInfo = {
 
 export type MethodState = "implemented" | "blocked" | "deferred-stub" | "renamed-equivalent" | "not-applicable";
 
+export type MigrationDetails = {
+  "commands": Array<CommandMigration>;
+  "hooks": Array<HookMigration>;
+  "mcpServers": Array<McpServerMigration>;
+  "plugins": Array<PluginsMigration>;
+  "sessions": Array<SessionMigration>;
+  "skills": Array<SkillMigration>;
+  "subagents": Array<SubagentMigration>;
+};
+
 export type Model = {
   "additionalSpeedTiers": Array<string>;
   "availabilityNux": ModelAvailabilityNux | null;

--- a/appserver/protocol/typescript/testdata/migration_details_contract.ts
+++ b/appserver/protocol/typescript/testdata/migration_details_contract.ts
@@ -1,0 +1,83 @@
+import type {
+  CommandMigration,
+  HookMigration,
+  McpServerMigration,
+  MethodParamsByName,
+  MethodResultsByName,
+  MigrationDetails,
+  PluginsMigration,
+  SessionMigration,
+  SkillMigration,
+  SubagentMigration,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+
+type Expected = {
+  plugins: Array<PluginsMigration>;
+  skills: Array<SkillMigration>;
+  sessions: Array<SessionMigration>;
+  mcpServers: Array<McpServerMigration>;
+  hooks: Array<HookMigration>;
+  subagents: Array<SubagentMigration>;
+  commands: Array<CommandMigration>;
+};
+type Contracts = [
+  Expect<Equal<MigrationDetails, Expected>>,
+  Expect<Equal<"externalAgentConfig/detect" extends keyof MethodParamsByName ? true : false, false>>,
+  Expect<Equal<"externalAgentConfig/detect" extends keyof MethodResultsByName ? true : false, false>>,
+  Expect<Equal<"externalAgentConfig/import" extends keyof MethodParamsByName ? true : false, false>>,
+  Expect<Equal<"externalAgentConfig/import" extends keyof MethodResultsByName ? true : false, false>>,
+];
+
+export const empty = {
+  plugins: [],
+  skills: [],
+  sessions: [],
+  mcpServers: [],
+  hooks: [],
+  subagents: [],
+  commands: [],
+} satisfies MigrationDetails;
+
+export const full = {
+  plugins: [{ marketplaceName: "market", pluginNames: ["one", "one"] }],
+  skills: [{ name: "skill" }],
+  sessions: [{ path: "session", cwd: "repo", title: null }],
+  mcpServers: [{ name: "mcp" }],
+  hooks: [{ name: "hook" }],
+  subagents: [{ name: "agent" }],
+  commands: [{ name: "command" }, { name: "command" }],
+} satisfies MigrationDetails;
+
+// @ts-expect-error all seven fields are required in generated TypeScript.
+export const rejectOmitted = {} satisfies MigrationDetails;
+// @ts-expect-error partial records are rejected in generated TypeScript.
+export const rejectPartial = { commands: [] } satisfies MigrationDetails;
+// @ts-expect-error plugins is non-null.
+export const rejectNullPlugins = { ...empty, plugins: null } satisfies MigrationDetails;
+// @ts-expect-error skills is non-null.
+export const rejectNullSkills = { ...empty, skills: null } satisfies MigrationDetails;
+// @ts-expect-error sessions is non-null.
+export const rejectNullSessions = { ...empty, sessions: null } satisfies MigrationDetails;
+// @ts-expect-error mcpServers is non-null.
+export const rejectNullMcpServers = { ...empty, mcpServers: null } satisfies MigrationDetails;
+// @ts-expect-error hooks is non-null.
+export const rejectNullHooks = { ...empty, hooks: null } satisfies MigrationDetails;
+// @ts-expect-error subagents is non-null.
+export const rejectNullSubagents = { ...empty, subagents: null } satisfies MigrationDetails;
+// @ts-expect-error commands is non-null.
+export const rejectNullCommands = { ...empty, commands: null } satisfies MigrationDetails;
+// @ts-expect-error nested command values remain strict.
+export const rejectMalformedCommand = { ...empty, commands: [{}] } satisfies MigrationDetails;
+// @ts-expect-error snake-case aliases do not replace the canonical field.
+export const rejectSnakeAlias = { ...empty, mcpServers: undefined, mcp_servers: [] } satisfies MigrationDetails;
+// @ts-expect-error fields absent from the public record are rejected.
+export const rejectExtra = { ...empty, extra: true } satisfies MigrationDetails;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 388 {
-		t.Fatalf("definition count = %d, want 388", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
+		t.Fatalf("definition count = %d, want 389", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- export the exact standalone Codex `MigrationDetails` parent over the seven existing migration leaf records
- preserve Rust serde semantics: omitted arrays decode to empty arrays, explicit null is rejected, unknown JSON fields are ignored, duplicate known fields are rejected, and canonical output emits all seven arrays
- generate exact all-required TypeScript while keeping the JSON Schema's serde-defaulted fields optional, without changing unrelated defaulted TypeScript fields
- keep external-agent methods, method bindings, item bindings, and runtime behavior unchanged

## Validation
- 30 focused repetitions and focused race
- 100% focused statement coverage for all five new codec/helper functions
- full protocol normal/race
- all 59 non-Monty packages, serialized normal/race; local Monty tests intentionally skipped per project direction
- strict TypeScript compile
- golangci-lint, go vet, go mod tidy/verify, deterministic generation, git diff --check
- configured pre-push hook passed three times with hooks.skipMontyRace=true
- all five existing Slang stdio/Unix-socket/WebSocket workflows against the committed binary
- pinned Codex source at 5c19155: normalized schema is byte-identical
- baseline/feature initialize + MCP status transcript is byte-identical (37,895 bytes, empty stderr)

Generated SHA-256:
- schema: `414b141bd850de27251367d4ff6f373445e3fc6a65ba0bda9b76b376ab74313e`
- TypeScript: `a65a9ca0bb5101b1a2c5ae51bb201c941445bad6fab766acdf53fc133f6863f2`
- strict fixture: `fef094dc85422739ff0d0185a0ef729f8fa4af91911c868c256315e6b9c13108`
- normalized definition: `4cc02c8a761344de6ab3d6889c063c0538138828fc6aef81183a34d906e5d13c`
- TypeScript block: `bdcccab8652929418dd0d1c593c7c5ab6e9caeba6d9b940907dfc415a2b211e9`
- committed trimpath binary: `a93428f9a113d4f183e2c3c440f17dc19c573944fbad1d6fc26b89fbd7d8fed5`
