### PR TITLE
feat(appserver): export fuzzy file search contracts

### DIFF
--- a/appserver/protocol/README.md
+++ b/appserver/protocol/README.md
@@ -490,6 +490,15 @@ in Go and JSON Schema but generates as TypeScript `bigint` to match the pinned
 ts-rs contract. The history record and its read-response wrapper remain unbound
 and do not add import execution, persistence, or history-read behavior.
 
+Exact standalone fuzzy-file-search params, result kind, result, response, and
+session notification records preserve the pinned camel-case envelopes and the
+intentional snake-case `match_type`/`file_name` result fields. Scores and match
+indices retain strict uint32 bounds, optional values canonicalize to explicit
+null, and non-null arrays canonicalize nil to `[]`. The request and notification
+methods remain deferred and unbound; these values add no filesystem access,
+search, ranking, cancellation, session, or notification behavior. Their strict
+compile contract is `typescript/testdata/fuzzy_file_search_contract.ts`.
+
 Exact standalone warning, guardian-warning, and error notification records
 establish the fixed public warning/error value layer. Canonical warning output
 requires explicit nullable thread id, while decoding also accepts omission to

--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(defs); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,8 +217,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_detect_types.go
+++ b/appserver/protocol/external_agent_config_detect_types.go
@@ -1,11 +1,9 @@
 package protocol
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 )
 
 const (
@@ -110,50 +108,7 @@ func decodeExternalAgentConfigObject(
 	objectName string,
 	knownFields ...string,
 ) (map[string]json.RawMessage, error) {
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	opening, err := decoder.Token()
-	if err != nil {
-		return nil, fmt.Errorf("decode %s: %w", objectName, err)
-	}
-	if opening != json.Delim('{') {
-		return nil, fmt.Errorf("%s must be an object", objectName)
-	}
-	known := make(map[string]struct{}, len(knownFields))
-	for _, name := range knownFields {
-		known[name] = struct{}{}
-	}
-	payload := make(map[string]json.RawMessage, len(known))
-	seen := make(map[string]bool, len(known))
-	for decoder.More() {
-		token, err := decoder.Token()
-		if err != nil {
-			return nil, fmt.Errorf("decode %s field name: %w", objectName, err)
-		}
-		name := token.(string)
-		var raw json.RawMessage
-		if err := decoder.Decode(&raw); err != nil {
-			return nil, fmt.Errorf("decode %s field %q: %w", objectName, name, err)
-		}
-		if _, ok := known[name]; !ok {
-			continue
-		}
-		if seen[name] {
-			return nil, fmt.Errorf("duplicate %s field %q", objectName, name)
-		}
-		seen[name] = true
-		payload[name] = append(json.RawMessage(nil), raw...)
-	}
-	if _, err := decoder.Token(); err != nil {
-		return nil, fmt.Errorf("decode %s: %w", objectName, err)
-	}
-	var trailing any
-	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
-		if err == nil {
-			return nil, fmt.Errorf("%s must contain one JSON value", objectName)
-		}
-		return nil, fmt.Errorf("decode %s trailing value: %w", objectName, err)
-	}
-	return payload, nil
+	return decodeRustSerdeObject(data, objectName, knownFields...)
 }
 
 func externalAgentConfigDetectParamsSchema() Schema {

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,8 +203,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -260,8 +260,8 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,8 +244,8 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -162,8 +162,8 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -175,8 +175,8 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -1,0 +1,461 @@
+package protocol
+
+import (
+	"encoding/json"
+	"math"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestFuzzyFileSearchSchemasAreExact(t *testing.T) {
+	uint32Schema := Schema{"type": "integer", "minimum": 0, "maximum": 4294967295}
+	resultSchema := closedThreadSessionParamSchema(Schema{
+		"root":       Schema{"type": "string"},
+		"path":       Schema{"type": "string"},
+		"match_type": Schema{"$ref": "#/$defs/FuzzyFileSearchMatchType"},
+		"file_name":  Schema{"type": "string"},
+		"score":      uint32Schema,
+		"indices": Schema{"anyOf": []any{
+			Schema{"type": "array", "items": uint32Schema}, Schema{"type": "null"},
+		}},
+	}, []string{"root", "path", "match_type", "file_name", "score"})
+	resultSchema["description"] = "Superset of [`codex_file_search::FileMatch`]"
+	wants := map[string]Schema{
+		"FuzzyFileSearchMatchType": {"type": "string", "enum": []any{"file", "directory"}},
+		"FuzzyFileSearchParams": closedThreadSessionParamSchema(Schema{
+			"query": Schema{"type": "string"},
+			"roots": Schema{"type": "array", "items": Schema{"type": "string"}},
+			"cancellationToken": Schema{"anyOf": []any{
+				Schema{"type": "string"}, Schema{"type": "null"},
+			}},
+		}, []string{"query", "roots"}),
+		"FuzzyFileSearchResult": resultSchema,
+		"FuzzyFileSearchResponse": closedThreadSessionParamSchema(Schema{
+			"files": Schema{"type": "array", "items": Schema{"$ref": "#/$defs/FuzzyFileSearchResult"}},
+		}, []string{"files"}),
+		"FuzzyFileSearchSessionUpdatedNotification": closedThreadSessionParamSchema(Schema{
+			"sessionId": Schema{"type": "string"},
+			"query":     Schema{"type": "string"},
+			"files":     Schema{"type": "array", "items": Schema{"$ref": "#/$defs/FuzzyFileSearchResult"}},
+		}, []string{"sessionId", "query", "files"}),
+		"FuzzyFileSearchSessionCompletedNotification": closedThreadSessionParamSchema(Schema{
+			"sessionId": Schema{"type": "string"},
+		}, []string{"sessionId"}),
+	}
+
+	defs := JSONSchema()["$defs"].(Schema)
+	for name, want := range wants {
+		got, ok := defs[name].(Schema)
+		if !ok || !reflect.DeepEqual(got, want) {
+			t.Errorf("%s schema = %#v, %v; want %#v", name, got, ok, want)
+		}
+	}
+}
+
+func TestFuzzyFileSearchMatchTypeIsClosed(t *testing.T) {
+	for _, value := range []FuzzyFileSearchMatchType{
+		FuzzyFileSearchMatchTypeFile,
+		FuzzyFileSearchMatchTypeDirectory,
+	} {
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			t.Fatalf("Marshal(%q): %v", value, err)
+		}
+		var roundTrip FuzzyFileSearchMatchType
+		if err := json.Unmarshal(encoded, &roundTrip); err != nil || roundTrip != value {
+			t.Fatalf("round trip = %q, %v; want %q", roundTrip, err, value)
+		}
+	}
+
+	for _, input := range []string{`null`, `""`, `"File"`, `"folder"`, `1`, `{}`, `[]`, `"file" {}`} {
+		var value FuzzyFileSearchMatchType
+		if err := json.Unmarshal([]byte(input), &value); err == nil {
+			t.Errorf("Unmarshal(%s) succeeded", input)
+		}
+	}
+	if _, err := json.Marshal(FuzzyFileSearchMatchType("other")); err == nil {
+		t.Fatal("invalid match type marshaled")
+	}
+	var value *FuzzyFileSearchMatchType
+	if err := value.UnmarshalJSON([]byte(`"file"`)); err == nil {
+		t.Fatal("nil match-type receiver succeeded")
+	}
+}
+
+func TestFuzzyFileSearchParamsAcceptRustWireForms(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     string
+		want      FuzzyFileSearchParams
+		canonical string
+	}{
+		{
+			name:      "empty omitted cancellation and unknown",
+			input:     `{"query":"","roots":[],"future":true}`,
+			want:      FuzzyFileSearchParams{Query: "", Roots: []string{}},
+			canonical: `{"query":"","roots":[],"cancellationToken":null}`,
+		},
+		{
+			name:  "opaque ordered duplicate roots and token",
+			input: `{"query":" ../needle ","roots":["","repo/../repo","/tmp","repo/../repo"],"cancellationToken":" token "}`,
+			want: FuzzyFileSearchParams{
+				Query: " ../needle ", Roots: []string{"", "repo/../repo", "/tmp", "repo/../repo"},
+				CancellationToken: stringPointer(" token "),
+			},
+			canonical: `{"query":" ../needle ","roots":["","repo/../repo","/tmp","repo/../repo"],"cancellationToken":" token "}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got FuzzyFileSearchParams
+			assertFuzzyFileSearchRoundTrip(t, tc.input, tc.canonical, &got)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("params = %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+
+	encoded, err := json.Marshal(FuzzyFileSearchParams{})
+	if err != nil || string(encoded) != `{"query":"","roots":[],"cancellationToken":null}` {
+		t.Fatalf("zero params = %s, %v", encoded, err)
+	}
+}
+
+func TestFuzzyFileSearchResultAcceptsRustWireForms(t *testing.T) {
+	maximum := uint32(math.MaxUint32)
+	indices := []uint32{maximum, 0, maximum}
+	cases := []struct {
+		name      string
+		input     string
+		want      FuzzyFileSearchResult
+		canonical string
+	}{
+		{
+			name:  "empty minimum omitted indices and unknown",
+			input: `{"root":"","path":"","match_type":"file","file_name":"","score":0,"future":true}`,
+			want: FuzzyFileSearchResult{
+				Root: "", Path: "", MatchType: FuzzyFileSearchMatchTypeFile, FileName: "", Score: 0,
+			},
+			canonical: `{"root":"","path":"","match_type":"file","file_name":"","score":0,"indices":null}`,
+		},
+		{
+			name:  "opaque paths maximum and duplicate indices",
+			input: `{"root":" repo/../repo ","path":"./a/../b","match_type":"directory","file_name":" name ","score":4294967295,"indices":[4294967295,0,4294967295]}`,
+			want: FuzzyFileSearchResult{
+				Root: " repo/../repo ", Path: "./a/../b", MatchType: FuzzyFileSearchMatchTypeDirectory,
+				FileName: " name ", Score: maximum, Indices: &indices,
+			},
+			canonical: `{"root":" repo/../repo ","path":"./a/../b","match_type":"directory","file_name":" name ","score":4294967295,"indices":[4294967295,0,4294967295]}`,
+		},
+		{
+			name:  "empty indices distinct from null",
+			input: `{"root":"r","path":"p","match_type":"file","file_name":"f","score":1,"indices":[]}`,
+			want: FuzzyFileSearchResult{
+				Root: "r", Path: "p", MatchType: FuzzyFileSearchMatchTypeFile,
+				FileName: "f", Score: 1, Indices: &[]uint32{},
+			},
+			canonical: `{"root":"r","path":"p","match_type":"file","file_name":"f","score":1,"indices":[]}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got FuzzyFileSearchResult
+			assertFuzzyFileSearchRoundTrip(t, tc.input, tc.canonical, &got)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("result = %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFuzzyFileSearchEnvelopesAcceptRustWireForms(t *testing.T) {
+	file := FuzzyFileSearchResult{
+		Root: "root", Path: "path", MatchType: FuzzyFileSearchMatchTypeFile,
+		FileName: "file", Score: 7,
+	}
+	directory := FuzzyFileSearchResult{
+		Root: "root", Path: "path", MatchType: FuzzyFileSearchMatchTypeDirectory,
+		FileName: "file", Score: 7,
+	}
+	resultWire := `{"root":"root","path":"path","match_type":"file","file_name":"file","score":7,"indices":null}`
+	directoryWire := `{"root":"root","path":"path","match_type":"directory","file_name":"file","score":7,"indices":null}`
+
+	var response FuzzyFileSearchResponse
+	assertFuzzyFileSearchRoundTrip(
+		t,
+		`{"files":[`+resultWire+`,`+directoryWire+`,`+resultWire+`],"future":true}`,
+		`{"files":[`+resultWire+`,`+directoryWire+`,`+resultWire+`]}`,
+		&response,
+	)
+	if !reflect.DeepEqual(response.Files, []FuzzyFileSearchResult{file, directory, file}) {
+		t.Fatalf("response order/duplicates changed: %#v", response.Files)
+	}
+
+	var updated FuzzyFileSearchSessionUpdatedNotification
+	assertFuzzyFileSearchRoundTrip(
+		t,
+		`{"sessionId":" session ","query":" query ","files":[`+resultWire+`,`+resultWire+`],"future":true}`,
+		`{"sessionId":" session ","query":" query ","files":[`+resultWire+`,`+resultWire+`]}`,
+		&updated,
+	)
+	if updated.SessionID != " session " || updated.Query != " query " ||
+		!reflect.DeepEqual(updated.Files, []FuzzyFileSearchResult{file, file}) {
+		t.Fatalf("updated notification = %#v", updated)
+	}
+
+	var completed FuzzyFileSearchSessionCompletedNotification
+	assertFuzzyFileSearchRoundTrip(
+		t,
+		`{"sessionId":"","future":true}`,
+		`{"sessionId":""}`,
+		&completed,
+	)
+	if completed.SessionID != "" {
+		t.Fatalf("completed notification = %#v", completed)
+	}
+
+	for _, tc := range []struct {
+		value any
+		want  string
+	}{
+		{FuzzyFileSearchResponse{}, `{"files":[]}`},
+		{FuzzyFileSearchSessionUpdatedNotification{}, `{"sessionId":"","query":"","files":[]}`},
+		{FuzzyFileSearchSessionCompletedNotification{}, `{"sessionId":""}`},
+	} {
+		encoded, err := json.Marshal(tc.value)
+		if err != nil || string(encoded) != tc.want {
+			t.Errorf("zero %T = %s, %v; want %s", tc.value, encoded, err, tc.want)
+		}
+	}
+}
+
+func TestFuzzyFileSearchRejectsMalformedWireForms(t *testing.T) {
+	validResult := `{"root":"r","path":"p","match_type":"file","file_name":"f","score":0,"indices":null}`
+	paramsInvalid := []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{}`,
+		`{"roots":[]}`, `{"query":null,"roots":[]}`, `{"query":1,"roots":[]}`,
+		`{"query":"q"}`, `{"query":"q","roots":null}`, `{"query":"q","roots":{}}`,
+		`{"query":"q","roots":[null]}`, `{"query":"q","roots":[1]}`,
+		`{"query":"q","roots":[],"cancellationToken":1}`,
+		`{"query":"a","query":"b","roots":[]}`,
+		`{"query":"q","roots":[],"roots":[]}`,
+		`{"query":"q","roots":[],"cancellationToken":null,"cancellationToken":"x"}`,
+		`{"query":"q","roots":[]`, `{"query":"q","roots":[]} {}`,
+	}
+	for _, input := range paramsInvalid {
+		var value FuzzyFileSearchParams
+		if err := json.Unmarshal([]byte(input), &value); err == nil {
+			t.Errorf("params Unmarshal(%s) succeeded", input)
+		}
+	}
+
+	resultInvalid := []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{}`,
+		`{"path":"p","match_type":"file","file_name":"f","score":0}`,
+		`{"root":null,"path":"p","match_type":"file","file_name":"f","score":0}`,
+		`{"root":"r","match_type":"file","file_name":"f","score":0}`,
+		`{"root":"r","path":"p","match_type":null,"file_name":"f","score":0}`,
+		`{"root":"r","path":"p","match_type":"other","file_name":"f","score":0}`,
+		`{"root":"r","path":"p","match_type":"file","score":0}`,
+		`{"root":"r","path":"p","match_type":"file","file_name":null,"score":0}`,
+		`{"root":"r","path":"p","match_type":"file","file_name":"f"}`,
+		`{"root":"r","path":"p","match_type":"file","file_name":"f","score":null}`,
+		`{"root":"r","path":"p","match_type":"file","file_name":"f","score":-1}`,
+		`{"root":"r","path":"p","match_type":"file","file_name":"f","score":0.5}`,
+		`{"root":"r","path":"p","match_type":"file","file_name":"f","score":1e3}`,
+		`{"root":"r","path":"p","match_type":"file","file_name":"f","score":4294967296}`,
+		`{"root":"r","path":"p","match_type":"file","file_name":"f","score":0,"indices":{}}`,
+		`{"root":"r","path":"p","match_type":"file","file_name":"f","score":0,"indices":[null]}`,
+		`{"root":"r","path":"p","match_type":"file","file_name":"f","score":0,"indices":[-1]}`,
+		`{"root":"r","path":"p","match_type":"file","file_name":"f","score":0,"indices":[0.5]}`,
+		`{"root":"r","path":"p","match_type":"file","file_name":"f","score":0,"indices":[1e3]}`,
+		`{"root":"r","path":"p","match_type":"file","file_name":"f","score":0,"indices":[4294967296]}`,
+		`{"root":"r","path":"p","matchType":"file","file_name":"f","score":0}`,
+		`{"root":"r","path":"p","match_type":"file","fileName":"f","score":0}`,
+		`{"root":"a","root":"b","path":"p","match_type":"file","file_name":"f","score":0}`,
+		validResult[:len(validResult)-1], validResult + ` {}`,
+	}
+	for _, input := range resultInvalid {
+		var value FuzzyFileSearchResult
+		if err := json.Unmarshal([]byte(input), &value); err == nil {
+			t.Errorf("result Unmarshal(%s) succeeded", input)
+		}
+	}
+
+	envelopeInvalid := map[string][]string{
+		"response": {
+			``, `null`, `{}`, `{"files":null}`, `{"files":{}}`, `{"files":[null]}`,
+			`{"files":[{}]}`, `{"files":[],"files":[]}`, `{"files":[]`, `{"files":[]} {}`,
+		},
+		"updated": {
+			``, `null`, `{}`, `{"query":"q","files":[]}`, `{"sessionId":null,"query":"q","files":[]}`,
+			`{"sessionId":"s","files":[]}`, `{"sessionId":"s","query":null,"files":[]}`,
+			`{"sessionId":"s","query":"q"}`, `{"sessionId":"s","query":"q","files":null}`,
+			`{"sessionId":"s","query":"q","files":[null]}`,
+			`{"sessionId":"s","query":"q","files":[],"files":[]}`,
+		},
+		"completed": {
+			``, `null`, `{}`, `{"sessionId":null}`, `{"sessionId":1}`, `{"session_id":"s"}`,
+			`{"sessionId":"a","sessionId":"b"}`, `{"sessionId":"s"`, `{"sessionId":"s"} {}`,
+		},
+	}
+	for _, input := range envelopeInvalid["response"] {
+		var value FuzzyFileSearchResponse
+		if err := json.Unmarshal([]byte(input), &value); err == nil {
+			t.Errorf("response Unmarshal(%s) succeeded", input)
+		}
+	}
+	for _, input := range envelopeInvalid["updated"] {
+		var value FuzzyFileSearchSessionUpdatedNotification
+		if err := json.Unmarshal([]byte(input), &value); err == nil {
+			t.Errorf("updated Unmarshal(%s) succeeded", input)
+		}
+	}
+	for _, input := range envelopeInvalid["completed"] {
+		var value FuzzyFileSearchSessionCompletedNotification
+		if err := json.Unmarshal([]byte(input), &value); err == nil {
+			t.Errorf("completed Unmarshal(%s) succeeded", input)
+		}
+	}
+
+	var params *FuzzyFileSearchParams
+	if err := params.UnmarshalJSON([]byte(`{"query":"q","roots":[]}`)); err == nil {
+		t.Fatal("nil params receiver succeeded")
+	}
+	var result *FuzzyFileSearchResult
+	if err := result.UnmarshalJSON([]byte(validResult)); err == nil {
+		t.Fatal("nil result receiver succeeded")
+	}
+	var response *FuzzyFileSearchResponse
+	if err := response.UnmarshalJSON([]byte(`{"files":[]}`)); err == nil {
+		t.Fatal("nil response receiver succeeded")
+	}
+	var updated *FuzzyFileSearchSessionUpdatedNotification
+	if err := updated.UnmarshalJSON([]byte(`{"sessionId":"s","query":"q","files":[]}`)); err == nil {
+		t.Fatal("nil updated receiver succeeded")
+	}
+	var completed *FuzzyFileSearchSessionCompletedNotification
+	if err := completed.UnmarshalJSON([]byte(`{"sessionId":"s"}`)); err == nil {
+		t.Fatal("nil completed receiver succeeded")
+	}
+
+	bad := FuzzyFileSearchResult{MatchType: FuzzyFileSearchMatchType("other")}
+	for _, value := range []any{
+		bad,
+		FuzzyFileSearchResponse{Files: []FuzzyFileSearchResult{bad}},
+		FuzzyFileSearchSessionUpdatedNotification{Files: []FuzzyFileSearchResult{bad}},
+	} {
+		if _, err := json.Marshal(value); err == nil {
+			t.Errorf("invalid nested %T marshaled", value)
+		}
+	}
+}
+
+func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
+	names := []string{
+		"FuzzyFileSearchMatchType",
+		"FuzzyFileSearchParams",
+		"FuzzyFileSearchResult",
+		"FuzzyFileSearchResponse",
+		"FuzzyFileSearchSessionUpdatedNotification",
+		"FuzzyFileSearchSessionCompletedNotification",
+	}
+	for _, binding := range WireTypeBindings() {
+		for _, name := range names {
+			if slices.Contains(binding.Params, name) || slices.Contains(binding.Result, name) {
+				t.Fatalf("%s unexpectedly bound: %#v", name, binding)
+			}
+		}
+	}
+	for _, method := range []string{
+		"fuzzyFileSearch",
+		"fuzzyFileSearch/sessionUpdated",
+		"fuzzyFileSearch/sessionCompleted",
+	} {
+		info, ok := LookupMethod(method)
+		if !ok || info.State != MethodDeferredStub {
+			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestFuzzyFileSearchTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	for _, want := range []string{
+		`export type FuzzyFileSearchMatchType = "file" | "directory";`,
+		"export type FuzzyFileSearchParams = {\n" +
+			"  \"cancellationToken\": string | null;\n" +
+			"  \"query\": string;\n" +
+			"  \"roots\": Array<string>;\n" +
+			"};",
+		"export type FuzzyFileSearchResult = {\n" +
+			"  \"file_name\": string;\n" +
+			"  \"indices\": Array<number> | null;\n" +
+			"  \"match_type\": FuzzyFileSearchMatchType;\n" +
+			"  \"path\": string;\n" +
+			"  \"root\": string;\n" +
+			"  \"score\": number;\n" +
+			"};",
+		"export type FuzzyFileSearchResponse = {\n" +
+			"  \"files\": Array<FuzzyFileSearchResult>;\n" +
+			"};",
+		"export type FuzzyFileSearchSessionUpdatedNotification = {\n" +
+			"  \"files\": Array<FuzzyFileSearchResult>;\n" +
+			"  \"query\": string;\n" +
+			"  \"sessionId\": string;\n" +
+			"};",
+		"export type FuzzyFileSearchSessionCompletedNotification = {\n" +
+			"  \"sessionId\": string;\n" +
+			"};",
+	} {
+		if !strings.Contains(string(generated), want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}
+
+func assertFuzzyFileSearchRoundTrip(t *testing.T, input, canonical string, target any) {
+	t.Helper()
+	if err := json.Unmarshal([]byte(input), target); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	encoded, err := json.Marshal(target)
+	if err != nil || string(encoded) != canonical {
+		t.Fatalf("canonical = %s, %v; want %s", encoded, err, canonical)
+	}
+	copy := reflect.New(reflect.TypeOf(target).Elem()).Interface()
+	if err := json.Unmarshal(encoded, copy); err != nil || !reflect.DeepEqual(copy, target) {
+		t.Fatalf("round trip = %#v, %v; want %#v", copy, err, target)
+	}
+}
+
+var (
+	_ json.Marshaler   = FuzzyFileSearchMatchType("")
+	_ json.Unmarshaler = (*FuzzyFileSearchMatchType)(nil)
+	_ json.Marshaler   = FuzzyFileSearchParams{}
+	_ json.Unmarshaler = (*FuzzyFileSearchParams)(nil)
+	_ json.Marshaler   = FuzzyFileSearchResult{}
+	_ json.Unmarshaler = (*FuzzyFileSearchResult)(nil)
+	_ json.Marshaler   = FuzzyFileSearchResponse{}
+	_ json.Unmarshaler = (*FuzzyFileSearchResponse)(nil)
+	_ json.Marshaler   = FuzzyFileSearchSessionUpdatedNotification{}
+	_ json.Unmarshaler = (*FuzzyFileSearchSessionUpdatedNotification)(nil)
+	_ json.Marshaler   = FuzzyFileSearchSessionCompletedNotification{}
+	_ json.Unmarshaler = (*FuzzyFileSearchSessionCompletedNotification)(nil)
+)

--- a/appserver/protocol/fuzzy_file_search_types.go
+++ b/appserver/protocol/fuzzy_file_search_types.go
@@ -1,0 +1,375 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// FuzzyFileSearchMatchType is the exact closed public kind of a fuzzy-search
+// result. It does not imply that Gollem searched or accessed a path.
+type FuzzyFileSearchMatchType string
+
+const (
+	FuzzyFileSearchMatchTypeFile      FuzzyFileSearchMatchType = "file"
+	FuzzyFileSearchMatchTypeDirectory FuzzyFileSearchMatchType = "directory"
+)
+
+func (t FuzzyFileSearchMatchType) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(t, "fuzzy-file-search match type", FuzzyFileSearchMatchType.valid)
+}
+
+func (t *FuzzyFileSearchMatchType) UnmarshalJSON(data []byte) error {
+	return unmarshalThreadTurnLeafEnum(data, t, "fuzzy-file-search match type", FuzzyFileSearchMatchType.valid)
+}
+
+func (t FuzzyFileSearchMatchType) valid() bool {
+	switch t {
+	case FuzzyFileSearchMatchTypeFile, FuzzyFileSearchMatchTypeDirectory:
+		return true
+	default:
+		return false
+	}
+}
+
+// FuzzyFileSearchParams is an exact standalone search description. Its roots
+// remain opaque strings and grant no filesystem authority.
+type FuzzyFileSearchParams struct {
+	Query             string   `json:"query"`
+	Roots             []string `json:"roots"`
+	CancellationToken *string  `json:"cancellationToken"`
+}
+
+func (p FuzzyFileSearchParams) MarshalJSON() ([]byte, error) {
+	roots := p.Roots
+	if roots == nil {
+		roots = []string{}
+	}
+	return json.Marshal(struct {
+		Query             string   `json:"query"`
+		Roots             []string `json:"roots"`
+		CancellationToken *string  `json:"cancellationToken"`
+	}{Query: p.Query, Roots: roots, CancellationToken: p.CancellationToken})
+}
+
+func (p *FuzzyFileSearchParams) UnmarshalJSON(data []byte) error {
+	if p == nil {
+		return errors.New("decode fuzzy-file-search params into nil receiver")
+	}
+	const objectName = "fuzzy-file-search params"
+	payload, err := decodeRustSerdeObject(
+		data, objectName, "query", "roots", "cancellationToken",
+	)
+	if err != nil {
+		return err
+	}
+	query, err := decodeRequiredThreadItemValue[string](payload, objectName, "query")
+	if err != nil {
+		return err
+	}
+	roots, err := decodeRequiredThreadItemArray[string](payload, objectName, "roots")
+	if err != nil {
+		return err
+	}
+	cancellationToken, err := decodeOptionalNullableFuzzyFileSearchValue[string](
+		payload, objectName, "cancellationToken",
+	)
+	if err != nil {
+		return err
+	}
+	*p = FuzzyFileSearchParams{
+		Query: query, Roots: roots, CancellationToken: cancellationToken,
+	}
+	return nil
+}
+
+// FuzzyFileSearchResult is the exact standalone public result record. Scores,
+// indices, and paths remain descriptive values with no ranking or path meaning.
+type FuzzyFileSearchResult struct {
+	Root      string                   `json:"root"`
+	Path      string                   `json:"path"`
+	MatchType FuzzyFileSearchMatchType `json:"match_type"`
+	FileName  string                   `json:"file_name"`
+	Score     uint32                   `json:"score"`
+	Indices   *[]uint32                `json:"indices"`
+}
+
+func (r FuzzyFileSearchResult) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Root      string                   `json:"root"`
+		Path      string                   `json:"path"`
+		MatchType FuzzyFileSearchMatchType `json:"match_type"`
+		FileName  string                   `json:"file_name"`
+		Score     uint32                   `json:"score"`
+		Indices   *[]uint32                `json:"indices"`
+	}{
+		Root: r.Root, Path: r.Path, MatchType: r.MatchType,
+		FileName: r.FileName, Score: r.Score, Indices: r.Indices,
+	})
+}
+
+func (r *FuzzyFileSearchResult) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("decode fuzzy-file-search result into nil receiver")
+	}
+	const objectName = "fuzzy-file-search result"
+	payload, err := decodeRustSerdeObject(
+		data, objectName, "root", "path", "match_type", "file_name", "score", "indices",
+	)
+	if err != nil {
+		return err
+	}
+	root, err := decodeRequiredThreadItemValue[string](payload, objectName, "root")
+	if err != nil {
+		return err
+	}
+	path, err := decodeRequiredThreadItemValue[string](payload, objectName, "path")
+	if err != nil {
+		return err
+	}
+	matchType, err := decodeRequiredThreadItemValue[FuzzyFileSearchMatchType](
+		payload, objectName, "match_type",
+	)
+	if err != nil {
+		return err
+	}
+	fileName, err := decodeRequiredThreadItemValue[string](payload, objectName, "file_name")
+	if err != nil {
+		return err
+	}
+	score, err := decodeRequiredThreadItemValue[uint32](payload, objectName, "score")
+	if err != nil {
+		return err
+	}
+	indices, err := decodeOptionalNullableFuzzyFileSearchArray[uint32](
+		payload, objectName, "indices",
+	)
+	if err != nil {
+		return err
+	}
+	*r = FuzzyFileSearchResult{
+		Root: root, Path: path, MatchType: matchType,
+		FileName: fileName, Score: score, Indices: indices,
+	}
+	return nil
+}
+
+// FuzzyFileSearchResponse is an exact standalone fuzzy-search result envelope.
+type FuzzyFileSearchResponse struct {
+	Files []FuzzyFileSearchResult `json:"files"`
+}
+
+func (r FuzzyFileSearchResponse) MarshalJSON() ([]byte, error) {
+	return marshalFuzzyFileSearchFiles(r.Files)
+}
+
+func (r *FuzzyFileSearchResponse) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("decode fuzzy-file-search response into nil receiver")
+	}
+	files, err := unmarshalFuzzyFileSearchFiles(data, "fuzzy-file-search response")
+	if err != nil {
+		return err
+	}
+	*r = FuzzyFileSearchResponse{Files: files}
+	return nil
+}
+
+// FuzzyFileSearchSessionUpdatedNotification is an exact standalone session
+// snapshot. Gollem does not produce or bind this notification.
+type FuzzyFileSearchSessionUpdatedNotification struct {
+	SessionID string                  `json:"sessionId"`
+	Query     string                  `json:"query"`
+	Files     []FuzzyFileSearchResult `json:"files"`
+}
+
+func (n FuzzyFileSearchSessionUpdatedNotification) MarshalJSON() ([]byte, error) {
+	files := n.Files
+	if files == nil {
+		files = []FuzzyFileSearchResult{}
+	}
+	return json.Marshal(struct {
+		SessionID string                  `json:"sessionId"`
+		Query     string                  `json:"query"`
+		Files     []FuzzyFileSearchResult `json:"files"`
+	}{SessionID: n.SessionID, Query: n.Query, Files: files})
+}
+
+func (n *FuzzyFileSearchSessionUpdatedNotification) UnmarshalJSON(data []byte) error {
+	if n == nil {
+		return errors.New("decode fuzzy-file-search session update into nil receiver")
+	}
+	const objectName = "fuzzy-file-search session update"
+	payload, err := decodeRustSerdeObject(data, objectName, "sessionId", "query", "files")
+	if err != nil {
+		return err
+	}
+	sessionID, err := decodeRequiredThreadItemValue[string](payload, objectName, "sessionId")
+	if err != nil {
+		return err
+	}
+	query, err := decodeRequiredThreadItemValue[string](payload, objectName, "query")
+	if err != nil {
+		return err
+	}
+	files, err := decodeRequiredThreadItemArray[FuzzyFileSearchResult](payload, objectName, "files")
+	if err != nil {
+		return err
+	}
+	*n = FuzzyFileSearchSessionUpdatedNotification{
+		SessionID: sessionID, Query: query, Files: files,
+	}
+	return nil
+}
+
+// FuzzyFileSearchSessionCompletedNotification is an exact standalone session
+// completion marker. Gollem does not produce or bind this notification.
+type FuzzyFileSearchSessionCompletedNotification struct {
+	SessionID string `json:"sessionId"`
+}
+
+func (n FuzzyFileSearchSessionCompletedNotification) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		SessionID string `json:"sessionId"`
+	}{SessionID: n.SessionID})
+}
+
+func (n *FuzzyFileSearchSessionCompletedNotification) UnmarshalJSON(data []byte) error {
+	if n == nil {
+		return errors.New("decode fuzzy-file-search session completion into nil receiver")
+	}
+	const objectName = "fuzzy-file-search session completion"
+	payload, err := decodeRustSerdeObject(data, objectName, "sessionId")
+	if err != nil {
+		return err
+	}
+	sessionID, err := decodeRequiredThreadItemValue[string](payload, objectName, "sessionId")
+	if err != nil {
+		return err
+	}
+	*n = FuzzyFileSearchSessionCompletedNotification{SessionID: sessionID}
+	return nil
+}
+
+func marshalFuzzyFileSearchFiles(files []FuzzyFileSearchResult) ([]byte, error) {
+	if files == nil {
+		files = []FuzzyFileSearchResult{}
+	}
+	return json.Marshal(struct {
+		Files []FuzzyFileSearchResult `json:"files"`
+	}{Files: files})
+}
+
+func unmarshalFuzzyFileSearchFiles(data []byte, objectName string) ([]FuzzyFileSearchResult, error) {
+	payload, err := decodeRustSerdeObject(data, objectName, "files")
+	if err != nil {
+		return nil, err
+	}
+	return decodeRequiredThreadItemArray[FuzzyFileSearchResult](payload, objectName, "files")
+}
+
+func decodeOptionalNullableFuzzyFileSearchValue[T any](
+	payload map[string]json.RawMessage,
+	objectName string,
+	fieldName string,
+) (*T, error) {
+	raw, ok := payload[fieldName]
+	if !ok || isJSONNull(raw) {
+		return nil, nil
+	}
+	var value T
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return nil, fmt.Errorf("decode %s %s: %w", objectName, fieldName, err)
+	}
+	return &value, nil
+}
+
+func decodeOptionalNullableFuzzyFileSearchArray[T any](
+	payload map[string]json.RawMessage,
+	objectName string,
+	fieldName string,
+) (*[]T, error) {
+	raw, ok := payload[fieldName]
+	if !ok || isJSONNull(raw) {
+		return nil, nil
+	}
+	var elements []json.RawMessage
+	if err := json.Unmarshal(raw, &elements); err != nil {
+		return nil, fmt.Errorf("decode %s %s: %w", objectName, fieldName, err)
+	}
+	values := make([]T, len(elements))
+	for index, element := range elements {
+		if isJSONNull(element) {
+			return nil, fmt.Errorf("decode %s %s[%d]: value cannot be null", objectName, fieldName, index)
+		}
+		if err := json.Unmarshal(element, &values[index]); err != nil {
+			return nil, fmt.Errorf("decode %s %s[%d]: %w", objectName, fieldName, index, err)
+		}
+	}
+	return &values, nil
+}
+
+func fuzzyFileSearchParamsSchema() Schema {
+	return closedThreadSessionParamSchema(Schema{
+		"query": Schema{"type": "string"},
+		"roots": Schema{"type": "array", "items": Schema{"type": "string"}},
+		"cancellationToken": Schema{"anyOf": []any{
+			Schema{"type": "string"}, Schema{"type": "null"},
+		}},
+	}, []string{"query", "roots"})
+}
+
+func fuzzyFileSearchResultSchema() Schema {
+	uint32Schema := Schema{"type": "integer", "minimum": 0, "maximum": 4294967295}
+	schema := closedThreadSessionParamSchema(Schema{
+		"root":       Schema{"type": "string"},
+		"path":       Schema{"type": "string"},
+		"match_type": Schema{"$ref": "#/$defs/FuzzyFileSearchMatchType"},
+		"file_name":  Schema{"type": "string"},
+		"score":      uint32Schema,
+		"indices": Schema{"anyOf": []any{
+			Schema{"type": "array", "items": uint32Schema}, Schema{"type": "null"},
+		}},
+	}, []string{"root", "path", "match_type", "file_name", "score"})
+	schema["description"] = "Superset of [`codex_file_search::FileMatch`]"
+	return schema
+}
+
+func fuzzyFileSearchResponseSchema() Schema {
+	return closedThreadSessionParamSchema(Schema{
+		"files": Schema{
+			"type": "array", "items": Schema{"$ref": "#/$defs/FuzzyFileSearchResult"},
+		},
+	}, []string{"files"})
+}
+
+func fuzzyFileSearchSessionUpdatedNotificationSchema() Schema {
+	return closedThreadSessionParamSchema(Schema{
+		"sessionId": Schema{"type": "string"},
+		"query":     Schema{"type": "string"},
+		"files": Schema{
+			"type": "array", "items": Schema{"$ref": "#/$defs/FuzzyFileSearchResult"},
+		},
+	}, []string{"sessionId", "query", "files"})
+}
+
+func fuzzyFileSearchSessionCompletedNotificationSchema() Schema {
+	return closedThreadSessionParamSchema(Schema{
+		"sessionId": Schema{"type": "string"},
+	}, []string{"sessionId"})
+}
+
+var (
+	_ json.Marshaler   = FuzzyFileSearchMatchType("")
+	_ json.Unmarshaler = (*FuzzyFileSearchMatchType)(nil)
+	_ json.Marshaler   = FuzzyFileSearchParams{}
+	_ json.Unmarshaler = (*FuzzyFileSearchParams)(nil)
+	_ json.Marshaler   = FuzzyFileSearchResult{}
+	_ json.Unmarshaler = (*FuzzyFileSearchResult)(nil)
+	_ json.Marshaler   = FuzzyFileSearchResponse{}
+	_ json.Unmarshaler = (*FuzzyFileSearchResponse)(nil)
+	_ json.Marshaler   = FuzzyFileSearchSessionUpdatedNotification{}
+	_ json.Unmarshaler = (*FuzzyFileSearchSessionUpdatedNotification)(nil)
+	_ json.Marshaler   = FuzzyFileSearchSessionCompletedNotification{}
+	_ json.Unmarshaler = (*FuzzyFileSearchSessionCompletedNotification)(nil)
+)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 402 {
-		t.Fatalf("definition count = %d, want 402", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 408 {
+		t.Fatalf("definition count = %d, want 408", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 402 {
-		t.Fatalf("definition count = %d, want 402", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 408 {
+		t.Fatalf("definition count = %d, want 408", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 402 {
-		t.Fatalf("definition count = %d, want 402", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 408 {
+		t.Fatalf("definition count = %d, want 408", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 402 {
-		t.Fatalf("definition count = %d, want 402", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 408 {
+		t.Fatalf("definition count = %d, want 408", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 402 {
-		t.Fatalf("definition count = %d, want 402", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 408 {
+		t.Fatalf("definition count = %d, want 408", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 402 {
-		t.Fatalf("definition count = %d, want 402", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 408 {
+		t.Fatalf("definition count = %d, want 408", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/rust_serde_object.go
+++ b/appserver/protocol/rust_serde_object.go
@@ -1,0 +1,62 @@
+package protocol
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// decodeRustSerdeObject preserves serde's unknown-field behavior while
+// rejecting duplicate known fields and trailing JSON values.
+func decodeRustSerdeObject(
+	data []byte,
+	objectName string,
+	knownFields ...string,
+) (map[string]json.RawMessage, error) {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	opening, err := decoder.Token()
+	if err != nil {
+		return nil, fmt.Errorf("decode %s: %w", objectName, err)
+	}
+	if opening != json.Delim('{') {
+		return nil, fmt.Errorf("%s must be an object", objectName)
+	}
+	known := make(map[string]struct{}, len(knownFields))
+	for _, name := range knownFields {
+		known[name] = struct{}{}
+	}
+	payload := make(map[string]json.RawMessage, len(known))
+	seen := make(map[string]bool, len(known))
+	for decoder.More() {
+		token, err := decoder.Token()
+		if err != nil {
+			return nil, fmt.Errorf("decode %s field name: %w", objectName, err)
+		}
+		name := token.(string)
+		var raw json.RawMessage
+		if err := decoder.Decode(&raw); err != nil {
+			return nil, fmt.Errorf("decode %s field %q: %w", objectName, name, err)
+		}
+		if _, ok := known[name]; !ok {
+			continue
+		}
+		if seen[name] {
+			return nil, fmt.Errorf("duplicate %s field %q", objectName, name)
+		}
+		seen[name] = true
+		payload[name] = append(json.RawMessage(nil), raw...)
+	}
+	if _, err := decoder.Token(); err != nil {
+		return nil, fmt.Errorf("decode %s: %w", objectName, err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return nil, fmt.Errorf("%s must contain one JSON value", objectName)
+		}
+		return nil, fmt.Errorf("decode %s trailing value: %w", objectName, err)
+	}
+	return payload, nil
+}

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -326,6 +326,12 @@ func wireSchemaDefinitions() Schema {
 		{Name: "ExternalAgentConfigImportHistoriesReadResponse", Type: reflect.TypeFor[ExternalAgentConfigImportHistoriesReadResponse]()},
 		{Name: "ExternalAgentConfigImportProgressNotification", Type: reflect.TypeFor[ExternalAgentConfigImportProgressNotification]()},
 		{Name: "ExternalAgentConfigImportCompletedNotification", Type: reflect.TypeFor[ExternalAgentConfigImportCompletedNotification]()},
+		{Name: "FuzzyFileSearchMatchType", Type: reflect.TypeFor[FuzzyFileSearchMatchType]()},
+		{Name: "FuzzyFileSearchParams", Type: reflect.TypeFor[FuzzyFileSearchParams]()},
+		{Name: "FuzzyFileSearchResult", Type: reflect.TypeFor[FuzzyFileSearchResult]()},
+		{Name: "FuzzyFileSearchResponse", Type: reflect.TypeFor[FuzzyFileSearchResponse]()},
+		{Name: "FuzzyFileSearchSessionUpdatedNotification", Type: reflect.TypeFor[FuzzyFileSearchSessionUpdatedNotification]()},
+		{Name: "FuzzyFileSearchSessionCompletedNotification", Type: reflect.TypeFor[FuzzyFileSearchSessionCompletedNotification]()},
 		{Name: "PermissionGrantScope", Type: reflect.TypeFor[PermissionGrantScope]()},
 		{Name: "PermissionsApprovalRequestParams", Type: reflect.TypeFor[PermissionsApprovalRequestParams]()},
 		{Name: "PermissionsRequestApprovalParams", Type: reflect.TypeFor[PermissionsRequestApprovalParams]()},
@@ -585,6 +591,14 @@ func wireSchemaDefinitions() Schema {
 	schemas["ExternalAgentConfigImportHistoriesReadResponse"] = externalAgentConfigImportHistoriesReadResponseSchema()
 	schemas["ExternalAgentConfigImportProgressNotification"] = externalAgentConfigImportNotificationSchema()
 	schemas["ExternalAgentConfigImportCompletedNotification"] = externalAgentConfigImportNotificationSchema()
+	schemas["FuzzyFileSearchMatchType"] = stringEnumSchema(
+		string(FuzzyFileSearchMatchTypeFile), string(FuzzyFileSearchMatchTypeDirectory),
+	)
+	schemas["FuzzyFileSearchParams"] = fuzzyFileSearchParamsSchema()
+	schemas["FuzzyFileSearchResult"] = fuzzyFileSearchResultSchema()
+	schemas["FuzzyFileSearchResponse"] = fuzzyFileSearchResponseSchema()
+	schemas["FuzzyFileSearchSessionUpdatedNotification"] = fuzzyFileSearchSessionUpdatedNotificationSchema()
+	schemas["FuzzyFileSearchSessionCompletedNotification"] = fuzzyFileSearchSessionCompletedNotificationSchema()
 	schemas["McpServerToolCallParams"] = mcpServerToolCallParamsSchema()
 	schemas["McpServerToolCallResponse"] = mcpServerToolCallResponseSchema()
 	schemas["ResourceContent"] = resourceContentSchema()

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -4425,6 +4425,138 @@
         }
       ]
     },
+    "FuzzyFileSearchMatchType": {
+      "enum": [
+        "file",
+        "directory"
+      ],
+      "type": "string"
+    },
+    "FuzzyFileSearchParams": {
+      "additionalProperties": false,
+      "properties": {
+        "cancellationToken": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "query": {
+          "type": "string"
+        },
+        "roots": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "query",
+        "roots"
+      ],
+      "type": "object"
+    },
+    "FuzzyFileSearchResponse": {
+      "additionalProperties": false,
+      "properties": {
+        "files": {
+          "items": {
+            "$ref": "#/$defs/FuzzyFileSearchResult"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "files"
+      ],
+      "type": "object"
+    },
+    "FuzzyFileSearchResult": {
+      "additionalProperties": false,
+      "description": "Superset of [`codex_file_search::FileMatch`]",
+      "properties": {
+        "file_name": {
+          "type": "string"
+        },
+        "indices": {
+          "anyOf": [
+            {
+              "items": {
+                "maximum": 4294967295,
+                "minimum": 0,
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "match_type": {
+          "$ref": "#/$defs/FuzzyFileSearchMatchType"
+        },
+        "path": {
+          "type": "string"
+        },
+        "root": {
+          "type": "string"
+        },
+        "score": {
+          "maximum": 4294967295,
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "root",
+        "path",
+        "match_type",
+        "file_name",
+        "score"
+      ],
+      "type": "object"
+    },
+    "FuzzyFileSearchSessionCompletedNotification": {
+      "additionalProperties": false,
+      "properties": {
+        "sessionId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "sessionId"
+      ],
+      "type": "object"
+    },
+    "FuzzyFileSearchSessionUpdatedNotification": {
+      "additionalProperties": false,
+      "properties": {
+        "files": {
+          "items": {
+            "$ref": "#/$defs/FuzzyFileSearchResult"
+          },
+          "type": "array"
+        },
+        "query": {
+          "type": "string"
+        },
+        "sessionId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "sessionId",
+        "query",
+        "files"
+      ],
+      "type": "object"
+    },
     "GitInfo": {
       "additionalProperties": false,
       "properties": {

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 402 {
-		t.Fatalf("definition count = %d, want 402", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 408 {
+		t.Fatalf("definition count = %d, want 408", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 402 {
-		t.Fatalf("definition count = %d, want 402", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 408 {
+		t.Fatalf("definition count = %d, want 408", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 402 {
-		t.Fatalf("definition count = %d, want 402", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 408 {
+		t.Fatalf("definition count = %d, want 408", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -40,7 +40,8 @@ func MarshalTypeScript() ([]byte, error) {
 		definition := defs[name]
 		if name == "MigrationDetails" || name == "ExternalAgentConfigMigrationItem" ||
 			name == "ExternalAgentConfigImportItemTypeFailure" ||
-			name == "ExternalAgentConfigImportItemTypeSuccess" {
+			name == "ExternalAgentConfigImportItemTypeSuccess" ||
+			name == "FuzzyFileSearchParams" || name == "FuzzyFileSearchResult" {
 			// Rust accepts omitted serde default/Option fields while generated
 			// TypeScript requires callers to provide their canonical values.
 			schema, _ := typeScriptSchema(definition)
@@ -62,6 +63,12 @@ func MarshalTypeScript() ([]byte, error) {
 				}
 			case "ExternalAgentConfigImportItemTypeSuccess":
 				schema["required"] = []string{"itemType", "cwd", "source", "target"}
+			case "FuzzyFileSearchParams":
+				schema["required"] = []string{"query", "roots", "cancellationToken"}
+			case "FuzzyFileSearchResult":
+				schema["required"] = []string{
+					"root", "path", "match_type", "file_name", "score", "indices",
+				}
 			}
 			definition = schema
 		}

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -1436,6 +1436,37 @@ export type FunctionCallOutputContentItem = {
   "type": "encrypted_content";
 };
 
+export type FuzzyFileSearchMatchType = "file" | "directory";
+
+export type FuzzyFileSearchParams = {
+  "cancellationToken": string | null;
+  "query": string;
+  "roots": Array<string>;
+};
+
+export type FuzzyFileSearchResponse = {
+  "files": Array<FuzzyFileSearchResult>;
+};
+
+export type FuzzyFileSearchResult = {
+  "file_name": string;
+  "indices": Array<number> | null;
+  "match_type": FuzzyFileSearchMatchType;
+  "path": string;
+  "root": string;
+  "score": number;
+};
+
+export type FuzzyFileSearchSessionCompletedNotification = {
+  "sessionId": string;
+};
+
+export type FuzzyFileSearchSessionUpdatedNotification = {
+  "files": Array<FuzzyFileSearchResult>;
+  "query": string;
+  "sessionId": string;
+};
+
 export type GitInfo = {
   "branch": string | null;
   "originUrl": string | null;

--- a/appserver/protocol/typescript/testdata/fuzzy_file_search_contract.ts
+++ b/appserver/protocol/typescript/testdata/fuzzy_file_search_contract.ts
@@ -1,0 +1,163 @@
+import type {
+  FuzzyFileSearchMatchType,
+  FuzzyFileSearchParams,
+  FuzzyFileSearchResult,
+  FuzzyFileSearchResponse,
+  FuzzyFileSearchSessionCompletedNotification,
+  FuzzyFileSearchSessionUpdatedNotification,
+  MethodParamsByName,
+  MethodResultsByName,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+type IsUnknown<T> = unknown extends T
+  ? ([keyof T] extends [never] ? true : false)
+  : false;
+type ParamsForKnownMethod<M extends string> = M extends keyof MethodParamsByName
+  ? MethodParamsByName[M]
+  : unknown;
+type ResultForKnownMethod<M extends string> = M extends keyof MethodResultsByName
+  ? MethodResultsByName[M]
+  : unknown;
+
+type Contracts = [
+  Expect<Equal<FuzzyFileSearchMatchType, "file" | "directory">>,
+  Expect<Equal<
+    FuzzyFileSearchParams,
+    { query: string; roots: Array<string>; cancellationToken: string | null }
+  >>,
+  Expect<Equal<
+    FuzzyFileSearchResult,
+    {
+      root: string;
+      path: string;
+      match_type: FuzzyFileSearchMatchType;
+      file_name: string;
+      score: number;
+      indices: Array<number> | null;
+    }
+  >>,
+  Expect<Equal<FuzzyFileSearchResponse, { files: Array<FuzzyFileSearchResult> }>>,
+  Expect<Equal<
+    FuzzyFileSearchSessionUpdatedNotification,
+    { sessionId: string; query: string; files: Array<FuzzyFileSearchResult> }
+  >>,
+  Expect<Equal<FuzzyFileSearchSessionCompletedNotification, { sessionId: string }>>,
+  Expect<IsUnknown<ParamsForKnownMethod<"fuzzyFileSearch">>>,
+  Expect<IsUnknown<ResultForKnownMethod<"fuzzyFileSearch">>>,
+  Expect<IsUnknown<ParamsForKnownMethod<"fuzzyFileSearch/sessionUpdated">>>,
+  Expect<IsUnknown<ResultForKnownMethod<"fuzzyFileSearch/sessionUpdated">>>,
+  Expect<IsUnknown<ParamsForKnownMethod<"fuzzyFileSearch/sessionCompleted">>>,
+  Expect<IsUnknown<ResultForKnownMethod<"fuzzyFileSearch/sessionCompleted">>>,
+];
+
+declare const contracts: Contracts;
+void contracts;
+
+const file = "file" satisfies FuzzyFileSearchMatchType;
+const directory = "directory" satisfies FuzzyFileSearchMatchType;
+const params = {
+  query: "",
+  roots: ["", "repo/../repo", "", "repo/../repo"],
+  cancellationToken: null,
+} satisfies FuzzyFileSearchParams;
+const result = {
+  root: "",
+  path: "",
+  match_type: file,
+  file_name: "",
+  score: 0,
+  indices: null,
+} satisfies FuzzyFileSearchResult;
+({
+  ...result,
+  root: " repo ",
+  path: "./a/../b",
+  match_type: directory,
+  file_name: " name ",
+  score: 4_294_967_295,
+  indices: [4_294_967_295, 0, 4_294_967_295],
+}) satisfies FuzzyFileSearchResult;
+({ files: [] }) satisfies FuzzyFileSearchResponse;
+({ files: [result, result] }) satisfies FuzzyFileSearchResponse;
+({ sessionId: "", query: "", files: [] }) satisfies FuzzyFileSearchSessionUpdatedNotification;
+({ sessionId: " session ", query: " query ", files: [result, result] }) satisfies FuzzyFileSearchSessionUpdatedNotification;
+({ sessionId: "" }) satisfies FuzzyFileSearchSessionCompletedNotification;
+
+// @ts-expect-error match types are closed.
+"folder" satisfies FuzzyFileSearchMatchType;
+// @ts-expect-error query is required.
+({ roots: [], cancellationToken: null }) satisfies FuzzyFileSearchParams;
+// @ts-expect-error roots are required.
+({ query: "", cancellationToken: null }) satisfies FuzzyFileSearchParams;
+// @ts-expect-error cancellationToken is required by exact ts-rs output.
+({ query: "", roots: [] }) satisfies FuzzyFileSearchParams;
+// @ts-expect-error roots are non-null.
+({ ...params, roots: null }) satisfies FuzzyFileSearchParams;
+// @ts-expect-error cancellationToken is nullable string only.
+({ ...params, cancellationToken: 1 }) satisfies FuzzyFileSearchParams;
+// @ts-expect-error snake-case aliases do not replace canonical params fields.
+({ query: "", roots: [], cancellation_token: null }) satisfies FuzzyFileSearchParams;
+// @ts-expect-error fields absent from params are rejected.
+({ ...params, extra: true }) satisfies FuzzyFileSearchParams;
+
+// @ts-expect-error root is required.
+({ path: "", match_type: file, file_name: "", score: 0, indices: null }) satisfies FuzzyFileSearchResult;
+// @ts-expect-error path is required.
+({ root: "", match_type: file, file_name: "", score: 0, indices: null }) satisfies FuzzyFileSearchResult;
+// @ts-expect-error match_type is required.
+({ root: "", path: "", file_name: "", score: 0, indices: null }) satisfies FuzzyFileSearchResult;
+// @ts-expect-error file_name is required.
+({ root: "", path: "", match_type: file, score: 0, indices: null }) satisfies FuzzyFileSearchResult;
+// @ts-expect-error score is required.
+({ root: "", path: "", match_type: file, file_name: "", indices: null }) satisfies FuzzyFileSearchResult;
+// @ts-expect-error indices is required by exact ts-rs output.
+({ root: "", path: "", match_type: file, file_name: "", score: 0 }) satisfies FuzzyFileSearchResult;
+// @ts-expect-error result strings are non-null.
+({ ...result, root: null }) satisfies FuzzyFileSearchResult;
+// @ts-expect-error score is numeric.
+({ ...result, score: "0" }) satisfies FuzzyFileSearchResult;
+// @ts-expect-error indices are an array or null.
+({ ...result, indices: 0 }) satisfies FuzzyFileSearchResult;
+// @ts-expect-error result names intentionally remain snake case.
+({ ...result, match_type: undefined, matchType: file }) satisfies FuzzyFileSearchResult;
+// @ts-expect-error result names intentionally remain snake case.
+({ ...result, file_name: undefined, fileName: "" }) satisfies FuzzyFileSearchResult;
+// @ts-expect-error fields absent from results are rejected.
+({ ...result, extra: true }) satisfies FuzzyFileSearchResult;
+
+// @ts-expect-error files are required.
+({}) satisfies FuzzyFileSearchResponse;
+// @ts-expect-error files are non-null.
+({ files: null }) satisfies FuzzyFileSearchResponse;
+// @ts-expect-error response entries retain exact result fields.
+({ files: [{ root: "", path: "", match_type: file, file_name: "", score: 0 }] }) satisfies FuzzyFileSearchResponse;
+// @ts-expect-error fields absent from responses are rejected.
+({ files: [], extra: true }) satisfies FuzzyFileSearchResponse;
+
+// @ts-expect-error sessionId is required.
+({ query: "", files: [] }) satisfies FuzzyFileSearchSessionUpdatedNotification;
+// @ts-expect-error query is required.
+({ sessionId: "", files: [] }) satisfies FuzzyFileSearchSessionUpdatedNotification;
+// @ts-expect-error files are required.
+({ sessionId: "", query: "" }) satisfies FuzzyFileSearchSessionUpdatedNotification;
+// @ts-expect-error files are non-null.
+({ sessionId: "", query: "", files: null }) satisfies FuzzyFileSearchSessionUpdatedNotification;
+// @ts-expect-error snake-case aliases do not replace canonical notification fields.
+({ session_id: "", query: "", files: [] }) satisfies FuzzyFileSearchSessionUpdatedNotification;
+// @ts-expect-error fields absent from updated notifications are rejected.
+({ sessionId: "", query: "", files: [], extra: true }) satisfies FuzzyFileSearchSessionUpdatedNotification;
+
+// @ts-expect-error sessionId is required.
+({}) satisfies FuzzyFileSearchSessionCompletedNotification;
+// @ts-expect-error sessionId is non-null.
+({ sessionId: null }) satisfies FuzzyFileSearchSessionCompletedNotification;
+// @ts-expect-error snake-case aliases do not replace canonical notification fields.
+({ session_id: "" }) satisfies FuzzyFileSearchSessionCompletedNotification;
+// @ts-expect-error fields absent from completed notifications are rejected.
+({ sessionId: "", extra: true }) satisfies FuzzyFileSearchSessionCompletedNotification;

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 402 {
-		t.Fatalf("definition count = %d, want 402", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
+		t.Fatalf("definition count = %d, want 408", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- export the exact standalone fuzzy-file-search enum, params, result, response, and session notification contracts
- preserve Rust serde canonicalization, intentional snake-case result fields, strict uint32 bounds, nullable options, array order, and duplicates
- keep fuzzy-file-search request and notification methods deferred and unbound with no filesystem, search, ranking, cancellation, session, or runtime authority
- move the shared serde-compatible object decoder behind a neutral helper while preserving the existing external-agent wrapper

## Verification
- deliberate-red Go and strict TypeScript boundaries
- focused tests x30 and focused race
- 100% statement coverage for all new/modified codec, helper, and schema functions
- full protocol normal/race
- fresh serialized normal/race across exactly 59 non-Monty packages
- golangci-lint: 0 issues; go vet; go mod tidy clean
- deterministic 408-definition generation and strict TypeScript
- exact normalized upstream schemars and parsed ts-rs semantics
- configured pre-push before commit and during push with hooks.skipMontyRace=true
- all five Slang real-binary stdio/Unix-socket/WebSocket workflows
- reproducible trimpath/buildvcs-disabled binary and byte-identical baseline live transcript