### PR TITLE
feat(appserver): export external-agent detect contracts

### DIFF
--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(defs); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -1,0 +1,269 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestExternalAgentConfigDetectSchemasAreExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	wantParams := closedThreadSessionParamSchema(Schema{
+		"includeHome": Schema{
+			"type": "boolean", "description": externalAgentConfigDetectIncludeHomeDescription,
+		},
+		"cwds": Schema{
+			"anyOf": []any{
+				Schema{"type": "array", "items": Schema{"type": "string"}},
+				Schema{"type": "null"},
+			},
+			"description": externalAgentConfigDetectCWDsDescription,
+		},
+	}, nil)
+	wantResponse := closedThreadSessionParamSchema(Schema{
+		"items": Schema{
+			"type": "array", "items": Schema{"$ref": "#/$defs/ExternalAgentConfigMigrationItem"},
+		},
+	}, []string{"items"})
+	for name, want := range map[string]Schema{
+		"ExternalAgentConfigDetectParams":   wantParams,
+		"ExternalAgentConfigDetectResponse": wantResponse,
+	} {
+		got, ok := defs[name].(Schema)
+		if !ok {
+			t.Errorf("$defs missing %s", name)
+			continue
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("%s = %#v, want %#v", name, got, want)
+		}
+	}
+}
+
+func TestExternalAgentConfigDetectParamsAcceptsRustWireForms(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     string
+		want      ExternalAgentConfigDetectParams
+		canonical string
+	}{
+		{
+			name: "defaults omitted", input: `{}`,
+			want: ExternalAgentConfigDetectParams{}, canonical: `{"cwds":null}`,
+		},
+		{
+			name: "false null and unknown", input: `{"includeHome":false,"cwds":null,"future":true}`,
+			want: ExternalAgentConfigDetectParams{}, canonical: `{"cwds":null}`,
+		},
+		{
+			name: "home and empty cwd list", input: `{"includeHome":true,"cwds":[]}`,
+			want:      ExternalAgentConfigDetectParams{IncludeHome: true, CWDs: []string{}},
+			canonical: `{"includeHome":true,"cwds":[]}`,
+		},
+		{
+			name:      "opaque ordered cwd list",
+			input:     `{"cwds":["","repo/../repo","/tmp/repo",""]}`,
+			want:      ExternalAgentConfigDetectParams{CWDs: []string{"", "repo/../repo", "/tmp/repo", ""}},
+			canonical: `{"cwds":["","repo/../repo","/tmp/repo",""]}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var params ExternalAgentConfigDetectParams
+			if err := json.Unmarshal([]byte(tc.input), &params); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			if !reflect.DeepEqual(params, tc.want) {
+				t.Fatalf("params = %#v, want %#v", params, tc.want)
+			}
+			encoded, err := json.Marshal(params)
+			if err != nil || string(encoded) != tc.canonical {
+				t.Fatalf("canonical = %s, %v; want %s", encoded, err, tc.canonical)
+			}
+			var roundTrip ExternalAgentConfigDetectParams
+			if err := json.Unmarshal(encoded, &roundTrip); err != nil || !reflect.DeepEqual(roundTrip, params) {
+				t.Fatalf("round trip = %#v, %v; want %#v", roundTrip, err, params)
+			}
+		})
+	}
+
+	params := ExternalAgentConfigDetectParams{CWDs: nil}
+	encoded, err := json.Marshal(params)
+	if err != nil || string(encoded) != `{"cwds":null}` {
+		t.Fatalf("nil cwd list = %s, %v; want explicit null", encoded, err)
+	}
+}
+
+func TestExternalAgentConfigDetectResponseAcceptsRustWireForms(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  ExternalAgentConfigDetectResponse
+	}{
+		{
+			name: "empty and unknown", input: `{"items":[],"future":{"nested":true}}`,
+			want: ExternalAgentConfigDetectResponse{Items: []ExternalAgentConfigMigrationItem{}},
+		},
+		{
+			name: "ordered duplicate items",
+			input: `{"items":[` +
+				`{"itemType":"CONFIG","description":"config"},` +
+				`{"itemType":"CONFIG","description":"config","cwd":"repo/../repo","details":{}},` +
+				`{"itemType":"CONFIG","description":"config"}` +
+				`]}`,
+			want: ExternalAgentConfigDetectResponse{Items: []ExternalAgentConfigMigrationItem{
+				{ItemType: ExternalAgentConfigMigrationItemTypeConfig, Description: "config"},
+				{
+					ItemType: ExternalAgentConfigMigrationItemTypeConfig, Description: "config",
+					CWD: stringPointer("repo/../repo"), Details: &MigrationDetails{},
+				},
+				{ItemType: ExternalAgentConfigMigrationItemTypeConfig, Description: "config"},
+			}},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var response ExternalAgentConfigDetectResponse
+			if err := json.Unmarshal([]byte(tc.input), &response); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			if !reflect.DeepEqual(response, canonicalExternalAgentConfigDetectResponse(tc.want)) {
+				t.Fatalf("response = %#v, want %#v", response, canonicalExternalAgentConfigDetectResponse(tc.want))
+			}
+			encoded, err := json.Marshal(response)
+			if err != nil {
+				t.Fatalf("Marshal: %v", err)
+			}
+			var roundTrip ExternalAgentConfigDetectResponse
+			if err := json.Unmarshal(encoded, &roundTrip); err != nil || !reflect.DeepEqual(roundTrip, response) {
+				t.Fatalf("round trip = %#v, %v; want %#v", roundTrip, err, response)
+			}
+		})
+	}
+
+	encoded, err := json.Marshal(ExternalAgentConfigDetectResponse{})
+	if err != nil || string(encoded) != `{"items":[]}` {
+		t.Fatalf("zero response = %s, %v; want non-null empty items", encoded, err)
+	}
+}
+
+func TestExternalAgentConfigDetectParamsRejectsMalformedWireForms(t *testing.T) {
+	invalid := []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`,
+		`{"includeHome":null}`, `{"includeHome":0}`, `{"includeHome":"true"}`,
+		`{"includeHome":[]}`, `{"includeHome":{}}`,
+		`{"cwds":"repo"}`, `{"cwds":1}`, `{"cwds":true}`, `{"cwds":{}}`,
+		`{"cwds":[null]}`, `{"cwds":[1]}`, `{"cwds":[true]}`, `{"cwds":[{}]}`, `{"cwds":[[]]}`,
+		`{"includeHome":false,"includeHome":true}`,
+		`{"cwds":null,"cwds":[]}`,
+		`{"includeHome":true`, `{} {}`,
+	}
+	for _, input := range invalid {
+		var params ExternalAgentConfigDetectParams
+		if err := json.Unmarshal([]byte(input), &params); err == nil {
+			t.Errorf("Unmarshal(%s) succeeded", input)
+		}
+	}
+
+	var params *ExternalAgentConfigDetectParams
+	if err := params.UnmarshalJSON([]byte(`{}`)); err == nil {
+		t.Fatal("nil ExternalAgentConfigDetectParams receiver succeeded")
+	}
+}
+
+func TestExternalAgentConfigDetectResponseRejectsMalformedWireForms(t *testing.T) {
+	invalid := []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{}`,
+		`{"items":null}`, `{"items":{}}`, `{"items":"items"}`, `{"items":1}`, `{"items":true}`,
+		`{"items":[null]}`, `{"items":[{}]}`, `{"items":[1]}`,
+		`{"items":[{"itemType":"OTHER","description":"bad"}]}`,
+		`{"items":[],"items":[]}`, `{"items":[]`, `{"items":[]} {}`,
+	}
+	for _, input := range invalid {
+		var response ExternalAgentConfigDetectResponse
+		if err := json.Unmarshal([]byte(input), &response); err == nil {
+			t.Errorf("Unmarshal(%s) succeeded", input)
+		}
+	}
+
+	var response *ExternalAgentConfigDetectResponse
+	if err := response.UnmarshalJSON([]byte(`{"items":[]}`)); err == nil {
+		t.Fatal("nil ExternalAgentConfigDetectResponse receiver succeeded")
+	}
+}
+
+func TestDecodeExternalAgentConfigDetectObjectRejectsMalformedEnvelopes(t *testing.T) {
+	invalid := []string{``, `null`, `{"`, `{"includeHome":}`, `{"unknown":1`, `{} {}`, `{} {`}
+	for _, input := range invalid {
+		if _, err := decodeExternalAgentConfigDetectObject(
+			[]byte(input), "external-agent config detect params", "includeHome", "cwds",
+		); err == nil {
+			t.Errorf("decodeExternalAgentConfigDetectObject(%q) succeeded", input)
+		}
+	}
+}
+
+func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
+	for _, binding := range WireTypeBindings() {
+		for _, name := range []string{"ExternalAgentConfigDetectParams", "ExternalAgentConfigDetectResponse"} {
+			if slices.Contains(binding.Params, name) || slices.Contains(binding.Result, name) {
+				t.Fatalf("%s unexpectedly bound: %#v", name, binding)
+			}
+		}
+	}
+	info, ok := LookupMethod("externalAgentConfig/detect")
+	if !ok || info.State != MethodDeferredStub {
+		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestExternalAgentConfigDetectTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	source := string(generated)
+	for _, want := range []string{
+		"export type ExternalAgentConfigDetectParams = {\n" +
+			"  \"cwds\"?: Array<string> | null;\n" +
+			"  \"includeHome\"?: boolean;\n" +
+			"};",
+		"export type ExternalAgentConfigDetectResponse = {\n" +
+			"  \"items\": Array<ExternalAgentConfigMigrationItem>;\n" +
+			"};",
+	} {
+		if !strings.Contains(source, want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}
+
+func canonicalExternalAgentConfigDetectResponse(response ExternalAgentConfigDetectResponse) ExternalAgentConfigDetectResponse {
+	encoded, err := json.Marshal(response)
+	if err != nil {
+		panic(err)
+	}
+	var canonical ExternalAgentConfigDetectResponse
+	if err := json.Unmarshal(encoded, &canonical); err != nil {
+		panic(err)
+	}
+	return canonical
+}
+
+var (
+	_ json.Marshaler   = ExternalAgentConfigDetectParams{}
+	_ json.Unmarshaler = (*ExternalAgentConfigDetectParams)(nil)
+	_ json.Marshaler   = ExternalAgentConfigDetectResponse{}
+	_ json.Unmarshaler = (*ExternalAgentConfigDetectResponse)(nil)
+)

--- a/appserver/protocol/external_agent_config_detect_types.go
+++ b/appserver/protocol/external_agent_config_detect_types.go
@@ -1,0 +1,187 @@
+package protocol
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+const (
+	externalAgentConfigDetectIncludeHomeDescription = "If true, include detection under the user's home directory."
+	externalAgentConfigDetectCWDsDescription        = "Zero or more working directories to include for repo-scoped detection."
+)
+
+// ExternalAgentConfigDetectParams is the exact standalone public request for
+// describing detection scope. It does not grant filesystem access or authority.
+type ExternalAgentConfigDetectParams struct {
+	IncludeHome bool     `json:"includeHome,omitempty"`
+	CWDs        []string `json:"cwds"`
+}
+
+func (p ExternalAgentConfigDetectParams) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		IncludeHome bool     `json:"includeHome,omitempty"`
+		CWDs        []string `json:"cwds"`
+	}{IncludeHome: p.IncludeHome, CWDs: p.CWDs})
+}
+
+func (p *ExternalAgentConfigDetectParams) UnmarshalJSON(data []byte) error {
+	if p == nil {
+		return errors.New("decode external-agent config detect params into nil receiver")
+	}
+	const objectName = "external-agent config detect params"
+	payload, err := decodeExternalAgentConfigDetectObject(data, objectName, "includeHome", "cwds")
+	if err != nil {
+		return err
+	}
+	includeHome, err := decodeOptionalConfigBool(payload, objectName, "includeHome")
+	if err != nil {
+		return err
+	}
+	cwds, err := decodeOptionalNullableExternalAgentConfigCWDs(payload, objectName)
+	if err != nil {
+		return err
+	}
+	*p = ExternalAgentConfigDetectParams{IncludeHome: includeHome, CWDs: cwds}
+	return nil
+}
+
+func decodeOptionalNullableExternalAgentConfigCWDs(
+	payload map[string]json.RawMessage,
+	objectName string,
+) ([]string, error) {
+	raw, ok := payload["cwds"]
+	if !ok || isJSONNull(raw) {
+		return nil, nil
+	}
+	var elements []json.RawMessage
+	if err := json.Unmarshal(raw, &elements); err != nil {
+		return nil, fmt.Errorf("decode %s cwds: %w", objectName, err)
+	}
+	values := make([]string, len(elements))
+	for index, element := range elements {
+		if isJSONNull(element) {
+			return nil, fmt.Errorf("decode %s cwds[%d]: value cannot be null", objectName, index)
+		}
+		if err := json.Unmarshal(element, &values[index]); err != nil {
+			return nil, fmt.Errorf("decode %s cwds[%d]: %w", objectName, index, err)
+		}
+	}
+	return values, nil
+}
+
+// ExternalAgentConfigDetectResponse is the exact standalone public collection
+// of migration items. It does not imply that detection has been implemented.
+type ExternalAgentConfigDetectResponse struct {
+	Items []ExternalAgentConfigMigrationItem `json:"items"`
+}
+
+func (r ExternalAgentConfigDetectResponse) MarshalJSON() ([]byte, error) {
+	items := r.Items
+	if items == nil {
+		items = []ExternalAgentConfigMigrationItem{}
+	}
+	return json.Marshal(struct {
+		Items []ExternalAgentConfigMigrationItem `json:"items"`
+	}{Items: items})
+}
+
+func (r *ExternalAgentConfigDetectResponse) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("decode external-agent config detect response into nil receiver")
+	}
+	const objectName = "external-agent config detect response"
+	payload, err := decodeExternalAgentConfigDetectObject(data, objectName, "items")
+	if err != nil {
+		return err
+	}
+	items, err := decodeRequiredThreadItemArray[ExternalAgentConfigMigrationItem](payload, objectName, "items")
+	if err != nil {
+		return err
+	}
+	*r = ExternalAgentConfigDetectResponse{Items: items}
+	return nil
+}
+
+func decodeExternalAgentConfigDetectObject(
+	data []byte,
+	objectName string,
+	knownFields ...string,
+) (map[string]json.RawMessage, error) {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	opening, err := decoder.Token()
+	if err != nil {
+		return nil, fmt.Errorf("decode %s: %w", objectName, err)
+	}
+	if opening != json.Delim('{') {
+		return nil, fmt.Errorf("%s must be an object", objectName)
+	}
+	known := make(map[string]struct{}, len(knownFields))
+	for _, name := range knownFields {
+		known[name] = struct{}{}
+	}
+	payload := make(map[string]json.RawMessage, len(known))
+	seen := make(map[string]bool, len(known))
+	for decoder.More() {
+		token, err := decoder.Token()
+		if err != nil {
+			return nil, fmt.Errorf("decode %s field name: %w", objectName, err)
+		}
+		name := token.(string)
+		var raw json.RawMessage
+		if err := decoder.Decode(&raw); err != nil {
+			return nil, fmt.Errorf("decode %s field %q: %w", objectName, name, err)
+		}
+		if _, ok := known[name]; !ok {
+			continue
+		}
+		if seen[name] {
+			return nil, fmt.Errorf("duplicate %s field %q", objectName, name)
+		}
+		seen[name] = true
+		payload[name] = append(json.RawMessage(nil), raw...)
+	}
+	if _, err := decoder.Token(); err != nil {
+		return nil, fmt.Errorf("decode %s: %w", objectName, err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return nil, fmt.Errorf("%s must contain one JSON value", objectName)
+		}
+		return nil, fmt.Errorf("decode %s trailing value: %w", objectName, err)
+	}
+	return payload, nil
+}
+
+func externalAgentConfigDetectParamsSchema() Schema {
+	return closedThreadSessionParamSchema(Schema{
+		"includeHome": Schema{
+			"type": "boolean", "description": externalAgentConfigDetectIncludeHomeDescription,
+		},
+		"cwds": Schema{
+			"anyOf": []any{
+				Schema{"type": "array", "items": Schema{"type": "string"}},
+				Schema{"type": "null"},
+			},
+			"description": externalAgentConfigDetectCWDsDescription,
+		},
+	}, nil)
+}
+
+func externalAgentConfigDetectResponseSchema() Schema {
+	return closedThreadSessionParamSchema(Schema{
+		"items": Schema{
+			"type": "array", "items": Schema{"$ref": "#/$defs/ExternalAgentConfigMigrationItem"},
+		},
+	}, []string{"items"})
+}
+
+var (
+	_ json.Marshaler   = ExternalAgentConfigDetectParams{}
+	_ json.Unmarshaler = (*ExternalAgentConfigDetectParams)(nil)
+	_ json.Marshaler   = ExternalAgentConfigDetectResponse{}
+	_ json.Unmarshaler = (*ExternalAgentConfigDetectResponse)(nil)
+)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 391 {
-		t.Fatalf("definition count = %d, want 391", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 393 {
+		t.Fatalf("definition count = %d, want 393", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 391 {
-		t.Fatalf("definition count = %d, want 391", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 393 {
+		t.Fatalf("definition count = %d, want 393", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 391 {
-		t.Fatalf("definition count = %d, want 391", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 393 {
+		t.Fatalf("definition count = %d, want 393", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 391 {
-		t.Fatalf("definition count = %d, want 391", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 393 {
+		t.Fatalf("definition count = %d, want 393", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 391 {
-		t.Fatalf("definition count = %d, want 391", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 393 {
+		t.Fatalf("definition count = %d, want 393", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 391 {
-		t.Fatalf("definition count = %d, want 391", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 393 {
+		t.Fatalf("definition count = %d, want 393", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -315,6 +315,8 @@ func wireSchemaDefinitions() Schema {
 		{Name: "MigrationDetails", Type: reflect.TypeFor[MigrationDetails]()},
 		{Name: "ExternalAgentConfigMigrationItemType", Type: reflect.TypeFor[ExternalAgentConfigMigrationItemType]()},
 		{Name: "ExternalAgentConfigMigrationItem", Type: reflect.TypeFor[ExternalAgentConfigMigrationItem]()},
+		{Name: "ExternalAgentConfigDetectParams", Type: reflect.TypeFor[ExternalAgentConfigDetectParams]()},
+		{Name: "ExternalAgentConfigDetectResponse", Type: reflect.TypeFor[ExternalAgentConfigDetectResponse]()},
 		{Name: "PermissionGrantScope", Type: reflect.TypeFor[PermissionGrantScope]()},
 		{Name: "PermissionsApprovalRequestParams", Type: reflect.TypeFor[PermissionsApprovalRequestParams]()},
 		{Name: "PermissionsRequestApprovalParams", Type: reflect.TypeFor[PermissionsRequestApprovalParams]()},
@@ -563,6 +565,8 @@ func wireSchemaDefinitions() Schema {
 		string(ExternalAgentConfigMigrationItemTypeSessions),
 	)
 	schemas["ExternalAgentConfigMigrationItem"] = externalAgentConfigMigrationItemSchema()
+	schemas["ExternalAgentConfigDetectParams"] = externalAgentConfigDetectParamsSchema()
+	schemas["ExternalAgentConfigDetectResponse"] = externalAgentConfigDetectResponseSchema()
 	schemas["McpServerToolCallParams"] = mcpServerToolCallParamsSchema()
 	schemas["McpServerToolCallResponse"] = mcpServerToolCallResponseSchema()
 	schemas["ResourceContent"] = resourceContentSchema()

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -3137,6 +3137,45 @@
       },
       "type": "array"
     },
+    "ExternalAgentConfigDetectParams": {
+      "additionalProperties": false,
+      "properties": {
+        "cwds": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Zero or more working directories to include for repo-scoped detection."
+        },
+        "includeHome": {
+          "description": "If true, include detection under the user's home directory.",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "ExternalAgentConfigDetectResponse": {
+      "additionalProperties": false,
+      "properties": {
+        "items": {
+          "items": {
+            "$ref": "#/$defs/ExternalAgentConfigMigrationItem"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object"
+    },
     "ExternalAgentConfigMigrationItem": {
       "additionalProperties": false,
       "properties": {

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 391 {
-		t.Fatalf("definition count = %d, want 391", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 393 {
+		t.Fatalf("definition count = %d, want 393", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 391 {
-		t.Fatalf("definition count = %d, want 391", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 393 {
+		t.Fatalf("definition count = %d, want 393", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 391 {
-		t.Fatalf("definition count = %d, want 391", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 393 {
+		t.Fatalf("definition count = %d, want 393", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -1121,6 +1121,15 @@ export type ErrorNotification = {
 
 export type ExecPolicyAmendment = Array<string>;
 
+export type ExternalAgentConfigDetectParams = {
+  "cwds"?: Array<string> | null;
+  "includeHome"?: boolean;
+};
+
+export type ExternalAgentConfigDetectResponse = {
+  "items": Array<ExternalAgentConfigMigrationItem>;
+};
+
 export type ExternalAgentConfigMigrationItem = {
   "cwd": string | null;
   "description": string;

--- a/appserver/protocol/typescript/testdata/external_agent_config_detect_contract.ts
+++ b/appserver/protocol/typescript/testdata/external_agent_config_detect_contract.ts
@@ -1,0 +1,72 @@
+import type {
+  ExternalAgentConfigDetectParams,
+  ExternalAgentConfigDetectResponse,
+  ExternalAgentConfigMigrationItem,
+  MethodParamsByName,
+  MethodResultsByName,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+
+type Contracts = [
+  Expect<Equal<ExternalAgentConfigDetectParams, {
+    cwds?: Array<string> | null;
+    includeHome?: boolean;
+  }>>,
+  Expect<Equal<ExternalAgentConfigDetectResponse, {
+    items: Array<ExternalAgentConfigMigrationItem>;
+  }>>,
+  Expect<Equal<"externalAgentConfig/detect" extends keyof MethodParamsByName ? true : false, false>>,
+  Expect<Equal<"externalAgentConfig/detect" extends keyof MethodResultsByName ? true : false, false>>,
+  Expect<Equal<"externalAgentConfig/import" extends keyof MethodParamsByName ? true : false, false>>,
+  Expect<Equal<"externalAgentConfig/import" extends keyof MethodResultsByName ? true : false, false>>,
+];
+
+export const defaults = {} satisfies ExternalAgentConfigDetectParams;
+export const home = { includeHome: true, cwds: null } satisfies ExternalAgentConfigDetectParams;
+export const repos = { cwds: ["", "repo/../repo", "/tmp/repo", ""] } satisfies ExternalAgentConfigDetectParams;
+
+export const item = {
+  itemType: "CONFIG",
+  description: "config",
+  cwd: null,
+  details: null,
+} satisfies ExternalAgentConfigMigrationItem;
+export const response = { items: [item, item] } satisfies ExternalAgentConfigDetectResponse;
+
+// @ts-expect-error includeHome is a non-null boolean.
+export const rejectNullIncludeHome = { includeHome: null } satisfies ExternalAgentConfigDetectParams;
+// @ts-expect-error includeHome is a boolean.
+export const rejectNumericIncludeHome = { includeHome: 1 } satisfies ExternalAgentConfigDetectParams;
+// @ts-expect-error optional fields do not accept explicit undefined.
+export const rejectUndefinedIncludeHome = { includeHome: undefined } satisfies ExternalAgentConfigDetectParams;
+// @ts-expect-error cwds is a nullable string array.
+export const rejectScalarCwds = { cwds: "repo" } satisfies ExternalAgentConfigDetectParams;
+// @ts-expect-error cwd entries are non-null strings.
+export const rejectNullCwd = { cwds: [null] } satisfies ExternalAgentConfigDetectParams;
+// @ts-expect-error cwd entries are strings.
+export const rejectNumericCwd = { cwds: [1] } satisfies ExternalAgentConfigDetectParams;
+// @ts-expect-error optional fields do not accept explicit undefined.
+export const rejectUndefinedCwds = { cwds: undefined } satisfies ExternalAgentConfigDetectParams;
+// @ts-expect-error snake-case aliases do not replace canonical fields.
+export const rejectSnakeAlias = { include_home: true } satisfies ExternalAgentConfigDetectParams;
+// @ts-expect-error fields absent from the public request are rejected.
+export const rejectParamsExtra = { includeHome: true, extra: true } satisfies ExternalAgentConfigDetectParams;
+
+// @ts-expect-error items is required.
+export const rejectMissingItems = {} satisfies ExternalAgentConfigDetectResponse;
+// @ts-expect-error items is non-null.
+export const rejectNullItems = { items: null } satisfies ExternalAgentConfigDetectResponse;
+// @ts-expect-error items is an array.
+export const rejectScalarItems = { items: item } satisfies ExternalAgentConfigDetectResponse;
+// @ts-expect-error response items retain strict migration-item fields.
+export const rejectMalformedItem = { items: [{ itemType: "CONFIG", description: "config" }] } satisfies ExternalAgentConfigDetectResponse;
+// @ts-expect-error fields absent from the public response are rejected.
+export const rejectResponseExtra = { items: [], extra: true } satisfies ExternalAgentConfigDetectResponse;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 391 {
-		t.Fatalf("definition count = %d, want 391", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
+		t.Fatalf("definition count = %d, want 393", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- export exact standalone `ExternalAgentConfigDetectParams` and `ExternalAgentConfigDetectResponse`
- preserve Rust default/option behavior, opaque ordered path strings, and strict response items
- keep `externalAgentConfig/detect` deferred and unbound with all method/item/runtime behavior unchanged

## Contract
- omitted `includeHome` defaults false and false is omitted canonically
- omitted or null `cwds` canonicalizes to explicit null; empty/relative/absolute/duplicate strings are preserved
- response `items` is required and canonicalizes nil to an empty non-null array
- duplicate known fields and malformed values fail; unknown parent fields are discarded

## Validation
- deliberate-red Go and strict TypeScript contracts
- focused tests x30, focused race, and 100% statement coverage for all eight new functions
- full protocol and all 59 non-Monty packages under fresh normal/race suites
- deterministic 393-definition generation, strict TypeScript, lint, vet, tidy, configured pre-push and push-time hook
- exact normalized parity with public Codex `5c19155cbd93bfa099016e7487259f61669823ff`
- exact structural reversal to PR #187 tree `791212dfc7dbaa70a50ccaabf9b324e4f822ef4f`
- byte-identical 37,897-byte baseline/feature live transcript with empty stderr

Local Monty normal/race/coverage remains skipped per standing direction; hosted checks are unchanged.
