### PR TITLE
feat(protocol): add external-agent migration item

### DIFF
--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(defs); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -1,0 +1,231 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestExternalAgentConfigMigrationItemSchemaIsExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	got, ok := defs["ExternalAgentConfigMigrationItem"].(Schema)
+	if !ok {
+		t.Fatal("$defs missing ExternalAgentConfigMigrationItem")
+	}
+	want := closedThreadSessionParamSchema(Schema{
+		"itemType":    Schema{"$ref": "#/$defs/ExternalAgentConfigMigrationItemType"},
+		"description": Schema{"type": "string"},
+		"cwd": Schema{"anyOf": []any{
+			Schema{"type": "string"}, Schema{"type": "null"},
+		}},
+		"details": Schema{"anyOf": []any{
+			Schema{"$ref": "#/$defs/MigrationDetails"}, Schema{"type": "null"},
+		}},
+	}, []string{"itemType", "description"})
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ExternalAgentConfigMigrationItem = %#v, want %#v", got, want)
+	}
+}
+
+func TestExternalAgentConfigMigrationItemAcceptsRustWireForms(t *testing.T) {
+	relative := "repo/../repo"
+	absolute := "/tmp/repo"
+	cases := []struct {
+		name  string
+		input string
+		want  ExternalAgentConfigMigrationItem
+	}{
+		{
+			name:  "options omitted",
+			input: `{"itemType":"CONFIG","description":"config"}`,
+			want: ExternalAgentConfigMigrationItem{
+				ItemType:    ExternalAgentConfigMigrationItemTypeConfig,
+				Description: "config",
+			},
+		},
+		{
+			name: "explicit null and unknown",
+			input: `{"itemType":"AGENTS_MD","description":"","cwd":null,"details":null,` +
+				`"future":{"nested":true}}`,
+			want: ExternalAgentConfigMigrationItem{
+				ItemType: ExternalAgentConfigMigrationItemTypeAgentsMD,
+			},
+		},
+		{
+			name:  "relative generic path",
+			input: `{"itemType":"SESSIONS","description":"sessions","cwd":"repo/../repo"}`,
+			want: ExternalAgentConfigMigrationItem{
+				ItemType:    ExternalAgentConfigMigrationItemTypeSessions,
+				Description: "sessions",
+				CWD:         &relative,
+			},
+		},
+		{
+			name: "absolute path and defaulted details",
+			input: `{"itemType":"SKILLS","description":"skills","cwd":"/tmp/repo",` +
+				`"details":{"skills":[{"name":"one"}]}}`,
+			want: ExternalAgentConfigMigrationItem{
+				ItemType:    ExternalAgentConfigMigrationItemTypeSkills,
+				Description: "skills",
+				CWD:         &absolute,
+				Details:     &MigrationDetails{Skills: []SkillMigration{{Name: "one"}}},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var item ExternalAgentConfigMigrationItem
+			if err := json.Unmarshal([]byte(tc.input), &item); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			if !reflect.DeepEqual(item, canonicalExternalAgentConfigMigrationItem(tc.want)) {
+				t.Fatalf("item = %#v, want %#v", item, canonicalExternalAgentConfigMigrationItem(tc.want))
+			}
+			encoded, err := json.Marshal(item)
+			if err != nil {
+				t.Fatalf("Marshal: %v", err)
+			}
+			var roundTrip ExternalAgentConfigMigrationItem
+			if err := json.Unmarshal(encoded, &roundTrip); err != nil || !reflect.DeepEqual(roundTrip, item) {
+				t.Fatalf("round trip = %#v, %v; want %#v", roundTrip, err, item)
+			}
+		})
+	}
+
+	var emptyPath ExternalAgentConfigMigrationItem
+	if err := json.Unmarshal([]byte(`{"itemType":"HOOKS","description":"hook","cwd":""}`), &emptyPath); err != nil {
+		t.Fatalf("empty generic cwd: %v", err)
+	}
+	if emptyPath.CWD == nil || *emptyPath.CWD != "" {
+		t.Fatalf("empty cwd = %#v, want explicit empty string", emptyPath.CWD)
+	}
+}
+
+func TestExternalAgentConfigMigrationItemCanonicalizesNullableFields(t *testing.T) {
+	input := `{"itemType":"COMMANDS","description":"commands"}`
+	var item ExternalAgentConfigMigrationItem
+	if err := json.Unmarshal([]byte(input), &item); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	encoded, err := json.Marshal(item)
+	want := `{"itemType":"COMMANDS","description":"commands","cwd":null,"details":null}`
+	if err != nil || string(encoded) != want {
+		t.Fatalf("canonical = %s, %v; want %s", encoded, err, want)
+	}
+}
+
+func TestExternalAgentConfigMigrationItemRejectsMalformedWireForms(t *testing.T) {
+	invalid := []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{}`,
+		`{"description":"config"}`,
+		`{"itemType":"CONFIG"}`,
+		`{"itemType":null,"description":"config"}`,
+		`{"itemType":"OTHER","description":"config"}`,
+		`{"itemType":1,"description":"config"}`,
+		`{"itemType":"CONFIG","description":null}`,
+		`{"itemType":"CONFIG","description":1}`,
+		`{"itemType":"CONFIG","description":true}`,
+		`{"itemType":"CONFIG","description":{}}`,
+		`{"itemType":"CONFIG","description":[]}`,
+		`{"itemType":"CONFIG","description":"config","cwd":1}`,
+		`{"itemType":"CONFIG","description":"config","cwd":true}`,
+		`{"itemType":"CONFIG","description":"config","cwd":{}}`,
+		`{"itemType":"CONFIG","description":"config","cwd":[]}`,
+		`{"itemType":"CONFIG","description":"config","details":"details"}`,
+		`{"itemType":"CONFIG","description":"config","details":[]}`,
+		`{"itemType":"CONFIG","description":"config","details":{"skills":null}}`,
+		`{"itemType":"CONFIG","itemType":"SKILLS","description":"config"}`,
+		`{"itemType":"CONFIG","description":"one","description":"two"}`,
+		`{"itemType":"CONFIG","description":"config","cwd":null,"cwd":"repo"}`,
+		`{"itemType":"CONFIG","description":"config","details":null,"details":{}}`,
+		`{"itemType":"CONFIG","description":"config"`,
+		`{"itemType":"CONFIG","description":"config"} {}`,
+	}
+	for _, input := range invalid {
+		var item ExternalAgentConfigMigrationItem
+		if err := json.Unmarshal([]byte(input), &item); err == nil {
+			t.Errorf("Unmarshal(%s) succeeded", input)
+		}
+	}
+
+	var item *ExternalAgentConfigMigrationItem
+	if err := item.UnmarshalJSON([]byte(`{"itemType":"CONFIG","description":"config"}`)); err == nil {
+		t.Fatal("nil ExternalAgentConfigMigrationItem receiver succeeded")
+	}
+}
+
+func TestDecodeExternalAgentConfigMigrationItemObjectRejectsMalformedEnvelopes(t *testing.T) {
+	invalid := []string{
+		``,
+		`null`,
+		`{"`,
+		`{"itemType":}`,
+		`{"unknown":1`,
+		`{} {}`,
+		`{} {`,
+	}
+	for _, input := range invalid {
+		if _, err := decodeExternalAgentConfigMigrationItemObject([]byte(input)); err == nil {
+			t.Errorf("decodeExternalAgentConfigMigrationItemObject(%q) succeeded", input)
+		}
+	}
+}
+
+func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
+	for _, binding := range WireTypeBindings() {
+		if slices.Contains(binding.Params, "ExternalAgentConfigMigrationItem") ||
+			slices.Contains(binding.Result, "ExternalAgentConfigMigrationItem") {
+			t.Fatalf("ExternalAgentConfigMigrationItem unexpectedly bound: %#v", binding)
+		}
+	}
+	for _, method := range []string{"externalAgentConfig/detect", "externalAgentConfig/import"} {
+		info, ok := LookupMethod(method)
+		if !ok || info.State != MethodDeferredStub {
+			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestExternalAgentConfigMigrationItemTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	want := "export type ExternalAgentConfigMigrationItem = {\n" +
+		"  \"cwd\": string | null;\n" +
+		"  \"description\": string;\n" +
+		"  \"details\": MigrationDetails | null;\n" +
+		"  \"itemType\": ExternalAgentConfigMigrationItemType;\n" +
+		"};"
+	if !strings.Contains(string(generated), want) {
+		t.Errorf("generated TypeScript missing %q", want)
+	}
+}
+
+func canonicalExternalAgentConfigMigrationItem(item ExternalAgentConfigMigrationItem) ExternalAgentConfigMigrationItem {
+	encoded, err := json.Marshal(item)
+	if err != nil {
+		panic(err)
+	}
+	var canonical ExternalAgentConfigMigrationItem
+	if err := json.Unmarshal(encoded, &canonical); err != nil {
+		panic(err)
+	}
+	return canonical
+}
+
+var (
+	_ json.Marshaler   = ExternalAgentConfigMigrationItem{}
+	_ json.Unmarshaler = (*ExternalAgentConfigMigrationItem)(nil)
+)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_types.go
+++ b/appserver/protocol/external_agent_config_migration_item_types.go
@@ -1,0 +1,125 @@
+package protocol
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// ExternalAgentConfigMigrationItem describes one standalone migration category.
+// Its cwd and details fields are descriptive data, not filesystem authority.
+type ExternalAgentConfigMigrationItem struct {
+	ItemType    ExternalAgentConfigMigrationItemType `json:"itemType"`
+	Description string                               `json:"description"`
+	CWD         *string                              `json:"cwd"`
+	Details     *MigrationDetails                    `json:"details"`
+}
+
+func (i ExternalAgentConfigMigrationItem) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		ItemType    ExternalAgentConfigMigrationItemType `json:"itemType"`
+		Description string                               `json:"description"`
+		CWD         *string                              `json:"cwd"`
+		Details     *MigrationDetails                    `json:"details"`
+	}{
+		ItemType: i.ItemType, Description: i.Description, CWD: i.CWD, Details: i.Details,
+	})
+}
+
+func (i *ExternalAgentConfigMigrationItem) UnmarshalJSON(data []byte) error {
+	if i == nil {
+		return errors.New("decode external-agent config migration item into nil receiver")
+	}
+	const objectName = "external-agent config migration item"
+	payload, err := decodeExternalAgentConfigMigrationItemObject(data)
+	if err != nil {
+		return err
+	}
+	itemType, err := decodeRequiredThreadItemValue[ExternalAgentConfigMigrationItemType](payload, objectName, "itemType")
+	if err != nil {
+		return err
+	}
+	description, err := decodeRequiredThreadItemValue[string](payload, objectName, "description")
+	if err != nil {
+		return err
+	}
+	cwd, err := decodeOptionalNullableConfigValue[string](payload, objectName, "cwd")
+	if err != nil {
+		return err
+	}
+	details, err := decodeOptionalNullableConfigValue[MigrationDetails](payload, objectName, "details")
+	if err != nil {
+		return err
+	}
+	*i = ExternalAgentConfigMigrationItem{
+		ItemType: itemType, Description: description, CWD: cwd, Details: details,
+	}
+	return nil
+}
+
+func decodeExternalAgentConfigMigrationItemObject(data []byte) (map[string]json.RawMessage, error) {
+	const objectName = "external-agent config migration item"
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	opening, err := decoder.Token()
+	if err != nil {
+		return nil, fmt.Errorf("decode %s: %w", objectName, err)
+	}
+	if opening != json.Delim('{') {
+		return nil, fmt.Errorf("%s must be an object", objectName)
+	}
+	known := map[string]struct{}{
+		"itemType": {}, "description": {}, "cwd": {}, "details": {},
+	}
+	payload := make(map[string]json.RawMessage, len(known))
+	seen := make(map[string]bool, len(known))
+	for decoder.More() {
+		token, err := decoder.Token()
+		if err != nil {
+			return nil, fmt.Errorf("decode %s field name: %w", objectName, err)
+		}
+		name := token.(string)
+		var raw json.RawMessage
+		if err := decoder.Decode(&raw); err != nil {
+			return nil, fmt.Errorf("decode %s field %q: %w", objectName, name, err)
+		}
+		if _, ok := known[name]; !ok {
+			continue
+		}
+		if seen[name] {
+			return nil, fmt.Errorf("duplicate %s field %q", objectName, name)
+		}
+		seen[name] = true
+		payload[name] = append(json.RawMessage(nil), raw...)
+	}
+	if _, err := decoder.Token(); err != nil {
+		return nil, fmt.Errorf("decode %s: %w", objectName, err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return nil, fmt.Errorf("%s must contain one JSON value", objectName)
+		}
+		return nil, fmt.Errorf("decode %s trailing value: %w", objectName, err)
+	}
+	return payload, nil
+}
+
+func externalAgentConfigMigrationItemSchema() Schema {
+	return closedThreadSessionParamSchema(Schema{
+		"itemType":    Schema{"$ref": "#/$defs/ExternalAgentConfigMigrationItemType"},
+		"description": Schema{"type": "string"},
+		"cwd": Schema{"anyOf": []any{
+			Schema{"type": "string"}, Schema{"type": "null"},
+		}},
+		"details": Schema{"anyOf": []any{
+			Schema{"$ref": "#/$defs/MigrationDetails"}, Schema{"type": "null"},
+		}},
+	}, []string{"itemType", "description"})
+}
+
+var (
+	_ json.Marshaler   = ExternalAgentConfigMigrationItem{}
+	_ json.Unmarshaler = (*ExternalAgentConfigMigrationItem)(nil)
+)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 390 {
-		t.Fatalf("definition count = %d, want 390", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 391 {
+		t.Fatalf("definition count = %d, want 391", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 390 {
-		t.Fatalf("definition count = %d, want 390", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 391 {
+		t.Fatalf("definition count = %d, want 391", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 390 {
-		t.Fatalf("definition count = %d, want 390", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 391 {
+		t.Fatalf("definition count = %d, want 391", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 390 {
-		t.Fatalf("definition count = %d, want 390", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 391 {
+		t.Fatalf("definition count = %d, want 391", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 390 {
-		t.Fatalf("definition count = %d, want 390", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 391 {
+		t.Fatalf("definition count = %d, want 391", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 390 {
-		t.Fatalf("definition count = %d, want 390", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 391 {
+		t.Fatalf("definition count = %d, want 391", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -314,6 +314,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "CommandMigration", Type: reflect.TypeFor[CommandMigration]()},
 		{Name: "MigrationDetails", Type: reflect.TypeFor[MigrationDetails]()},
 		{Name: "ExternalAgentConfigMigrationItemType", Type: reflect.TypeFor[ExternalAgentConfigMigrationItemType]()},
+		{Name: "ExternalAgentConfigMigrationItem", Type: reflect.TypeFor[ExternalAgentConfigMigrationItem]()},
 		{Name: "PermissionGrantScope", Type: reflect.TypeFor[PermissionGrantScope]()},
 		{Name: "PermissionsApprovalRequestParams", Type: reflect.TypeFor[PermissionsApprovalRequestParams]()},
 		{Name: "PermissionsRequestApprovalParams", Type: reflect.TypeFor[PermissionsRequestApprovalParams]()},
@@ -561,6 +562,7 @@ func wireSchemaDefinitions() Schema {
 		string(ExternalAgentConfigMigrationItemTypeCommands),
 		string(ExternalAgentConfigMigrationItemTypeSessions),
 	)
+	schemas["ExternalAgentConfigMigrationItem"] = externalAgentConfigMigrationItemSchema()
 	schemas["McpServerToolCallParams"] = mcpServerToolCallParamsSchema()
 	schemas["McpServerToolCallResponse"] = mcpServerToolCallResponseSchema()
 	schemas["ResourceContent"] = resourceContentSchema()

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -3137,6 +3137,42 @@
       },
       "type": "array"
     },
+    "ExternalAgentConfigMigrationItem": {
+      "additionalProperties": false,
+      "properties": {
+        "cwd": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "description": {
+          "type": "string"
+        },
+        "details": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/MigrationDetails"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "itemType": {
+          "$ref": "#/$defs/ExternalAgentConfigMigrationItemType"
+        }
+      },
+      "required": [
+        "itemType",
+        "description"
+      ],
+      "type": "object"
+    },
     "ExternalAgentConfigMigrationItemType": {
       "enum": [
         "AGENTS_MD",

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 390 {
-		t.Fatalf("definition count = %d, want 390", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 391 {
+		t.Fatalf("definition count = %d, want 391", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 390 {
-		t.Fatalf("definition count = %d, want 390", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 391 {
+		t.Fatalf("definition count = %d, want 391", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 390 {
-		t.Fatalf("definition count = %d, want 390", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 391 {
+		t.Fatalf("definition count = %d, want 391", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -37,17 +37,21 @@ func MarshalTypeScript() ([]byte, error) {
 	sort.Strings(names)
 	for _, name := range names {
 		definition := defs[name]
-		if name == "MigrationDetails" {
-			// Rust accepts omitted serde-defaulted arrays while its generated
-			// TypeScript record requires callers to provide every field.
+		if name == "MigrationDetails" || name == "ExternalAgentConfigMigrationItem" {
+			// Rust accepts omitted serde default/Option fields while generated
+			// TypeScript requires callers to provide their canonical values.
 			schema, _ := typeScriptSchema(definition)
 			renderSchema := make(Schema, len(schema)+1)
 			for key, value := range schema {
 				renderSchema[key] = value
 			}
 			schema = renderSchema
-			schema["required"] = []string{
-				"plugins", "skills", "sessions", "mcpServers", "hooks", "subagents", "commands",
+			if name == "MigrationDetails" {
+				schema["required"] = []string{
+					"plugins", "skills", "sessions", "mcpServers", "hooks", "subagents", "commands",
+				}
+			} else {
+				schema["required"] = []string{"itemType", "description", "cwd", "details"}
 			}
 			definition = schema
 		}

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -1121,6 +1121,13 @@ export type ErrorNotification = {
 
 export type ExecPolicyAmendment = Array<string>;
 
+export type ExternalAgentConfigMigrationItem = {
+  "cwd": string | null;
+  "description": string;
+  "details": MigrationDetails | null;
+  "itemType": ExternalAgentConfigMigrationItemType;
+};
+
 export type ExternalAgentConfigMigrationItemType = "AGENTS_MD" | "CONFIG" | "SKILLS" | "PLUGINS" | "MCP_SERVER_CONFIG" | "SUBAGENTS" | "HOOKS" | "COMMANDS" | "SESSIONS";
 
 export type FileChangeApprovalDecision = "accept" | "acceptForSession" | "decline" | "cancel";

--- a/appserver/protocol/typescript/testdata/external_agent_config_migration_item_contract.ts
+++ b/appserver/protocol/typescript/testdata/external_agent_config_migration_item_contract.ts
@@ -1,0 +1,79 @@
+import type {
+  ExternalAgentConfigMigrationItem,
+  ExternalAgentConfigMigrationItemType,
+  MethodParamsByName,
+  MethodResultsByName,
+  MigrationDetails,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+
+type Expected = {
+  itemType: ExternalAgentConfigMigrationItemType;
+  description: string;
+  cwd: string | null;
+  details: MigrationDetails | null;
+};
+type Contracts = [
+  Expect<Equal<ExternalAgentConfigMigrationItem, Expected>>,
+  Expect<Equal<"externalAgentConfig/detect" extends keyof MethodParamsByName ? true : false, false>>,
+  Expect<Equal<"externalAgentConfig/detect" extends keyof MethodResultsByName ? true : false, false>>,
+  Expect<Equal<"externalAgentConfig/import" extends keyof MethodParamsByName ? true : false, false>>,
+  Expect<Equal<"externalAgentConfig/import" extends keyof MethodResultsByName ? true : false, false>>,
+];
+
+const emptyDetails = {
+  plugins: [],
+  skills: [],
+  sessions: [],
+  mcpServers: [],
+  hooks: [],
+  subagents: [],
+  commands: [],
+} satisfies MigrationDetails;
+
+export const home = {
+  itemType: "AGENTS_MD",
+  description: "agents",
+  cwd: null,
+  details: null,
+} satisfies ExternalAgentConfigMigrationItem;
+
+export const repo = {
+  itemType: "SKILLS",
+  description: "skills",
+  cwd: "repo/../repo",
+  details: { ...emptyDetails, skills: [{ name: "one" }] },
+} satisfies ExternalAgentConfigMigrationItem;
+
+// @ts-expect-error itemType is required.
+export const rejectMissingItemType = { description: "config", cwd: null, details: null } satisfies ExternalAgentConfigMigrationItem;
+// @ts-expect-error description is required.
+export const rejectMissingDescription = { itemType: "CONFIG", cwd: null, details: null } satisfies ExternalAgentConfigMigrationItem;
+// @ts-expect-error cwd remains required-nullable in generated TypeScript.
+export const rejectMissingCwd = { itemType: "CONFIG", description: "config", details: null } satisfies ExternalAgentConfigMigrationItem;
+// @ts-expect-error details remains required-nullable in generated TypeScript.
+export const rejectMissingDetails = { itemType: "CONFIG", description: "config", cwd: null } satisfies ExternalAgentConfigMigrationItem;
+// @ts-expect-error itemType is non-null.
+export const rejectNullItemType = { ...home, itemType: null } satisfies ExternalAgentConfigMigrationItem;
+// @ts-expect-error itemType is closed.
+export const rejectUnknownItemType = { ...home, itemType: "OTHER" } satisfies ExternalAgentConfigMigrationItem;
+// @ts-expect-error description is non-null.
+export const rejectNullDescription = { ...home, description: null } satisfies ExternalAgentConfigMigrationItem;
+// @ts-expect-error cwd is nullable string data.
+export const rejectNumericCwd = { ...home, cwd: 1 } satisfies ExternalAgentConfigMigrationItem;
+// @ts-expect-error details is nullable MigrationDetails.
+export const rejectArrayDetails = { ...home, details: [] } satisfies ExternalAgentConfigMigrationItem;
+// @ts-expect-error nested details remain strict.
+export const rejectMalformedDetails = { ...home, details: { ...emptyDetails, skills: [{}] } } satisfies ExternalAgentConfigMigrationItem;
+// @ts-expect-error snake-case aliases do not replace canonical fields.
+export const rejectSnakeAlias = { item_type: "CONFIG", description: "config", cwd: null, details: null } satisfies ExternalAgentConfigMigrationItem;
+// @ts-expect-error fields absent from the public record are rejected.
+export const rejectExtra = { ...home, extra: true } satisfies ExternalAgentConfigMigrationItem;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 390 {
-		t.Fatalf("definition count = %d, want 390", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
+		t.Fatalf("definition count = %d, want 391", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary

- add the standalone `ExternalAgentConfigMigrationItem` protocol record
- preserve Rust `Option` input semantics while emitting canonical explicit nulls
- generate the exact closed JSON Schema and required-nullable TypeScript record
- keep external-agent methods deferred and all method/item bindings unchanged

## Validation

- focused contract tests repeated 30 times and under the race detector
- 100% statement coverage for all new codec and schema functions
- full protocol normal/race tests
- all 59 non-Monty packages in normal/race modes
- strict TypeScript compilation and deterministic generation
- exact normalized parity with pinned Codex schema and TypeScript
- `golangci-lint`, `go vet`, `go mod tidy`, `go mod verify`, and configured pre-push hook
- byte-identical baseline/feature initialize and MCP-status transcript
- no-commit reversal restores the exact prior tree

Local Monty tests were intentionally skipped per project workflow configuration; hosted CI remains unchanged.
