### PR TITLE
feat(protocol): export hook value foundation

### DIFF
--- a/appserver/protocol/README.md
+++ b/appserver/protocol/README.md
@@ -499,6 +499,15 @@ methods remain deferred and unbound; these values add no filesystem access,
 search, ranking, cancellation, session, or notification behavior. Their strict
 compile contract is `typescript/testdata/fuzzy_file_search_contract.ts`.
 
+Exact standalone hook event, execution-mode, handler-type, output-kind,
+run-status, scope, source, and trust-status enums plus `HookOutputEntry`
+establish the dependency-free public hook value layer. All literals remain
+closed and case-sensitive; output entries require kind and text while serde
+input discards unknown fields. No hook summary, lifecycle/list parent, method
+binding, discovery, trust decision, execution, persistence, or notification
+producer is added. Their strict compile contract is
+`typescript/testdata/hook_value_foundation_contract.ts`.
+
 Exact standalone warning, guardian-warning, and error notification records
 establish the fixed public warning/error value layer. Canonical warning output
 requires explicit nullable thread id, while decoding also accepts omission to

--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(defs); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,8 +217,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,8 +203,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -260,8 +260,8 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,8 +244,8 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -162,8 +162,8 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -175,8 +175,8 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -381,8 +381,8 @@ func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_value_foundation_contract_test.go
+++ b/appserver/protocol/hook_value_foundation_contract_test.go
@@ -1,0 +1,226 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestHookValueFoundationSchemasAreExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	assertStringEnum(t, defs["HookEventName"],
+		"preToolUse", "permissionRequest", "postToolUse", "preCompact", "postCompact",
+		"sessionStart", "userPromptSubmit", "subagentStart", "subagentStop", "stop",
+	)
+	assertStringEnum(t, defs["HookExecutionMode"], "sync", "async")
+	assertStringEnum(t, defs["HookHandlerType"], "command", "prompt", "agent")
+	assertStringEnum(t, defs["HookOutputEntryKind"], "warning", "stop", "feedback", "context", "error")
+	assertStringEnum(t, defs["HookRunStatus"], "running", "completed", "failed", "blocked", "stopped")
+	assertStringEnum(t, defs["HookScope"], "thread", "turn")
+	assertStringEnum(t, defs["HookSource"],
+		"system", "user", "project", "mdm", "sessionFlags", "plugin",
+		"cloudRequirements", "cloudManagedConfig", "legacyManagedConfigFile",
+		"legacyManagedConfigMdm", "unknown",
+	)
+	assertStringEnum(t, defs["HookTrustStatus"], "managed", "untrusted", "trusted", "modified")
+
+	wantEntry := closedThreadSessionParamSchema(Schema{
+		"kind": Schema{"$ref": "#/$defs/HookOutputEntryKind"},
+		"text": Schema{"type": "string"},
+	}, []string{"kind", "text"})
+	if got, ok := defs["HookOutputEntry"].(Schema); !ok || !reflect.DeepEqual(got, wantEntry) {
+		t.Fatalf("HookOutputEntry schema = %#v, %v; want %#v", got, ok, wantEntry)
+	}
+}
+
+func TestHookValueFoundationEnumsAcceptExactValues(t *testing.T) {
+	assertHookEnumValues(t, []HookEventName{
+		HookEventNamePreToolUse, HookEventNamePermissionRequest, HookEventNamePostToolUse,
+		HookEventNamePreCompact, HookEventNamePostCompact, HookEventNameSessionStart,
+		HookEventNameUserPromptSubmit, HookEventNameSubagentStart,
+		HookEventNameSubagentStop, HookEventNameStop,
+	})
+	assertHookEnumValues(t, []HookExecutionMode{HookExecutionModeSync, HookExecutionModeAsync})
+	assertHookEnumValues(t, []HookHandlerType{HookHandlerTypeCommand, HookHandlerTypePrompt, HookHandlerTypeAgent})
+	assertHookEnumValues(t, []HookOutputEntryKind{
+		HookOutputEntryKindWarning, HookOutputEntryKindStop, HookOutputEntryKindFeedback,
+		HookOutputEntryKindContext, HookOutputEntryKindError,
+	})
+	assertHookEnumValues(t, []HookRunStatus{
+		HookRunStatusRunning, HookRunStatusCompleted, HookRunStatusFailed,
+		HookRunStatusBlocked, HookRunStatusStopped,
+	})
+	assertHookEnumValues(t, []HookScope{HookScopeThread, HookScopeTurn})
+	assertHookEnumValues(t, []HookSource{
+		HookSourceSystem, HookSourceUser, HookSourceProject, HookSourceMDM,
+		HookSourceSessionFlags, HookSourcePlugin, HookSourceCloudRequirements,
+		HookSourceCloudManagedConfig, HookSourceLegacyManagedConfigFile,
+		HookSourceLegacyManagedConfigMDM, HookSourceUnknown,
+	})
+	assertHookEnumValues(t, []HookTrustStatus{
+		HookTrustStatusManaged, HookTrustStatusUntrusted,
+		HookTrustStatusTrusted, HookTrustStatusModified,
+	})
+}
+
+func TestHookValueFoundationEnumsRejectMalformedValues(t *testing.T) {
+	common := []string{``, `null`, `""`, `1`, `true`, `{}`, `[]`, `"value" {}`}
+	assertHookEnumRejects[HookEventName](t, append(common, `"PreToolUse"`, `"pre_tool_use"`, `"other"`)...)
+	assertHookEnumRejects[HookExecutionMode](t, append(common, `"Sync"`, `"other"`)...)
+	assertHookEnumRejects[HookHandlerType](t, append(common, `"Command"`, `"other"`)...)
+	assertHookEnumRejects[HookOutputEntryKind](t, append(common, `"Warning"`, `"other"`)...)
+	assertHookEnumRejects[HookRunStatus](t, append(common, `"Running"`, `"other"`)...)
+	assertHookEnumRejects[HookScope](t, append(common, `"Thread"`, `"other"`)...)
+	assertHookEnumRejects[HookSource](t, append(common, `"session_flags"`, `"SessionFlags"`, `"other"`)...)
+	assertHookEnumRejects[HookTrustStatus](t, append(common, `"Managed"`, `"other"`)...)
+}
+
+func TestHookValueFoundationNilReceiversAndInvalidMarshalFailClosed(t *testing.T) {
+	nilReceivers := []json.Unmarshaler{
+		(*HookEventName)(nil), (*HookExecutionMode)(nil), (*HookHandlerType)(nil),
+		(*HookOutputEntryKind)(nil), (*HookRunStatus)(nil), (*HookScope)(nil),
+		(*HookSource)(nil), (*HookTrustStatus)(nil),
+	}
+	for _, receiver := range nilReceivers {
+		if err := receiver.UnmarshalJSON([]byte(`"value"`)); err == nil {
+			t.Errorf("nil %T receiver succeeded", receiver)
+		}
+	}
+	invalid := []any{
+		HookEventName(""), HookEventName("other"),
+		HookExecutionMode(""), HookExecutionMode("other"),
+		HookHandlerType(""), HookHandlerType("other"),
+		HookOutputEntryKind(""), HookOutputEntryKind("other"),
+		HookRunStatus(""), HookRunStatus("other"),
+		HookScope(""), HookScope("other"),
+		HookSource(""), HookSource("other"),
+		HookTrustStatus(""), HookTrustStatus("other"),
+	}
+	for _, value := range invalid {
+		if _, err := json.Marshal(value); err == nil {
+			t.Errorf("invalid %T %q marshaled", value, value)
+		}
+	}
+}
+
+func TestHookOutputEntryAcceptsRustWireForms(t *testing.T) {
+	cases := []struct {
+		input string
+		want  HookOutputEntry
+		wire  string
+	}{
+		{`{"kind":"warning","text":"","future":true}`, HookOutputEntry{Kind: HookOutputEntryKindWarning, Text: ""}, `{"kind":"warning","text":""}`},
+		{`{"kind":"stop","text":" stop "}`, HookOutputEntry{Kind: HookOutputEntryKindStop, Text: " stop "}, `{"kind":"stop","text":" stop "}`},
+		{`{"kind":"feedback","text":"same"}`, HookOutputEntry{Kind: HookOutputEntryKindFeedback, Text: "same"}, `{"kind":"feedback","text":"same"}`},
+		{`{"kind":"context","text":"same"}`, HookOutputEntry{Kind: HookOutputEntryKindContext, Text: "same"}, `{"kind":"context","text":"same"}`},
+		{`{"kind":"error","text":" error "}`, HookOutputEntry{Kind: HookOutputEntryKindError, Text: " error "}, `{"kind":"error","text":" error "}`},
+	}
+	for _, tc := range cases {
+		var got HookOutputEntry
+		if err := json.Unmarshal([]byte(tc.input), &got); err != nil {
+			t.Fatalf("Unmarshal(%s): %v", tc.input, err)
+		}
+		if got != tc.want {
+			t.Fatalf("entry = %#v, want %#v", got, tc.want)
+		}
+		encoded, err := json.Marshal(got)
+		if err != nil || string(encoded) != tc.wire {
+			t.Fatalf("Marshal(%#v) = %s, %v; want %s", got, encoded, err, tc.wire)
+		}
+	}
+}
+
+func TestHookOutputEntryRejectsMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{}`,
+		`{"text":"x"}`, `{"kind":"warning"}`,
+		`{"kind":null,"text":"x"}`, `{"kind":"other","text":"x"}`,
+		`{"kind":"warning","text":null}`, `{"kind":"warning","text":1}`,
+		`{"Kind":"warning","text":"x"}`, `{"kind":"warning","Text":"x"}`,
+		`{"kind":"warning","kind":"error","text":"x"}`,
+		`{"kind":"warning","text":"x","text":"y"}`,
+		`{"kind":"warning","text":"x"`, `{"kind":"warning","text":"x"} {}`,
+	} {
+		assertJSONRejects[HookOutputEntry](t, input)
+	}
+	var entry *HookOutputEntry
+	if err := entry.UnmarshalJSON([]byte(`{"kind":"warning","text":"x"}`)); err == nil {
+		t.Fatal("nil HookOutputEntry receiver succeeded")
+	}
+	if _, err := json.Marshal(HookOutputEntry{}); err == nil {
+		t.Fatal("zero HookOutputEntry marshaled")
+	}
+}
+
+func TestHookValueFoundationRemainsStandalone(t *testing.T) {
+	names := []string{
+		"HookEventName", "HookExecutionMode", "HookHandlerType",
+		"HookOutputEntryKind", "HookRunStatus", "HookScope", "HookSource",
+		"HookTrustStatus", "HookOutputEntry",
+	}
+	for _, binding := range WireTypeBindings() {
+		for _, name := range names {
+			if slices.Contains(binding.Params, name) || slices.Contains(binding.Result, name) {
+				t.Fatalf("%s unexpectedly bound to %s", name, binding.Method)
+			}
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestHookValueFoundationTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	source := string(generated)
+	for _, want := range []string{
+		`export type HookEventName = "preToolUse" | "permissionRequest" | "postToolUse" | "preCompact" | "postCompact" | "sessionStart" | "userPromptSubmit" | "subagentStart" | "subagentStop" | "stop";`,
+		`export type HookExecutionMode = "sync" | "async";`,
+		`export type HookHandlerType = "command" | "prompt" | "agent";`,
+		`export type HookOutputEntryKind = "warning" | "stop" | "feedback" | "context" | "error";`,
+		`export type HookRunStatus = "running" | "completed" | "failed" | "blocked" | "stopped";`,
+		`export type HookScope = "thread" | "turn";`,
+		`export type HookSource = "system" | "user" | "project" | "mdm" | "sessionFlags" | "plugin" | "cloudRequirements" | "cloudManagedConfig" | "legacyManagedConfigFile" | "legacyManagedConfigMdm" | "unknown";`,
+		`export type HookTrustStatus = "managed" | "untrusted" | "trusted" | "modified";`,
+		"export type HookOutputEntry = {\n  \"kind\": HookOutputEntryKind;\n  \"text\": string;\n};",
+	} {
+		if !strings.Contains(source, want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}
+
+func assertHookEnumValues[T ~string](t *testing.T, values []T) {
+	t.Helper()
+	for _, value := range values {
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			t.Fatalf("Marshal(%T(%q)): %v", value, value, err)
+		}
+		var got T
+		if err := json.Unmarshal(encoded, &got); err != nil || got != value {
+			t.Fatalf("round trip %T(%q) = %q, %v", value, value, got, err)
+		}
+	}
+}
+
+func assertHookEnumRejects[T ~string](t *testing.T, inputs ...string) {
+	t.Helper()
+	for _, input := range inputs {
+		var value T
+		if err := json.Unmarshal([]byte(input), &value); err == nil {
+			t.Errorf("%T Unmarshal(%s) succeeded", value, input)
+		}
+	}
+}

--- a/appserver/protocol/hook_value_foundation_types.go
+++ b/appserver/protocol/hook_value_foundation_types.go
@@ -1,0 +1,284 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// HookEventName is the exact closed public hook lifecycle event name. It does
+// not imply that Gollem discovers or executes hooks.
+type HookEventName string
+
+const (
+	HookEventNamePreToolUse        HookEventName = "preToolUse"
+	HookEventNamePermissionRequest HookEventName = "permissionRequest"
+	HookEventNamePostToolUse       HookEventName = "postToolUse"
+	HookEventNamePreCompact        HookEventName = "preCompact"
+	HookEventNamePostCompact       HookEventName = "postCompact"
+	HookEventNameSessionStart      HookEventName = "sessionStart"
+	HookEventNameUserPromptSubmit  HookEventName = "userPromptSubmit"
+	HookEventNameSubagentStart     HookEventName = "subagentStart"
+	HookEventNameSubagentStop      HookEventName = "subagentStop"
+	HookEventNameStop              HookEventName = "stop"
+)
+
+func (n HookEventName) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(n, "hook event name", HookEventName.valid)
+}
+
+func (n *HookEventName) UnmarshalJSON(data []byte) error {
+	return unmarshalThreadTurnLeafEnum(data, n, "hook event name", HookEventName.valid)
+}
+
+func (n HookEventName) valid() bool {
+	switch n {
+	case HookEventNamePreToolUse, HookEventNamePermissionRequest,
+		HookEventNamePostToolUse, HookEventNamePreCompact, HookEventNamePostCompact,
+		HookEventNameSessionStart, HookEventNameUserPromptSubmit,
+		HookEventNameSubagentStart, HookEventNameSubagentStop, HookEventNameStop:
+		return true
+	default:
+		return false
+	}
+}
+
+// HookExecutionMode is the exact closed public hook execution mode.
+type HookExecutionMode string
+
+const (
+	HookExecutionModeSync  HookExecutionMode = "sync"
+	HookExecutionModeAsync HookExecutionMode = "async"
+)
+
+func (m HookExecutionMode) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(m, "hook execution mode", HookExecutionMode.valid)
+}
+
+func (m *HookExecutionMode) UnmarshalJSON(data []byte) error {
+	return unmarshalThreadTurnLeafEnum(data, m, "hook execution mode", HookExecutionMode.valid)
+}
+
+func (m HookExecutionMode) valid() bool {
+	return m == HookExecutionModeSync || m == HookExecutionModeAsync
+}
+
+// HookHandlerType is the exact closed public hook handler type.
+type HookHandlerType string
+
+const (
+	HookHandlerTypeCommand HookHandlerType = "command"
+	HookHandlerTypePrompt  HookHandlerType = "prompt"
+	HookHandlerTypeAgent   HookHandlerType = "agent"
+)
+
+func (h HookHandlerType) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(h, "hook handler type", HookHandlerType.valid)
+}
+
+func (h *HookHandlerType) UnmarshalJSON(data []byte) error {
+	return unmarshalThreadTurnLeafEnum(data, h, "hook handler type", HookHandlerType.valid)
+}
+
+func (h HookHandlerType) valid() bool {
+	return h == HookHandlerTypeCommand || h == HookHandlerTypePrompt || h == HookHandlerTypeAgent
+}
+
+// HookOutputEntryKind is the exact closed public hook output category.
+type HookOutputEntryKind string
+
+const (
+	HookOutputEntryKindWarning  HookOutputEntryKind = "warning"
+	HookOutputEntryKindStop     HookOutputEntryKind = "stop"
+	HookOutputEntryKindFeedback HookOutputEntryKind = "feedback"
+	HookOutputEntryKindContext  HookOutputEntryKind = "context"
+	HookOutputEntryKindError    HookOutputEntryKind = "error"
+)
+
+func (k HookOutputEntryKind) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(k, "hook output entry kind", HookOutputEntryKind.valid)
+}
+
+func (k *HookOutputEntryKind) UnmarshalJSON(data []byte) error {
+	return unmarshalThreadTurnLeafEnum(data, k, "hook output entry kind", HookOutputEntryKind.valid)
+}
+
+func (k HookOutputEntryKind) valid() bool {
+	switch k {
+	case HookOutputEntryKindWarning, HookOutputEntryKindStop, HookOutputEntryKindFeedback,
+		HookOutputEntryKindContext, HookOutputEntryKindError:
+		return true
+	default:
+		return false
+	}
+}
+
+// HookRunStatus is the exact closed public hook run status.
+type HookRunStatus string
+
+const (
+	HookRunStatusRunning   HookRunStatus = "running"
+	HookRunStatusCompleted HookRunStatus = "completed"
+	HookRunStatusFailed    HookRunStatus = "failed"
+	HookRunStatusBlocked   HookRunStatus = "blocked"
+	HookRunStatusStopped   HookRunStatus = "stopped"
+)
+
+func (s HookRunStatus) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(s, "hook run status", HookRunStatus.valid)
+}
+
+func (s *HookRunStatus) UnmarshalJSON(data []byte) error {
+	return unmarshalThreadTurnLeafEnum(data, s, "hook run status", HookRunStatus.valid)
+}
+
+func (s HookRunStatus) valid() bool {
+	switch s {
+	case HookRunStatusRunning, HookRunStatusCompleted, HookRunStatusFailed,
+		HookRunStatusBlocked, HookRunStatusStopped:
+		return true
+	default:
+		return false
+	}
+}
+
+// HookScope is the exact closed public hook run ownership scope.
+type HookScope string
+
+const (
+	HookScopeThread HookScope = "thread"
+	HookScopeTurn   HookScope = "turn"
+)
+
+func (s HookScope) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(s, "hook scope", HookScope.valid)
+}
+
+func (s *HookScope) UnmarshalJSON(data []byte) error {
+	return unmarshalThreadTurnLeafEnum(data, s, "hook scope", HookScope.valid)
+}
+
+func (s HookScope) valid() bool {
+	return s == HookScopeThread || s == HookScopeTurn
+}
+
+// HookSource is the exact closed public source classification for hook data.
+// A value carries no path, trust, loading, or execution authority.
+type HookSource string
+
+const (
+	HookSourceSystem                  HookSource = "system"
+	HookSourceUser                    HookSource = "user"
+	HookSourceProject                 HookSource = "project"
+	HookSourceMDM                     HookSource = "mdm"
+	HookSourceSessionFlags            HookSource = "sessionFlags"
+	HookSourcePlugin                  HookSource = "plugin"
+	HookSourceCloudRequirements       HookSource = "cloudRequirements"
+	HookSourceCloudManagedConfig      HookSource = "cloudManagedConfig"
+	HookSourceLegacyManagedConfigFile HookSource = "legacyManagedConfigFile"
+	HookSourceLegacyManagedConfigMDM  HookSource = "legacyManagedConfigMdm"
+	HookSourceUnknown                 HookSource = "unknown"
+)
+
+func (s HookSource) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(s, "hook source", HookSource.valid)
+}
+
+func (s *HookSource) UnmarshalJSON(data []byte) error {
+	return unmarshalThreadTurnLeafEnum(data, s, "hook source", HookSource.valid)
+}
+
+func (s HookSource) valid() bool {
+	switch s {
+	case HookSourceSystem, HookSourceUser, HookSourceProject, HookSourceMDM,
+		HookSourceSessionFlags, HookSourcePlugin, HookSourceCloudRequirements,
+		HookSourceCloudManagedConfig, HookSourceLegacyManagedConfigFile,
+		HookSourceLegacyManagedConfigMDM, HookSourceUnknown:
+		return true
+	default:
+		return false
+	}
+}
+
+// HookTrustStatus is the exact closed public hook trust classification. It is
+// descriptive only and does not grant execution authority.
+type HookTrustStatus string
+
+const (
+	HookTrustStatusManaged   HookTrustStatus = "managed"
+	HookTrustStatusUntrusted HookTrustStatus = "untrusted"
+	HookTrustStatusTrusted   HookTrustStatus = "trusted"
+	HookTrustStatusModified  HookTrustStatus = "modified"
+)
+
+func (s HookTrustStatus) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(s, "hook trust status", HookTrustStatus.valid)
+}
+
+func (s *HookTrustStatus) UnmarshalJSON(data []byte) error {
+	return unmarshalThreadTurnLeafEnum(data, s, "hook trust status", HookTrustStatus.valid)
+}
+
+func (s HookTrustStatus) valid() bool {
+	switch s {
+	case HookTrustStatusManaged, HookTrustStatusUntrusted,
+		HookTrustStatusTrusted, HookTrustStatusModified:
+		return true
+	default:
+		return false
+	}
+}
+
+// HookOutputEntry is one exact standalone descriptive hook output value.
+type HookOutputEntry struct {
+	Kind HookOutputEntryKind `json:"kind"`
+	Text string              `json:"text"`
+}
+
+func (e HookOutputEntry) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Kind HookOutputEntryKind `json:"kind"`
+		Text string              `json:"text"`
+	}{Kind: e.Kind, Text: e.Text})
+}
+
+func (e *HookOutputEntry) UnmarshalJSON(data []byte) error {
+	if e == nil {
+		return errors.New("decode hook output entry into nil receiver")
+	}
+	const objectName = "hook output entry"
+	payload, err := decodeRustSerdeObject(data, objectName, "kind", "text")
+	if err != nil {
+		return err
+	}
+	kind, err := decodeRequiredThreadItemValue[HookOutputEntryKind](payload, objectName, "kind")
+	if err != nil {
+		return err
+	}
+	text, err := decodeRequiredThreadItemValue[string](payload, objectName, "text")
+	if err != nil {
+		return err
+	}
+	*e = HookOutputEntry{Kind: kind, Text: text}
+	return nil
+}
+
+var (
+	_ json.Marshaler   = HookEventName("")
+	_ json.Unmarshaler = (*HookEventName)(nil)
+	_ json.Marshaler   = HookExecutionMode("")
+	_ json.Unmarshaler = (*HookExecutionMode)(nil)
+	_ json.Marshaler   = HookHandlerType("")
+	_ json.Unmarshaler = (*HookHandlerType)(nil)
+	_ json.Marshaler   = HookOutputEntryKind("")
+	_ json.Unmarshaler = (*HookOutputEntryKind)(nil)
+	_ json.Marshaler   = HookRunStatus("")
+	_ json.Unmarshaler = (*HookRunStatus)(nil)
+	_ json.Marshaler   = HookScope("")
+	_ json.Unmarshaler = (*HookScope)(nil)
+	_ json.Marshaler   = HookSource("")
+	_ json.Unmarshaler = (*HookSource)(nil)
+	_ json.Marshaler   = HookTrustStatus("")
+	_ json.Unmarshaler = (*HookTrustStatus)(nil)
+	_ json.Marshaler   = HookOutputEntry{}
+	_ json.Unmarshaler = (*HookOutputEntry)(nil)
+)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 408 {
-		t.Fatalf("definition count = %d, want 408", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 417 {
+		t.Fatalf("definition count = %d, want 417", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 408 {
-		t.Fatalf("definition count = %d, want 408", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 417 {
+		t.Fatalf("definition count = %d, want 417", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 408 {
-		t.Fatalf("definition count = %d, want 408", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 417 {
+		t.Fatalf("definition count = %d, want 417", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 408 {
-		t.Fatalf("definition count = %d, want 408", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 417 {
+		t.Fatalf("definition count = %d, want 417", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 408 {
-		t.Fatalf("definition count = %d, want 408", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 417 {
+		t.Fatalf("definition count = %d, want 417", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 408 {
-		t.Fatalf("definition count = %d, want 408", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 417 {
+		t.Fatalf("definition count = %d, want 417", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -332,6 +332,15 @@ func wireSchemaDefinitions() Schema {
 		{Name: "FuzzyFileSearchResponse", Type: reflect.TypeFor[FuzzyFileSearchResponse]()},
 		{Name: "FuzzyFileSearchSessionUpdatedNotification", Type: reflect.TypeFor[FuzzyFileSearchSessionUpdatedNotification]()},
 		{Name: "FuzzyFileSearchSessionCompletedNotification", Type: reflect.TypeFor[FuzzyFileSearchSessionCompletedNotification]()},
+		{Name: "HookEventName", Type: reflect.TypeFor[HookEventName]()},
+		{Name: "HookExecutionMode", Type: reflect.TypeFor[HookExecutionMode]()},
+		{Name: "HookHandlerType", Type: reflect.TypeFor[HookHandlerType]()},
+		{Name: "HookOutputEntryKind", Type: reflect.TypeFor[HookOutputEntryKind]()},
+		{Name: "HookRunStatus", Type: reflect.TypeFor[HookRunStatus]()},
+		{Name: "HookScope", Type: reflect.TypeFor[HookScope]()},
+		{Name: "HookSource", Type: reflect.TypeFor[HookSource]()},
+		{Name: "HookTrustStatus", Type: reflect.TypeFor[HookTrustStatus]()},
+		{Name: "HookOutputEntry", Type: reflect.TypeFor[HookOutputEntry]()},
 		{Name: "PermissionGrantScope", Type: reflect.TypeFor[PermissionGrantScope]()},
 		{Name: "PermissionsApprovalRequestParams", Type: reflect.TypeFor[PermissionsApprovalRequestParams]()},
 		{Name: "PermissionsRequestApprovalParams", Type: reflect.TypeFor[PermissionsRequestApprovalParams]()},
@@ -599,6 +608,44 @@ func wireSchemaDefinitions() Schema {
 	schemas["FuzzyFileSearchResponse"] = fuzzyFileSearchResponseSchema()
 	schemas["FuzzyFileSearchSessionUpdatedNotification"] = fuzzyFileSearchSessionUpdatedNotificationSchema()
 	schemas["FuzzyFileSearchSessionCompletedNotification"] = fuzzyFileSearchSessionCompletedNotificationSchema()
+	schemas["HookEventName"] = stringEnumSchema(
+		string(HookEventNamePreToolUse), string(HookEventNamePermissionRequest),
+		string(HookEventNamePostToolUse), string(HookEventNamePreCompact),
+		string(HookEventNamePostCompact), string(HookEventNameSessionStart),
+		string(HookEventNameUserPromptSubmit), string(HookEventNameSubagentStart),
+		string(HookEventNameSubagentStop), string(HookEventNameStop),
+	)
+	schemas["HookExecutionMode"] = stringEnumSchema(
+		string(HookExecutionModeSync), string(HookExecutionModeAsync),
+	)
+	schemas["HookHandlerType"] = stringEnumSchema(
+		string(HookHandlerTypeCommand), string(HookHandlerTypePrompt), string(HookHandlerTypeAgent),
+	)
+	schemas["HookOutputEntryKind"] = stringEnumSchema(
+		string(HookOutputEntryKindWarning), string(HookOutputEntryKindStop),
+		string(HookOutputEntryKindFeedback), string(HookOutputEntryKindContext),
+		string(HookOutputEntryKindError),
+	)
+	schemas["HookRunStatus"] = stringEnumSchema(
+		string(HookRunStatusRunning), string(HookRunStatusCompleted),
+		string(HookRunStatusFailed), string(HookRunStatusBlocked), string(HookRunStatusStopped),
+	)
+	schemas["HookScope"] = stringEnumSchema(string(HookScopeThread), string(HookScopeTurn))
+	schemas["HookSource"] = stringEnumSchema(
+		string(HookSourceSystem), string(HookSourceUser), string(HookSourceProject),
+		string(HookSourceMDM), string(HookSourceSessionFlags), string(HookSourcePlugin),
+		string(HookSourceCloudRequirements), string(HookSourceCloudManagedConfig),
+		string(HookSourceLegacyManagedConfigFile), string(HookSourceLegacyManagedConfigMDM),
+		string(HookSourceUnknown),
+	)
+	schemas["HookTrustStatus"] = stringEnumSchema(
+		string(HookTrustStatusManaged), string(HookTrustStatusUntrusted),
+		string(HookTrustStatusTrusted), string(HookTrustStatusModified),
+	)
+	schemas["HookOutputEntry"] = closedThreadSessionParamSchema(Schema{
+		"kind": Schema{"$ref": "#/$defs/HookOutputEntryKind"},
+		"text": Schema{"type": "string"},
+	}, []string{"kind", "text"})
 	schemas["McpServerToolCallParams"] = mcpServerToolCallParamsSchema()
 	schemas["McpServerToolCallResponse"] = mcpServerToolCallResponseSchema()
 	schemas["ResourceContent"] = resourceContentSchema()

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -4626,6 +4626,36 @@
       ],
       "type": "object"
     },
+    "HookEventName": {
+      "enum": [
+        "preToolUse",
+        "permissionRequest",
+        "postToolUse",
+        "preCompact",
+        "postCompact",
+        "sessionStart",
+        "userPromptSubmit",
+        "subagentStart",
+        "subagentStop",
+        "stop"
+      ],
+      "type": "string"
+    },
+    "HookExecutionMode": {
+      "enum": [
+        "sync",
+        "async"
+      ],
+      "type": "string"
+    },
+    "HookHandlerType": {
+      "enum": [
+        "command",
+        "prompt",
+        "agent"
+      ],
+      "type": "string"
+    },
     "HookMigration": {
       "additionalProperties": false,
       "properties": {
@@ -4637,6 +4667,32 @@
         "name"
       ],
       "type": "object"
+    },
+    "HookOutputEntry": {
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "$ref": "#/$defs/HookOutputEntryKind"
+        },
+        "text": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "text"
+      ],
+      "type": "object"
+    },
+    "HookOutputEntryKind": {
+      "enum": [
+        "warning",
+        "stop",
+        "feedback",
+        "context",
+        "error"
+      ],
+      "type": "string"
     },
     "HookPromptFragment": {
       "additionalProperties": false,
@@ -4653,6 +4709,48 @@
         "hookRunId"
       ],
       "type": "object"
+    },
+    "HookRunStatus": {
+      "enum": [
+        "running",
+        "completed",
+        "failed",
+        "blocked",
+        "stopped"
+      ],
+      "type": "string"
+    },
+    "HookScope": {
+      "enum": [
+        "thread",
+        "turn"
+      ],
+      "type": "string"
+    },
+    "HookSource": {
+      "enum": [
+        "system",
+        "user",
+        "project",
+        "mdm",
+        "sessionFlags",
+        "plugin",
+        "cloudRequirements",
+        "cloudManagedConfig",
+        "legacyManagedConfigFile",
+        "legacyManagedConfigMdm",
+        "unknown"
+      ],
+      "type": "string"
+    },
+    "HookTrustStatus": {
+      "enum": [
+        "managed",
+        "untrusted",
+        "trusted",
+        "modified"
+      ],
+      "type": "string"
     },
     "ImageDetail": {
       "enum": [

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 408 {
-		t.Fatalf("definition count = %d, want 408", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 417 {
+		t.Fatalf("definition count = %d, want 417", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 408 {
-		t.Fatalf("definition count = %d, want 408", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 417 {
+		t.Fatalf("definition count = %d, want 417", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 408 {
-		t.Fatalf("definition count = %d, want 408", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 417 {
+		t.Fatalf("definition count = %d, want 417", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -1483,14 +1483,35 @@ export type GuardianWarningNotification = {
   "threadId": string;
 };
 
+export type HookEventName = "preToolUse" | "permissionRequest" | "postToolUse" | "preCompact" | "postCompact" | "sessionStart" | "userPromptSubmit" | "subagentStart" | "subagentStop" | "stop";
+
+export type HookExecutionMode = "sync" | "async";
+
+export type HookHandlerType = "command" | "prompt" | "agent";
+
 export type HookMigration = {
   "name": string;
 };
+
+export type HookOutputEntry = {
+  "kind": HookOutputEntryKind;
+  "text": string;
+};
+
+export type HookOutputEntryKind = "warning" | "stop" | "feedback" | "context" | "error";
 
 export type HookPromptFragment = {
   "hookRunId": string;
   "text": string;
 };
+
+export type HookRunStatus = "running" | "completed" | "failed" | "blocked" | "stopped";
+
+export type HookScope = "thread" | "turn";
+
+export type HookSource = "system" | "user" | "project" | "mdm" | "sessionFlags" | "plugin" | "cloudRequirements" | "cloudManagedConfig" | "legacyManagedConfigFile" | "legacyManagedConfigMdm" | "unknown";
+
+export type HookTrustStatus = "managed" | "untrusted" | "trusted" | "modified";
 
 export type ImageDetail = "auto" | "low" | "high" | "original";
 

--- a/appserver/protocol/typescript/testdata/hook_value_foundation_contract.ts
+++ b/appserver/protocol/typescript/testdata/hook_value_foundation_contract.ts
@@ -1,0 +1,119 @@
+import type {
+  HookEventName,
+  HookExecutionMode,
+  HookHandlerType,
+  HookOutputEntry,
+  HookOutputEntryKind,
+  HookRunStatus,
+  HookScope,
+  HookSource,
+  HookTrustStatus,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+
+type Contracts = [
+  Expect<Equal<HookEventName,
+    | "preToolUse" | "permissionRequest" | "postToolUse"
+    | "preCompact" | "postCompact" | "sessionStart"
+    | "userPromptSubmit" | "subagentStart" | "subagentStop" | "stop"
+  >>,
+  Expect<Equal<HookExecutionMode, "sync" | "async">>,
+  Expect<Equal<HookHandlerType, "command" | "prompt" | "agent">>,
+  Expect<Equal<HookOutputEntryKind, "warning" | "stop" | "feedback" | "context" | "error">>,
+  Expect<Equal<HookRunStatus, "running" | "completed" | "failed" | "blocked" | "stopped">>,
+  Expect<Equal<HookScope, "thread" | "turn">>,
+  Expect<Equal<HookSource,
+    | "system" | "user" | "project" | "mdm" | "sessionFlags" | "plugin"
+    | "cloudRequirements" | "cloudManagedConfig"
+    | "legacyManagedConfigFile" | "legacyManagedConfigMdm" | "unknown"
+  >>,
+  Expect<Equal<HookTrustStatus, "managed" | "untrusted" | "trusted" | "modified">>,
+  Expect<Equal<HookOutputEntry, { kind: HookOutputEntryKind; text: string }>>,
+];
+
+declare const contracts: Contracts;
+void contracts;
+
+"preToolUse" satisfies HookEventName;
+"permissionRequest" satisfies HookEventName;
+"postToolUse" satisfies HookEventName;
+"preCompact" satisfies HookEventName;
+"postCompact" satisfies HookEventName;
+"sessionStart" satisfies HookEventName;
+"userPromptSubmit" satisfies HookEventName;
+"subagentStart" satisfies HookEventName;
+"subagentStop" satisfies HookEventName;
+"stop" satisfies HookEventName;
+"sync" satisfies HookExecutionMode;
+"async" satisfies HookExecutionMode;
+"command" satisfies HookHandlerType;
+"prompt" satisfies HookHandlerType;
+"agent" satisfies HookHandlerType;
+"warning" satisfies HookOutputEntryKind;
+"stop" satisfies HookOutputEntryKind;
+"feedback" satisfies HookOutputEntryKind;
+"context" satisfies HookOutputEntryKind;
+"error" satisfies HookOutputEntryKind;
+"running" satisfies HookRunStatus;
+"completed" satisfies HookRunStatus;
+"failed" satisfies HookRunStatus;
+"blocked" satisfies HookRunStatus;
+"stopped" satisfies HookRunStatus;
+"thread" satisfies HookScope;
+"turn" satisfies HookScope;
+"system" satisfies HookSource;
+"user" satisfies HookSource;
+"project" satisfies HookSource;
+"mdm" satisfies HookSource;
+"sessionFlags" satisfies HookSource;
+"plugin" satisfies HookSource;
+"cloudRequirements" satisfies HookSource;
+"cloudManagedConfig" satisfies HookSource;
+"legacyManagedConfigFile" satisfies HookSource;
+"legacyManagedConfigMdm" satisfies HookSource;
+"unknown" satisfies HookSource;
+"managed" satisfies HookTrustStatus;
+"untrusted" satisfies HookTrustStatus;
+"trusted" satisfies HookTrustStatus;
+"modified" satisfies HookTrustStatus;
+({ kind: "warning", text: "" }) satisfies HookOutputEntry;
+({ kind: "error", text: " error " }) satisfies HookOutputEntry;
+
+// @ts-expect-error event names are closed and case-sensitive.
+"PreToolUse" satisfies HookEventName;
+// @ts-expect-error execution modes are closed.
+"blocking" satisfies HookExecutionMode;
+// @ts-expect-error handler types are closed.
+"shell" satisfies HookHandlerType;
+// @ts-expect-error entry kinds are closed.
+"info" satisfies HookOutputEntryKind;
+// @ts-expect-error run statuses are closed.
+"pending" satisfies HookRunStatus;
+// @ts-expect-error scopes are closed.
+"session" satisfies HookScope;
+// @ts-expect-error sources are closed and case-sensitive.
+"session_flags" satisfies HookSource;
+// @ts-expect-error trust statuses are closed.
+"unknown" satisfies HookTrustStatus;
+// @ts-expect-error kind is required.
+({ text: "" }) satisfies HookOutputEntry;
+// @ts-expect-error text is required.
+({ kind: "warning" }) satisfies HookOutputEntry;
+// @ts-expect-error kind is non-null.
+({ kind: null, text: "" }) satisfies HookOutputEntry;
+// @ts-expect-error text is non-null.
+({ kind: "warning", text: null }) satisfies HookOutputEntry;
+// @ts-expect-error kind retains its exact enum.
+({ kind: "info", text: "" }) satisfies HookOutputEntry;
+// @ts-expect-error text is a string.
+({ kind: "warning", text: 1 }) satisfies HookOutputEntry;
+// @ts-expect-error noncanonical aliases do not replace canonical fields.
+({ Kind: "warning", text: "" }) satisfies HookOutputEntry;
+// @ts-expect-error fields absent from the public record are rejected.
+({ kind: "warning", text: "", extra: true }) satisfies HookOutputEntry;

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 408 {
-		t.Fatalf("definition count = %d, want 408", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
+		t.Fatalf("definition count = %d, want 417", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary

- export the nine standalone hook enum and value contracts from the pinned Codex app-server protocol
- add fail-closed Go JSON contracts and strict TypeScript compile-time coverage
- regenerate the schema and TypeScript client while preserving existing method and item bindings

## Impact

This adds the dependency-complete hook primitives needed for subsequent `HookRunSummary` and hook notification slices. The new types are standalone and do not change the app-server method surface.

## Validation

- focused hook contracts, including 30 repeated runs and race coverage
- full protocol normal, race, and aggregate coverage suites
- all 59 non-Monty packages in normal and race modes
- strict TypeScript contract fixture and deterministic generation
- `golangci-lint run ./...`, `go vet ./...`, and tidy-module verification
- byte-identical reproducible builds and exact live initialize/status transcript compatibility
- all five Slang compatibility workflows
- configured pre-push hook (local Monty race intentionally skipped via `hooks.skipMontyRace=true`)
- exact normalized schema and parsed TypeScript agreement with pinned Codex `5c19155cbd93bfa099016e7487259f61669823ff`