### PR TITLE
feat(protocol): add external-agent migration item type

### DIFF
--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(defs); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -1,0 +1,112 @@
+package protocol
+
+import (
+	"encoding/json"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestExternalAgentConfigMigrationItemTypeSchemaIsExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	assertStringEnum(
+		t,
+		defs["ExternalAgentConfigMigrationItemType"],
+		"AGENTS_MD",
+		"CONFIG",
+		"SKILLS",
+		"PLUGINS",
+		"MCP_SERVER_CONFIG",
+		"SUBAGENTS",
+		"HOOKS",
+		"COMMANDS",
+		"SESSIONS",
+	)
+}
+
+func TestExternalAgentConfigMigrationItemTypeAcceptsExactValues(t *testing.T) {
+	for _, input := range []string{
+		`"AGENTS_MD"`,
+		`"CONFIG"`,
+		`"SKILLS"`,
+		`"PLUGINS"`,
+		`"MCP_SERVER_CONFIG"`,
+		`"SUBAGENTS"`,
+		`"HOOKS"`,
+		`"COMMANDS"`,
+		`"SESSIONS"`,
+	} {
+		var itemType ExternalAgentConfigMigrationItemType
+		if err := json.Unmarshal([]byte(input), &itemType); err != nil {
+			t.Fatalf("unmarshal ExternalAgentConfigMigrationItemType %s: %v", input, err)
+		}
+		encoded, err := json.Marshal(itemType)
+		if err != nil {
+			t.Fatalf("marshal ExternalAgentConfigMigrationItemType %s: %v", input, err)
+		}
+		if got := string(encoded); got != input {
+			t.Fatalf("ExternalAgentConfigMigrationItemType round trip = %s, want %s", got, input)
+		}
+	}
+}
+
+func TestExternalAgentConfigMigrationItemTypeRejectsMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `""`, `"OTHER"`, `"agents_md"`, `"AgentsMd"`,
+		`"AGENT_MD"`, `"MCP_SERVER"`, `"mcp_server_config"`,
+		`"SUB_AGENTS"`, `"COMMAND"`, `"SESSION"`,
+		`1`, `true`, `{}`, `[]`, `"CONFIG" {}`, `"SESSIONS" x`,
+	} {
+		assertJSONRejects[ExternalAgentConfigMigrationItemType](t, input)
+	}
+}
+
+func TestExternalAgentConfigMigrationItemTypeNilReceiverAndInvalidMarshalFailClosed(t *testing.T) {
+	var itemType *ExternalAgentConfigMigrationItemType
+	if err := itemType.UnmarshalJSON([]byte(`"CONFIG"`)); err == nil {
+		t.Fatal("nil ExternalAgentConfigMigrationItemType receiver succeeded")
+	}
+	if _, err := json.Marshal(ExternalAgentConfigMigrationItemType("OTHER")); err == nil {
+		t.Fatal("invalid ExternalAgentConfigMigrationItemType marshaled")
+	}
+}
+
+func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
+	for _, binding := range WireTypeBindings() {
+		if slices.Contains(binding.Params, "ExternalAgentConfigMigrationItemType") ||
+			slices.Contains(binding.Result, "ExternalAgentConfigMigrationItemType") {
+			t.Fatalf("ExternalAgentConfigMigrationItemType unexpectedly bound to %s", binding.Method)
+		}
+	}
+	for _, method := range []string{"externalAgentConfig/detect", "externalAgentConfig/import"} {
+		info, ok := LookupMethod(method)
+		if !ok || info.State != MethodDeferredStub {
+			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestExternalAgentConfigMigrationItemTypeTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	want := `export type ExternalAgentConfigMigrationItemType = "AGENTS_MD" | "CONFIG" | "SKILLS" | "PLUGINS" | "MCP_SERVER_CONFIG" | "SUBAGENTS" | "HOOKS" | "COMMANDS" | "SESSIONS";`
+	if !strings.Contains(string(generated), want) {
+		t.Errorf("generated TypeScript missing %q", want)
+	}
+}
+
+var (
+	_ json.Marshaler   = ExternalAgentConfigMigrationItemType("")
+	_ json.Unmarshaler = (*ExternalAgentConfigMigrationItemType)(nil)
+)

--- a/appserver/protocol/external_agent_config_migration_item_type_types.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_types.go
@@ -1,0 +1,50 @@
+package protocol
+
+import "encoding/json"
+
+// ExternalAgentConfigMigrationItemType is the exact closed public category for
+// an external-agent migration item. It remains standalone from discovery,
+// import, configuration, and runtime behavior.
+type ExternalAgentConfigMigrationItemType string
+
+const (
+	ExternalAgentConfigMigrationItemTypeAgentsMD        ExternalAgentConfigMigrationItemType = "AGENTS_MD"
+	ExternalAgentConfigMigrationItemTypeConfig          ExternalAgentConfigMigrationItemType = "CONFIG"
+	ExternalAgentConfigMigrationItemTypeSkills          ExternalAgentConfigMigrationItemType = "SKILLS"
+	ExternalAgentConfigMigrationItemTypePlugins         ExternalAgentConfigMigrationItemType = "PLUGINS"
+	ExternalAgentConfigMigrationItemTypeMCPServerConfig ExternalAgentConfigMigrationItemType = "MCP_SERVER_CONFIG"
+	ExternalAgentConfigMigrationItemTypeSubagents       ExternalAgentConfigMigrationItemType = "SUBAGENTS"
+	ExternalAgentConfigMigrationItemTypeHooks           ExternalAgentConfigMigrationItemType = "HOOKS"
+	ExternalAgentConfigMigrationItemTypeCommands        ExternalAgentConfigMigrationItemType = "COMMANDS"
+	ExternalAgentConfigMigrationItemTypeSessions        ExternalAgentConfigMigrationItemType = "SESSIONS"
+)
+
+func (t ExternalAgentConfigMigrationItemType) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(t, "external-agent migration item type", ExternalAgentConfigMigrationItemType.valid)
+}
+
+func (t *ExternalAgentConfigMigrationItemType) UnmarshalJSON(data []byte) error {
+	return unmarshalThreadTurnLeafEnum(data, t, "external-agent migration item type", ExternalAgentConfigMigrationItemType.valid)
+}
+
+func (t ExternalAgentConfigMigrationItemType) valid() bool {
+	switch t {
+	case ExternalAgentConfigMigrationItemTypeAgentsMD,
+		ExternalAgentConfigMigrationItemTypeConfig,
+		ExternalAgentConfigMigrationItemTypeSkills,
+		ExternalAgentConfigMigrationItemTypePlugins,
+		ExternalAgentConfigMigrationItemTypeMCPServerConfig,
+		ExternalAgentConfigMigrationItemTypeSubagents,
+		ExternalAgentConfigMigrationItemTypeHooks,
+		ExternalAgentConfigMigrationItemTypeCommands,
+		ExternalAgentConfigMigrationItemTypeSessions:
+		return true
+	default:
+		return false
+	}
+}
+
+var (
+	_ json.Marshaler   = ExternalAgentConfigMigrationItemType("")
+	_ json.Unmarshaler = (*ExternalAgentConfigMigrationItemType)(nil)
+)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 389 {
-		t.Fatalf("definition count = %d, want 389", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 390 {
+		t.Fatalf("definition count = %d, want 390", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 389 {
-		t.Fatalf("definition count = %d, want 389", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 390 {
+		t.Fatalf("definition count = %d, want 390", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 389 {
-		t.Fatalf("definition count = %d, want 389", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 390 {
+		t.Fatalf("definition count = %d, want 390", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 389 {
-		t.Fatalf("definition count = %d, want 389", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 390 {
+		t.Fatalf("definition count = %d, want 390", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 389 {
-		t.Fatalf("definition count = %d, want 389", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 390 {
+		t.Fatalf("definition count = %d, want 390", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 389 {
-		t.Fatalf("definition count = %d, want 389", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 390 {
+		t.Fatalf("definition count = %d, want 390", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -313,6 +313,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "SubagentMigration", Type: reflect.TypeFor[SubagentMigration]()},
 		{Name: "CommandMigration", Type: reflect.TypeFor[CommandMigration]()},
 		{Name: "MigrationDetails", Type: reflect.TypeFor[MigrationDetails]()},
+		{Name: "ExternalAgentConfigMigrationItemType", Type: reflect.TypeFor[ExternalAgentConfigMigrationItemType]()},
 		{Name: "PermissionGrantScope", Type: reflect.TypeFor[PermissionGrantScope]()},
 		{Name: "PermissionsApprovalRequestParams", Type: reflect.TypeFor[PermissionsApprovalRequestParams]()},
 		{Name: "PermissionsRequestApprovalParams", Type: reflect.TypeFor[PermissionsRequestApprovalParams]()},
@@ -549,6 +550,17 @@ func wireSchemaDefinitions() Schema {
 	schemas["SubagentMigration"] = subagentMigrationSchema()
 	schemas["CommandMigration"] = commandMigrationSchema()
 	schemas["MigrationDetails"] = migrationDetailsSchema()
+	schemas["ExternalAgentConfigMigrationItemType"] = stringEnumSchema(
+		string(ExternalAgentConfigMigrationItemTypeAgentsMD),
+		string(ExternalAgentConfigMigrationItemTypeConfig),
+		string(ExternalAgentConfigMigrationItemTypeSkills),
+		string(ExternalAgentConfigMigrationItemTypePlugins),
+		string(ExternalAgentConfigMigrationItemTypeMCPServerConfig),
+		string(ExternalAgentConfigMigrationItemTypeSubagents),
+		string(ExternalAgentConfigMigrationItemTypeHooks),
+		string(ExternalAgentConfigMigrationItemTypeCommands),
+		string(ExternalAgentConfigMigrationItemTypeSessions),
+	)
 	schemas["McpServerToolCallParams"] = mcpServerToolCallParamsSchema()
 	schemas["McpServerToolCallResponse"] = mcpServerToolCallResponseSchema()
 	schemas["ResourceContent"] = resourceContentSchema()

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -3137,6 +3137,20 @@
       },
       "type": "array"
     },
+    "ExternalAgentConfigMigrationItemType": {
+      "enum": [
+        "AGENTS_MD",
+        "CONFIG",
+        "SKILLS",
+        "PLUGINS",
+        "MCP_SERVER_CONFIG",
+        "SUBAGENTS",
+        "HOOKS",
+        "COMMANDS",
+        "SESSIONS"
+      ],
+      "type": "string"
+    },
     "FileChangeApprovalDecision": {
       "enum": [
         "accept",

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 389 {
-		t.Fatalf("definition count = %d, want 389", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 390 {
+		t.Fatalf("definition count = %d, want 390", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 389 {
-		t.Fatalf("definition count = %d, want 389", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 390 {
+		t.Fatalf("definition count = %d, want 390", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 389 {
-		t.Fatalf("definition count = %d, want 389", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 390 {
+		t.Fatalf("definition count = %d, want 390", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -1121,6 +1121,8 @@ export type ErrorNotification = {
 
 export type ExecPolicyAmendment = Array<string>;
 
+export type ExternalAgentConfigMigrationItemType = "AGENTS_MD" | "CONFIG" | "SKILLS" | "PLUGINS" | "MCP_SERVER_CONFIG" | "SUBAGENTS" | "HOOKS" | "COMMANDS" | "SESSIONS";
+
 export type FileChangeApprovalDecision = "accept" | "acceptForSession" | "decline" | "cancel";
 
 export type FileChangeApprovalRequestParams = {

--- a/appserver/protocol/typescript/testdata/external_agent_config_migration_item_type_contract.ts
+++ b/appserver/protocol/typescript/testdata/external_agent_config_migration_item_type_contract.ts
@@ -1,0 +1,67 @@
+import type {
+  ExternalAgentConfigMigrationItemType,
+  MethodParamsByName,
+  MethodResultsByName,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+
+type Expected =
+  | "AGENTS_MD"
+  | "CONFIG"
+  | "SKILLS"
+  | "PLUGINS"
+  | "MCP_SERVER_CONFIG"
+  | "SUBAGENTS"
+  | "HOOKS"
+  | "COMMANDS"
+  | "SESSIONS";
+type Contracts = [
+  Expect<Equal<ExternalAgentConfigMigrationItemType, Expected>>,
+  Expect<Equal<"externalAgentConfig/detect" extends keyof MethodParamsByName ? true : false, false>>,
+  Expect<Equal<"externalAgentConfig/detect" extends keyof MethodResultsByName ? true : false, false>>,
+  Expect<Equal<"externalAgentConfig/import" extends keyof MethodParamsByName ? true : false, false>>,
+  Expect<Equal<"externalAgentConfig/import" extends keyof MethodResultsByName ? true : false, false>>,
+];
+
+export const values = [
+  "AGENTS_MD",
+  "CONFIG",
+  "SKILLS",
+  "PLUGINS",
+  "MCP_SERVER_CONFIG",
+  "SUBAGENTS",
+  "HOOKS",
+  "COMMANDS",
+  "SESSIONS",
+] satisfies ExternalAgentConfigMigrationItemType[];
+
+// @ts-expect-error item types are closed.
+export const rejectUnknown = "OTHER" satisfies ExternalAgentConfigMigrationItemType;
+// @ts-expect-error empty strings are not item types.
+export const rejectEmpty = "" satisfies ExternalAgentConfigMigrationItemType;
+// @ts-expect-error exact uppercase spelling is required.
+export const rejectLowercase = "config" satisfies ExternalAgentConfigMigrationItemType;
+// @ts-expect-error camel-case aliases are rejected.
+export const rejectCamelCase = "agentsMd" satisfies ExternalAgentConfigMigrationItemType;
+// @ts-expect-error singular aliases are rejected.
+export const rejectSingular = "SESSION" satisfies ExternalAgentConfigMigrationItemType;
+// @ts-expect-error exact MCP spelling is required.
+export const rejectMcpAlias = "MCP_SERVER" satisfies ExternalAgentConfigMigrationItemType;
+// @ts-expect-error item types are non-null.
+export const rejectNull = null satisfies ExternalAgentConfigMigrationItemType;
+// @ts-expect-error item types are strings.
+export const rejectNumber = 1 satisfies ExternalAgentConfigMigrationItemType;
+// @ts-expect-error item types are strings.
+export const rejectBoolean = true satisfies ExternalAgentConfigMigrationItemType;
+// @ts-expect-error item types are strings.
+export const rejectObject = {} satisfies ExternalAgentConfigMigrationItemType;
+// @ts-expect-error item types are strings.
+export const rejectArray = [] satisfies ExternalAgentConfigMigrationItemType;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 389 {
-		t.Fatalf("definition count = %d, want 389", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
+		t.Fatalf("definition count = %d, want 390", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- export the exact closed `ExternalAgentConfigMigrationItemType` wire enum
- register it in deterministic JSON Schema and TypeScript generation
- add strict Go and TypeScript contract coverage while keeping external-agent methods deferred

## Verification
- focused tests repeated 30 times, focused race, and 100% focused statement coverage
- full protocol and all non-Monty package normal/race suites
- lint, vet, tidy/verify, deterministic generation, strict TypeScript, and pre-push gates
- all five Slang live transport workflows
- exact upstream schema/TypeScript parity, structural reversal, and baseline/feature transcript comparison

Local Monty tests were skipped per project direction; hosted checks remain unchanged.