### PR TITLE
feat(appserver): export external-agent import contracts

### DIFF
--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(defs); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -194,13 +194,13 @@ func TestExternalAgentConfigDetectResponseRejectsMalformedWireForms(t *testing.T
 	}
 }
 
-func TestDecodeExternalAgentConfigDetectObjectRejectsMalformedEnvelopes(t *testing.T) {
+func TestDecodeExternalAgentConfigObjectRejectsMalformedEnvelopes(t *testing.T) {
 	invalid := []string{``, `null`, `{"`, `{"includeHome":}`, `{"unknown":1`, `{} {}`, `{} {`}
 	for _, input := range invalid {
-		if _, err := decodeExternalAgentConfigDetectObject(
+		if _, err := decodeExternalAgentConfigObject(
 			[]byte(input), "external-agent config detect params", "includeHome", "cwds",
 		); err == nil {
-			t.Errorf("decodeExternalAgentConfigDetectObject(%q) succeeded", input)
+			t.Errorf("decodeExternalAgentConfigObject(%q) succeeded", input)
 		}
 	}
 }
@@ -217,8 +217,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_detect_types.go
+++ b/appserver/protocol/external_agent_config_detect_types.go
@@ -32,7 +32,7 @@ func (p *ExternalAgentConfigDetectParams) UnmarshalJSON(data []byte) error {
 		return errors.New("decode external-agent config detect params into nil receiver")
 	}
 	const objectName = "external-agent config detect params"
-	payload, err := decodeExternalAgentConfigDetectObject(data, objectName, "includeHome", "cwds")
+	payload, err := decodeExternalAgentConfigObject(data, objectName, "includeHome", "cwds")
 	if err != nil {
 		return err
 	}
@@ -93,7 +93,7 @@ func (r *ExternalAgentConfigDetectResponse) UnmarshalJSON(data []byte) error {
 		return errors.New("decode external-agent config detect response into nil receiver")
 	}
 	const objectName = "external-agent config detect response"
-	payload, err := decodeExternalAgentConfigDetectObject(data, objectName, "items")
+	payload, err := decodeExternalAgentConfigObject(data, objectName, "items")
 	if err != nil {
 		return err
 	}
@@ -105,7 +105,7 @@ func (r *ExternalAgentConfigDetectResponse) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func decodeExternalAgentConfigDetectObject(
+func decodeExternalAgentConfigObject(
 	data []byte,
 	objectName string,
 	knownFields ...string,

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -1,0 +1,255 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestExternalAgentConfigImportSchemasAreExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	wantParams := closedThreadSessionParamSchema(Schema{
+		"migrationItems": Schema{
+			"type": "array", "items": Schema{"$ref": "#/$defs/ExternalAgentConfigMigrationItem"},
+		},
+		"source": Schema{
+			"anyOf":       []any{Schema{"type": "string"}, Schema{"type": "null"}},
+			"description": "Source product that produced the migration items. Missing means unspecified.",
+		},
+	}, []string{"migrationItems"})
+	wantResponse := closedThreadSessionParamSchema(Schema{
+		"importId": Schema{"type": "string"},
+	}, []string{"importId"})
+	for name, want := range map[string]Schema{
+		"ExternalAgentConfigImportParams":   wantParams,
+		"ExternalAgentConfigImportResponse": wantResponse,
+	} {
+		got, ok := defs[name].(Schema)
+		if !ok {
+			t.Errorf("$defs missing %s", name)
+			continue
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("%s = %#v, want %#v", name, got, want)
+		}
+	}
+}
+
+func TestExternalAgentConfigImportParamsAcceptsRustWireForms(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     string
+		want      ExternalAgentConfigImportParams
+		canonical string
+	}{
+		{
+			name: "empty with source omitted", input: `{"migrationItems":[]}`,
+			want:      ExternalAgentConfigImportParams{MigrationItems: []ExternalAgentConfigMigrationItem{}},
+			canonical: `{"migrationItems":[],"source":null}`,
+		},
+		{
+			name: "explicit null and unknown", input: `{"migrationItems":[],"source":null,"future":true}`,
+			want:      ExternalAgentConfigImportParams{MigrationItems: []ExternalAgentConfigMigrationItem{}},
+			canonical: `{"migrationItems":[],"source":null}`,
+		},
+		{
+			name: "empty source", input: `{"migrationItems":[],"source":""}`,
+			want: ExternalAgentConfigImportParams{
+				MigrationItems: []ExternalAgentConfigMigrationItem{}, Source: stringPointer(""),
+			},
+			canonical: `{"migrationItems":[],"source":""}`,
+		},
+		{
+			name: "ordered duplicate strict items and source",
+			input: `{"migrationItems":[` +
+				`{"itemType":"CONFIG","description":"config"},` +
+				`{"itemType":"CONFIG","description":"config","cwd":"repo/../repo","details":{}},` +
+				`{"itemType":"CONFIG","description":"config"}` +
+				`],"source":" Claude Code "}`,
+			want: ExternalAgentConfigImportParams{
+				MigrationItems: []ExternalAgentConfigMigrationItem{
+					{ItemType: ExternalAgentConfigMigrationItemTypeConfig, Description: "config"},
+					{
+						ItemType: ExternalAgentConfigMigrationItemTypeConfig, Description: "config",
+						CWD: stringPointer("repo/../repo"), Details: &MigrationDetails{},
+					},
+					{ItemType: ExternalAgentConfigMigrationItemTypeConfig, Description: "config"},
+				},
+				Source: stringPointer(" Claude Code "),
+			},
+			canonical: `{"migrationItems":[` +
+				`{"itemType":"CONFIG","description":"config","cwd":null,"details":null},` +
+				`{"itemType":"CONFIG","description":"config","cwd":"repo/../repo","details":` +
+				`{"plugins":[],"skills":[],"sessions":[],"mcpServers":[],"hooks":[],"subagents":[],"commands":[]}},` +
+				`{"itemType":"CONFIG","description":"config","cwd":null,"details":null}` +
+				`],"source":" Claude Code "}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var params ExternalAgentConfigImportParams
+			if err := json.Unmarshal([]byte(tc.input), &params); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			if !reflect.DeepEqual(params, canonicalExternalAgentConfigImportParams(tc.want)) {
+				t.Fatalf("params = %#v, want %#v", params, canonicalExternalAgentConfigImportParams(tc.want))
+			}
+			encoded, err := json.Marshal(params)
+			if err != nil || string(encoded) != tc.canonical {
+				t.Fatalf("canonical = %s, %v; want %s", encoded, err, tc.canonical)
+			}
+			var roundTrip ExternalAgentConfigImportParams
+			if err := json.Unmarshal(encoded, &roundTrip); err != nil || !reflect.DeepEqual(roundTrip, params) {
+				t.Fatalf("round trip = %#v, %v; want %#v", roundTrip, err, params)
+			}
+		})
+	}
+
+	encoded, err := json.Marshal(ExternalAgentConfigImportParams{})
+	if err != nil || string(encoded) != `{"migrationItems":[],"source":null}` {
+		t.Fatalf("zero params = %s, %v; want non-null items and explicit-null source", encoded, err)
+	}
+}
+
+func TestExternalAgentConfigImportResponseAcceptsRustWireForms(t *testing.T) {
+	for _, tc := range []struct {
+		input string
+		want  string
+	}{
+		{input: `{"importId":""}`, want: ""},
+		{input: `{"importId":"import-1","future":{"nested":true}}`, want: "import-1"},
+	} {
+		var response ExternalAgentConfigImportResponse
+		if err := json.Unmarshal([]byte(tc.input), &response); err != nil {
+			t.Fatalf("Unmarshal(%s): %v", tc.input, err)
+		}
+		if response.ImportID != tc.want {
+			t.Fatalf("response = %#v, want import ID %q", response, tc.want)
+		}
+		encoded, err := json.Marshal(response)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		var roundTrip ExternalAgentConfigImportResponse
+		if err := json.Unmarshal(encoded, &roundTrip); err != nil || roundTrip != response {
+			t.Fatalf("round trip = %#v, %v; want %#v", roundTrip, err, response)
+		}
+	}
+
+	encoded, err := json.Marshal(ExternalAgentConfigImportResponse{})
+	if err != nil || string(encoded) != `{"importId":""}` {
+		t.Fatalf("zero response = %s, %v; want empty import ID", encoded, err)
+	}
+}
+
+func TestExternalAgentConfigImportParamsRejectsMalformedWireForms(t *testing.T) {
+	invalid := []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{}`,
+		`{"migrationItems":null}`, `{"migrationItems":{}}`, `{"migrationItems":"items"}`,
+		`{"migrationItems":1}`, `{"migrationItems":true}`,
+		`{"migrationItems":[null]}`, `{"migrationItems":[{}]}`, `{"migrationItems":[1]}`,
+		`{"migrationItems":[{"itemType":"OTHER","description":"bad"}]}`,
+		`{"migrationItems":[{"itemType":"CONFIG","description":"config","details":{"skills":null}}]}`,
+		`{"migrationItems":[],"source":1}`, `{"migrationItems":[],"source":true}`,
+		`{"migrationItems":[],"source":[]}`, `{"migrationItems":[],"source":{}}`,
+		`{"migrationItems":[],"migrationItems":[]}`,
+		`{"migrationItems":[],"source":null,"source":"codex"}`,
+		`{"migrationItems":[]`, `{"migrationItems":[]} {}`,
+	}
+	for _, input := range invalid {
+		var params ExternalAgentConfigImportParams
+		if err := json.Unmarshal([]byte(input), &params); err == nil {
+			t.Errorf("Unmarshal(%s) succeeded", input)
+		}
+	}
+
+	var params *ExternalAgentConfigImportParams
+	if err := params.UnmarshalJSON([]byte(`{"migrationItems":[]}`)); err == nil {
+		t.Fatal("nil ExternalAgentConfigImportParams receiver succeeded")
+	}
+}
+
+func TestExternalAgentConfigImportResponseRejectsMalformedWireForms(t *testing.T) {
+	invalid := []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{}`,
+		`{"importId":null}`, `{"importId":1}`, `{"importId":true}`,
+		`{"importId":[]}`, `{"importId":{}}`,
+		`{"importId":"one","importId":"two"}`, `{"importId":""`, `{"importId":""} {}`,
+	}
+	for _, input := range invalid {
+		var response ExternalAgentConfigImportResponse
+		if err := json.Unmarshal([]byte(input), &response); err == nil {
+			t.Errorf("Unmarshal(%s) succeeded", input)
+		}
+	}
+
+	var response *ExternalAgentConfigImportResponse
+	if err := response.UnmarshalJSON([]byte(`{"importId":""}`)); err == nil {
+		t.Fatal("nil ExternalAgentConfigImportResponse receiver succeeded")
+	}
+}
+
+func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
+	for _, binding := range WireTypeBindings() {
+		for _, name := range []string{"ExternalAgentConfigImportParams", "ExternalAgentConfigImportResponse"} {
+			if slices.Contains(binding.Params, name) || slices.Contains(binding.Result, name) {
+				t.Fatalf("%s unexpectedly bound: %#v", name, binding)
+			}
+		}
+	}
+	info, ok := LookupMethod("externalAgentConfig/import")
+	if !ok || info.State != MethodDeferredStub {
+		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestExternalAgentConfigImportTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	source := string(generated)
+	for _, want := range []string{
+		"export type ExternalAgentConfigImportParams = {\n" +
+			"  \"migrationItems\": Array<ExternalAgentConfigMigrationItem>;\n" +
+			"  \"source\"?: string | null;\n" +
+			"};",
+		"export type ExternalAgentConfigImportResponse = {\n" +
+			"  \"importId\": string;\n" +
+			"};",
+	} {
+		if !strings.Contains(source, want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}
+
+func canonicalExternalAgentConfigImportParams(params ExternalAgentConfigImportParams) ExternalAgentConfigImportParams {
+	encoded, err := json.Marshal(params)
+	if err != nil {
+		panic(err)
+	}
+	var canonical ExternalAgentConfigImportParams
+	if err := json.Unmarshal(encoded, &canonical); err != nil {
+		panic(err)
+	}
+	return canonical
+}
+
+var (
+	_ json.Marshaler   = ExternalAgentConfigImportParams{}
+	_ json.Unmarshaler = (*ExternalAgentConfigImportParams)(nil)
+	_ json.Marshaler   = ExternalAgentConfigImportResponse{}
+	_ json.Unmarshaler = (*ExternalAgentConfigImportResponse)(nil)
+)

--- a/appserver/protocol/external_agent_config_import_types.go
+++ b/appserver/protocol/external_agent_config_import_types.go
@@ -1,0 +1,119 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+const externalAgentConfigImportSourceDescription = "Source product that produced the migration items. Missing means unspecified."
+
+// ExternalAgentConfigImportParams is the exact standalone public import
+// description. It does not grant path access or authorize import execution.
+type ExternalAgentConfigImportParams struct {
+	MigrationItems []ExternalAgentConfigMigrationItem `json:"migrationItems"`
+	Source         *string                            `json:"source"`
+}
+
+func (p ExternalAgentConfigImportParams) MarshalJSON() ([]byte, error) {
+	items := p.MigrationItems
+	if items == nil {
+		items = []ExternalAgentConfigMigrationItem{}
+	}
+	return json.Marshal(struct {
+		MigrationItems []ExternalAgentConfigMigrationItem `json:"migrationItems"`
+		Source         *string                            `json:"source"`
+	}{MigrationItems: items, Source: p.Source})
+}
+
+func (p *ExternalAgentConfigImportParams) UnmarshalJSON(data []byte) error {
+	if p == nil {
+		return errors.New("decode external-agent config import params into nil receiver")
+	}
+	const objectName = "external-agent config import params"
+	payload, err := decodeExternalAgentConfigObject(data, objectName, "migrationItems", "source")
+	if err != nil {
+		return err
+	}
+	items, err := decodeRequiredThreadItemArray[ExternalAgentConfigMigrationItem](
+		payload, objectName, "migrationItems",
+	)
+	if err != nil {
+		return err
+	}
+	source, err := decodeOptionalNullableExternalAgentConfigImportSource(payload, objectName)
+	if err != nil {
+		return err
+	}
+	*p = ExternalAgentConfigImportParams{MigrationItems: items, Source: source}
+	return nil
+}
+
+func decodeOptionalNullableExternalAgentConfigImportSource(
+	payload map[string]json.RawMessage,
+	objectName string,
+) (*string, error) {
+	raw, ok := payload["source"]
+	if !ok || isJSONNull(raw) {
+		return nil, nil
+	}
+	var source string
+	if err := json.Unmarshal(raw, &source); err != nil {
+		return nil, fmt.Errorf("decode %s source: %w", objectName, err)
+	}
+	return &source, nil
+}
+
+// ExternalAgentConfigImportResponse is the exact standalone public import ID.
+// It does not imply that an import has run or persisted any configuration.
+type ExternalAgentConfigImportResponse struct {
+	ImportID string `json:"importId"`
+}
+
+func (r ExternalAgentConfigImportResponse) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		ImportID string `json:"importId"`
+	}{ImportID: r.ImportID})
+}
+
+func (r *ExternalAgentConfigImportResponse) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("decode external-agent config import response into nil receiver")
+	}
+	const objectName = "external-agent config import response"
+	payload, err := decodeExternalAgentConfigObject(data, objectName, "importId")
+	if err != nil {
+		return err
+	}
+	importID, err := decodeRequiredThreadItemValue[string](payload, objectName, "importId")
+	if err != nil {
+		return err
+	}
+	*r = ExternalAgentConfigImportResponse{ImportID: importID}
+	return nil
+}
+
+func externalAgentConfigImportParamsSchema() Schema {
+	return closedThreadSessionParamSchema(Schema{
+		"migrationItems": Schema{
+			"type": "array", "items": Schema{"$ref": "#/$defs/ExternalAgentConfigMigrationItem"},
+		},
+		"source": Schema{
+			"anyOf":       []any{Schema{"type": "string"}, Schema{"type": "null"}},
+			"description": externalAgentConfigImportSourceDescription,
+		},
+	}, []string{"migrationItems"})
+}
+
+func externalAgentConfigImportResponseSchema() Schema {
+	return closedThreadSessionParamSchema(Schema{
+		"importId": Schema{"type": "string"},
+	}, []string{"importId"})
+}
+
+var (
+	_ json.Marshaler   = ExternalAgentConfigImportParams{}
+	_ json.Unmarshaler = (*ExternalAgentConfigImportParams)(nil)
+	_ json.Marshaler   = ExternalAgentConfigImportResponse{}
+	_ json.Unmarshaler = (*ExternalAgentConfigImportResponse)(nil)
+)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 393 {
-		t.Fatalf("definition count = %d, want 393", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 395 {
+		t.Fatalf("definition count = %d, want 395", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 393 {
-		t.Fatalf("definition count = %d, want 393", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 395 {
+		t.Fatalf("definition count = %d, want 395", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 393 {
-		t.Fatalf("definition count = %d, want 393", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 395 {
+		t.Fatalf("definition count = %d, want 395", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 393 {
-		t.Fatalf("definition count = %d, want 393", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 395 {
+		t.Fatalf("definition count = %d, want 395", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 393 {
-		t.Fatalf("definition count = %d, want 393", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 395 {
+		t.Fatalf("definition count = %d, want 395", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 393 {
-		t.Fatalf("definition count = %d, want 393", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 395 {
+		t.Fatalf("definition count = %d, want 395", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -317,6 +317,8 @@ func wireSchemaDefinitions() Schema {
 		{Name: "ExternalAgentConfigMigrationItem", Type: reflect.TypeFor[ExternalAgentConfigMigrationItem]()},
 		{Name: "ExternalAgentConfigDetectParams", Type: reflect.TypeFor[ExternalAgentConfigDetectParams]()},
 		{Name: "ExternalAgentConfigDetectResponse", Type: reflect.TypeFor[ExternalAgentConfigDetectResponse]()},
+		{Name: "ExternalAgentConfigImportParams", Type: reflect.TypeFor[ExternalAgentConfigImportParams]()},
+		{Name: "ExternalAgentConfigImportResponse", Type: reflect.TypeFor[ExternalAgentConfigImportResponse]()},
 		{Name: "PermissionGrantScope", Type: reflect.TypeFor[PermissionGrantScope]()},
 		{Name: "PermissionsApprovalRequestParams", Type: reflect.TypeFor[PermissionsApprovalRequestParams]()},
 		{Name: "PermissionsRequestApprovalParams", Type: reflect.TypeFor[PermissionsRequestApprovalParams]()},
@@ -567,6 +569,8 @@ func wireSchemaDefinitions() Schema {
 	schemas["ExternalAgentConfigMigrationItem"] = externalAgentConfigMigrationItemSchema()
 	schemas["ExternalAgentConfigDetectParams"] = externalAgentConfigDetectParamsSchema()
 	schemas["ExternalAgentConfigDetectResponse"] = externalAgentConfigDetectResponseSchema()
+	schemas["ExternalAgentConfigImportParams"] = externalAgentConfigImportParamsSchema()
+	schemas["ExternalAgentConfigImportResponse"] = externalAgentConfigImportResponseSchema()
 	schemas["McpServerToolCallParams"] = mcpServerToolCallParamsSchema()
 	schemas["McpServerToolCallResponse"] = mcpServerToolCallResponseSchema()
 	schemas["ResourceContent"] = resourceContentSchema()

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -3176,6 +3176,44 @@
       ],
       "type": "object"
     },
+    "ExternalAgentConfigImportParams": {
+      "additionalProperties": false,
+      "properties": {
+        "migrationItems": {
+          "items": {
+            "$ref": "#/$defs/ExternalAgentConfigMigrationItem"
+          },
+          "type": "array"
+        },
+        "source": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Source product that produced the migration items. Missing means unspecified."
+        }
+      },
+      "required": [
+        "migrationItems"
+      ],
+      "type": "object"
+    },
+    "ExternalAgentConfigImportResponse": {
+      "additionalProperties": false,
+      "properties": {
+        "importId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "importId"
+      ],
+      "type": "object"
+    },
     "ExternalAgentConfigMigrationItem": {
       "additionalProperties": false,
       "properties": {

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 393 {
-		t.Fatalf("definition count = %d, want 393", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 395 {
+		t.Fatalf("definition count = %d, want 395", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 393 {
-		t.Fatalf("definition count = %d, want 393", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 395 {
+		t.Fatalf("definition count = %d, want 395", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 393 {
-		t.Fatalf("definition count = %d, want 393", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 395 {
+		t.Fatalf("definition count = %d, want 395", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -1130,6 +1130,15 @@ export type ExternalAgentConfigDetectResponse = {
   "items": Array<ExternalAgentConfigMigrationItem>;
 };
 
+export type ExternalAgentConfigImportParams = {
+  "migrationItems": Array<ExternalAgentConfigMigrationItem>;
+  "source"?: string | null;
+};
+
+export type ExternalAgentConfigImportResponse = {
+  "importId": string;
+};
+
 export type ExternalAgentConfigMigrationItem = {
   "cwd": string | null;
   "description": string;

--- a/appserver/protocol/typescript/testdata/external_agent_config_import_contract.ts
+++ b/appserver/protocol/typescript/testdata/external_agent_config_import_contract.ts
@@ -1,0 +1,67 @@
+import type {
+  ExternalAgentConfigImportParams,
+  ExternalAgentConfigImportResponse,
+  ExternalAgentConfigMigrationItem,
+  MethodParamsByName,
+  MethodResultsByName,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+
+type Contracts = [
+  Expect<Equal<ExternalAgentConfigImportParams, {
+    migrationItems: Array<ExternalAgentConfigMigrationItem>;
+    source?: string | null;
+  }>>,
+  Expect<Equal<ExternalAgentConfigImportResponse, { importId: string }>>,
+  Expect<Equal<"externalAgentConfig/detect" extends keyof MethodParamsByName ? true : false, false>>,
+  Expect<Equal<"externalAgentConfig/detect" extends keyof MethodResultsByName ? true : false, false>>,
+  Expect<Equal<"externalAgentConfig/import" extends keyof MethodParamsByName ? true : false, false>>,
+  Expect<Equal<"externalAgentConfig/import" extends keyof MethodResultsByName ? true : false, false>>,
+];
+
+export const item = {
+  itemType: "CONFIG",
+  description: "config",
+  cwd: null,
+  details: null,
+} satisfies ExternalAgentConfigMigrationItem;
+export const empty = { migrationItems: [] } satisfies ExternalAgentConfigImportParams;
+export const nullSource = { migrationItems: [item, item], source: null } satisfies ExternalAgentConfigImportParams;
+export const namedSource = { migrationItems: [item], source: " Claude Code " } satisfies ExternalAgentConfigImportParams;
+export const response = { importId: "" } satisfies ExternalAgentConfigImportResponse;
+
+// @ts-expect-error migrationItems is required.
+export const rejectMissingItems = {} satisfies ExternalAgentConfigImportParams;
+// @ts-expect-error migrationItems is non-null.
+export const rejectNullItems = { migrationItems: null } satisfies ExternalAgentConfigImportParams;
+// @ts-expect-error migrationItems is an array.
+export const rejectScalarItems = { migrationItems: item } satisfies ExternalAgentConfigImportParams;
+// @ts-expect-error migration items retain strict nullable fields.
+export const rejectMalformedItem = { migrationItems: [{ itemType: "CONFIG", description: "config" }] } satisfies ExternalAgentConfigImportParams;
+// @ts-expect-error source is a nullable string.
+export const rejectNumericSource = { migrationItems: [], source: 1 } satisfies ExternalAgentConfigImportParams;
+// @ts-expect-error optional fields do not accept explicit undefined.
+export const rejectUndefinedSource = { migrationItems: [], source: undefined } satisfies ExternalAgentConfigImportParams;
+// @ts-expect-error snake-case aliases do not replace canonical fields.
+export const rejectSnakeAlias = { migration_items: [] } satisfies ExternalAgentConfigImportParams;
+// @ts-expect-error fields absent from the public request are rejected.
+export const rejectParamsExtra = { migrationItems: [], extra: true } satisfies ExternalAgentConfigImportParams;
+
+// @ts-expect-error importId is required.
+export const rejectMissingImportId = {} satisfies ExternalAgentConfigImportResponse;
+// @ts-expect-error importId is non-null.
+export const rejectNullImportId = { importId: null } satisfies ExternalAgentConfigImportResponse;
+// @ts-expect-error importId is a string.
+export const rejectNumericImportId = { importId: 1 } satisfies ExternalAgentConfigImportResponse;
+// @ts-expect-error snake-case aliases do not replace canonical fields.
+export const rejectImportIdAlias = { import_id: "import-1" } satisfies ExternalAgentConfigImportResponse;
+// @ts-expect-error fields absent from the public response are rejected.
+export const rejectResponseExtra = { importId: "import-1", extra: true } satisfies ExternalAgentConfigImportResponse;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 393 {
-		t.Fatalf("definition count = %d, want 393", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
+		t.Fatalf("definition count = %d, want 395", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- export exact standalone `ExternalAgentConfigImportParams` and `ExternalAgentConfigImportResponse`
- preserve required non-null ordered migration items, optional nullable source with canonical explicit null, and required string import ID
- keep `externalAgentConfig/import` deferred and unbound with unchanged method/item metadata and no import or filesystem authority
- rename the shared external-agent object decoder now used by detect and import

## Exactness evidence
- deliberate red: missing Go records; 2 missing generated TypeScript exports, 2 false identities, 13 unused negative directives
- generated schema/TypeScript match pinned public Codex `5c19155cbd93bfa099016e7487259f61669823ff`
- normalized schema pair SHA-256 `f70c9bc3dfecc279dcf9fb336d0a5bd78f331e4d1caa92e2ed8f849bd9264f9f`
- normalized TypeScript semantics SHA-256 `1aa5077cdb4f1ab7e49d4fda507c3fd6513ec2220c9abb10d4fce783dd9feda8`
- generated schema SHA-256 `593dd10284696a7f87f7cca730e92925a160949f9bb3a384636c9720c959be81`
- generated TypeScript SHA-256 `9c22b4497085850e8659bca4f11412f8b0167d7e5fd5a6bcba70c66b08228897`
- strict fixture SHA-256 `729117ea96145e3f050dcbf7d37e58f298f58239c59bbb8f41330f54b4690194`
- reversing feature commit `0ab5060f5bd6c9fdf015a95d73f35be2f28466df` restores exact PR #188 tree `20e24407649f1dc59274684bce20dd149f030d95`

## Verification
- focused tests x30 and focused race
- 100% statement coverage for all 7 new functions
- full protocol normal/race
- all 59 non-Monty packages under fresh normal/race suites
- `golangci-lint run ./...` (0 issues), `go vet ./...`, `go mod tidy` verification
- configured pre-push and push-time hook passed with `hooks.skipMontyRace=true`; hosted CI unchanged
- deterministic 395-definition generation and strict TypeScript
- all 5 prior Slang real-process workflows against reproducible feature binary SHA-256 `aac5868d2d2e5aeb37e521988b0c6e9493073a2197c964fcbfaf72c70e4a4f7d`
- baseline/feature initialize and MCP status transcript byte-identical at 37,903 bytes, SHA-256 `f881f298c6e53fe2b0d39451eeac515637d19ef2dd2f0c1e8f9979e3da3dc63e`, empty stderr
