### PR TITLE
feat(appserver): export external-agent import item results

### DIFF
--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(defs); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,8 +217,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,8 +203,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -1,0 +1,291 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestExternalAgentConfigImportItemResultSchemasAreExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	nullableString := func() Schema {
+		return Schema{"anyOf": []any{Schema{"type": "string"}, Schema{"type": "null"}}}
+	}
+	wantSuccess := closedThreadSessionParamSchema(Schema{
+		"itemType": Schema{"$ref": "#/$defs/ExternalAgentConfigMigrationItemType"},
+		"cwd":      nullableString(),
+		"source":   nullableString(),
+		"target":   nullableString(),
+	}, []string{"itemType"})
+	wantFailure := closedThreadSessionParamSchema(Schema{
+		"itemType":     Schema{"$ref": "#/$defs/ExternalAgentConfigMigrationItemType"},
+		"errorType":    nullableString(),
+		"failureStage": Schema{"type": "string"},
+		"message":      Schema{"type": "string"},
+		"cwd":          nullableString(),
+		"source":       nullableString(),
+	}, []string{"itemType", "failureStage", "message"})
+	for name, want := range map[string]Schema{
+		"ExternalAgentConfigImportItemTypeSuccess": wantSuccess,
+		"ExternalAgentConfigImportItemTypeFailure": wantFailure,
+	} {
+		got, ok := defs[name].(Schema)
+		if !ok {
+			t.Errorf("$defs missing %s", name)
+			continue
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("%s = %#v, want %#v", name, got, want)
+		}
+	}
+}
+
+func TestExternalAgentConfigImportItemTypeSuccessAcceptsRustWireForms(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     string
+		want      ExternalAgentConfigImportItemTypeSuccess
+		canonical string
+	}{
+		{
+			name: "options omitted", input: `{"itemType":"CONFIG"}`,
+			want: ExternalAgentConfigImportItemTypeSuccess{
+				ItemType: ExternalAgentConfigMigrationItemTypeConfig,
+			},
+			canonical: `{"itemType":"CONFIG","cwd":null,"source":null,"target":null}`,
+		},
+		{
+			name: "explicit null and unknown", input: `{"itemType":"SKILLS","cwd":null,"source":null,"target":null,"future":true}`,
+			want: ExternalAgentConfigImportItemTypeSuccess{
+				ItemType: ExternalAgentConfigMigrationItemTypeSkills,
+			},
+			canonical: `{"itemType":"SKILLS","cwd":null,"source":null,"target":null}`,
+		},
+		{
+			name: "opaque strings", input: `{"itemType":"PLUGINS","cwd":"repo/../repo","source":" Claude Code ","target":""}`,
+			want: ExternalAgentConfigImportItemTypeSuccess{
+				ItemType: ExternalAgentConfigMigrationItemTypePlugins,
+				CWD:      stringPointer("repo/../repo"),
+				Source:   stringPointer(" Claude Code "),
+				Target:   stringPointer(""),
+			},
+			canonical: `{"itemType":"PLUGINS","cwd":"repo/../repo","source":" Claude Code ","target":""}`,
+		},
+		{
+			name: "empty cwd", input: `{"itemType":"COMMANDS","cwd":"","source":"","target":"target"}`,
+			want: ExternalAgentConfigImportItemTypeSuccess{
+				ItemType: ExternalAgentConfigMigrationItemTypeCommands,
+				CWD:      stringPointer(""), Source: stringPointer(""), Target: stringPointer("target"),
+			},
+			canonical: `{"itemType":"COMMANDS","cwd":"","source":"","target":"target"}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var value ExternalAgentConfigImportItemTypeSuccess
+			if err := json.Unmarshal([]byte(tc.input), &value); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			if !reflect.DeepEqual(value, tc.want) {
+				t.Fatalf("value = %#v, want %#v", value, tc.want)
+			}
+			encoded, err := json.Marshal(value)
+			if err != nil || string(encoded) != tc.canonical {
+				t.Fatalf("canonical = %s, %v; want %s", encoded, err, tc.canonical)
+			}
+			var roundTrip ExternalAgentConfigImportItemTypeSuccess
+			if err := json.Unmarshal(encoded, &roundTrip); err != nil || !reflect.DeepEqual(roundTrip, value) {
+				t.Fatalf("round trip = %#v, %v; want %#v", roundTrip, err, value)
+			}
+		})
+	}
+}
+
+func TestExternalAgentConfigImportItemTypeFailureAcceptsRustWireForms(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     string
+		want      ExternalAgentConfigImportItemTypeFailure
+		canonical string
+	}{
+		{
+			name:  "options omitted and required strings empty",
+			input: `{"itemType":"CONFIG","failureStage":"","message":""}`,
+			want: ExternalAgentConfigImportItemTypeFailure{
+				ItemType: ExternalAgentConfigMigrationItemTypeConfig,
+			},
+			canonical: `{"itemType":"CONFIG","errorType":null,"failureStage":"","message":"","cwd":null,"source":null}`,
+		},
+		{
+			name:  "explicit null and unknown",
+			input: `{"itemType":"HOOKS","errorType":null,"failureStage":"write","message":"failed","cwd":null,"source":null,"future":true}`,
+			want: ExternalAgentConfigImportItemTypeFailure{
+				ItemType:     ExternalAgentConfigMigrationItemTypeHooks,
+				FailureStage: "write", Message: "failed",
+			},
+			canonical: `{"itemType":"HOOKS","errorType":null,"failureStage":"write","message":"failed","cwd":null,"source":null}`,
+		},
+		{
+			name:  "opaque strings",
+			input: `{"itemType":"SESSIONS","errorType":" IO ","failureStage":" import ","message":" message ","cwd":"/tmp/../repo","source":""}`,
+			want: ExternalAgentConfigImportItemTypeFailure{
+				ItemType:  ExternalAgentConfigMigrationItemTypeSessions,
+				ErrorType: stringPointer(" IO "), FailureStage: " import ", Message: " message ",
+				CWD: stringPointer("/tmp/../repo"), Source: stringPointer(""),
+			},
+			canonical: `{"itemType":"SESSIONS","errorType":" IO ","failureStage":" import ","message":" message ","cwd":"/tmp/../repo","source":""}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var value ExternalAgentConfigImportItemTypeFailure
+			if err := json.Unmarshal([]byte(tc.input), &value); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			if !reflect.DeepEqual(value, tc.want) {
+				t.Fatalf("value = %#v, want %#v", value, tc.want)
+			}
+			encoded, err := json.Marshal(value)
+			if err != nil || string(encoded) != tc.canonical {
+				t.Fatalf("canonical = %s, %v; want %s", encoded, err, tc.canonical)
+			}
+			var roundTrip ExternalAgentConfigImportItemTypeFailure
+			if err := json.Unmarshal(encoded, &roundTrip); err != nil || !reflect.DeepEqual(roundTrip, value) {
+				t.Fatalf("round trip = %#v, %v; want %#v", roundTrip, err, value)
+			}
+		})
+	}
+}
+
+func TestExternalAgentConfigImportItemResultsRejectMalformedWireForms(t *testing.T) {
+	successInvalid := []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{}`,
+		`{"itemType":null}`, `{"itemType":"OTHER"}`, `{"itemType":1}`,
+		`{"itemType":"CONFIG","cwd":1}`, `{"itemType":"CONFIG","source":true}`,
+		`{"itemType":"CONFIG","target":[]}`, `{"itemType":"CONFIG","itemType":"SKILLS"}`,
+		`{"itemType":"CONFIG","cwd":null,"cwd":"repo"}`,
+		`{"itemType":"CONFIG","source":null,"source":"source"}`,
+		`{"itemType":"CONFIG","target":null,"target":"target"}`,
+		`{"itemType":"CONFIG"`, `{"itemType":"CONFIG"} {}`,
+	}
+	for _, input := range successInvalid {
+		var value ExternalAgentConfigImportItemTypeSuccess
+		if err := json.Unmarshal([]byte(input), &value); err == nil {
+			t.Errorf("success Unmarshal(%s) succeeded", input)
+		}
+	}
+	var success *ExternalAgentConfigImportItemTypeSuccess
+	if err := success.UnmarshalJSON([]byte(`{"itemType":"CONFIG"}`)); err == nil {
+		t.Fatal("nil success receiver succeeded")
+	}
+	if _, err := json.Marshal(ExternalAgentConfigImportItemTypeSuccess{}); err == nil {
+		t.Fatal("success with invalid zero item type marshaled")
+	}
+
+	failureInvalid := []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{}`,
+		`{"itemType":"CONFIG","message":"missing stage"}`,
+		`{"itemType":"CONFIG","failureStage":"missing message"}`,
+		`{"itemType":null,"failureStage":"x","message":"x"}`,
+		`{"itemType":"OTHER","failureStage":"x","message":"x"}`,
+		`{"itemType":"CONFIG","failureStage":null,"message":"x"}`,
+		`{"itemType":"CONFIG","failureStage":"x","message":null}`,
+		`{"itemType":"CONFIG","failureStage":1,"message":"x"}`,
+		`{"itemType":"CONFIG","failureStage":"x","message":1}`,
+		`{"itemType":"CONFIG","failureStage":"x","message":"x","errorType":1}`,
+		`{"itemType":"CONFIG","failureStage":"x","message":"x","cwd":true}`,
+		`{"itemType":"CONFIG","failureStage":"x","message":"x","source":[]}`,
+		`{"itemType":"CONFIG","itemType":"SKILLS","failureStage":"x","message":"x"}`,
+		`{"itemType":"CONFIG","errorType":null,"errorType":"error","failureStage":"x","message":"x"}`,
+		`{"itemType":"CONFIG","failureStage":"x","failureStage":"y","message":"x"}`,
+		`{"itemType":"CONFIG","failureStage":"x","message":"x","message":"y"}`,
+		`{"itemType":"CONFIG","failureStage":"x","message":"x","cwd":null,"cwd":"repo"}`,
+		`{"itemType":"CONFIG","failureStage":"x","message":"x","source":null,"source":"source"}`,
+		`{"itemType":"CONFIG","failureStage":"x","message":"x"`,
+		`{"itemType":"CONFIG","failureStage":"x","message":"x"} {}`,
+	}
+	for _, input := range failureInvalid {
+		var value ExternalAgentConfigImportItemTypeFailure
+		if err := json.Unmarshal([]byte(input), &value); err == nil {
+			t.Errorf("failure Unmarshal(%s) succeeded", input)
+		}
+	}
+	var failure *ExternalAgentConfigImportItemTypeFailure
+	if err := failure.UnmarshalJSON([]byte(`{"itemType":"CONFIG","failureStage":"","message":""}`)); err == nil {
+		t.Fatal("nil failure receiver succeeded")
+	}
+	if _, err := json.Marshal(ExternalAgentConfigImportItemTypeFailure{}); err == nil {
+		t.Fatal("failure with invalid zero item type marshaled")
+	}
+}
+
+func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
+	names := []string{
+		"ExternalAgentConfigImportItemTypeSuccess",
+		"ExternalAgentConfigImportItemTypeFailure",
+	}
+	for _, binding := range WireTypeBindings() {
+		for _, name := range names {
+			if slices.Contains(binding.Params, name) || slices.Contains(binding.Result, name) {
+				t.Fatalf("%s unexpectedly bound: %#v", name, binding)
+			}
+		}
+	}
+	for _, method := range []string{
+		"externalAgentConfig/import",
+		"externalAgentConfig/import/readHistories",
+		"externalAgentConfig/import/progress",
+		"externalAgentConfig/import/completed",
+	} {
+		info, ok := LookupMethod(method)
+		if !ok || info.State != MethodDeferredStub {
+			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestExternalAgentConfigImportItemResultsTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	source := string(generated)
+	for _, want := range []string{
+		"export type ExternalAgentConfigImportItemTypeSuccess = {\n" +
+			"  \"cwd\": string | null;\n" +
+			"  \"itemType\": ExternalAgentConfigMigrationItemType;\n" +
+			"  \"source\": string | null;\n" +
+			"  \"target\": string | null;\n" +
+			"};",
+		"export type ExternalAgentConfigImportItemTypeFailure = {\n" +
+			"  \"cwd\": string | null;\n" +
+			"  \"errorType\": string | null;\n" +
+			"  \"failureStage\": string;\n" +
+			"  \"itemType\": ExternalAgentConfigMigrationItemType;\n" +
+			"  \"message\": string;\n" +
+			"  \"source\": string | null;\n" +
+			"};",
+	} {
+		if !strings.Contains(source, want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}
+
+var (
+	_ json.Marshaler   = ExternalAgentConfigImportItemTypeSuccess{}
+	_ json.Unmarshaler = (*ExternalAgentConfigImportItemTypeSuccess)(nil)
+	_ json.Marshaler   = ExternalAgentConfigImportItemTypeFailure{}
+	_ json.Unmarshaler = (*ExternalAgentConfigImportItemTypeFailure)(nil)
+)

--- a/appserver/protocol/external_agent_config_import_item_result_types.go
+++ b/appserver/protocol/external_agent_config_import_item_result_types.go
@@ -1,0 +1,149 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// ExternalAgentConfigImportItemTypeSuccess is an exact standalone import
+// result. Its paths and strings are descriptive data, not evidence or authority.
+type ExternalAgentConfigImportItemTypeSuccess struct {
+	ItemType ExternalAgentConfigMigrationItemType `json:"itemType"`
+	CWD      *string                              `json:"cwd"`
+	Source   *string                              `json:"source"`
+	Target   *string                              `json:"target"`
+}
+
+func (r ExternalAgentConfigImportItemTypeSuccess) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		ItemType ExternalAgentConfigMigrationItemType `json:"itemType"`
+		CWD      *string                              `json:"cwd"`
+		Source   *string                              `json:"source"`
+		Target   *string                              `json:"target"`
+	}{ItemType: r.ItemType, CWD: r.CWD, Source: r.Source, Target: r.Target})
+}
+
+func (r *ExternalAgentConfigImportItemTypeSuccess) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("decode external-agent config import item success into nil receiver")
+	}
+	const objectName = "external-agent config import item success"
+	payload, err := decodeExternalAgentConfigObject(data, objectName, "itemType", "cwd", "source", "target")
+	if err != nil {
+		return err
+	}
+	itemType, err := decodeRequiredThreadItemValue[ExternalAgentConfigMigrationItemType](payload, objectName, "itemType")
+	if err != nil {
+		return err
+	}
+	cwd, err := decodeOptionalNullableConfigValue[string](payload, objectName, "cwd")
+	if err != nil {
+		return err
+	}
+	source, err := decodeOptionalNullableConfigValue[string](payload, objectName, "source")
+	if err != nil {
+		return err
+	}
+	target, err := decodeOptionalNullableConfigValue[string](payload, objectName, "target")
+	if err != nil {
+		return err
+	}
+	*r = ExternalAgentConfigImportItemTypeSuccess{
+		ItemType: itemType, CWD: cwd, Source: source, Target: target,
+	}
+	return nil
+}
+
+// ExternalAgentConfigImportItemTypeFailure is an exact standalone import
+// failure description. It does not imply that import execution occurred.
+type ExternalAgentConfigImportItemTypeFailure struct {
+	ItemType     ExternalAgentConfigMigrationItemType `json:"itemType"`
+	ErrorType    *string                              `json:"errorType"`
+	FailureStage string                               `json:"failureStage"`
+	Message      string                               `json:"message"`
+	CWD          *string                              `json:"cwd"`
+	Source       *string                              `json:"source"`
+}
+
+func (r ExternalAgentConfigImportItemTypeFailure) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		ItemType     ExternalAgentConfigMigrationItemType `json:"itemType"`
+		ErrorType    *string                              `json:"errorType"`
+		FailureStage string                               `json:"failureStage"`
+		Message      string                               `json:"message"`
+		CWD          *string                              `json:"cwd"`
+		Source       *string                              `json:"source"`
+	}{
+		ItemType: r.ItemType, ErrorType: r.ErrorType, FailureStage: r.FailureStage,
+		Message: r.Message, CWD: r.CWD, Source: r.Source,
+	})
+}
+
+func (r *ExternalAgentConfigImportItemTypeFailure) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("decode external-agent config import item failure into nil receiver")
+	}
+	const objectName = "external-agent config import item failure"
+	payload, err := decodeExternalAgentConfigObject(
+		data, objectName, "itemType", "errorType", "failureStage", "message", "cwd", "source",
+	)
+	if err != nil {
+		return err
+	}
+	itemType, err := decodeRequiredThreadItemValue[ExternalAgentConfigMigrationItemType](payload, objectName, "itemType")
+	if err != nil {
+		return err
+	}
+	errorType, err := decodeOptionalNullableConfigValue[string](payload, objectName, "errorType")
+	if err != nil {
+		return err
+	}
+	failureStage, err := decodeRequiredThreadItemValue[string](payload, objectName, "failureStage")
+	if err != nil {
+		return err
+	}
+	message, err := decodeRequiredThreadItemValue[string](payload, objectName, "message")
+	if err != nil {
+		return err
+	}
+	cwd, err := decodeOptionalNullableConfigValue[string](payload, objectName, "cwd")
+	if err != nil {
+		return err
+	}
+	source, err := decodeOptionalNullableConfigValue[string](payload, objectName, "source")
+	if err != nil {
+		return err
+	}
+	*r = ExternalAgentConfigImportItemTypeFailure{
+		ItemType: itemType, ErrorType: errorType, FailureStage: failureStage,
+		Message: message, CWD: cwd, Source: source,
+	}
+	return nil
+}
+
+func externalAgentConfigImportItemTypeSuccessSchema() Schema {
+	return closedThreadSessionParamSchema(Schema{
+		"itemType": Schema{"$ref": "#/$defs/ExternalAgentConfigMigrationItemType"},
+		"cwd":      Schema{"anyOf": []any{Schema{"type": "string"}, Schema{"type": "null"}}},
+		"source":   Schema{"anyOf": []any{Schema{"type": "string"}, Schema{"type": "null"}}},
+		"target":   Schema{"anyOf": []any{Schema{"type": "string"}, Schema{"type": "null"}}},
+	}, []string{"itemType"})
+}
+
+func externalAgentConfigImportItemTypeFailureSchema() Schema {
+	return closedThreadSessionParamSchema(Schema{
+		"itemType":     Schema{"$ref": "#/$defs/ExternalAgentConfigMigrationItemType"},
+		"errorType":    Schema{"anyOf": []any{Schema{"type": "string"}, Schema{"type": "null"}}},
+		"failureStage": Schema{"type": "string"},
+		"message":      Schema{"type": "string"},
+		"cwd":          Schema{"anyOf": []any{Schema{"type": "string"}, Schema{"type": "null"}}},
+		"source":       Schema{"anyOf": []any{Schema{"type": "string"}, Schema{"type": "null"}}},
+	}, []string{"itemType", "failureStage", "message"})
+}
+
+var (
+	_ json.Marshaler   = ExternalAgentConfigImportItemTypeSuccess{}
+	_ json.Unmarshaler = (*ExternalAgentConfigImportItemTypeSuccess)(nil)
+	_ json.Marshaler   = ExternalAgentConfigImportItemTypeFailure{}
+	_ json.Unmarshaler = (*ExternalAgentConfigImportItemTypeFailure)(nil)
+)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 395 {
-		t.Fatalf("definition count = %d, want 395", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 397 {
+		t.Fatalf("definition count = %d, want 397", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 395 {
-		t.Fatalf("definition count = %d, want 395", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 397 {
+		t.Fatalf("definition count = %d, want 397", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 395 {
-		t.Fatalf("definition count = %d, want 395", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 397 {
+		t.Fatalf("definition count = %d, want 397", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 395 {
-		t.Fatalf("definition count = %d, want 395", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 397 {
+		t.Fatalf("definition count = %d, want 397", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 395 {
-		t.Fatalf("definition count = %d, want 395", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 397 {
+		t.Fatalf("definition count = %d, want 397", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 395 {
-		t.Fatalf("definition count = %d, want 395", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 397 {
+		t.Fatalf("definition count = %d, want 397", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -319,6 +319,8 @@ func wireSchemaDefinitions() Schema {
 		{Name: "ExternalAgentConfigDetectResponse", Type: reflect.TypeFor[ExternalAgentConfigDetectResponse]()},
 		{Name: "ExternalAgentConfigImportParams", Type: reflect.TypeFor[ExternalAgentConfigImportParams]()},
 		{Name: "ExternalAgentConfigImportResponse", Type: reflect.TypeFor[ExternalAgentConfigImportResponse]()},
+		{Name: "ExternalAgentConfigImportItemTypeFailure", Type: reflect.TypeFor[ExternalAgentConfigImportItemTypeFailure]()},
+		{Name: "ExternalAgentConfigImportItemTypeSuccess", Type: reflect.TypeFor[ExternalAgentConfigImportItemTypeSuccess]()},
 		{Name: "PermissionGrantScope", Type: reflect.TypeFor[PermissionGrantScope]()},
 		{Name: "PermissionsApprovalRequestParams", Type: reflect.TypeFor[PermissionsApprovalRequestParams]()},
 		{Name: "PermissionsRequestApprovalParams", Type: reflect.TypeFor[PermissionsRequestApprovalParams]()},
@@ -571,6 +573,8 @@ func wireSchemaDefinitions() Schema {
 	schemas["ExternalAgentConfigDetectResponse"] = externalAgentConfigDetectResponseSchema()
 	schemas["ExternalAgentConfigImportParams"] = externalAgentConfigImportParamsSchema()
 	schemas["ExternalAgentConfigImportResponse"] = externalAgentConfigImportResponseSchema()
+	schemas["ExternalAgentConfigImportItemTypeFailure"] = externalAgentConfigImportItemTypeFailureSchema()
+	schemas["ExternalAgentConfigImportItemTypeSuccess"] = externalAgentConfigImportItemTypeSuccessSchema()
 	schemas["McpServerToolCallParams"] = mcpServerToolCallParamsSchema()
 	schemas["McpServerToolCallResponse"] = mcpServerToolCallResponseSchema()
 	schemas["ResourceContent"] = resourceContentSchema()

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -3176,6 +3176,98 @@
       ],
       "type": "object"
     },
+    "ExternalAgentConfigImportItemTypeFailure": {
+      "additionalProperties": false,
+      "properties": {
+        "cwd": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "errorType": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "failureStage": {
+          "type": "string"
+        },
+        "itemType": {
+          "$ref": "#/$defs/ExternalAgentConfigMigrationItemType"
+        },
+        "message": {
+          "type": "string"
+        },
+        "source": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "itemType",
+        "failureStage",
+        "message"
+      ],
+      "type": "object"
+    },
+    "ExternalAgentConfigImportItemTypeSuccess": {
+      "additionalProperties": false,
+      "properties": {
+        "cwd": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "itemType": {
+          "$ref": "#/$defs/ExternalAgentConfigMigrationItemType"
+        },
+        "source": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "target": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "itemType"
+      ],
+      "type": "object"
+    },
     "ExternalAgentConfigImportParams": {
       "additionalProperties": false,
       "properties": {

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 395 {
-		t.Fatalf("definition count = %d, want 395", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 397 {
+		t.Fatalf("definition count = %d, want 397", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 395 {
-		t.Fatalf("definition count = %d, want 395", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 397 {
+		t.Fatalf("definition count = %d, want 397", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 395 {
-		t.Fatalf("definition count = %d, want 395", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 397 {
+		t.Fatalf("definition count = %d, want 397", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -37,7 +37,9 @@ func MarshalTypeScript() ([]byte, error) {
 	sort.Strings(names)
 	for _, name := range names {
 		definition := defs[name]
-		if name == "MigrationDetails" || name == "ExternalAgentConfigMigrationItem" {
+		if name == "MigrationDetails" || name == "ExternalAgentConfigMigrationItem" ||
+			name == "ExternalAgentConfigImportItemTypeFailure" ||
+			name == "ExternalAgentConfigImportItemTypeSuccess" {
 			// Rust accepts omitted serde default/Option fields while generated
 			// TypeScript requires callers to provide their canonical values.
 			schema, _ := typeScriptSchema(definition)
@@ -46,12 +48,19 @@ func MarshalTypeScript() ([]byte, error) {
 				renderSchema[key] = value
 			}
 			schema = renderSchema
-			if name == "MigrationDetails" {
+			switch name {
+			case "MigrationDetails":
 				schema["required"] = []string{
 					"plugins", "skills", "sessions", "mcpServers", "hooks", "subagents", "commands",
 				}
-			} else {
+			case "ExternalAgentConfigMigrationItem":
 				schema["required"] = []string{"itemType", "description", "cwd", "details"}
+			case "ExternalAgentConfigImportItemTypeFailure":
+				schema["required"] = []string{
+					"itemType", "errorType", "failureStage", "message", "cwd", "source",
+				}
+			case "ExternalAgentConfigImportItemTypeSuccess":
+				schema["required"] = []string{"itemType", "cwd", "source", "target"}
 			}
 			definition = schema
 		}

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -1130,6 +1130,22 @@ export type ExternalAgentConfigDetectResponse = {
   "items": Array<ExternalAgentConfigMigrationItem>;
 };
 
+export type ExternalAgentConfigImportItemTypeFailure = {
+  "cwd": string | null;
+  "errorType": string | null;
+  "failureStage": string;
+  "itemType": ExternalAgentConfigMigrationItemType;
+  "message": string;
+  "source": string | null;
+};
+
+export type ExternalAgentConfigImportItemTypeSuccess = {
+  "cwd": string | null;
+  "itemType": ExternalAgentConfigMigrationItemType;
+  "source": string | null;
+  "target": string | null;
+};
+
 export type ExternalAgentConfigImportParams = {
   "migrationItems": Array<ExternalAgentConfigMigrationItem>;
   "source"?: string | null;

--- a/appserver/protocol/typescript/testdata/external_agent_config_import_item_result_contract.ts
+++ b/appserver/protocol/typescript/testdata/external_agent_config_import_item_result_contract.ts
@@ -1,0 +1,97 @@
+import type {
+  ExternalAgentConfigImportItemTypeFailure,
+  ExternalAgentConfigImportItemTypeSuccess,
+  ExternalAgentConfigMigrationItemType,
+  MethodParamsByName,
+  MethodResultsByName,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+
+type Contracts = [
+  Expect<Equal<ExternalAgentConfigImportItemTypeSuccess, {
+    itemType: ExternalAgentConfigMigrationItemType;
+    cwd: string | null;
+    source: string | null;
+    target: string | null;
+  }>>,
+  Expect<Equal<ExternalAgentConfigImportItemTypeFailure, {
+    itemType: ExternalAgentConfigMigrationItemType;
+    errorType: string | null;
+    failureStage: string;
+    message: string;
+    cwd: string | null;
+    source: string | null;
+  }>>,
+  Expect<Equal<"externalAgentConfig/import" extends keyof MethodParamsByName ? true : false, false>>,
+  Expect<Equal<"externalAgentConfig/import" extends keyof MethodResultsByName ? true : false, false>>,
+  Expect<Equal<"externalAgentConfig/import/readHistories" extends keyof MethodParamsByName ? true : false, false>>,
+  Expect<Equal<"externalAgentConfig/import/readHistories" extends keyof MethodResultsByName ? true : false, false>>,
+];
+
+export const success = {
+  itemType: "CONFIG",
+  cwd: null,
+  source: " Claude Code ",
+  target: "",
+} satisfies ExternalAgentConfigImportItemTypeSuccess;
+
+export const failure = {
+  itemType: "HOOKS",
+  errorType: null,
+  failureStage: "",
+  message: "",
+  cwd: "repo/../repo",
+  source: null,
+} satisfies ExternalAgentConfigImportItemTypeFailure;
+
+// @ts-expect-error itemType is required.
+export const rejectSuccessMissingItemType = { cwd: null, source: null, target: null } satisfies ExternalAgentConfigImportItemTypeSuccess;
+// @ts-expect-error cwd remains required-nullable in generated TypeScript.
+export const rejectSuccessMissingCwd = { itemType: "CONFIG", source: null, target: null } satisfies ExternalAgentConfigImportItemTypeSuccess;
+// @ts-expect-error source remains required-nullable in generated TypeScript.
+export const rejectSuccessMissingSource = { itemType: "CONFIG", cwd: null, target: null } satisfies ExternalAgentConfigImportItemTypeSuccess;
+// @ts-expect-error target remains required-nullable in generated TypeScript.
+export const rejectSuccessMissingTarget = { itemType: "CONFIG", cwd: null, source: null } satisfies ExternalAgentConfigImportItemTypeSuccess;
+// @ts-expect-error itemType is closed.
+export const rejectSuccessUnknownItemType = { ...success, itemType: "OTHER" } satisfies ExternalAgentConfigImportItemTypeSuccess;
+// @ts-expect-error cwd is a nullable string.
+export const rejectSuccessNumericCwd = { ...success, cwd: 1 } satisfies ExternalAgentConfigImportItemTypeSuccess;
+// @ts-expect-error source is a nullable string.
+export const rejectSuccessNumericSource = { ...success, source: 1 } satisfies ExternalAgentConfigImportItemTypeSuccess;
+// @ts-expect-error target is a nullable string.
+export const rejectSuccessNumericTarget = { ...success, target: 1 } satisfies ExternalAgentConfigImportItemTypeSuccess;
+// @ts-expect-error snake-case aliases do not replace canonical fields.
+export const rejectSuccessSnakeAlias = { item_type: "CONFIG", cwd: null, source: null, target: null } satisfies ExternalAgentConfigImportItemTypeSuccess;
+// @ts-expect-error fields absent from the public record are rejected.
+export const rejectSuccessExtra = { ...success, extra: true } satisfies ExternalAgentConfigImportItemTypeSuccess;
+
+// @ts-expect-error itemType is required.
+export const rejectFailureMissingItemType = { ...failure, itemType: undefined } satisfies ExternalAgentConfigImportItemTypeFailure;
+// @ts-expect-error failureStage is required.
+export const rejectFailureMissingStage = { itemType: "CONFIG", errorType: null, message: "x", cwd: null, source: null } satisfies ExternalAgentConfigImportItemTypeFailure;
+// @ts-expect-error message is required.
+export const rejectFailureMissingMessage = { itemType: "CONFIG", errorType: null, failureStage: "x", cwd: null, source: null } satisfies ExternalAgentConfigImportItemTypeFailure;
+// @ts-expect-error errorType remains required-nullable in generated TypeScript.
+export const rejectFailureMissingErrorType = { itemType: "CONFIG", failureStage: "x", message: "x", cwd: null, source: null } satisfies ExternalAgentConfigImportItemTypeFailure;
+// @ts-expect-error cwd remains required-nullable in generated TypeScript.
+export const rejectFailureMissingCwd = { itemType: "CONFIG", errorType: null, failureStage: "x", message: "x", source: null } satisfies ExternalAgentConfigImportItemTypeFailure;
+// @ts-expect-error source remains required-nullable in generated TypeScript.
+export const rejectFailureMissingSource = { itemType: "CONFIG", errorType: null, failureStage: "x", message: "x", cwd: null } satisfies ExternalAgentConfigImportItemTypeFailure;
+// @ts-expect-error failureStage is non-null.
+export const rejectFailureNullStage = { ...failure, failureStage: null } satisfies ExternalAgentConfigImportItemTypeFailure;
+// @ts-expect-error message is non-null.
+export const rejectFailureNullMessage = { ...failure, message: null } satisfies ExternalAgentConfigImportItemTypeFailure;
+// @ts-expect-error itemType is closed.
+export const rejectFailureUnknownItemType = { ...failure, itemType: "OTHER" } satisfies ExternalAgentConfigImportItemTypeFailure;
+// @ts-expect-error errorType is a nullable string.
+export const rejectFailureNumericErrorType = { ...failure, errorType: 1 } satisfies ExternalAgentConfigImportItemTypeFailure;
+// @ts-expect-error fields absent from the public record are rejected.
+export const rejectFailureExtra = { ...failure, extra: true } satisfies ExternalAgentConfigImportItemTypeFailure;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 395 {
-		t.Fatalf("definition count = %d, want 395", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
+		t.Fatalf("definition count = %d, want 397", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- export exact standalone `ExternalAgentConfigImportItemTypeSuccess` and `ExternalAgentConfigImportItemTypeFailure` codecs and schemas
- preserve Rust input-optional/output-explicit-null option semantics and exact required-nullable generated TypeScript contracts
- keep import methods, history reads, progress/completion notifications, item bindings, and runtime behavior deferred and unbound

## Verification
- deliberate-red Go and strict TypeScript boundaries
- focused tests x30, focused race, and 100% statement coverage for all six new functions
- full protocol normal/race
- all 59 non-Monty packages under fresh serialized normal and configured race gates; documented runtime interrupt flake passed 10/10 isolated before the serialized suite passed
- golangci-lint (0 issues), vet, tidy/verify, configured pre-push and push-time hook
- deterministic 397-definition / 59-method / 5-item generation and strict TypeScript
- exact pinned Codex normalized schema and TypeScript semantic parity
- structural reversal to exact PR #189 tree `fa5a25fceaac57722cc5ed887bc92e899d1160f3`
- all five existing Slang workflows against reproducible binary SHA-256 `050598f3f845fe25198de77fff86c3a99c67ead3f3539d59f83f07a293925844`
- baseline/feature/committed transcript identity: 37,895 bytes, SHA-256 `71c2cac1626d7c888b941222a8e8d466c86796b4d0459aac6332f0d834df8ee9`, empty stderr

Local Monty normal/race/coverage was skipped per standing direction; hosted checks are unchanged.