### PR TITLE
feat(appserver): export external-agent import notifications

### DIFF
--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(defs); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,8 +217,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,8 +203,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,8 +244,8 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -1,0 +1,200 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestExternalAgentConfigImportNotificationSchemasAreExact(t *testing.T) {
+	want := closedThreadSessionParamSchema(Schema{
+		"importId": Schema{"type": "string"},
+		"itemTypeResults": Schema{
+			"type": "array", "items": Schema{"$ref": "#/$defs/ExternalAgentConfigImportTypeResult"},
+		},
+	}, []string{"importId", "itemTypeResults"})
+	for _, name := range []string{
+		"ExternalAgentConfigImportProgressNotification",
+		"ExternalAgentConfigImportCompletedNotification",
+	} {
+		got, ok := JSONSchema()["$defs"].(Schema)[name].(Schema)
+		if !ok || !reflect.DeepEqual(got, want) {
+			t.Errorf("%s schema = %#v, %v; want %#v", name, got, ok, want)
+		}
+	}
+}
+
+func TestExternalAgentConfigImportNotificationsAcceptRustWireForms(t *testing.T) {
+	inputs := []struct {
+		name      string
+		input     string
+		canonical string
+	}{
+		{
+			name:      "empty values and unknown",
+			input:     `{"importId":"","itemTypeResults":[],"future":true}`,
+			canonical: `{"importId":"","itemTypeResults":[]}`,
+		},
+		{
+			name: "ordered duplicate strict results",
+			input: `{"importId":" import-1 ","itemTypeResults":[` +
+				`{"itemType":"CONFIG","successes":[],"failures":[]},` +
+				`{"itemType":"HOOKS","successes":[{"itemType":"SKILLS","cwd":"repo/../repo","source":" Claude Code ","target":""}],"failures":[{"itemType":"HOOKS","failureStage":"","message":""}]},` +
+				`{"itemType":"CONFIG","successes":[],"failures":[]}` +
+				`]}`,
+			canonical: `{"importId":" import-1 ","itemTypeResults":[` +
+				`{"itemType":"CONFIG","successes":[],"failures":[]},` +
+				`{"itemType":"HOOKS","successes":[{"itemType":"SKILLS","cwd":"repo/../repo","source":" Claude Code ","target":""}],"failures":[{"itemType":"HOOKS","errorType":null,"failureStage":"","message":"","cwd":null,"source":null}]},` +
+				`{"itemType":"CONFIG","successes":[],"failures":[]}` +
+				`]}`,
+		},
+	}
+
+	for _, tc := range inputs {
+		t.Run(tc.name+"/progress", func(t *testing.T) {
+			var got ExternalAgentConfigImportProgressNotification
+			assertExternalAgentConfigImportNotificationRoundTrip(t, tc.input, tc.canonical, &got)
+		})
+		t.Run(tc.name+"/completed", func(t *testing.T) {
+			var got ExternalAgentConfigImportCompletedNotification
+			assertExternalAgentConfigImportNotificationRoundTrip(t, tc.input, tc.canonical, &got)
+		})
+	}
+
+	progress, err := json.Marshal(ExternalAgentConfigImportProgressNotification{})
+	if err != nil || string(progress) != `{"importId":"","itemTypeResults":[]}` {
+		t.Fatalf("progress nil slice = %s, %v; want non-null empty array", progress, err)
+	}
+	completed, err := json.Marshal(ExternalAgentConfigImportCompletedNotification{})
+	if err != nil || string(completed) != `{"importId":"","itemTypeResults":[]}` {
+		t.Fatalf("completed nil slice = %s, %v; want non-null empty array", completed, err)
+	}
+}
+
+func assertExternalAgentConfigImportNotificationRoundTrip(
+	t *testing.T,
+	input string,
+	canonical string,
+	value interface {
+		json.Marshaler
+		json.Unmarshaler
+	},
+) {
+	t.Helper()
+	if err := value.UnmarshalJSON([]byte(input)); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	encoded, err := value.MarshalJSON()
+	if err != nil || string(encoded) != canonical {
+		t.Fatalf("canonical = %s, %v; want %s", encoded, err, canonical)
+	}
+}
+
+func TestExternalAgentConfigImportNotificationsRejectMalformedWireForms(t *testing.T) {
+	invalid := []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{}`,
+		`{"itemTypeResults":[]}`,
+		`{"importId":null,"itemTypeResults":[]}`,
+		`{"importId":1,"itemTypeResults":[]}`,
+		`{"importId":"id"}`,
+		`{"importId":"id","itemTypeResults":null}`,
+		`{"importId":"id","itemTypeResults":{}}`,
+		`{"importId":"id","itemTypeResults":[null]}`,
+		`{"importId":"id","itemTypeResults":[{}]}`,
+		`{"importId":"id","itemTypeResults":[{"itemType":"OTHER","successes":[],"failures":[]}]}`,
+		`{"importId":"id","itemTypeResults":[{"itemType":"CONFIG","successes":[{}],"failures":[]}]}`,
+		`{"importId":"id","itemTypeResults":[{"itemType":"HOOKS","successes":[],"failures":[{"itemType":"HOOKS","message":"missing stage"}]}]}`,
+		`{"importId":"a","importId":"b","itemTypeResults":[]}`,
+		`{"importId":"id","itemTypeResults":[],"itemTypeResults":[]}`,
+		`{"importId":"id","itemTypeResults":[]`,
+		`{"importId":"id","itemTypeResults":[]} {}`,
+	}
+	for _, input := range invalid {
+		var progress ExternalAgentConfigImportProgressNotification
+		if err := json.Unmarshal([]byte(input), &progress); err == nil {
+			t.Errorf("progress Unmarshal(%s) succeeded", input)
+		}
+		var completed ExternalAgentConfigImportCompletedNotification
+		if err := json.Unmarshal([]byte(input), &completed); err == nil {
+			t.Errorf("completed Unmarshal(%s) succeeded", input)
+		}
+	}
+
+	var progress *ExternalAgentConfigImportProgressNotification
+	if err := progress.UnmarshalJSON([]byte(`{"importId":"id","itemTypeResults":[]}`)); err == nil {
+		t.Fatal("nil progress receiver succeeded")
+	}
+	var completed *ExternalAgentConfigImportCompletedNotification
+	if err := completed.UnmarshalJSON([]byte(`{"importId":"id","itemTypeResults":[]}`)); err == nil {
+		t.Fatal("nil completed receiver succeeded")
+	}
+	bad := []ExternalAgentConfigImportTypeResult{{}}
+	if _, err := json.Marshal(ExternalAgentConfigImportProgressNotification{ItemTypeResults: bad}); err == nil {
+		t.Fatal("progress with invalid nested result marshaled")
+	}
+	if _, err := json.Marshal(ExternalAgentConfigImportCompletedNotification{ItemTypeResults: bad}); err == nil {
+		t.Fatal("completed with invalid nested result marshaled")
+	}
+}
+
+func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
+	names := []string{
+		"ExternalAgentConfigImportProgressNotification",
+		"ExternalAgentConfigImportCompletedNotification",
+	}
+	for _, binding := range WireTypeBindings() {
+		for _, name := range names {
+			if slices.Contains(binding.Params, name) || slices.Contains(binding.Result, name) {
+				t.Fatalf("%s unexpectedly bound: %#v", name, binding)
+			}
+		}
+	}
+	for _, method := range []string{
+		"externalAgentConfig/import",
+		"externalAgentConfig/import/readHistories",
+		"externalAgentConfig/import/progress",
+		"externalAgentConfig/import/completed",
+	} {
+		info, ok := LookupMethod(method)
+		if !ok || info.State != MethodDeferredStub {
+			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestExternalAgentConfigImportNotificationTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	for _, name := range []string{
+		"ExternalAgentConfigImportProgressNotification",
+		"ExternalAgentConfigImportCompletedNotification",
+	} {
+		want := "export type " + name + " = {\n" +
+			"  \"importId\": string;\n" +
+			"  \"itemTypeResults\": Array<ExternalAgentConfigImportTypeResult>;\n" +
+			"};"
+		if !strings.Contains(string(generated), want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}
+
+var (
+	_ json.Marshaler   = ExternalAgentConfigImportProgressNotification{}
+	_ json.Unmarshaler = (*ExternalAgentConfigImportProgressNotification)(nil)
+	_ json.Marshaler   = ExternalAgentConfigImportCompletedNotification{}
+	_ json.Unmarshaler = (*ExternalAgentConfigImportCompletedNotification)(nil)
+)

--- a/appserver/protocol/external_agent_config_import_notification_types.go
+++ b/appserver/protocol/external_agent_config_import_notification_types.go
@@ -1,0 +1,110 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// ExternalAgentConfigImportProgressNotification is the exact standalone
+// progress value. It does not imply that Gollem produces import progress.
+type ExternalAgentConfigImportProgressNotification struct {
+	ImportID        string                                `json:"importId"`
+	ItemTypeResults []ExternalAgentConfigImportTypeResult `json:"itemTypeResults"`
+}
+
+func (n ExternalAgentConfigImportProgressNotification) MarshalJSON() ([]byte, error) {
+	return marshalExternalAgentConfigImportNotification(n.ImportID, n.ItemTypeResults)
+}
+
+func (n *ExternalAgentConfigImportProgressNotification) UnmarshalJSON(data []byte) error {
+	if n == nil {
+		return errors.New("decode external-agent config import progress notification into nil receiver")
+	}
+	importID, results, err := unmarshalExternalAgentConfigImportNotification(
+		data,
+		"external-agent config import progress notification",
+	)
+	if err != nil {
+		return err
+	}
+	*n = ExternalAgentConfigImportProgressNotification{ImportID: importID, ItemTypeResults: results}
+	return nil
+}
+
+// ExternalAgentConfigImportCompletedNotification is the exact standalone
+// completion value. It does not imply that Gollem executes imports.
+type ExternalAgentConfigImportCompletedNotification struct {
+	ImportID        string                                `json:"importId"`
+	ItemTypeResults []ExternalAgentConfigImportTypeResult `json:"itemTypeResults"`
+}
+
+func (n ExternalAgentConfigImportCompletedNotification) MarshalJSON() ([]byte, error) {
+	return marshalExternalAgentConfigImportNotification(n.ImportID, n.ItemTypeResults)
+}
+
+func (n *ExternalAgentConfigImportCompletedNotification) UnmarshalJSON(data []byte) error {
+	if n == nil {
+		return errors.New("decode external-agent config import completed notification into nil receiver")
+	}
+	importID, results, err := unmarshalExternalAgentConfigImportNotification(
+		data,
+		"external-agent config import completed notification",
+	)
+	if err != nil {
+		return err
+	}
+	*n = ExternalAgentConfigImportCompletedNotification{ImportID: importID, ItemTypeResults: results}
+	return nil
+}
+
+func marshalExternalAgentConfigImportNotification(
+	importID string,
+	results []ExternalAgentConfigImportTypeResult,
+) ([]byte, error) {
+	if results == nil {
+		results = []ExternalAgentConfigImportTypeResult{}
+	}
+	return json.Marshal(struct {
+		ImportID        string                                `json:"importId"`
+		ItemTypeResults []ExternalAgentConfigImportTypeResult `json:"itemTypeResults"`
+	}{ImportID: importID, ItemTypeResults: results})
+}
+
+func unmarshalExternalAgentConfigImportNotification(
+	data []byte,
+	objectName string,
+) (string, []ExternalAgentConfigImportTypeResult, error) {
+	payload, err := decodeExternalAgentConfigObject(data, objectName, "importId", "itemTypeResults")
+	if err != nil {
+		return "", nil, err
+	}
+	importID, err := decodeRequiredThreadItemValue[string](payload, objectName, "importId")
+	if err != nil {
+		return "", nil, err
+	}
+	results, err := decodeRequiredThreadItemArray[ExternalAgentConfigImportTypeResult](
+		payload,
+		objectName,
+		"itemTypeResults",
+	)
+	if err != nil {
+		return "", nil, err
+	}
+	return importID, results, nil
+}
+
+func externalAgentConfigImportNotificationSchema() Schema {
+	return closedThreadSessionParamSchema(Schema{
+		"importId": Schema{"type": "string"},
+		"itemTypeResults": Schema{
+			"type": "array", "items": Schema{"$ref": "#/$defs/ExternalAgentConfigImportTypeResult"},
+		},
+	}, []string{"importId", "itemTypeResults"})
+}
+
+var (
+	_ json.Marshaler   = ExternalAgentConfigImportProgressNotification{}
+	_ json.Unmarshaler = (*ExternalAgentConfigImportProgressNotification)(nil)
+	_ json.Marshaler   = ExternalAgentConfigImportCompletedNotification{}
+	_ json.Unmarshaler = (*ExternalAgentConfigImportCompletedNotification)(nil)
+)

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -175,8 +175,8 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 398 {
-		t.Fatalf("definition count = %d, want 398", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 400 {
+		t.Fatalf("definition count = %d, want 400", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 398 {
-		t.Fatalf("definition count = %d, want 398", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 400 {
+		t.Fatalf("definition count = %d, want 400", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 398 {
-		t.Fatalf("definition count = %d, want 398", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 400 {
+		t.Fatalf("definition count = %d, want 400", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 398 {
-		t.Fatalf("definition count = %d, want 398", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 400 {
+		t.Fatalf("definition count = %d, want 400", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 398 {
-		t.Fatalf("definition count = %d, want 398", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 400 {
+		t.Fatalf("definition count = %d, want 400", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 398 {
-		t.Fatalf("definition count = %d, want 398", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 400 {
+		t.Fatalf("definition count = %d, want 400", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -322,6 +322,8 @@ func wireSchemaDefinitions() Schema {
 		{Name: "ExternalAgentConfigImportItemTypeFailure", Type: reflect.TypeFor[ExternalAgentConfigImportItemTypeFailure]()},
 		{Name: "ExternalAgentConfigImportItemTypeSuccess", Type: reflect.TypeFor[ExternalAgentConfigImportItemTypeSuccess]()},
 		{Name: "ExternalAgentConfigImportTypeResult", Type: reflect.TypeFor[ExternalAgentConfigImportTypeResult]()},
+		{Name: "ExternalAgentConfigImportProgressNotification", Type: reflect.TypeFor[ExternalAgentConfigImportProgressNotification]()},
+		{Name: "ExternalAgentConfigImportCompletedNotification", Type: reflect.TypeFor[ExternalAgentConfigImportCompletedNotification]()},
 		{Name: "PermissionGrantScope", Type: reflect.TypeFor[PermissionGrantScope]()},
 		{Name: "PermissionsApprovalRequestParams", Type: reflect.TypeFor[PermissionsApprovalRequestParams]()},
 		{Name: "PermissionsRequestApprovalParams", Type: reflect.TypeFor[PermissionsRequestApprovalParams]()},
@@ -577,6 +579,8 @@ func wireSchemaDefinitions() Schema {
 	schemas["ExternalAgentConfigImportItemTypeFailure"] = externalAgentConfigImportItemTypeFailureSchema()
 	schemas["ExternalAgentConfigImportItemTypeSuccess"] = externalAgentConfigImportItemTypeSuccessSchema()
 	schemas["ExternalAgentConfigImportTypeResult"] = externalAgentConfigImportTypeResultSchema()
+	schemas["ExternalAgentConfigImportProgressNotification"] = externalAgentConfigImportNotificationSchema()
+	schemas["ExternalAgentConfigImportCompletedNotification"] = externalAgentConfigImportNotificationSchema()
 	schemas["McpServerToolCallParams"] = mcpServerToolCallParamsSchema()
 	schemas["McpServerToolCallResponse"] = mcpServerToolCallResponseSchema()
 	schemas["ResourceContent"] = resourceContentSchema()

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -3176,6 +3176,25 @@
       ],
       "type": "object"
     },
+    "ExternalAgentConfigImportCompletedNotification": {
+      "additionalProperties": false,
+      "properties": {
+        "importId": {
+          "type": "string"
+        },
+        "itemTypeResults": {
+          "items": {
+            "$ref": "#/$defs/ExternalAgentConfigImportTypeResult"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "importId",
+        "itemTypeResults"
+      ],
+      "type": "object"
+    },
     "ExternalAgentConfigImportItemTypeFailure": {
       "additionalProperties": false,
       "properties": {
@@ -3291,6 +3310,25 @@
       },
       "required": [
         "migrationItems"
+      ],
+      "type": "object"
+    },
+    "ExternalAgentConfigImportProgressNotification": {
+      "additionalProperties": false,
+      "properties": {
+        "importId": {
+          "type": "string"
+        },
+        "itemTypeResults": {
+          "items": {
+            "$ref": "#/$defs/ExternalAgentConfigImportTypeResult"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "importId",
+        "itemTypeResults"
       ],
       "type": "object"
     },

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 398 {
-		t.Fatalf("definition count = %d, want 398", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 400 {
+		t.Fatalf("definition count = %d, want 400", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 398 {
-		t.Fatalf("definition count = %d, want 398", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 400 {
+		t.Fatalf("definition count = %d, want 400", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 398 {
-		t.Fatalf("definition count = %d, want 398", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 400 {
+		t.Fatalf("definition count = %d, want 400", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -1130,6 +1130,11 @@ export type ExternalAgentConfigDetectResponse = {
   "items": Array<ExternalAgentConfigMigrationItem>;
 };
 
+export type ExternalAgentConfigImportCompletedNotification = {
+  "importId": string;
+  "itemTypeResults": Array<ExternalAgentConfigImportTypeResult>;
+};
+
 export type ExternalAgentConfigImportItemTypeFailure = {
   "cwd": string | null;
   "errorType": string | null;
@@ -1149,6 +1154,11 @@ export type ExternalAgentConfigImportItemTypeSuccess = {
 export type ExternalAgentConfigImportParams = {
   "migrationItems": Array<ExternalAgentConfigMigrationItem>;
   "source"?: string | null;
+};
+
+export type ExternalAgentConfigImportProgressNotification = {
+  "importId": string;
+  "itemTypeResults": Array<ExternalAgentConfigImportTypeResult>;
 };
 
 export type ExternalAgentConfigImportResponse = {

--- a/appserver/protocol/typescript/testdata/external_agent_config_import_notification_contract.ts
+++ b/appserver/protocol/typescript/testdata/external_agent_config_import_notification_contract.ts
@@ -1,0 +1,78 @@
+import type {
+  ExternalAgentConfigImportCompletedNotification,
+  ExternalAgentConfigImportProgressNotification,
+  ExternalAgentConfigImportTypeResult,
+  MethodParamsByName,
+  MethodResultsByName,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+type NotificationShape = {
+  importId: string;
+  itemTypeResults: Array<ExternalAgentConfigImportTypeResult>;
+};
+
+type Contracts = [
+  Expect<Equal<ExternalAgentConfigImportProgressNotification, NotificationShape>>,
+  Expect<Equal<ExternalAgentConfigImportCompletedNotification, NotificationShape>>,
+  Expect<Equal<ExternalAgentConfigImportProgressNotification, ExternalAgentConfigImportCompletedNotification>>,
+  Expect<Equal<"externalAgentConfig/import" extends keyof MethodParamsByName ? true : false, false>>,
+  Expect<Equal<"externalAgentConfig/import" extends keyof MethodResultsByName ? true : false, false>>,
+  Expect<Equal<"externalAgentConfig/import/readHistories" extends keyof MethodParamsByName ? true : false, false>>,
+  Expect<Equal<"externalAgentConfig/import/readHistories" extends keyof MethodResultsByName ? true : false, false>>,
+];
+
+export const progressEmpty = {
+  importId: "",
+  itemTypeResults: [],
+} satisfies ExternalAgentConfigImportProgressNotification;
+
+export const completedOrderedDuplicates = {
+  importId: " import-1 ",
+  itemTypeResults: [
+    { itemType: "CONFIG", successes: [], failures: [] },
+    { itemType: "HOOKS", successes: [], failures: [] },
+    { itemType: "CONFIG", successes: [], failures: [] },
+  ],
+} satisfies ExternalAgentConfigImportCompletedNotification;
+
+// @ts-expect-error importId is required.
+export const rejectProgressMissingImportId = { itemTypeResults: [] } satisfies ExternalAgentConfigImportProgressNotification;
+// @ts-expect-error itemTypeResults is required.
+export const rejectProgressMissingResults = { importId: "id" } satisfies ExternalAgentConfigImportProgressNotification;
+// @ts-expect-error importId is non-null.
+export const rejectProgressNullImportId = { ...progressEmpty, importId: null } satisfies ExternalAgentConfigImportProgressNotification;
+// @ts-expect-error itemTypeResults is non-null.
+export const rejectProgressNullResults = { ...progressEmpty, itemTypeResults: null } satisfies ExternalAgentConfigImportProgressNotification;
+// @ts-expect-error itemTypeResults must be an array.
+export const rejectProgressObjectResults = { ...progressEmpty, itemTypeResults: {} } satisfies ExternalAgentConfigImportProgressNotification;
+// @ts-expect-error nested results retain required failures.
+export const rejectProgressInvalidNested = { ...progressEmpty, itemTypeResults: [{ itemType: "CONFIG", successes: [] }] } satisfies ExternalAgentConfigImportProgressNotification;
+// @ts-expect-error snake-case aliases do not replace canonical fields.
+export const rejectProgressSnakeAlias = { import_id: "id", item_type_results: [] } satisfies ExternalAgentConfigImportProgressNotification;
+// @ts-expect-error fields absent from the public record are rejected.
+export const rejectProgressExtra = { ...progressEmpty, extra: true } satisfies ExternalAgentConfigImportProgressNotification;
+
+// @ts-expect-error importId is required.
+export const rejectCompletedMissingImportId = { itemTypeResults: [] } satisfies ExternalAgentConfigImportCompletedNotification;
+// @ts-expect-error itemTypeResults is required.
+export const rejectCompletedMissingResults = { importId: "id" } satisfies ExternalAgentConfigImportCompletedNotification;
+// @ts-expect-error importId is non-null.
+export const rejectCompletedNullImportId = { importId: null, itemTypeResults: [] } satisfies ExternalAgentConfigImportCompletedNotification;
+// @ts-expect-error itemTypeResults is non-null.
+export const rejectCompletedNullResults = { importId: "id", itemTypeResults: null } satisfies ExternalAgentConfigImportCompletedNotification;
+// @ts-expect-error itemTypeResults must be an array.
+export const rejectCompletedStringResults = { importId: "id", itemTypeResults: "results" } satisfies ExternalAgentConfigImportCompletedNotification;
+// @ts-expect-error nested item types remain closed.
+export const rejectCompletedInvalidNested = { importId: "id", itemTypeResults: [{ itemType: "OTHER", successes: [], failures: [] }] } satisfies ExternalAgentConfigImportCompletedNotification;
+// @ts-expect-error snake-case aliases do not replace canonical fields.
+export const rejectCompletedSnakeAlias = { import_id: "id", item_type_results: [] } satisfies ExternalAgentConfigImportCompletedNotification;
+// @ts-expect-error fields absent from the public record are rejected.
+export const rejectCompletedExtra = { ...completedOrderedDuplicates, extra: true } satisfies ExternalAgentConfigImportCompletedNotification;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 398 {
-		t.Fatalf("definition count = %d, want 398", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 400 {
+		t.Fatalf("definition count = %d, want 400", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- export exact standalone `ExternalAgentConfigImportProgressNotification` and `ExternalAgentConfigImportCompletedNotification` contracts
- preserve required import IDs, non-null result arrays, nil-to-empty canonicalization, strict nested results, order, duplicates, duplicate-known-field rejection, and unknown-parent discard
- keep both notification methods and external-agent request methods unbound with no import producer or runtime behavior

## Verification
- deliberate-red Go and strict TypeScript boundaries
- focused x30, focused race, and 100% statement coverage for all seven new codec/schema functions
- full protocol normal/race and fresh serialized normal/race across all 59 non-Monty packages
- `golangci-lint` (0 issues), `go vet ./...`, tidy verification, deterministic generation, configured pre-push twice and push-time hook
- exact pinned Codex normalized schema SHA-256 `a47ecdceac07c921e0ff7d90aa634d6e31ba4986800758c824f4789fc9f1d31f` and TypeScript semantics SHA-256 `d7534fa8cb79545d19bd1d80102fc6286aa6847f33132cfb5d2beef5491dbcaa`
- exact structural reversal to PR #191 tree `953bc7840635673c41d67dd003b39be492d8a451`
- reproducible binary SHA-256 `51d1752a6ed1fa05428ad32b751e0e447f4af1ed35e9add1a38526bf197606a2`
- byte-identical baseline/feature live transcript SHA-256 `8c9b26306f5bbb4ac6d2a6000eb0503280c971af15747d7a478cd4adac2ae742` and all five prior Slang workflows

Local Monty normal/race/coverage tests remain excluded per standing direction; hosted CI is unchanged.