### PR TITLE
feat(appserver): add hook run notification values

### DIFF
--- a/appserver/protocol/README.md
+++ b/appserver/protocol/README.md
@@ -508,6 +508,15 @@ binding, discovery, trust decision, execution, persistence, or notification
 producer is added. Their strict compile contract is
 `typescript/testdata/hook_value_foundation_contract.ts`.
 
+Exact standalone `HookRunSummary`, `HookStartedNotification`, and
+`HookCompletedNotification` records extend that value layer without binding a
+producer. Summary input accepts omitted source as `unknown` and omitted option
+fields as null; canonical output includes every field and normalizes nil
+entries to `[]`. Signed int64 fields remain `integer`/`int64` in JSON Schema
+and generate as TypeScript `bigint`. Both `hook/started` and `hook/completed`
+remain blocked and unbound. Their strict compile contract is
+`typescript/testdata/hook_run_notification_contract.ts`.
+
 Exact standalone warning, guardian-warning, and error notification records
 establish the fixed public warning/error value layer. Canonical warning output
 requires explicit nullable thread id, while decoding also accepts omission to

--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(defs); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,8 +217,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,8 +203,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -260,8 +260,8 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,8 +244,8 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -162,8 +162,8 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -175,8 +175,8 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -381,8 +381,8 @@ func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_run_notification_contract_test.go
+++ b/appserver/protocol/hook_run_notification_contract_test.go
@@ -1,0 +1,335 @@
+package protocol
+
+import (
+	"encoding/json"
+	"math"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestHookRunNotificationSchemasAreExact(t *testing.T) {
+	nullableString := Schema{"type": []any{"string", "null"}}
+	nullableInt64 := Schema{"type": []any{"integer", "null"}, "format": "int64"}
+	wantRun := closedThreadSessionParamSchema(Schema{
+		"id":            Schema{"type": "string"},
+		"eventName":     Schema{"$ref": "#/$defs/HookEventName"},
+		"handlerType":   Schema{"$ref": "#/$defs/HookHandlerType"},
+		"executionMode": Schema{"$ref": "#/$defs/HookExecutionMode"},
+		"scope":         Schema{"$ref": "#/$defs/HookScope"},
+		"sourcePath":    Schema{"$ref": "#/$defs/AbsolutePathBuf"},
+		"source": Schema{
+			"allOf":   []any{Schema{"$ref": "#/$defs/HookSource"}},
+			"default": "unknown",
+		},
+		"displayOrder":  Schema{"type": "integer", "format": "int64"},
+		"status":        Schema{"$ref": "#/$defs/HookRunStatus"},
+		"statusMessage": nullableString,
+		"startedAt":     Schema{"type": "integer", "format": "int64"},
+		"completedAt":   nullableInt64,
+		"durationMs":    nullableInt64,
+		"entries": Schema{
+			"type": "array", "items": Schema{"$ref": "#/$defs/HookOutputEntry"},
+		},
+	}, []string{
+		"displayOrder", "entries", "eventName", "executionMode", "handlerType",
+		"id", "scope", "sourcePath", "startedAt", "status",
+	})
+	wantNotification := closedThreadSessionParamSchema(Schema{
+		"threadId": Schema{"type": "string"},
+		"turnId":   nullableString,
+		"run":      Schema{"$ref": "#/$defs/HookRunSummary"},
+	}, []string{"run", "threadId"})
+
+	defs := JSONSchema()["$defs"].(Schema)
+	for name, want := range map[string]Schema{
+		"HookRunSummary":            wantRun,
+		"HookStartedNotification":   wantNotification,
+		"HookCompletedNotification": wantNotification,
+	} {
+		got, ok := defs[name].(Schema)
+		if !ok || !reflect.DeepEqual(got, want) {
+			t.Errorf("%s schema = %#v, %v; want %#v", name, got, ok, want)
+		}
+	}
+}
+
+func TestHookRunSummaryAcceptsRustWireForms(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     string
+		want      HookRunSummary
+		canonical string
+	}{
+		{
+			name: "omitted defaults nullable fields and minimum integers",
+			input: `{"id":"","eventName":"preToolUse","handlerType":"command",` +
+				`"executionMode":"sync","scope":"thread","sourcePath":"/hooks.json",` +
+				`"displayOrder":-9223372036854775808,"status":"running",` +
+				`"startedAt":-9223372036854775808,"entries":[],"future":true}`,
+			want: HookRunSummary{
+				ID: "", EventName: HookEventNamePreToolUse,
+				HandlerType: HookHandlerTypeCommand, ExecutionMode: HookExecutionModeSync,
+				Scope: HookScopeThread, SourcePath: AbsolutePathBuf("/hooks.json"),
+				Source: HookSourceUnknown, DisplayOrder: math.MinInt64,
+				Status: HookRunStatusRunning, StartedAt: math.MinInt64,
+				Entries: []HookOutputEntry{},
+			},
+			canonical: `{"id":"","eventName":"preToolUse","handlerType":"command",` +
+				`"executionMode":"sync","scope":"thread","sourcePath":"/hooks.json",` +
+				`"source":"unknown","displayOrder":-9223372036854775808,"status":"running",` +
+				`"statusMessage":null,"startedAt":-9223372036854775808,` +
+				`"completedAt":null,"durationMs":null,"entries":[]}`,
+		},
+		{
+			name: "explicit values maximum integers and duplicate entries",
+			input: `{"id":" run ","eventName":"stop","handlerType":"agent",` +
+				`"executionMode":"async","scope":"turn",` +
+				`"sourcePath":"/workspace/../workspace/hooks.json","source":"project",` +
+				`"displayOrder":9223372036854775807,"status":"completed",` +
+				`"statusMessage":" done ","startedAt":9223372036854775807,` +
+				`"completedAt":-9223372036854775808,"durationMs":0,` +
+				`"entries":[{"kind":"warning","text":""},{"kind":"warning","text":""}]}`,
+			want: HookRunSummary{
+				ID: " run ", EventName: HookEventNameStop,
+				HandlerType: HookHandlerTypeAgent, ExecutionMode: HookExecutionModeAsync,
+				Scope: HookScopeTurn, SourcePath: AbsolutePathBuf("/workspace/hooks.json"),
+				Source: HookSourceProject, DisplayOrder: math.MaxInt64,
+				Status: HookRunStatusCompleted, StatusMessage: stringPointer(" done "),
+				StartedAt: math.MaxInt64, CompletedAt: hookInt64Pointer(math.MinInt64),
+				DurationMS: hookInt64Pointer(0),
+				Entries: []HookOutputEntry{
+					{Kind: HookOutputEntryKindWarning, Text: ""},
+					{Kind: HookOutputEntryKindWarning, Text: ""},
+				},
+			},
+			canonical: `{"id":" run ","eventName":"stop","handlerType":"agent",` +
+				`"executionMode":"async","scope":"turn","sourcePath":"/workspace/hooks.json",` +
+				`"source":"project","displayOrder":9223372036854775807,"status":"completed",` +
+				`"statusMessage":" done ","startedAt":9223372036854775807,` +
+				`"completedAt":-9223372036854775808,"durationMs":0,` +
+				`"entries":[{"kind":"warning","text":""},{"kind":"warning","text":""}]}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got HookRunSummary
+			if err := json.Unmarshal([]byte(tc.input), &got); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("summary = %#v, want %#v", got, tc.want)
+			}
+			encoded, err := json.Marshal(got)
+			if err != nil || string(encoded) != tc.canonical {
+				t.Fatalf("canonical = %s, %v; want %s", encoded, err, tc.canonical)
+			}
+		})
+	}
+
+	nilEntries := sampleHookRunSummaryForContract()
+	nilEntries.Entries = nil
+	encoded, err := json.Marshal(nilEntries)
+	if err != nil || !strings.HasSuffix(string(encoded), `,"entries":[]}`) {
+		t.Fatalf("nil entries canonical = %s, %v; want []", encoded, err)
+	}
+}
+
+func TestHookRunSummaryRejectsMalformedWireForms(t *testing.T) {
+	valid := `{"id":"run","eventName":"preToolUse","handlerType":"command",` +
+		`"executionMode":"sync","scope":"thread","sourcePath":"/hooks.json",` +
+		`"source":"unknown","displayOrder":0,"status":"running","statusMessage":null,` +
+		`"startedAt":0,"completedAt":null,"durationMs":null,"entries":[]}`
+	invalid := []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{}`,
+		strings.Replace(valid, `"id":"run",`, ``, 1),
+		strings.Replace(valid, `"eventName":"preToolUse",`, ``, 1),
+		strings.Replace(valid, `"handlerType":"command",`, ``, 1),
+		strings.Replace(valid, `"executionMode":"sync",`, ``, 1),
+		strings.Replace(valid, `"scope":"thread",`, ``, 1),
+		strings.Replace(valid, `"sourcePath":"/hooks.json",`, ``, 1),
+		strings.Replace(valid, `"displayOrder":0,`, ``, 1),
+		strings.Replace(valid, `"status":"running",`, ``, 1),
+		strings.Replace(valid, `"startedAt":0,`, ``, 1),
+		strings.Replace(valid, `,"entries":[]`, ``, 1),
+		strings.Replace(valid, `"id":"run"`, `"id":null`, 1),
+		strings.Replace(valid, `"eventName":"preToolUse"`, `"eventName":"other"`, 1),
+		strings.Replace(valid, `"handlerType":"command"`, `"handlerType":"other"`, 1),
+		strings.Replace(valid, `"executionMode":"sync"`, `"executionMode":"other"`, 1),
+		strings.Replace(valid, `"scope":"thread"`, `"scope":"other"`, 1),
+		strings.Replace(valid, `"sourcePath":"/hooks.json"`, `"sourcePath":"relative"`, 1),
+		strings.Replace(valid, `"source":"unknown"`, `"source":null`, 1),
+		strings.Replace(valid, `"source":"unknown"`, `"source":"other"`, 1),
+		strings.Replace(valid, `"displayOrder":0`, `"displayOrder":0.5`, 1),
+		strings.Replace(valid, `"displayOrder":0`, `"displayOrder":9223372036854775808`, 1),
+		strings.Replace(valid, `"status":"running"`, `"status":"other"`, 1),
+		strings.Replace(valid, `"statusMessage":null`, `"statusMessage":1`, 1),
+		strings.Replace(valid, `"startedAt":0`, `"startedAt":1e3`, 1),
+		strings.Replace(valid, `"completedAt":null`, `"completedAt":-9223372036854775809`, 1),
+		strings.Replace(valid, `"durationMs":null`, `"durationMs":"0"`, 1),
+		strings.Replace(valid, `"entries":[]`, `"entries":null`, 1),
+		strings.Replace(valid, `"entries":[]`, `"entries":[null]`, 1),
+		strings.Replace(valid, `"entries":[]`, `"entries":[{"kind":"other","text":"x"}]`, 1),
+		strings.Replace(valid, `"id":"run"`, `"id":"run","id":"other"`, 1),
+		strings.TrimSuffix(valid, `}`), valid + ` {}`,
+	}
+	for _, input := range invalid {
+		assertJSONRejects[HookRunSummary](t, input)
+	}
+
+	var summary *HookRunSummary
+	if err := summary.UnmarshalJSON([]byte(valid)); err == nil {
+		t.Fatal("nil HookRunSummary receiver succeeded")
+	}
+	for _, value := range []HookRunSummary{
+		{},
+		sampleHookRunSummaryForContract(),
+	} {
+		if value.ID != "" {
+			value.SourcePath = AbsolutePathBuf("relative")
+		}
+		if _, err := json.Marshal(value); err == nil {
+			t.Errorf("invalid summary %#v marshaled", value)
+		}
+	}
+	invalidNested := sampleHookRunSummaryForContract()
+	invalidNested.Entries = []HookOutputEntry{{Kind: HookOutputEntryKind("other"), Text: "x"}}
+	if _, err := json.Marshal(invalidNested); err == nil {
+		t.Fatal("summary with invalid nested entry marshaled")
+	}
+}
+
+func TestHookNotificationsAcceptRustWireForms(t *testing.T) {
+	run := sampleHookRunSummaryForContract()
+	runJSON, err := json.Marshal(run)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name      string
+		input     string
+		canonical string
+		new       func() json.Unmarshaler
+	}{
+		{
+			"started omitted turn",
+			`{"threadId":"","run":` + string(runJSON) + `,"future":true}`,
+			`{"threadId":"","turnId":null,"run":` + string(runJSON) + `}`,
+			func() json.Unmarshaler { return new(HookStartedNotification) },
+		},
+		{
+			"started null turn",
+			`{"threadId":"thread","turnId":null,"run":` + string(runJSON) + `}`,
+			`{"threadId":"thread","turnId":null,"run":` + string(runJSON) + `}`,
+			func() json.Unmarshaler { return new(HookStartedNotification) },
+		},
+		{
+			"completed turn",
+			`{"threadId":"thread","turnId":" turn ","run":` + string(runJSON) + `}`,
+			`{"threadId":"thread","turnId":" turn ","run":` + string(runJSON) + `}`,
+			func() json.Unmarshaler { return new(HookCompletedNotification) },
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			value := tc.new()
+			if err := value.UnmarshalJSON([]byte(tc.input)); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			encoded, err := json.Marshal(value)
+			if err != nil || string(encoded) != tc.canonical {
+				t.Fatalf("canonical = %s, %v; want %s", encoded, err, tc.canonical)
+			}
+		})
+	}
+}
+
+func TestHookNotificationsRejectMalformedWireForms(t *testing.T) {
+	runJSON, err := json.Marshal(sampleHookRunSummaryForContract())
+	if err != nil {
+		t.Fatal(err)
+	}
+	valid := `{"threadId":"thread","turnId":null,"run":` + string(runJSON) + `}`
+	invalid := []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{}`,
+		strings.Replace(valid, `"threadId":"thread",`, ``, 1),
+		strings.Replace(valid, `"threadId":"thread"`, `"threadId":null`, 1),
+		strings.Replace(valid, `"turnId":null`, `"turnId":1`, 1),
+		strings.Replace(valid, `,"run":`+string(runJSON), ``, 1),
+		strings.Replace(valid, `"run":`+string(runJSON), `"run":null`, 1),
+		strings.Replace(valid, `"run":`+string(runJSON), `"run":{}`, 1),
+		strings.Replace(valid, `"threadId":"thread"`, `"threadId":"thread","threadId":"other"`, 1),
+		strings.TrimSuffix(valid, `}`), valid + ` {}`,
+	}
+	for _, input := range invalid {
+		assertJSONRejects[HookStartedNotification](t, input)
+		assertJSONRejects[HookCompletedNotification](t, input)
+	}
+	var started *HookStartedNotification
+	if err := started.UnmarshalJSON([]byte(valid)); err == nil {
+		t.Fatal("nil HookStartedNotification receiver succeeded")
+	}
+	var completed *HookCompletedNotification
+	if err := completed.UnmarshalJSON([]byte(valid)); err == nil {
+		t.Fatal("nil HookCompletedNotification receiver succeeded")
+	}
+	if _, err := json.Marshal(HookStartedNotification{}); err == nil {
+		t.Fatal("zero HookStartedNotification marshaled")
+	}
+	if _, err := json.Marshal(HookCompletedNotification{}); err == nil {
+		t.Fatal("zero HookCompletedNotification marshaled")
+	}
+}
+
+func TestHookRunNotificationsRemainStandalone(t *testing.T) {
+	names := []string{"HookRunSummary", "HookStartedNotification", "HookCompletedNotification"}
+	for _, binding := range WireTypeBindings() {
+		for _, name := range names {
+			if slices.Contains(binding.Params, name) || slices.Contains(binding.Result, name) {
+				t.Fatalf("%s unexpectedly bound: %#v", name, binding)
+			}
+		}
+	}
+	for _, method := range []string{"hook/started", "hook/completed"} {
+		info, ok := LookupMethod(method)
+		if !ok || info.State != MethodBlocked {
+			t.Fatalf("%s = %#v, %v; want blocked", method, info, ok)
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
+	}
+	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("surface changed: %d methods, %d wire bindings, %d item bindings", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
+	}
+}
+
+func TestHookRunNotificationTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := string(generated)
+	for _, want := range []string{
+		"export type HookRunSummary = {\n  \"completedAt\": bigint | null;\n  \"displayOrder\": bigint;\n  \"durationMs\": bigint | null;\n  \"entries\": Array<HookOutputEntry>;\n  \"eventName\": HookEventName;\n  \"executionMode\": HookExecutionMode;\n  \"handlerType\": HookHandlerType;\n  \"id\": string;\n  \"scope\": HookScope;\n  \"source\": HookSource;\n  \"sourcePath\": AbsolutePathBuf;\n  \"startedAt\": bigint;\n  \"status\": HookRunStatus;\n  \"statusMessage\": string | null;\n};",
+		"export type HookStartedNotification = {\n  \"run\": HookRunSummary;\n  \"threadId\": string;\n  \"turnId\": string | null;\n};",
+		"export type HookCompletedNotification = {\n  \"run\": HookRunSummary;\n  \"threadId\": string;\n  \"turnId\": string | null;\n};",
+	} {
+		if !strings.Contains(source, want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}
+
+func sampleHookRunSummaryForContract() HookRunSummary {
+	return HookRunSummary{
+		ID: "run", EventName: HookEventNamePreToolUse,
+		HandlerType: HookHandlerTypeCommand, ExecutionMode: HookExecutionModeSync,
+		Scope: HookScopeThread, SourcePath: AbsolutePathBuf("/hooks.json"),
+		Source: HookSourceUnknown, Status: HookRunStatusRunning,
+		Entries: []HookOutputEntry{},
+	}
+}
+
+func hookInt64Pointer(value int64) *int64 { return &value }

--- a/appserver/protocol/hook_run_notification_types.go
+++ b/appserver/protocol/hook_run_notification_types.go
@@ -1,0 +1,268 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// HookRunSummary is the exact standalone public summary of one hook run. It
+// does not imply that Gollem discovers or executes hooks.
+type HookRunSummary struct {
+	ID            string            `json:"id"`
+	EventName     HookEventName     `json:"eventName"`
+	HandlerType   HookHandlerType   `json:"handlerType"`
+	ExecutionMode HookExecutionMode `json:"executionMode"`
+	Scope         HookScope         `json:"scope"`
+	SourcePath    AbsolutePathBuf   `json:"sourcePath"`
+	Source        HookSource        `json:"source"`
+	DisplayOrder  int64             `json:"displayOrder"`
+	Status        HookRunStatus     `json:"status"`
+	StatusMessage *string           `json:"statusMessage"`
+	StartedAt     int64             `json:"startedAt"`
+	CompletedAt   *int64            `json:"completedAt"`
+	DurationMS    *int64            `json:"durationMs"`
+	Entries       []HookOutputEntry `json:"entries"`
+}
+
+func (s HookRunSummary) MarshalJSON() ([]byte, error) {
+	entries := s.Entries
+	if entries == nil {
+		entries = []HookOutputEntry{}
+	}
+	return json.Marshal(struct {
+		ID            string            `json:"id"`
+		EventName     HookEventName     `json:"eventName"`
+		HandlerType   HookHandlerType   `json:"handlerType"`
+		ExecutionMode HookExecutionMode `json:"executionMode"`
+		Scope         HookScope         `json:"scope"`
+		SourcePath    AbsolutePathBuf   `json:"sourcePath"`
+		Source        HookSource        `json:"source"`
+		DisplayOrder  int64             `json:"displayOrder"`
+		Status        HookRunStatus     `json:"status"`
+		StatusMessage *string           `json:"statusMessage"`
+		StartedAt     int64             `json:"startedAt"`
+		CompletedAt   *int64            `json:"completedAt"`
+		DurationMS    *int64            `json:"durationMs"`
+		Entries       []HookOutputEntry `json:"entries"`
+	}{
+		ID: s.ID, EventName: s.EventName, HandlerType: s.HandlerType,
+		ExecutionMode: s.ExecutionMode, Scope: s.Scope, SourcePath: s.SourcePath,
+		Source: s.Source, DisplayOrder: s.DisplayOrder, Status: s.Status,
+		StatusMessage: s.StatusMessage, StartedAt: s.StartedAt,
+		CompletedAt: s.CompletedAt, DurationMS: s.DurationMS, Entries: entries,
+	})
+}
+
+func (s *HookRunSummary) UnmarshalJSON(data []byte) error {
+	if s == nil {
+		return errors.New("decode hook run summary into nil receiver")
+	}
+	const objectName = "hook run summary"
+	payload, err := decodeRustSerdeObject(
+		data, objectName,
+		"id", "eventName", "handlerType", "executionMode", "scope", "sourcePath",
+		"source", "displayOrder", "status", "statusMessage", "startedAt",
+		"completedAt", "durationMs", "entries",
+	)
+	if err != nil {
+		return err
+	}
+	id, err := decodeRequiredThreadItemValue[string](payload, objectName, "id")
+	if err != nil {
+		return err
+	}
+	eventName, err := decodeRequiredThreadItemValue[HookEventName](payload, objectName, "eventName")
+	if err != nil {
+		return err
+	}
+	handlerType, err := decodeRequiredThreadItemValue[HookHandlerType](payload, objectName, "handlerType")
+	if err != nil {
+		return err
+	}
+	executionMode, err := decodeRequiredThreadItemValue[HookExecutionMode](payload, objectName, "executionMode")
+	if err != nil {
+		return err
+	}
+	scope, err := decodeRequiredThreadItemValue[HookScope](payload, objectName, "scope")
+	if err != nil {
+		return err
+	}
+	sourcePath, err := decodeRequiredThreadItemValue[AbsolutePathBuf](payload, objectName, "sourcePath")
+	if err != nil {
+		return err
+	}
+	source, err := decodeHookRunSource(payload, objectName)
+	if err != nil {
+		return err
+	}
+	displayOrder, err := decodeRequiredThreadItemValue[int64](payload, objectName, "displayOrder")
+	if err != nil {
+		return err
+	}
+	status, err := decodeRequiredThreadItemValue[HookRunStatus](payload, objectName, "status")
+	if err != nil {
+		return err
+	}
+	statusMessage, err := decodeOptionalNullableConfigValue[string](payload, objectName, "statusMessage")
+	if err != nil {
+		return err
+	}
+	startedAt, err := decodeRequiredThreadItemValue[int64](payload, objectName, "startedAt")
+	if err != nil {
+		return err
+	}
+	completedAt, err := decodeOptionalNullableConfigValue[int64](payload, objectName, "completedAt")
+	if err != nil {
+		return err
+	}
+	durationMS, err := decodeOptionalNullableConfigValue[int64](payload, objectName, "durationMs")
+	if err != nil {
+		return err
+	}
+	entries, err := decodeRequiredThreadItemArray[HookOutputEntry](payload, objectName, "entries")
+	if err != nil {
+		return err
+	}
+	*s = HookRunSummary{
+		ID: id, EventName: eventName, HandlerType: handlerType,
+		ExecutionMode: executionMode, Scope: scope, SourcePath: sourcePath,
+		Source: source, DisplayOrder: displayOrder, Status: status,
+		StatusMessage: statusMessage, StartedAt: startedAt, CompletedAt: completedAt,
+		DurationMS: durationMS, Entries: entries,
+	}
+	return nil
+}
+
+func decodeHookRunSource(payload map[string]json.RawMessage, objectName string) (HookSource, error) {
+	raw, ok := payload["source"]
+	if !ok {
+		return HookSourceUnknown, nil
+	}
+	if isJSONNull(raw) {
+		return "", fmt.Errorf("%s source cannot be null", objectName)
+	}
+	var source HookSource
+	if err := json.Unmarshal(raw, &source); err != nil {
+		return "", fmt.Errorf("decode %s source: %w", objectName, err)
+	}
+	return source, nil
+}
+
+// HookStartedNotification is the exact standalone public hook-start payload.
+type HookStartedNotification struct {
+	ThreadID string         `json:"threadId"`
+	TurnID   *string        `json:"turnId"`
+	Run      HookRunSummary `json:"run"`
+}
+
+func (n HookStartedNotification) MarshalJSON() ([]byte, error) {
+	return marshalHookRunNotification(n.ThreadID, n.TurnID, n.Run)
+}
+
+func (n *HookStartedNotification) UnmarshalJSON(data []byte) error {
+	if n == nil {
+		return errors.New("decode hook-started notification into nil receiver")
+	}
+	threadID, turnID, run, err := unmarshalHookRunNotification(data, "hook-started notification")
+	if err != nil {
+		return err
+	}
+	*n = HookStartedNotification{ThreadID: threadID, TurnID: turnID, Run: run}
+	return nil
+}
+
+// HookCompletedNotification is the exact standalone public hook-completion payload.
+type HookCompletedNotification struct {
+	ThreadID string         `json:"threadId"`
+	TurnID   *string        `json:"turnId"`
+	Run      HookRunSummary `json:"run"`
+}
+
+func (n HookCompletedNotification) MarshalJSON() ([]byte, error) {
+	return marshalHookRunNotification(n.ThreadID, n.TurnID, n.Run)
+}
+
+func (n *HookCompletedNotification) UnmarshalJSON(data []byte) error {
+	if n == nil {
+		return errors.New("decode hook-completed notification into nil receiver")
+	}
+	threadID, turnID, run, err := unmarshalHookRunNotification(data, "hook-completed notification")
+	if err != nil {
+		return err
+	}
+	*n = HookCompletedNotification{ThreadID: threadID, TurnID: turnID, Run: run}
+	return nil
+}
+
+func marshalHookRunNotification(threadID string, turnID *string, run HookRunSummary) ([]byte, error) {
+	return json.Marshal(struct {
+		ThreadID string         `json:"threadId"`
+		TurnID   *string        `json:"turnId"`
+		Run      HookRunSummary `json:"run"`
+	}{ThreadID: threadID, TurnID: turnID, Run: run})
+}
+
+func unmarshalHookRunNotification(data []byte, objectName string) (string, *string, HookRunSummary, error) {
+	payload, err := decodeRustSerdeObject(data, objectName, "threadId", "turnId", "run")
+	if err != nil {
+		return "", nil, HookRunSummary{}, err
+	}
+	threadID, err := decodeRequiredThreadItemValue[string](payload, objectName, "threadId")
+	if err != nil {
+		return "", nil, HookRunSummary{}, err
+	}
+	turnID, err := decodeOptionalNullableConfigValue[string](payload, objectName, "turnId")
+	if err != nil {
+		return "", nil, HookRunSummary{}, err
+	}
+	run, err := decodeRequiredThreadItemValue[HookRunSummary](payload, objectName, "run")
+	if err != nil {
+		return "", nil, HookRunSummary{}, err
+	}
+	return threadID, turnID, run, nil
+}
+
+func hookRunSummarySchema() Schema {
+	return closedThreadSessionParamSchema(Schema{
+		"id":            Schema{"type": "string"},
+		"eventName":     Schema{"$ref": "#/$defs/HookEventName"},
+		"handlerType":   Schema{"$ref": "#/$defs/HookHandlerType"},
+		"executionMode": Schema{"$ref": "#/$defs/HookExecutionMode"},
+		"scope":         Schema{"$ref": "#/$defs/HookScope"},
+		"sourcePath":    Schema{"$ref": "#/$defs/AbsolutePathBuf"},
+		"source": Schema{
+			"allOf":   []any{Schema{"$ref": "#/$defs/HookSource"}},
+			"default": "unknown",
+		},
+		"displayOrder":  Schema{"type": "integer", "format": "int64"},
+		"status":        Schema{"$ref": "#/$defs/HookRunStatus"},
+		"statusMessage": Schema{"type": []any{"string", "null"}},
+		"startedAt":     Schema{"type": "integer", "format": "int64"},
+		"completedAt":   Schema{"type": []any{"integer", "null"}, "format": "int64"},
+		"durationMs":    Schema{"type": []any{"integer", "null"}, "format": "int64"},
+		"entries": Schema{
+			"type": "array", "items": Schema{"$ref": "#/$defs/HookOutputEntry"},
+		},
+	}, []string{
+		"displayOrder", "entries", "eventName", "executionMode", "handlerType",
+		"id", "scope", "sourcePath", "startedAt", "status",
+	})
+}
+
+func hookRunNotificationSchema() Schema {
+	return closedThreadSessionParamSchema(Schema{
+		"threadId": Schema{"type": "string"},
+		"turnId":   Schema{"type": []any{"string", "null"}},
+		"run":      Schema{"$ref": "#/$defs/HookRunSummary"},
+	}, []string{"run", "threadId"})
+}
+
+var (
+	_ json.Marshaler   = HookRunSummary{}
+	_ json.Unmarshaler = (*HookRunSummary)(nil)
+	_ json.Marshaler   = HookStartedNotification{}
+	_ json.Unmarshaler = (*HookStartedNotification)(nil)
+	_ json.Marshaler   = HookCompletedNotification{}
+	_ json.Unmarshaler = (*HookCompletedNotification)(nil)
+)

--- a/appserver/protocol/hook_value_foundation_contract_test.go
+++ b/appserver/protocol/hook_value_foundation_contract_test.go
@@ -167,8 +167,8 @@ func TestHookValueFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 417 {
-		t.Fatalf("definition count = %d, want 417", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 420 {
+		t.Fatalf("definition count = %d, want 420", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 417 {
-		t.Fatalf("definition count = %d, want 417", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 420 {
+		t.Fatalf("definition count = %d, want 420", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 417 {
-		t.Fatalf("definition count = %d, want 417", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 420 {
+		t.Fatalf("definition count = %d, want 420", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 417 {
-		t.Fatalf("definition count = %d, want 417", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 420 {
+		t.Fatalf("definition count = %d, want 420", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 417 {
-		t.Fatalf("definition count = %d, want 417", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 420 {
+		t.Fatalf("definition count = %d, want 420", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 417 {
-		t.Fatalf("definition count = %d, want 417", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 420 {
+		t.Fatalf("definition count = %d, want 420", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -341,6 +341,9 @@ func wireSchemaDefinitions() Schema {
 		{Name: "HookSource", Type: reflect.TypeFor[HookSource]()},
 		{Name: "HookTrustStatus", Type: reflect.TypeFor[HookTrustStatus]()},
 		{Name: "HookOutputEntry", Type: reflect.TypeFor[HookOutputEntry]()},
+		{Name: "HookRunSummary", Type: reflect.TypeFor[HookRunSummary]()},
+		{Name: "HookStartedNotification", Type: reflect.TypeFor[HookStartedNotification]()},
+		{Name: "HookCompletedNotification", Type: reflect.TypeFor[HookCompletedNotification]()},
 		{Name: "PermissionGrantScope", Type: reflect.TypeFor[PermissionGrantScope]()},
 		{Name: "PermissionsApprovalRequestParams", Type: reflect.TypeFor[PermissionsApprovalRequestParams]()},
 		{Name: "PermissionsRequestApprovalParams", Type: reflect.TypeFor[PermissionsRequestApprovalParams]()},
@@ -646,6 +649,9 @@ func wireSchemaDefinitions() Schema {
 		"kind": Schema{"$ref": "#/$defs/HookOutputEntryKind"},
 		"text": Schema{"type": "string"},
 	}, []string{"kind", "text"})
+	schemas["HookRunSummary"] = hookRunSummarySchema()
+	schemas["HookStartedNotification"] = hookRunNotificationSchema()
+	schemas["HookCompletedNotification"] = hookRunNotificationSchema()
 	schemas["McpServerToolCallParams"] = mcpServerToolCallParamsSchema()
 	schemas["McpServerToolCallResponse"] = mcpServerToolCallResponseSchema()
 	schemas["ResourceContent"] = resourceContentSchema()

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -4626,6 +4626,28 @@
       ],
       "type": "object"
     },
+    "HookCompletedNotification": {
+      "additionalProperties": false,
+      "properties": {
+        "run": {
+          "$ref": "#/$defs/HookRunSummary"
+        },
+        "threadId": {
+          "type": "string"
+        },
+        "turnId": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "run",
+        "threadId"
+      ],
+      "type": "object"
+    },
     "HookEventName": {
       "enum": [
         "preToolUse",
@@ -4720,6 +4742,87 @@
       ],
       "type": "string"
     },
+    "HookRunSummary": {
+      "additionalProperties": false,
+      "properties": {
+        "completedAt": {
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "displayOrder": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "durationMs": {
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "entries": {
+          "items": {
+            "$ref": "#/$defs/HookOutputEntry"
+          },
+          "type": "array"
+        },
+        "eventName": {
+          "$ref": "#/$defs/HookEventName"
+        },
+        "executionMode": {
+          "$ref": "#/$defs/HookExecutionMode"
+        },
+        "handlerType": {
+          "$ref": "#/$defs/HookHandlerType"
+        },
+        "id": {
+          "type": "string"
+        },
+        "scope": {
+          "$ref": "#/$defs/HookScope"
+        },
+        "source": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/HookSource"
+            }
+          ],
+          "default": "unknown"
+        },
+        "sourcePath": {
+          "$ref": "#/$defs/AbsolutePathBuf"
+        },
+        "startedAt": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "status": {
+          "$ref": "#/$defs/HookRunStatus"
+        },
+        "statusMessage": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "displayOrder",
+        "entries",
+        "eventName",
+        "executionMode",
+        "handlerType",
+        "id",
+        "scope",
+        "sourcePath",
+        "startedAt",
+        "status"
+      ],
+      "type": "object"
+    },
     "HookScope": {
       "enum": [
         "thread",
@@ -4742,6 +4845,28 @@
         "unknown"
       ],
       "type": "string"
+    },
+    "HookStartedNotification": {
+      "additionalProperties": false,
+      "properties": {
+        "run": {
+          "$ref": "#/$defs/HookRunSummary"
+        },
+        "threadId": {
+          "type": "string"
+        },
+        "turnId": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "run",
+        "threadId"
+      ],
+      "type": "object"
     },
     "HookTrustStatus": {
       "enum": [

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 417 {
-		t.Fatalf("definition count = %d, want 417", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 420 {
+		t.Fatalf("definition count = %d, want 420", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 417 {
-		t.Fatalf("definition count = %d, want 417", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 420 {
+		t.Fatalf("definition count = %d, want 420", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 417 {
-		t.Fatalf("definition count = %d, want 417", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 420 {
+		t.Fatalf("definition count = %d, want 420", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 	"sort"
 	"strings"
 	"unicode"
@@ -41,7 +42,9 @@ func MarshalTypeScript() ([]byte, error) {
 		if name == "MigrationDetails" || name == "ExternalAgentConfigMigrationItem" ||
 			name == "ExternalAgentConfigImportItemTypeFailure" ||
 			name == "ExternalAgentConfigImportItemTypeSuccess" ||
-			name == "FuzzyFileSearchParams" || name == "FuzzyFileSearchResult" {
+			name == "FuzzyFileSearchParams" || name == "FuzzyFileSearchResult" ||
+			name == "HookRunSummary" || name == "HookStartedNotification" ||
+			name == "HookCompletedNotification" {
 			// Rust accepts omitted serde default/Option fields while generated
 			// TypeScript requires callers to provide their canonical values.
 			schema, _ := typeScriptSchema(definition)
@@ -69,31 +72,37 @@ func MarshalTypeScript() ([]byte, error) {
 				schema["required"] = []string{
 					"root", "path", "match_type", "file_name", "score", "indices",
 				}
+			case "HookRunSummary":
+				schema["required"] = []string{
+					"id", "eventName", "handlerType", "executionMode", "scope", "sourcePath",
+					"source", "displayOrder", "status", "statusMessage", "startedAt",
+					"completedAt", "durationMs", "entries",
+				}
+			case "HookStartedNotification", "HookCompletedNotification":
+				schema["required"] = []string{"threadId", "turnId", "run"}
 			}
 			definition = schema
 		}
 		if name == "ExternalAgentConfigImportHistory" {
 			// ts-rs maps this Rust i64 to bigint. Apply the hint only to a
 			// render copy so the public JSON Schema remains exact.
-			schema, _ := typeScriptSchema(definition)
-			renderSchema := make(Schema, len(schema))
-			for key, value := range schema {
-				renderSchema[key] = value
-			}
-			properties, _ := typeScriptSchema(schema["properties"])
-			renderProperties := make(Schema, len(properties))
-			for key, value := range properties {
-				renderProperties[key] = value
-			}
-			completedAtMS, _ := typeScriptSchema(properties["completedAtMs"])
-			renderCompletedAtMS := make(Schema, len(completedAtMS)+1)
-			for key, value := range completedAtMS {
-				renderCompletedAtMS[key] = value
-			}
-			renderCompletedAtMS[typeScriptBigIntKeyword] = true
-			renderProperties["completedAtMs"] = renderCompletedAtMS
-			renderSchema["properties"] = renderProperties
-			definition = renderSchema
+			definition = typeScriptDefinitionWithBigIntProperties(definition, "completedAtMs")
+		}
+		if name == "HookRunSummary" {
+			// ts-rs maps each Rust i64 field to bigint, including nullable i64
+			// options. Keep these hints out of the public JSON Schema.
+			definition = typeScriptDefinitionWithBigIntProperties(
+				definition, "displayOrder", "startedAt", "completedAt", "durationMs",
+			)
+			definition = typeScriptDefinitionWithPropertySchemas(definition, Schema{
+				"source":        Schema{"$ref": "#/$defs/HookSource"},
+				"statusMessage": Schema{"anyOf": []any{Schema{"type": "string"}, Schema{"type": "null"}}},
+			})
+		}
+		if name == "HookStartedNotification" || name == "HookCompletedNotification" {
+			definition = typeScriptDefinitionWithPropertySchemas(definition, Schema{
+				"turnId": Schema{"anyOf": []any{Schema{"type": "string"}, Schema{"type": "null"}}},
+			})
 		}
 		typeName, err := typeScriptType(definition, 0)
 		if err != nil {
@@ -267,16 +276,76 @@ func writeTypeScriptItemBindings(out *bytes.Buffer) {
 	out.WriteString("}[KnownItemKind];\n")
 }
 
+func typeScriptDefinitionWithBigIntProperties(definition any, names ...string) Schema {
+	schema, _ := typeScriptSchema(definition)
+	renderSchema := make(Schema, len(schema))
+	for key, value := range schema {
+		renderSchema[key] = value
+	}
+	properties, _ := typeScriptSchema(schema["properties"])
+	renderProperties := make(Schema, len(properties))
+	for key, value := range properties {
+		renderProperties[key] = value
+	}
+	for _, name := range names {
+		property, _ := typeScriptSchema(properties[name])
+		renderProperty := make(Schema, len(property)+1)
+		for key, value := range property {
+			renderProperty[key] = value
+		}
+		renderProperty[typeScriptBigIntKeyword] = true
+		renderProperties[name] = renderProperty
+	}
+	renderSchema["properties"] = renderProperties
+	return renderSchema
+}
+
+func typeScriptDefinitionWithPropertySchemas(definition any, replacements Schema) Schema {
+	schema, _ := typeScriptSchema(definition)
+	renderSchema := make(Schema, len(schema))
+	for key, value := range schema {
+		renderSchema[key] = value
+	}
+	properties, _ := typeScriptSchema(schema["properties"])
+	renderProperties := make(Schema, len(properties))
+	for key, value := range properties {
+		renderProperties[key] = value
+	}
+	for name, replacement := range replacements {
+		renderProperties[name] = replacement
+	}
+	renderSchema["properties"] = renderProperties
+	return renderSchema
+}
+
 func typeScriptType(value any, indent int) (string, error) {
 	schema, ok := typeScriptSchema(value)
 	if !ok || len(schema) == 0 {
 		return "unknown", nil
 	}
 	if bigint, _ := schema[typeScriptBigIntKeyword].(bool); bigint {
-		if schema["type"] != "integer" {
+		if schema["type"] == "integer" {
+			return "bigint", nil
+		}
+		types, ok := typeScriptAnySlice(schema["type"])
+		if !ok {
 			return "", errors.New("TypeScript bigint schema must have integer type")
 		}
-		return "bigint", nil
+		parts := make([]string, 0, len(types))
+		for _, value := range types {
+			switch value {
+			case "integer":
+				parts = appendUniqueTypeScript(parts, "bigint")
+			case "null":
+				parts = appendUniqueTypeScript(parts, "null")
+			default:
+				return "", errors.New("TypeScript bigint schema type array must contain only integer and null")
+			}
+		}
+		if !slices.Contains(parts, "bigint") {
+			return "", errors.New("TypeScript bigint schema type array must contain integer")
+		}
+		return strings.Join(parts, " | "), nil
 	}
 	if ref, ok := schema["$ref"].(string); ok {
 		const prefix = "#/$defs/"

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -1483,6 +1483,12 @@ export type GuardianWarningNotification = {
   "threadId": string;
 };
 
+export type HookCompletedNotification = {
+  "run": HookRunSummary;
+  "threadId": string;
+  "turnId": string | null;
+};
+
 export type HookEventName = "preToolUse" | "permissionRequest" | "postToolUse" | "preCompact" | "postCompact" | "sessionStart" | "userPromptSubmit" | "subagentStart" | "subagentStop" | "stop";
 
 export type HookExecutionMode = "sync" | "async";
@@ -1507,9 +1513,32 @@ export type HookPromptFragment = {
 
 export type HookRunStatus = "running" | "completed" | "failed" | "blocked" | "stopped";
 
+export type HookRunSummary = {
+  "completedAt": bigint | null;
+  "displayOrder": bigint;
+  "durationMs": bigint | null;
+  "entries": Array<HookOutputEntry>;
+  "eventName": HookEventName;
+  "executionMode": HookExecutionMode;
+  "handlerType": HookHandlerType;
+  "id": string;
+  "scope": HookScope;
+  "source": HookSource;
+  "sourcePath": AbsolutePathBuf;
+  "startedAt": bigint;
+  "status": HookRunStatus;
+  "statusMessage": string | null;
+};
+
 export type HookScope = "thread" | "turn";
 
 export type HookSource = "system" | "user" | "project" | "mdm" | "sessionFlags" | "plugin" | "cloudRequirements" | "cloudManagedConfig" | "legacyManagedConfigFile" | "legacyManagedConfigMdm" | "unknown";
+
+export type HookStartedNotification = {
+  "run": HookRunSummary;
+  "threadId": string;
+  "turnId": string | null;
+};
 
 export type HookTrustStatus = "managed" | "untrusted" | "trusted" | "modified";
 

--- a/appserver/protocol/typescript/testdata/hook_run_notification_contract.ts
+++ b/appserver/protocol/typescript/testdata/hook_run_notification_contract.ts
@@ -1,0 +1,124 @@
+import type {
+  HookCompletedNotification,
+  HookRunSummary,
+  HookStartedNotification,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+
+type Run = {
+  id: string;
+  eventName: "preToolUse" | "permissionRequest" | "postToolUse" | "preCompact" | "postCompact" | "sessionStart" | "userPromptSubmit" | "subagentStart" | "subagentStop" | "stop";
+  handlerType: "command" | "prompt" | "agent";
+  executionMode: "sync" | "async";
+  scope: "thread" | "turn";
+  sourcePath: string;
+  source: "system" | "user" | "project" | "mdm" | "sessionFlags" | "plugin" | "cloudRequirements" | "cloudManagedConfig" | "legacyManagedConfigFile" | "legacyManagedConfigMdm" | "unknown";
+  displayOrder: bigint;
+  status: "running" | "completed" | "failed" | "blocked" | "stopped";
+  statusMessage: string | null;
+  startedAt: bigint;
+  completedAt: bigint | null;
+  durationMs: bigint | null;
+  entries: Array<{ kind: "warning" | "stop" | "feedback" | "context" | "error"; text: string }>;
+};
+type Notification = { threadId: string; turnId: string | null; run: HookRunSummary };
+
+type Contracts = [
+  Expect<Equal<HookRunSummary, Run>>,
+  Expect<Equal<HookStartedNotification, Notification>>,
+  Expect<Equal<HookCompletedNotification, Notification>>,
+  Expect<Equal<HookStartedNotification, HookCompletedNotification>>,
+];
+declare const contracts: Contracts;
+void contracts;
+
+const run = {
+  id: "",
+  eventName: "preToolUse",
+  handlerType: "command",
+  executionMode: "sync",
+  scope: "thread",
+  sourcePath: "/hooks.json",
+  source: "unknown",
+  displayOrder: -9_223_372_036_854_775_808n,
+  status: "running",
+  statusMessage: null,
+  startedAt: 9_223_372_036_854_775_807n,
+  completedAt: null,
+  durationMs: 0n,
+  entries: [],
+} satisfies HookRunSummary;
+({ ...run, entries: [{ kind: "warning", text: "" }, { kind: "warning", text: "" }] }) satisfies HookRunSummary;
+({ threadId: "", turnId: null, run }) satisfies HookStartedNotification;
+({ threadId: "thread", turnId: " turn ", run }) satisfies HookCompletedNotification;
+
+// @ts-expect-error id is required.
+({ ...run, id: undefined }) satisfies HookRunSummary;
+// @ts-expect-error eventName is required.
+({ ...run, eventName: undefined }) satisfies HookRunSummary;
+// @ts-expect-error handlerType is closed.
+({ ...run, handlerType: "shell" }) satisfies HookRunSummary;
+// @ts-expect-error executionMode is closed.
+({ ...run, executionMode: "blocking" }) satisfies HookRunSummary;
+// @ts-expect-error scope is closed.
+({ ...run, scope: "session" }) satisfies HookRunSummary;
+// @ts-expect-error sourcePath is required.
+({ ...run, sourcePath: undefined }) satisfies HookRunSummary;
+// @ts-expect-error source is required by exact ts-rs output.
+({ ...run, source: undefined }) satisfies HookRunSummary;
+// @ts-expect-error source is non-null.
+({ ...run, source: null }) satisfies HookRunSummary;
+// @ts-expect-error displayOrder is bigint.
+({ ...run, displayOrder: 0 }) satisfies HookRunSummary;
+// @ts-expect-error status is closed.
+({ ...run, status: "pending" }) satisfies HookRunSummary;
+// @ts-expect-error statusMessage is required by exact ts-rs output.
+({ ...run, statusMessage: undefined }) satisfies HookRunSummary;
+// @ts-expect-error statusMessage is nullable string only.
+({ ...run, statusMessage: 1 }) satisfies HookRunSummary;
+// @ts-expect-error startedAt is bigint.
+({ ...run, startedAt: 0 }) satisfies HookRunSummary;
+// @ts-expect-error completedAt is required by exact ts-rs output.
+({ ...run, completedAt: undefined }) satisfies HookRunSummary;
+// @ts-expect-error completedAt is nullable bigint only.
+({ ...run, completedAt: 0 }) satisfies HookRunSummary;
+// @ts-expect-error durationMs is required by exact ts-rs output.
+({ ...run, durationMs: undefined }) satisfies HookRunSummary;
+// @ts-expect-error durationMs is nullable bigint only.
+({ ...run, durationMs: "0" }) satisfies HookRunSummary;
+// @ts-expect-error entries are required.
+({ ...run, entries: undefined }) satisfies HookRunSummary;
+// @ts-expect-error entries are non-null.
+({ ...run, entries: null }) satisfies HookRunSummary;
+// @ts-expect-error nested entries retain exact kinds.
+({ ...run, entries: [{ kind: "info", text: "" }] }) satisfies HookRunSummary;
+// @ts-expect-error nested entry text is required.
+({ ...run, entries: [{ kind: "warning" }] }) satisfies HookRunSummary;
+// @ts-expect-error snake-case aliases do not replace canonical fields.
+({ ...run, eventName: undefined, event_name: "preToolUse" }) satisfies HookRunSummary;
+// @ts-expect-error fields absent from the public record are rejected.
+({ ...run, extra: true }) satisfies HookRunSummary;
+// @ts-expect-error threadId is required.
+({ turnId: null, run }) satisfies HookStartedNotification;
+// @ts-expect-error threadId is non-null.
+({ threadId: null, turnId: null, run }) satisfies HookStartedNotification;
+// @ts-expect-error turnId is required by exact ts-rs output.
+({ threadId: "", run }) satisfies HookStartedNotification;
+// @ts-expect-error turnId is nullable string only.
+({ threadId: "", turnId: 1, run }) satisfies HookStartedNotification;
+// @ts-expect-error run is required.
+({ threadId: "", turnId: null }) satisfies HookCompletedNotification;
+// @ts-expect-error run is non-null.
+({ threadId: "", turnId: null, run: null }) satisfies HookCompletedNotification;
+// @ts-expect-error nested runs remain strict.
+({ threadId: "", turnId: null, run: { ...run, source: null } }) satisfies HookCompletedNotification;
+// @ts-expect-error snake-case aliases do not replace canonical notification fields.
+({ thread_id: "", turnId: null, run }) satisfies HookStartedNotification;
+// @ts-expect-error fields absent from notifications are rejected.
+({ threadId: "", turnId: null, run, extra: true }) satisfies HookCompletedNotification;

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 417 {
-		t.Fatalf("definition count = %d, want 417", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
+		t.Fatalf("definition count = %d, want 420", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- add exact standalone HookRunSummary, HookStartedNotification, and HookCompletedNotification wire values
- preserve Rust serde defaults/nullability and canonical output while keeping hook methods blocked and unbound
- generate exact bigint TypeScript fields and strict compile coverage

## Verification
- go test ./appserver/protocol -count=1
- go test -race ./appserver/protocol -count=1
- go test ./appserver/protocol -coverprofile=/tmp/gollem-hook-run-notifications.cover -count=1 (97.2%; new implementation 100%)
- go list ./... | grep -v /ext/monty | xargs go test -count=1
- go list ./... | grep -v /ext/monty | xargs go vet
- tsc --project appserver/protocol/typescript/tsconfig.json

Local Monty tests intentionally skipped per project direction; hosted CI remains unchanged.