### PR TITLE
feat(appserver): export external-agent import type result

### DIFF
--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(defs); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,8 +217,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,8 +203,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,8 +244,8 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -1,0 +1,207 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestExternalAgentConfigImportTypeResultSchemaIsExact(t *testing.T) {
+	want := closedThreadSessionParamSchema(Schema{
+		"itemType": Schema{"$ref": "#/$defs/ExternalAgentConfigMigrationItemType"},
+		"successes": Schema{
+			"type": "array", "items": Schema{"$ref": "#/$defs/ExternalAgentConfigImportItemTypeSuccess"},
+		},
+		"failures": Schema{
+			"type": "array", "items": Schema{"$ref": "#/$defs/ExternalAgentConfigImportItemTypeFailure"},
+		},
+	}, []string{"itemType", "successes", "failures"})
+	got, ok := JSONSchema()["$defs"].(Schema)["ExternalAgentConfigImportTypeResult"].(Schema)
+	if !ok || !reflect.DeepEqual(got, want) {
+		t.Fatalf("ExternalAgentConfigImportTypeResult schema = %#v, %v; want %#v", got, ok, want)
+	}
+}
+
+func TestExternalAgentConfigImportTypeResultAcceptsRustWireForms(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     string
+		want      ExternalAgentConfigImportTypeResult
+		canonical string
+	}{
+		{
+			name: "empty arrays and unknown", input: `{"itemType":"CONFIG","successes":[],"failures":[],"future":true}`,
+			want: ExternalAgentConfigImportTypeResult{
+				ItemType:  ExternalAgentConfigMigrationItemTypeConfig,
+				Successes: []ExternalAgentConfigImportItemTypeSuccess{},
+				Failures:  []ExternalAgentConfigImportItemTypeFailure{},
+			},
+			canonical: `{"itemType":"CONFIG","successes":[],"failures":[]}`,
+		},
+		{
+			name: "ordered duplicate strict results",
+			input: `{"itemType":"HOOKS","successes":[` +
+				`{"itemType":"CONFIG"},` +
+				`{"itemType":"SKILLS","cwd":"repo/../repo","source":" Claude Code ","target":""},` +
+				`{"itemType":"CONFIG"}` +
+				`],"failures":[` +
+				`{"itemType":"HOOKS","failureStage":"","message":""},` +
+				`{"itemType":"SESSIONS","errorType":" IO ","failureStage":" import ","message":" failed ","cwd":"/tmp/../repo","source":""},` +
+				`{"itemType":"HOOKS","failureStage":"","message":""}` +
+				`]}`,
+			want: ExternalAgentConfigImportTypeResult{
+				ItemType: ExternalAgentConfigMigrationItemTypeHooks,
+				Successes: []ExternalAgentConfigImportItemTypeSuccess{
+					{ItemType: ExternalAgentConfigMigrationItemTypeConfig},
+					{
+						ItemType: ExternalAgentConfigMigrationItemTypeSkills,
+						CWD:      stringPointer("repo/../repo"), Source: stringPointer(" Claude Code "), Target: stringPointer(""),
+					},
+					{ItemType: ExternalAgentConfigMigrationItemTypeConfig},
+				},
+				Failures: []ExternalAgentConfigImportItemTypeFailure{
+					{ItemType: ExternalAgentConfigMigrationItemTypeHooks},
+					{
+						ItemType:  ExternalAgentConfigMigrationItemTypeSessions,
+						ErrorType: stringPointer(" IO "), FailureStage: " import ", Message: " failed ",
+						CWD: stringPointer("/tmp/../repo"), Source: stringPointer(""),
+					},
+					{ItemType: ExternalAgentConfigMigrationItemTypeHooks},
+				},
+			},
+			canonical: `{"itemType":"HOOKS","successes":[` +
+				`{"itemType":"CONFIG","cwd":null,"source":null,"target":null},` +
+				`{"itemType":"SKILLS","cwd":"repo/../repo","source":" Claude Code ","target":""},` +
+				`{"itemType":"CONFIG","cwd":null,"source":null,"target":null}` +
+				`],"failures":[` +
+				`{"itemType":"HOOKS","errorType":null,"failureStage":"","message":"","cwd":null,"source":null},` +
+				`{"itemType":"SESSIONS","errorType":" IO ","failureStage":" import ","message":" failed ","cwd":"/tmp/../repo","source":""},` +
+				`{"itemType":"HOOKS","errorType":null,"failureStage":"","message":"","cwd":null,"source":null}` +
+				`]}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var result ExternalAgentConfigImportTypeResult
+			if err := json.Unmarshal([]byte(tc.input), &result); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			if !reflect.DeepEqual(result, tc.want) {
+				t.Fatalf("result = %#v, want %#v", result, tc.want)
+			}
+			encoded, err := json.Marshal(result)
+			if err != nil || string(encoded) != tc.canonical {
+				t.Fatalf("canonical = %s, %v; want %s", encoded, err, tc.canonical)
+			}
+			var roundTrip ExternalAgentConfigImportTypeResult
+			if err := json.Unmarshal(encoded, &roundTrip); err != nil || !reflect.DeepEqual(roundTrip, result) {
+				t.Fatalf("round trip = %#v, %v; want %#v", roundTrip, err, result)
+			}
+		})
+	}
+
+	encoded, err := json.Marshal(ExternalAgentConfigImportTypeResult{
+		ItemType: ExternalAgentConfigMigrationItemTypeConfig,
+	})
+	if err != nil || string(encoded) != `{"itemType":"CONFIG","successes":[],"failures":[]}` {
+		t.Fatalf("nil slices = %s, %v; want non-null empty arrays", encoded, err)
+	}
+}
+
+func TestExternalAgentConfigImportTypeResultRejectsMalformedWireForms(t *testing.T) {
+	invalid := []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{}`,
+		`{"itemType":null,"successes":[],"failures":[]}`,
+		`{"itemType":"OTHER","successes":[],"failures":[]}`,
+		`{"itemType":"CONFIG","failures":[]}`,
+		`{"itemType":"CONFIG","successes":[]}`,
+		`{"itemType":"CONFIG","successes":null,"failures":[]}`,
+		`{"itemType":"CONFIG","successes":[],"failures":null}`,
+		`{"itemType":"CONFIG","successes":{},"failures":[]}`,
+		`{"itemType":"CONFIG","successes":[],"failures":"failures"}`,
+		`{"itemType":"CONFIG","successes":[null],"failures":[]}`,
+		`{"itemType":"CONFIG","successes":[{}],"failures":[]}`,
+		`{"itemType":"CONFIG","successes":[{"itemType":"OTHER"}],"failures":[]}`,
+		`{"itemType":"CONFIG","successes":[{"itemType":"CONFIG","cwd":1}],"failures":[]}`,
+		`{"itemType":"CONFIG","successes":[],"failures":[null]}`,
+		`{"itemType":"CONFIG","successes":[],"failures":[{}]}`,
+		`{"itemType":"CONFIG","successes":[],"failures":[{"itemType":"HOOKS","message":"missing stage"}]}`,
+		`{"itemType":"CONFIG","successes":[],"failures":[{"itemType":"HOOKS","failureStage":"x","message":null}]}`,
+		`{"itemType":"CONFIG","itemType":"SKILLS","successes":[],"failures":[]}`,
+		`{"itemType":"CONFIG","successes":[],"successes":[],"failures":[]}`,
+		`{"itemType":"CONFIG","successes":[],"failures":[],"failures":[]}`,
+		`{"itemType":"CONFIG","successes":[],"failures":[]`,
+		`{"itemType":"CONFIG","successes":[],"failures":[]} {}`,
+	}
+	for _, input := range invalid {
+		var result ExternalAgentConfigImportTypeResult
+		if err := json.Unmarshal([]byte(input), &result); err == nil {
+			t.Errorf("Unmarshal(%s) succeeded", input)
+		}
+	}
+
+	var result *ExternalAgentConfigImportTypeResult
+	if err := result.UnmarshalJSON([]byte(`{"itemType":"CONFIG","successes":[],"failures":[]}`)); err == nil {
+		t.Fatal("nil ExternalAgentConfigImportTypeResult receiver succeeded")
+	}
+	if _, err := json.Marshal(ExternalAgentConfigImportTypeResult{}); err == nil {
+		t.Fatal("invalid zero result marshaled")
+	}
+	if _, err := json.Marshal(ExternalAgentConfigImportTypeResult{
+		ItemType:  ExternalAgentConfigMigrationItemTypeConfig,
+		Successes: []ExternalAgentConfigImportItemTypeSuccess{{}},
+	}); err == nil {
+		t.Fatal("invalid nested success marshaled")
+	}
+}
+
+func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
+	const name = "ExternalAgentConfigImportTypeResult"
+	for _, binding := range WireTypeBindings() {
+		if slices.Contains(binding.Params, name) || slices.Contains(binding.Result, name) {
+			t.Fatalf("%s unexpectedly bound: %#v", name, binding)
+		}
+	}
+	for _, method := range []string{
+		"externalAgentConfig/import",
+		"externalAgentConfig/import/readHistories",
+		"externalAgentConfig/import/progress",
+		"externalAgentConfig/import/completed",
+	} {
+		info, ok := LookupMethod(method)
+		if !ok || info.State != MethodDeferredStub {
+			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestExternalAgentConfigImportTypeResultTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	want := "export type ExternalAgentConfigImportTypeResult = {\n" +
+		"  \"failures\": Array<ExternalAgentConfigImportItemTypeFailure>;\n" +
+		"  \"itemType\": ExternalAgentConfigMigrationItemType;\n" +
+		"  \"successes\": Array<ExternalAgentConfigImportItemTypeSuccess>;\n" +
+		"};"
+	if !strings.Contains(string(generated), want) {
+		t.Fatalf("generated TypeScript missing %q", want)
+	}
+}
+
+var (
+	_ json.Marshaler   = ExternalAgentConfigImportTypeResult{}
+	_ json.Unmarshaler = (*ExternalAgentConfigImportTypeResult)(nil)
+)

--- a/appserver/protocol/external_agent_config_import_type_result_types.go
+++ b/appserver/protocol/external_agent_config_import_type_result_types.go
@@ -1,0 +1,78 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// ExternalAgentConfigImportTypeResult is an exact standalone result summary.
+// Its nested records describe outcomes without proving that an import ran.
+type ExternalAgentConfigImportTypeResult struct {
+	ItemType  ExternalAgentConfigMigrationItemType       `json:"itemType"`
+	Successes []ExternalAgentConfigImportItemTypeSuccess `json:"successes"`
+	Failures  []ExternalAgentConfigImportItemTypeFailure `json:"failures"`
+}
+
+func (r ExternalAgentConfigImportTypeResult) MarshalJSON() ([]byte, error) {
+	successes := r.Successes
+	if successes == nil {
+		successes = []ExternalAgentConfigImportItemTypeSuccess{}
+	}
+	failures := r.Failures
+	if failures == nil {
+		failures = []ExternalAgentConfigImportItemTypeFailure{}
+	}
+	return json.Marshal(struct {
+		ItemType  ExternalAgentConfigMigrationItemType       `json:"itemType"`
+		Successes []ExternalAgentConfigImportItemTypeSuccess `json:"successes"`
+		Failures  []ExternalAgentConfigImportItemTypeFailure `json:"failures"`
+	}{ItemType: r.ItemType, Successes: successes, Failures: failures})
+}
+
+func (r *ExternalAgentConfigImportTypeResult) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("decode external-agent config import type result into nil receiver")
+	}
+	const objectName = "external-agent config import type result"
+	payload, err := decodeExternalAgentConfigObject(data, objectName, "itemType", "successes", "failures")
+	if err != nil {
+		return err
+	}
+	itemType, err := decodeRequiredThreadItemValue[ExternalAgentConfigMigrationItemType](payload, objectName, "itemType")
+	if err != nil {
+		return err
+	}
+	successes, err := decodeRequiredThreadItemArray[ExternalAgentConfigImportItemTypeSuccess](
+		payload, objectName, "successes",
+	)
+	if err != nil {
+		return err
+	}
+	failures, err := decodeRequiredThreadItemArray[ExternalAgentConfigImportItemTypeFailure](
+		payload, objectName, "failures",
+	)
+	if err != nil {
+		return err
+	}
+	*r = ExternalAgentConfigImportTypeResult{
+		ItemType: itemType, Successes: successes, Failures: failures,
+	}
+	return nil
+}
+
+func externalAgentConfigImportTypeResultSchema() Schema {
+	return closedThreadSessionParamSchema(Schema{
+		"itemType": Schema{"$ref": "#/$defs/ExternalAgentConfigMigrationItemType"},
+		"successes": Schema{
+			"type": "array", "items": Schema{"$ref": "#/$defs/ExternalAgentConfigImportItemTypeSuccess"},
+		},
+		"failures": Schema{
+			"type": "array", "items": Schema{"$ref": "#/$defs/ExternalAgentConfigImportItemTypeFailure"},
+		},
+	}, []string{"itemType", "successes", "failures"})
+}
+
+var (
+	_ json.Marshaler   = ExternalAgentConfigImportTypeResult{}
+	_ json.Unmarshaler = (*ExternalAgentConfigImportTypeResult)(nil)
+)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 397 {
-		t.Fatalf("definition count = %d, want 397", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 398 {
+		t.Fatalf("definition count = %d, want 398", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 397 {
-		t.Fatalf("definition count = %d, want 397", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 398 {
+		t.Fatalf("definition count = %d, want 398", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 397 {
-		t.Fatalf("definition count = %d, want 397", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 398 {
+		t.Fatalf("definition count = %d, want 398", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 397 {
-		t.Fatalf("definition count = %d, want 397", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 398 {
+		t.Fatalf("definition count = %d, want 398", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 397 {
-		t.Fatalf("definition count = %d, want 397", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 398 {
+		t.Fatalf("definition count = %d, want 398", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 397 {
-		t.Fatalf("definition count = %d, want 397", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 398 {
+		t.Fatalf("definition count = %d, want 398", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -321,6 +321,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "ExternalAgentConfigImportResponse", Type: reflect.TypeFor[ExternalAgentConfigImportResponse]()},
 		{Name: "ExternalAgentConfigImportItemTypeFailure", Type: reflect.TypeFor[ExternalAgentConfigImportItemTypeFailure]()},
 		{Name: "ExternalAgentConfigImportItemTypeSuccess", Type: reflect.TypeFor[ExternalAgentConfigImportItemTypeSuccess]()},
+		{Name: "ExternalAgentConfigImportTypeResult", Type: reflect.TypeFor[ExternalAgentConfigImportTypeResult]()},
 		{Name: "PermissionGrantScope", Type: reflect.TypeFor[PermissionGrantScope]()},
 		{Name: "PermissionsApprovalRequestParams", Type: reflect.TypeFor[PermissionsApprovalRequestParams]()},
 		{Name: "PermissionsRequestApprovalParams", Type: reflect.TypeFor[PermissionsRequestApprovalParams]()},
@@ -575,6 +576,7 @@ func wireSchemaDefinitions() Schema {
 	schemas["ExternalAgentConfigImportResponse"] = externalAgentConfigImportResponseSchema()
 	schemas["ExternalAgentConfigImportItemTypeFailure"] = externalAgentConfigImportItemTypeFailureSchema()
 	schemas["ExternalAgentConfigImportItemTypeSuccess"] = externalAgentConfigImportItemTypeSuccessSchema()
+	schemas["ExternalAgentConfigImportTypeResult"] = externalAgentConfigImportTypeResultSchema()
 	schemas["McpServerToolCallParams"] = mcpServerToolCallParamsSchema()
 	schemas["McpServerToolCallResponse"] = mcpServerToolCallResponseSchema()
 	schemas["ResourceContent"] = resourceContentSchema()

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -3306,6 +3306,32 @@
       ],
       "type": "object"
     },
+    "ExternalAgentConfigImportTypeResult": {
+      "additionalProperties": false,
+      "properties": {
+        "failures": {
+          "items": {
+            "$ref": "#/$defs/ExternalAgentConfigImportItemTypeFailure"
+          },
+          "type": "array"
+        },
+        "itemType": {
+          "$ref": "#/$defs/ExternalAgentConfigMigrationItemType"
+        },
+        "successes": {
+          "items": {
+            "$ref": "#/$defs/ExternalAgentConfigImportItemTypeSuccess"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "itemType",
+        "successes",
+        "failures"
+      ],
+      "type": "object"
+    },
     "ExternalAgentConfigMigrationItem": {
       "additionalProperties": false,
       "properties": {

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 397 {
-		t.Fatalf("definition count = %d, want 397", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 398 {
+		t.Fatalf("definition count = %d, want 398", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 397 {
-		t.Fatalf("definition count = %d, want 397", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 398 {
+		t.Fatalf("definition count = %d, want 398", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 397 {
-		t.Fatalf("definition count = %d, want 397", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 398 {
+		t.Fatalf("definition count = %d, want 398", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -1155,6 +1155,12 @@ export type ExternalAgentConfigImportResponse = {
   "importId": string;
 };
 
+export type ExternalAgentConfigImportTypeResult = {
+  "failures": Array<ExternalAgentConfigImportItemTypeFailure>;
+  "itemType": ExternalAgentConfigMigrationItemType;
+  "successes": Array<ExternalAgentConfigImportItemTypeSuccess>;
+};
+
 export type ExternalAgentConfigMigrationItem = {
   "cwd": string | null;
   "description": string;

--- a/appserver/protocol/typescript/testdata/external_agent_config_import_type_result_contract.ts
+++ b/appserver/protocol/typescript/testdata/external_agent_config_import_type_result_contract.ts
@@ -1,0 +1,75 @@
+import type {
+  ExternalAgentConfigImportItemTypeFailure,
+  ExternalAgentConfigImportItemTypeSuccess,
+  ExternalAgentConfigImportTypeResult,
+  ExternalAgentConfigMigrationItemType,
+  MethodParamsByName,
+  MethodResultsByName,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+
+type Contracts = [
+  Expect<Equal<ExternalAgentConfigImportTypeResult, {
+    itemType: ExternalAgentConfigMigrationItemType;
+    successes: Array<ExternalAgentConfigImportItemTypeSuccess>;
+    failures: Array<ExternalAgentConfigImportItemTypeFailure>;
+  }>>,
+  Expect<Equal<"externalAgentConfig/import" extends keyof MethodParamsByName ? true : false, false>>,
+  Expect<Equal<"externalAgentConfig/import" extends keyof MethodResultsByName ? true : false, false>>,
+  Expect<Equal<"externalAgentConfig/import/readHistories" extends keyof MethodParamsByName ? true : false, false>>,
+  Expect<Equal<"externalAgentConfig/import/readHistories" extends keyof MethodResultsByName ? true : false, false>>,
+];
+
+export const empty = {
+  itemType: "CONFIG",
+  successes: [],
+  failures: [],
+} satisfies ExternalAgentConfigImportTypeResult;
+
+export const orderedDuplicates = {
+  itemType: "HOOKS",
+  successes: [
+    { itemType: "CONFIG", cwd: null, source: null, target: null },
+    { itemType: "SKILLS", cwd: "repo/../repo", source: " Claude Code ", target: "" },
+    { itemType: "CONFIG", cwd: null, source: null, target: null },
+  ],
+  failures: [
+    { itemType: "HOOKS", errorType: null, failureStage: "", message: "", cwd: null, source: null },
+    { itemType: "HOOKS", errorType: null, failureStage: "", message: "", cwd: null, source: null },
+  ],
+} satisfies ExternalAgentConfigImportTypeResult;
+
+// @ts-expect-error itemType is required.
+export const rejectMissingItemType = { successes: [], failures: [] } satisfies ExternalAgentConfigImportTypeResult;
+// @ts-expect-error successes is required.
+export const rejectMissingSuccesses = { itemType: "CONFIG", failures: [] } satisfies ExternalAgentConfigImportTypeResult;
+// @ts-expect-error failures is required.
+export const rejectMissingFailures = { itemType: "CONFIG", successes: [] } satisfies ExternalAgentConfigImportTypeResult;
+// @ts-expect-error itemType is non-null.
+export const rejectNullItemType = { ...empty, itemType: null } satisfies ExternalAgentConfigImportTypeResult;
+// @ts-expect-error itemType is closed.
+export const rejectUnknownItemType = { ...empty, itemType: "OTHER" } satisfies ExternalAgentConfigImportTypeResult;
+// @ts-expect-error successes is non-null.
+export const rejectNullSuccesses = { ...empty, successes: null } satisfies ExternalAgentConfigImportTypeResult;
+// @ts-expect-error failures is non-null.
+export const rejectNullFailures = { ...empty, failures: null } satisfies ExternalAgentConfigImportTypeResult;
+// @ts-expect-error successes must be an array.
+export const rejectObjectSuccesses = { ...empty, successes: {} } satisfies ExternalAgentConfigImportTypeResult;
+// @ts-expect-error failures must be an array.
+export const rejectStringFailures = { ...empty, failures: "failures" } satisfies ExternalAgentConfigImportTypeResult;
+// @ts-expect-error nested success retains required target.
+export const rejectInvalidSuccess = { ...empty, successes: [{ itemType: "CONFIG", cwd: null, source: null }] } satisfies ExternalAgentConfigImportTypeResult;
+// @ts-expect-error nested failure retains required failureStage.
+export const rejectInvalidFailure = { ...empty, failures: [{ itemType: "HOOKS", errorType: null, message: "x", cwd: null, source: null }] } satisfies ExternalAgentConfigImportTypeResult;
+// @ts-expect-error snake-case aliases do not replace canonical fields.
+export const rejectSnakeAlias = { item_type: "CONFIG", successes: [], failures: [] } satisfies ExternalAgentConfigImportTypeResult;
+// @ts-expect-error fields absent from the public record are rejected.
+export const rejectExtra = { ...empty, extra: true } satisfies ExternalAgentConfigImportTypeResult;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 397 {
-		t.Fatalf("definition count = %d, want 397", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
+		t.Fatalf("definition count = %d, want 398", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- export exact standalone `ExternalAgentConfigImportTypeResult` over the already exported strict success/failure leaves
- preserve required non-null arrays, order/duplicates, and Rust-compatible nil-to-empty canonical output
- keep import/history methods, progress/completion notifications, item bindings, and runtime behavior unchanged

## Verification
- deliberate red: missing Go symbol; missing TypeScript export, false exact identity, 13 unused negative directives
- focused x30, focused race, and 100% statement coverage for all three new production functions
- full protocol plus fresh normal/race across all 59 non-Monty packages
- `golangci-lint` (0 issues), `go vet ./...`, tidy verification, deterministic generation, strict TypeScript
- configured pre-push and push-time hooks
- exact pinned Codex schema and TypeScript semantic parity
- exact structural reversal to PR #190 tree
- reproducible binary SHA-256 `8ab7f08452a362a84a774d6adb453056741725b07a1690d302d83db1a9a28924`
- all five Slang transport workflows and byte-identical baseline/feature live transcript

Local Monty normal/race/coverage tests remain skipped per standing direction; hosted CI is unchanged.