### PR TITLE
feat(protocol): export hook metadata list contracts

### DIFF
--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(defs); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,8 +217,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,8 +203,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -260,8 +260,8 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,8 +244,8 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -162,8 +162,8 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -175,8 +175,8 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -381,8 +381,8 @@ func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_metadata_list_contract_test.go
+++ b/appserver/protocol/hook_metadata_list_contract_test.go
@@ -1,0 +1,373 @@
+package protocol
+
+import (
+	"encoding/json"
+	"math"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestHookMetadataListSchemasAreExact(t *testing.T) {
+	nullableString := Schema{"type": []any{"string", "null"}}
+	want := map[string]Schema{
+		"HookErrorInfo": closedThreadSessionParamSchema(Schema{
+			"path": Schema{"type": "string"}, "message": Schema{"type": "string"},
+		}, []string{"message", "path"}),
+		"HookMetadata": closedThreadSessionParamSchema(Schema{
+			"key":           Schema{"type": "string"},
+			"eventName":     Schema{"$ref": "#/$defs/HookEventName"},
+			"handlerType":   Schema{"$ref": "#/$defs/HookHandlerType"},
+			"matcher":       nullableString,
+			"command":       nullableString,
+			"timeoutSec":    Schema{"type": "integer", "format": "uint64", "minimum": float64(0)},
+			"statusMessage": nullableString,
+			"sourcePath":    Schema{"$ref": "#/$defs/AbsolutePathBuf"},
+			"source":        Schema{"$ref": "#/$defs/HookSource"},
+			"pluginId":      nullableString,
+			"displayOrder":  Schema{"type": "integer", "format": "int64"},
+			"enabled":       Schema{"type": "boolean"},
+			"isManaged":     Schema{"type": "boolean"},
+			"currentHash":   Schema{"type": "string"},
+			"trustStatus":   Schema{"$ref": "#/$defs/HookTrustStatus"},
+		}, []string{
+			"currentHash", "displayOrder", "enabled", "eventName", "handlerType",
+			"isManaged", "key", "source", "sourcePath", "timeoutSec", "trustStatus",
+		}),
+		"HooksListEntry": closedThreadSessionParamSchema(Schema{
+			"cwd":      Schema{"type": "string"},
+			"hooks":    Schema{"type": "array", "items": Schema{"$ref": "#/$defs/HookMetadata"}},
+			"warnings": Schema{"type": "array", "items": Schema{"type": "string"}},
+			"errors":   Schema{"type": "array", "items": Schema{"$ref": "#/$defs/HookErrorInfo"}},
+		}, []string{"cwd", "errors", "hooks", "warnings"}),
+		"HooksListParams": closedThreadSessionParamSchema(Schema{
+			"cwds": Schema{
+				"type": "array", "items": Schema{"type": "string"},
+				"description": "When empty, defaults to the current session working directory.",
+			},
+		}, nil),
+		"HooksListResponse": closedThreadSessionParamSchema(Schema{
+			"data": Schema{"type": "array", "items": Schema{"$ref": "#/$defs/HooksListEntry"}},
+		}, []string{"data"}),
+	}
+
+	defs := JSONSchema()["$defs"].(Schema)
+	for name, expected := range want {
+		got, ok := defs[name].(Schema)
+		if !ok || !reflect.DeepEqual(got, expected) {
+			t.Errorf("%s schema = %#v, %v; want %#v", name, got, ok, expected)
+		}
+	}
+}
+
+func TestHookMetadataAcceptsRustWireForms(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     string
+		want      HookMetadata
+		canonical string
+	}{
+		{
+			name: "omitted options empty values and unsigned maximum",
+			input: `{"key":"","eventName":"preToolUse","handlerType":"command",` +
+				`"timeoutSec":18446744073709551615,"sourcePath":"/hooks.json",` +
+				`"source":"unknown","displayOrder":-9223372036854775808,` +
+				`"enabled":false,"isManaged":false,"currentHash":"",` +
+				`"trustStatus":"untrusted","future":true}`,
+			want: HookMetadata{
+				Key: "", EventName: HookEventNamePreToolUse, HandlerType: HookHandlerTypeCommand,
+				TimeoutSec: math.MaxUint64, SourcePath: AbsolutePathBuf("/hooks.json"),
+				Source: HookSourceUnknown, DisplayOrder: math.MinInt64,
+				CurrentHash: "", TrustStatus: HookTrustStatusUntrusted,
+			},
+			canonical: `{"key":"","eventName":"preToolUse","handlerType":"command",` +
+				`"matcher":null,"command":null,"timeoutSec":18446744073709551615,` +
+				`"statusMessage":null,"sourcePath":"/hooks.json","source":"unknown",` +
+				`"pluginId":null,"displayOrder":-9223372036854775808,"enabled":false,` +
+				`"isManaged":false,"currentHash":"","trustStatus":"untrusted"}`,
+		},
+		{
+			name: "explicit null and present options",
+			input: `{"key":" key ","eventName":"stop","handlerType":"agent",` +
+				`"matcher":" matcher ","command":"","timeoutSec":0,"statusMessage":null,` +
+				`"sourcePath":"/repo/../repo/hooks.json","source":"project","pluginId":" plugin ",` +
+				`"displayOrder":9223372036854775807,"enabled":true,"isManaged":true,` +
+				`"currentHash":" hash ","trustStatus":"managed"}`,
+			want: HookMetadata{
+				Key: " key ", EventName: HookEventNameStop, HandlerType: HookHandlerTypeAgent,
+				Matcher: stringPointer(" matcher "), Command: stringPointer(""), TimeoutSec: 0,
+				SourcePath: AbsolutePathBuf("/repo/hooks.json"), Source: HookSourceProject,
+				PluginID: stringPointer(" plugin "), DisplayOrder: math.MaxInt64,
+				Enabled: true, IsManaged: true, CurrentHash: " hash ", TrustStatus: HookTrustStatusManaged,
+			},
+			canonical: `{"key":" key ","eventName":"stop","handlerType":"agent",` +
+				`"matcher":" matcher ","command":"","timeoutSec":0,"statusMessage":null,` +
+				`"sourcePath":"/repo/hooks.json","source":"project","pluginId":" plugin ",` +
+				`"displayOrder":9223372036854775807,"enabled":true,"isManaged":true,` +
+				`"currentHash":" hash ","trustStatus":"managed"}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got HookMetadata
+			if err := json.Unmarshal([]byte(tc.input), &got); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("metadata = %#v, want %#v", got, tc.want)
+			}
+			encoded, err := json.Marshal(got)
+			if err != nil || string(encoded) != tc.canonical {
+				t.Fatalf("canonical = %s, %v; want %s", encoded, err, tc.canonical)
+			}
+		})
+	}
+}
+
+func TestHookListGraphAcceptsRustWireForms(t *testing.T) {
+	var errorInfo HookErrorInfo
+	if err := json.Unmarshal([]byte(`{"path":"relative/../hook.json","message":"","future":true}`), &errorInfo); err != nil {
+		t.Fatalf("Unmarshal error info: %v", err)
+	}
+	encoded, err := json.Marshal(errorInfo)
+	if err != nil || string(encoded) != `{"path":"relative/../hook.json","message":""}` {
+		t.Fatalf("error info canonical = %s, %v", encoded, err)
+	}
+
+	metadata := sampleHookMetadataForContract()
+	metadataJSON, err := json.Marshal(metadata)
+	if err != nil {
+		t.Fatal(err)
+	}
+	input := `{"cwd":"repo/../repo","hooks":[` + string(metadataJSON) + `,` + string(metadataJSON) + `],` +
+		`"warnings":[""," warning ",""],"errors":[{"path":"relative/../hook.json","message":""},` +
+		`{"path":"relative/../hook.json","message":""}],"future":true}`
+	var entry HooksListEntry
+	if err := json.Unmarshal([]byte(input), &entry); err != nil {
+		t.Fatalf("Unmarshal entry: %v", err)
+	}
+	if entry.CWD != "repo/../repo" || len(entry.Hooks) != 2 || len(entry.Warnings) != 3 ||
+		len(entry.Errors) != 2 || !reflect.DeepEqual(entry.Hooks[0], entry.Hooks[1]) ||
+		!reflect.DeepEqual(entry.Errors[0], entry.Errors[1]) {
+		t.Fatalf("entry order/duplicates changed: %#v", entry)
+	}
+
+	encoded, err = json.Marshal(HooksListEntry{CWD: ""})
+	if err != nil || string(encoded) != `{"cwd":"","hooks":[],"warnings":[],"errors":[]}` {
+		t.Fatalf("nil entry slices = %s, %v", encoded, err)
+	}
+	encoded, err = json.Marshal(HooksListResponse{})
+	if err != nil || string(encoded) != `{"data":[]}` {
+		t.Fatalf("nil response data = %s, %v", encoded, err)
+	}
+
+	for _, tc := range []struct {
+		input     string
+		want      []string
+		canonical string
+	}{
+		{`{}`, []string{}, `{}`},
+		{`{"cwds":[],"future":true}`, []string{}, `{}`},
+		{`{"cwds":["","repo/../repo",""]}`, []string{"", "repo/../repo", ""}, `{"cwds":["","repo/../repo",""]}`},
+	} {
+		var params HooksListParams
+		if err := json.Unmarshal([]byte(tc.input), &params); err != nil {
+			t.Fatalf("Unmarshal params %s: %v", tc.input, err)
+		}
+		if !slices.Equal(params.CWDs, tc.want) {
+			t.Fatalf("params %s = %#v, want %#v", tc.input, params.CWDs, tc.want)
+		}
+		encoded, err := json.Marshal(params)
+		if err != nil || string(encoded) != tc.canonical {
+			t.Fatalf("params canonical = %s, %v; want %s", encoded, err, tc.canonical)
+		}
+	}
+
+	responseInput := `{"data":[` + input + `,` + input + `],"future":true}`
+	var response HooksListResponse
+	if err := json.Unmarshal([]byte(responseInput), &response); err != nil {
+		t.Fatalf("Unmarshal response: %v", err)
+	}
+	if len(response.Data) != 2 || !reflect.DeepEqual(response.Data[0], response.Data[1]) {
+		t.Fatalf("response order/duplicates changed: %#v", response)
+	}
+}
+
+func TestHookMetadataRejectsMalformedWireForms(t *testing.T) {
+	validBytes, err := json.Marshal(sampleHookMetadataForContract())
+	if err != nil {
+		t.Fatal(err)
+	}
+	valid := string(validBytes)
+	invalid := []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{}`,
+		strings.Replace(valid, `"key":"key",`, ``, 1),
+		strings.Replace(valid, `"eventName":"preToolUse",`, ``, 1),
+		strings.Replace(valid, `"handlerType":"command",`, ``, 1),
+		strings.Replace(valid, `"timeoutSec":1,`, ``, 1),
+		strings.Replace(valid, `"sourcePath":"/hooks.json",`, ``, 1),
+		strings.Replace(valid, `"source":"project",`, ``, 1),
+		strings.Replace(valid, `"displayOrder":-1,`, ``, 1),
+		strings.Replace(valid, `"enabled":true,`, ``, 1),
+		strings.Replace(valid, `"isManaged":false,`, ``, 1),
+		strings.Replace(valid, `"currentHash":"hash",`, ``, 1),
+		strings.Replace(valid, `"trustStatus":"trusted"`, ``, 1),
+		strings.Replace(valid, `"key":"key"`, `"key":null`, 1),
+		strings.Replace(valid, `"eventName":"preToolUse"`, `"eventName":"other"`, 1),
+		strings.Replace(valid, `"handlerType":"command"`, `"handlerType":"other"`, 1),
+		strings.Replace(valid, `"matcher":null`, `"matcher":1`, 1),
+		strings.Replace(valid, `"command":null`, `"command":false`, 1),
+		strings.Replace(valid, `"timeoutSec":1`, `"timeoutSec":-1`, 1),
+		strings.Replace(valid, `"timeoutSec":1`, `"timeoutSec":0.5`, 1),
+		strings.Replace(valid, `"timeoutSec":1`, `"timeoutSec":1e3`, 1),
+		strings.Replace(valid, `"timeoutSec":1`, `"timeoutSec":18446744073709551616`, 1),
+		strings.Replace(valid, `"statusMessage":null`, `"statusMessage":[]`, 1),
+		strings.Replace(valid, `"sourcePath":"/hooks.json"`, `"sourcePath":"relative"`, 1),
+		strings.Replace(valid, `"source":"project"`, `"source":null`, 1),
+		strings.Replace(valid, `"source":"project"`, `"source":"other"`, 1),
+		strings.Replace(valid, `"pluginId":null`, `"pluginId":1`, 1),
+		strings.Replace(valid, `"displayOrder":-1`, `"displayOrder":0.5`, 1),
+		strings.Replace(valid, `"displayOrder":-1`, `"displayOrder":9223372036854775808`, 1),
+		strings.Replace(valid, `"enabled":true`, `"enabled":null`, 1),
+		strings.Replace(valid, `"isManaged":false`, `"isManaged":"false"`, 1),
+		strings.Replace(valid, `"currentHash":"hash"`, `"currentHash":1`, 1),
+		strings.Replace(valid, `"trustStatus":"trusted"`, `"trustStatus":"other"`, 1),
+		strings.Replace(valid, `"key":"key"`, `"key":"key","key":"other"`, 1),
+		strings.TrimSuffix(valid, `}`), valid + ` {}`,
+	}
+	for _, input := range invalid {
+		assertJSONRejects[HookMetadata](t, input)
+	}
+
+	var value *HookMetadata
+	if err := value.UnmarshalJSON(validBytes); err == nil {
+		t.Fatal("nil HookMetadata receiver succeeded")
+	}
+	bad := sampleHookMetadataForContract()
+	bad.SourcePath = AbsolutePathBuf("relative")
+	if _, err := json.Marshal(bad); err == nil {
+		t.Fatal("metadata with relative source path marshaled")
+	}
+	for name, mutate := range map[string]func(*HookMetadata){
+		"event": func(value *HookMetadata) { value.EventName = HookEventName("other") },
+		"handler": func(value *HookMetadata) {
+			value.HandlerType = HookHandlerType("other")
+		},
+		"source": func(value *HookMetadata) { value.Source = HookSource("other") },
+		"trust":  func(value *HookMetadata) { value.TrustStatus = HookTrustStatus("other") },
+	} {
+		t.Run("marshal invalid "+name, func(t *testing.T) {
+			value := sampleHookMetadataForContract()
+			mutate(&value)
+			if _, err := json.Marshal(value); err == nil {
+				t.Fatalf("invalid metadata %#v marshaled", value)
+			}
+		})
+	}
+}
+
+func TestHookListGraphRejectsMalformedWireForms(t *testing.T) {
+	metadataJSON, err := json.Marshal(sampleHookMetadataForContract())
+	if err != nil {
+		t.Fatal(err)
+	}
+	validEntry := `{"cwd":"/repo","hooks":[` + string(metadataJSON) + `],"warnings":[],"errors":[]}`
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{}`,
+		`{"message":"x"}`, `{"path":null,"message":"x"}`, `{"path":"p","message":null}`,
+		`{"path":"p","message":"x","path":"q"}`, `{"path":"p","message":"x"} {}`,
+	} {
+		assertJSONRejects[HookErrorInfo](t, input)
+	}
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{}`,
+		strings.Replace(validEntry, `"cwd":"/repo",`, ``, 1),
+		strings.Replace(validEntry, `"hooks":[`+string(metadataJSON)+`],`, ``, 1),
+		strings.Replace(validEntry, `"warnings":[],`, ``, 1),
+		strings.Replace(validEntry, `,"errors":[]`, ``, 1),
+		strings.Replace(validEntry, `"cwd":"/repo"`, `"cwd":null`, 1),
+		strings.Replace(validEntry, `"hooks":[`+string(metadataJSON)+`]`, `"hooks":null`, 1),
+		strings.Replace(validEntry, `"hooks":[`+string(metadataJSON)+`]`, `"hooks":[null]`, 1),
+		strings.Replace(validEntry, `"warnings":[]`, `"warnings":[null]`, 1),
+		strings.Replace(validEntry, `"errors":[]`, `"errors":[null]`, 1),
+		strings.Replace(validEntry, `"cwd":"/repo"`, `"cwd":"/repo","cwd":"other"`, 1),
+		strings.TrimSuffix(validEntry, `}`), validEntry + ` {}`,
+	} {
+		assertJSONRejects[HooksListEntry](t, input)
+	}
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{"cwds":null}`, `{"cwds":{}}`,
+		`{"cwds":[null]}`, `{"cwds":[1]}`, `{"cwds":[],"cwds":[]}`, `{} {}`,
+	} {
+		assertJSONRejects[HooksListParams](t, input)
+	}
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{}`, `{"data":null}`, `{"data":{}}`,
+		`{"data":[null]}`, `{"data":[{}]}`, `{"data":[],"data":[]}`, `{"data":[]} {}`,
+	} {
+		assertJSONRejects[HooksListResponse](t, input)
+	}
+
+	var errorInfo *HookErrorInfo
+	if err := errorInfo.UnmarshalJSON([]byte(`{"path":"p","message":"m"}`)); err == nil {
+		t.Fatal("nil HookErrorInfo receiver succeeded")
+	}
+	var entry *HooksListEntry
+	if err := entry.UnmarshalJSON([]byte(validEntry)); err == nil {
+		t.Fatal("nil HooksListEntry receiver succeeded")
+	}
+	var params *HooksListParams
+	if err := params.UnmarshalJSON([]byte(`{}`)); err == nil {
+		t.Fatal("nil HooksListParams receiver succeeded")
+	}
+	var response *HooksListResponse
+	if err := response.UnmarshalJSON([]byte(`{"data":[]}`)); err == nil {
+		t.Fatal("nil HooksListResponse receiver succeeded")
+	}
+	invalidNested := sampleHookMetadataForContract()
+	invalidNested.TrustStatus = HookTrustStatus("other")
+	if _, err := json.Marshal(HooksListEntry{Hooks: []HookMetadata{invalidNested}}); err == nil {
+		t.Fatal("entry with invalid nested metadata marshaled")
+	}
+}
+
+func TestHookMetadataListContractsStayStandalone(t *testing.T) {
+	names := []string{
+		"HookErrorInfo", "HookMetadata", "HooksListEntry", "HooksListParams", "HooksListResponse",
+	}
+	for _, binding := range WireTypeBindings() {
+		if binding.Method == "hooks/list" {
+			t.Fatalf("hooks/list unexpectedly bound: %#v", binding)
+		}
+		for _, name := range names {
+			if slices.Contains(binding.Params, name) || slices.Contains(binding.Result, name) {
+				t.Errorf("standalone definition %s unexpectedly bound by %s", name, binding.Method)
+			}
+		}
+	}
+	for _, binding := range ItemPayloadBindings() {
+		if slices.Contains(names, binding.Type) {
+			t.Errorf("standalone definition %s unexpectedly bound to item %s", binding.Type, binding.Kind)
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Errorf("definition count = %d, want 425", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 {
+		t.Errorf("wire binding count = %d, want 59", got)
+	}
+	if got := len(ItemPayloadBindings()); got != 5 {
+		t.Errorf("item binding count = %d, want 5", got)
+	}
+}
+
+func sampleHookMetadataForContract() HookMetadata {
+	return HookMetadata{
+		Key: "key", EventName: HookEventNamePreToolUse, HandlerType: HookHandlerTypeCommand,
+		TimeoutSec: 1, SourcePath: AbsolutePathBuf("/hooks.json"), Source: HookSourceProject,
+		DisplayOrder: -1, Enabled: true, IsManaged: false, CurrentHash: "hash",
+		TrustStatus: HookTrustStatusTrusted,
+	}
+}

--- a/appserver/protocol/hook_metadata_list_types.go
+++ b/appserver/protocol/hook_metadata_list_types.go
@@ -1,0 +1,360 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// HookErrorInfo is one descriptive hook-discovery error. It does not imply
+// that Gollem scans hook files.
+type HookErrorInfo struct {
+	Path    string `json:"path"`
+	Message string `json:"message"`
+}
+
+func (e HookErrorInfo) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Path    string `json:"path"`
+		Message string `json:"message"`
+	}{Path: e.Path, Message: e.Message})
+}
+
+func (e *HookErrorInfo) UnmarshalJSON(data []byte) error {
+	if e == nil {
+		return errors.New("decode hook error info into nil receiver")
+	}
+	const objectName = "hook error info"
+	payload, err := decodeRustSerdeObject(data, objectName, "path", "message")
+	if err != nil {
+		return err
+	}
+	path, err := decodeRequiredThreadItemValue[string](payload, objectName, "path")
+	if err != nil {
+		return err
+	}
+	message, err := decodeRequiredThreadItemValue[string](payload, objectName, "message")
+	if err != nil {
+		return err
+	}
+	*e = HookErrorInfo{Path: path, Message: message}
+	return nil
+}
+
+// HookMetadata is exact standalone public metadata for one configured hook.
+// Its fields are descriptive and do not grant trust or execution authority.
+type HookMetadata struct {
+	Key           string          `json:"key"`
+	EventName     HookEventName   `json:"eventName"`
+	HandlerType   HookHandlerType `json:"handlerType"`
+	Matcher       *string         `json:"matcher"`
+	Command       *string         `json:"command"`
+	TimeoutSec    uint64          `json:"timeoutSec"`
+	StatusMessage *string         `json:"statusMessage"`
+	SourcePath    AbsolutePathBuf `json:"sourcePath"`
+	Source        HookSource      `json:"source"`
+	PluginID      *string         `json:"pluginId"`
+	DisplayOrder  int64           `json:"displayOrder"`
+	Enabled       bool            `json:"enabled"`
+	IsManaged     bool            `json:"isManaged"`
+	CurrentHash   string          `json:"currentHash"`
+	TrustStatus   HookTrustStatus `json:"trustStatus"`
+}
+
+func (m HookMetadata) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Key           string          `json:"key"`
+		EventName     HookEventName   `json:"eventName"`
+		HandlerType   HookHandlerType `json:"handlerType"`
+		Matcher       *string         `json:"matcher"`
+		Command       *string         `json:"command"`
+		TimeoutSec    uint64          `json:"timeoutSec"`
+		StatusMessage *string         `json:"statusMessage"`
+		SourcePath    AbsolutePathBuf `json:"sourcePath"`
+		Source        HookSource      `json:"source"`
+		PluginID      *string         `json:"pluginId"`
+		DisplayOrder  int64           `json:"displayOrder"`
+		Enabled       bool            `json:"enabled"`
+		IsManaged     bool            `json:"isManaged"`
+		CurrentHash   string          `json:"currentHash"`
+		TrustStatus   HookTrustStatus `json:"trustStatus"`
+	}{
+		Key: m.Key, EventName: m.EventName, HandlerType: m.HandlerType,
+		Matcher: m.Matcher, Command: m.Command, TimeoutSec: m.TimeoutSec,
+		StatusMessage: m.StatusMessage, SourcePath: m.SourcePath, Source: m.Source,
+		PluginID: m.PluginID, DisplayOrder: m.DisplayOrder, Enabled: m.Enabled,
+		IsManaged: m.IsManaged, CurrentHash: m.CurrentHash, TrustStatus: m.TrustStatus,
+	})
+}
+
+func (m *HookMetadata) UnmarshalJSON(data []byte) error {
+	if m == nil {
+		return errors.New("decode hook metadata into nil receiver")
+	}
+	const objectName = "hook metadata"
+	payload, err := decodeRustSerdeObject(
+		data, objectName,
+		"key", "eventName", "handlerType", "matcher", "command", "timeoutSec",
+		"statusMessage", "sourcePath", "source", "pluginId", "displayOrder",
+		"enabled", "isManaged", "currentHash", "trustStatus",
+	)
+	if err != nil {
+		return err
+	}
+	key, err := decodeRequiredThreadItemValue[string](payload, objectName, "key")
+	if err != nil {
+		return err
+	}
+	eventName, err := decodeRequiredThreadItemValue[HookEventName](payload, objectName, "eventName")
+	if err != nil {
+		return err
+	}
+	handlerType, err := decodeRequiredThreadItemValue[HookHandlerType](payload, objectName, "handlerType")
+	if err != nil {
+		return err
+	}
+	matcher, err := decodeOptionalNullableConfigValue[string](payload, objectName, "matcher")
+	if err != nil {
+		return err
+	}
+	command, err := decodeOptionalNullableConfigValue[string](payload, objectName, "command")
+	if err != nil {
+		return err
+	}
+	timeoutSec, err := decodeRequiredThreadItemValue[uint64](payload, objectName, "timeoutSec")
+	if err != nil {
+		return err
+	}
+	statusMessage, err := decodeOptionalNullableConfigValue[string](payload, objectName, "statusMessage")
+	if err != nil {
+		return err
+	}
+	sourcePath, err := decodeRequiredThreadItemValue[AbsolutePathBuf](payload, objectName, "sourcePath")
+	if err != nil {
+		return err
+	}
+	source, err := decodeRequiredThreadItemValue[HookSource](payload, objectName, "source")
+	if err != nil {
+		return err
+	}
+	pluginID, err := decodeOptionalNullableConfigValue[string](payload, objectName, "pluginId")
+	if err != nil {
+		return err
+	}
+	displayOrder, err := decodeRequiredThreadItemValue[int64](payload, objectName, "displayOrder")
+	if err != nil {
+		return err
+	}
+	enabled, err := decodeRequiredThreadItemValue[bool](payload, objectName, "enabled")
+	if err != nil {
+		return err
+	}
+	isManaged, err := decodeRequiredThreadItemValue[bool](payload, objectName, "isManaged")
+	if err != nil {
+		return err
+	}
+	currentHash, err := decodeRequiredThreadItemValue[string](payload, objectName, "currentHash")
+	if err != nil {
+		return err
+	}
+	trustStatus, err := decodeRequiredThreadItemValue[HookTrustStatus](payload, objectName, "trustStatus")
+	if err != nil {
+		return err
+	}
+	*m = HookMetadata{
+		Key: key, EventName: eventName, HandlerType: handlerType,
+		Matcher: matcher, Command: command, TimeoutSec: timeoutSec,
+		StatusMessage: statusMessage, SourcePath: sourcePath, Source: source,
+		PluginID: pluginID, DisplayOrder: displayOrder, Enabled: enabled,
+		IsManaged: isManaged, CurrentHash: currentHash, TrustStatus: trustStatus,
+	}
+	return nil
+}
+
+// HooksListEntry is exact standalone hook metadata and diagnostics for one cwd.
+type HooksListEntry struct {
+	CWD      string          `json:"cwd"`
+	Hooks    []HookMetadata  `json:"hooks"`
+	Warnings []string        `json:"warnings"`
+	Errors   []HookErrorInfo `json:"errors"`
+}
+
+func (e HooksListEntry) MarshalJSON() ([]byte, error) {
+	hooks := e.Hooks
+	if hooks == nil {
+		hooks = []HookMetadata{}
+	}
+	warnings := e.Warnings
+	if warnings == nil {
+		warnings = []string{}
+	}
+	errors := e.Errors
+	if errors == nil {
+		errors = []HookErrorInfo{}
+	}
+	return json.Marshal(struct {
+		CWD      string          `json:"cwd"`
+		Hooks    []HookMetadata  `json:"hooks"`
+		Warnings []string        `json:"warnings"`
+		Errors   []HookErrorInfo `json:"errors"`
+	}{CWD: e.CWD, Hooks: hooks, Warnings: warnings, Errors: errors})
+}
+
+func (e *HooksListEntry) UnmarshalJSON(data []byte) error {
+	if e == nil {
+		return errors.New("decode hooks list entry into nil receiver")
+	}
+	const objectName = "hooks list entry"
+	payload, err := decodeRustSerdeObject(data, objectName, "cwd", "hooks", "warnings", "errors")
+	if err != nil {
+		return err
+	}
+	cwd, err := decodeRequiredThreadItemValue[string](payload, objectName, "cwd")
+	if err != nil {
+		return err
+	}
+	hooks, err := decodeRequiredThreadItemArray[HookMetadata](payload, objectName, "hooks")
+	if err != nil {
+		return err
+	}
+	warnings, err := decodeRequiredThreadItemArray[string](payload, objectName, "warnings")
+	if err != nil {
+		return err
+	}
+	errors, err := decodeRequiredThreadItemArray[HookErrorInfo](payload, objectName, "errors")
+	if err != nil {
+		return err
+	}
+	*e = HooksListEntry{CWD: cwd, Hooks: hooks, Warnings: warnings, Errors: errors}
+	return nil
+}
+
+// HooksListParams is the exact standalone public request shape. Gollem does
+// not bind it to hooks/list or interpret its working directories.
+type HooksListParams struct {
+	CWDs []string `json:"cwds,omitempty"`
+}
+
+func (p HooksListParams) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		CWDs []string `json:"cwds,omitempty"`
+	}{CWDs: p.CWDs})
+}
+
+func (p *HooksListParams) UnmarshalJSON(data []byte) error {
+	if p == nil {
+		return errors.New("decode hooks list params into nil receiver")
+	}
+	const objectName = "hooks list params"
+	payload, err := decodeRustSerdeObject(data, objectName, "cwds")
+	if err != nil {
+		return err
+	}
+	cwds := []string{}
+	if _, ok := payload["cwds"]; ok {
+		cwds, err = decodeRequiredThreadItemArray[string](payload, objectName, "cwds")
+		if err != nil {
+			return err
+		}
+	}
+	*p = HooksListParams{CWDs: cwds}
+	return nil
+}
+
+// HooksListResponse is the exact standalone public hook-list envelope.
+type HooksListResponse struct {
+	Data []HooksListEntry `json:"data"`
+}
+
+func (r HooksListResponse) MarshalJSON() ([]byte, error) {
+	data := r.Data
+	if data == nil {
+		data = []HooksListEntry{}
+	}
+	return json.Marshal(struct {
+		Data []HooksListEntry `json:"data"`
+	}{Data: data})
+}
+
+func (r *HooksListResponse) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("decode hooks list response into nil receiver")
+	}
+	const objectName = "hooks list response"
+	payload, err := decodeRustSerdeObject(data, objectName, "data")
+	if err != nil {
+		return err
+	}
+	entries, err := decodeRequiredThreadItemArray[HooksListEntry](payload, objectName, "data")
+	if err != nil {
+		return err
+	}
+	*r = HooksListResponse{Data: entries}
+	return nil
+}
+
+func hookErrorInfoSchema() Schema {
+	return closedThreadSessionParamSchema(Schema{
+		"path": Schema{"type": "string"}, "message": Schema{"type": "string"},
+	}, []string{"message", "path"})
+}
+
+func hookMetadataSchema() Schema {
+	nullableString := Schema{"type": []any{"string", "null"}}
+	return closedThreadSessionParamSchema(Schema{
+		"key":           Schema{"type": "string"},
+		"eventName":     Schema{"$ref": "#/$defs/HookEventName"},
+		"handlerType":   Schema{"$ref": "#/$defs/HookHandlerType"},
+		"matcher":       nullableString,
+		"command":       nullableString,
+		"timeoutSec":    Schema{"type": "integer", "format": "uint64", "minimum": float64(0)},
+		"statusMessage": nullableString,
+		"sourcePath":    Schema{"$ref": "#/$defs/AbsolutePathBuf"},
+		"source":        Schema{"$ref": "#/$defs/HookSource"},
+		"pluginId":      nullableString,
+		"displayOrder":  Schema{"type": "integer", "format": "int64"},
+		"enabled":       Schema{"type": "boolean"},
+		"isManaged":     Schema{"type": "boolean"},
+		"currentHash":   Schema{"type": "string"},
+		"trustStatus":   Schema{"$ref": "#/$defs/HookTrustStatus"},
+	}, []string{
+		"currentHash", "displayOrder", "enabled", "eventName", "handlerType",
+		"isManaged", "key", "source", "sourcePath", "timeoutSec", "trustStatus",
+	})
+}
+
+func hooksListEntrySchema() Schema {
+	return closedThreadSessionParamSchema(Schema{
+		"cwd":      Schema{"type": "string"},
+		"hooks":    Schema{"type": "array", "items": Schema{"$ref": "#/$defs/HookMetadata"}},
+		"warnings": Schema{"type": "array", "items": Schema{"type": "string"}},
+		"errors":   Schema{"type": "array", "items": Schema{"$ref": "#/$defs/HookErrorInfo"}},
+	}, []string{"cwd", "errors", "hooks", "warnings"})
+}
+
+func hooksListParamsSchema() Schema {
+	return closedThreadSessionParamSchema(Schema{
+		"cwds": Schema{
+			"type": "array", "items": Schema{"type": "string"},
+			"description": "When empty, defaults to the current session working directory.",
+		},
+	}, nil)
+}
+
+func hooksListResponseSchema() Schema {
+	return closedThreadSessionParamSchema(Schema{
+		"data": Schema{"type": "array", "items": Schema{"$ref": "#/$defs/HooksListEntry"}},
+	}, []string{"data"})
+}
+
+var (
+	_ json.Marshaler   = HookErrorInfo{}
+	_ json.Unmarshaler = (*HookErrorInfo)(nil)
+	_ json.Marshaler   = HookMetadata{}
+	_ json.Unmarshaler = (*HookMetadata)(nil)
+	_ json.Marshaler   = HooksListEntry{}
+	_ json.Unmarshaler = (*HooksListEntry)(nil)
+	_ json.Marshaler   = HooksListParams{}
+	_ json.Unmarshaler = (*HooksListParams)(nil)
+	_ json.Marshaler   = HooksListResponse{}
+	_ json.Unmarshaler = (*HooksListResponse)(nil)
+)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_run_notification_contract_test.go
+++ b/appserver/protocol/hook_run_notification_contract_test.go
@@ -297,8 +297,8 @@ func TestHookRunNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("surface changed: %d methods, %d wire bindings, %d item bindings", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/hook_value_foundation_contract_test.go
+++ b/appserver/protocol/hook_value_foundation_contract_test.go
@@ -167,8 +167,8 @@ func TestHookValueFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 420 {
-		t.Fatalf("definition count = %d, want 420", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 425 {
+		t.Fatalf("definition count = %d, want 425", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 420 {
-		t.Fatalf("definition count = %d, want 420", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 425 {
+		t.Fatalf("definition count = %d, want 425", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 420 {
-		t.Fatalf("definition count = %d, want 420", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 425 {
+		t.Fatalf("definition count = %d, want 425", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 420 {
-		t.Fatalf("definition count = %d, want 420", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 425 {
+		t.Fatalf("definition count = %d, want 425", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 420 {
-		t.Fatalf("definition count = %d, want 420", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 425 {
+		t.Fatalf("definition count = %d, want 425", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 420 {
-		t.Fatalf("definition count = %d, want 420", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 425 {
+		t.Fatalf("definition count = %d, want 425", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -344,6 +344,11 @@ func wireSchemaDefinitions() Schema {
 		{Name: "HookRunSummary", Type: reflect.TypeFor[HookRunSummary]()},
 		{Name: "HookStartedNotification", Type: reflect.TypeFor[HookStartedNotification]()},
 		{Name: "HookCompletedNotification", Type: reflect.TypeFor[HookCompletedNotification]()},
+		{Name: "HookErrorInfo", Type: reflect.TypeFor[HookErrorInfo]()},
+		{Name: "HookMetadata", Type: reflect.TypeFor[HookMetadata]()},
+		{Name: "HooksListEntry", Type: reflect.TypeFor[HooksListEntry]()},
+		{Name: "HooksListParams", Type: reflect.TypeFor[HooksListParams]()},
+		{Name: "HooksListResponse", Type: reflect.TypeFor[HooksListResponse]()},
 		{Name: "PermissionGrantScope", Type: reflect.TypeFor[PermissionGrantScope]()},
 		{Name: "PermissionsApprovalRequestParams", Type: reflect.TypeFor[PermissionsApprovalRequestParams]()},
 		{Name: "PermissionsRequestApprovalParams", Type: reflect.TypeFor[PermissionsRequestApprovalParams]()},
@@ -652,6 +657,11 @@ func wireSchemaDefinitions() Schema {
 	schemas["HookRunSummary"] = hookRunSummarySchema()
 	schemas["HookStartedNotification"] = hookRunNotificationSchema()
 	schemas["HookCompletedNotification"] = hookRunNotificationSchema()
+	schemas["HookErrorInfo"] = hookErrorInfoSchema()
+	schemas["HookMetadata"] = hookMetadataSchema()
+	schemas["HooksListEntry"] = hooksListEntrySchema()
+	schemas["HooksListParams"] = hooksListParamsSchema()
+	schemas["HooksListResponse"] = hooksListResponseSchema()
 	schemas["McpServerToolCallParams"] = mcpServerToolCallParamsSchema()
 	schemas["McpServerToolCallResponse"] = mcpServerToolCallResponseSchema()
 	schemas["ResourceContent"] = resourceContentSchema()

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -4648,6 +4648,22 @@
       ],
       "type": "object"
     },
+    "HookErrorInfo": {
+      "additionalProperties": false,
+      "properties": {
+        "message": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "message",
+        "path"
+      ],
+      "type": "object"
+    },
     "HookEventName": {
       "enum": [
         "preToolUse",
@@ -4677,6 +4693,85 @@
         "agent"
       ],
       "type": "string"
+    },
+    "HookMetadata": {
+      "additionalProperties": false,
+      "properties": {
+        "command": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "currentHash": {
+          "type": "string"
+        },
+        "displayOrder": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "eventName": {
+          "$ref": "#/$defs/HookEventName"
+        },
+        "handlerType": {
+          "$ref": "#/$defs/HookHandlerType"
+        },
+        "isManaged": {
+          "type": "boolean"
+        },
+        "key": {
+          "type": "string"
+        },
+        "matcher": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "pluginId": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "source": {
+          "$ref": "#/$defs/HookSource"
+        },
+        "sourcePath": {
+          "$ref": "#/$defs/AbsolutePathBuf"
+        },
+        "statusMessage": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "timeoutSec": {
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "trustStatus": {
+          "$ref": "#/$defs/HookTrustStatus"
+        }
+      },
+      "required": [
+        "currentHash",
+        "displayOrder",
+        "enabled",
+        "eventName",
+        "handlerType",
+        "isManaged",
+        "key",
+        "source",
+        "sourcePath",
+        "timeoutSec",
+        "trustStatus"
+      ],
+      "type": "object"
     },
     "HookMigration": {
       "additionalProperties": false,
@@ -4876,6 +4971,67 @@
         "modified"
       ],
       "type": "string"
+    },
+    "HooksListEntry": {
+      "additionalProperties": false,
+      "properties": {
+        "cwd": {
+          "type": "string"
+        },
+        "errors": {
+          "items": {
+            "$ref": "#/$defs/HookErrorInfo"
+          },
+          "type": "array"
+        },
+        "hooks": {
+          "items": {
+            "$ref": "#/$defs/HookMetadata"
+          },
+          "type": "array"
+        },
+        "warnings": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "cwd",
+        "errors",
+        "hooks",
+        "warnings"
+      ],
+      "type": "object"
+    },
+    "HooksListParams": {
+      "additionalProperties": false,
+      "properties": {
+        "cwds": {
+          "description": "When empty, defaults to the current session working directory.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "HooksListResponse": {
+      "additionalProperties": false,
+      "properties": {
+        "data": {
+          "items": {
+            "$ref": "#/$defs/HooksListEntry"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "data"
+      ],
+      "type": "object"
     },
     "ImageDetail": {
       "enum": [

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 420 {
-		t.Fatalf("definition count = %d, want 420", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 425 {
+		t.Fatalf("definition count = %d, want 425", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 420 {
-		t.Fatalf("definition count = %d, want 420", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 425 {
+		t.Fatalf("definition count = %d, want 425", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 420 {
-		t.Fatalf("definition count = %d, want 420", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 425 {
+		t.Fatalf("definition count = %d, want 425", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -44,7 +44,7 @@ func MarshalTypeScript() ([]byte, error) {
 			name == "ExternalAgentConfigImportItemTypeSuccess" ||
 			name == "FuzzyFileSearchParams" || name == "FuzzyFileSearchResult" ||
 			name == "HookRunSummary" || name == "HookStartedNotification" ||
-			name == "HookCompletedNotification" {
+			name == "HookCompletedNotification" || name == "HookMetadata" {
 			// Rust accepts omitted serde default/Option fields while generated
 			// TypeScript requires callers to provide their canonical values.
 			schema, _ := typeScriptSchema(definition)
@@ -80,6 +80,12 @@ func MarshalTypeScript() ([]byte, error) {
 				}
 			case "HookStartedNotification", "HookCompletedNotification":
 				schema["required"] = []string{"threadId", "turnId", "run"}
+			case "HookMetadata":
+				schema["required"] = []string{
+					"key", "eventName", "handlerType", "matcher", "command", "timeoutSec",
+					"statusMessage", "sourcePath", "source", "pluginId", "displayOrder",
+					"enabled", "isManaged", "currentHash", "trustStatus",
+				}
 			}
 			definition = schema
 		}
@@ -97,6 +103,20 @@ func MarshalTypeScript() ([]byte, error) {
 			definition = typeScriptDefinitionWithPropertySchemas(definition, Schema{
 				"source":        Schema{"$ref": "#/$defs/HookSource"},
 				"statusMessage": Schema{"anyOf": []any{Schema{"type": "string"}, Schema{"type": "null"}}},
+			})
+		}
+		if name == "HookMetadata" {
+			// ts-rs maps Rust u64 and i64 fields to bigint. Keep the render hints
+			// out of the exact public JSON Schema.
+			definition = typeScriptDefinitionWithBigIntProperties(
+				definition, "timeoutSec", "displayOrder",
+			)
+			nullableString := Schema{
+				"anyOf": []any{Schema{"type": "string"}, Schema{"type": "null"}},
+			}
+			definition = typeScriptDefinitionWithPropertySchemas(definition, Schema{
+				"matcher": nullableString, "command": nullableString,
+				"statusMessage": nullableString, "pluginId": nullableString,
 			})
 		}
 		if name == "HookStartedNotification" || name == "HookCompletedNotification" {

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -1489,11 +1489,34 @@ export type HookCompletedNotification = {
   "turnId": string | null;
 };
 
+export type HookErrorInfo = {
+  "message": string;
+  "path": string;
+};
+
 export type HookEventName = "preToolUse" | "permissionRequest" | "postToolUse" | "preCompact" | "postCompact" | "sessionStart" | "userPromptSubmit" | "subagentStart" | "subagentStop" | "stop";
 
 export type HookExecutionMode = "sync" | "async";
 
 export type HookHandlerType = "command" | "prompt" | "agent";
+
+export type HookMetadata = {
+  "command": string | null;
+  "currentHash": string;
+  "displayOrder": bigint;
+  "enabled": boolean;
+  "eventName": HookEventName;
+  "handlerType": HookHandlerType;
+  "isManaged": boolean;
+  "key": string;
+  "matcher": string | null;
+  "pluginId": string | null;
+  "source": HookSource;
+  "sourcePath": AbsolutePathBuf;
+  "statusMessage": string | null;
+  "timeoutSec": bigint;
+  "trustStatus": HookTrustStatus;
+};
 
 export type HookMigration = {
   "name": string;
@@ -1541,6 +1564,21 @@ export type HookStartedNotification = {
 };
 
 export type HookTrustStatus = "managed" | "untrusted" | "trusted" | "modified";
+
+export type HooksListEntry = {
+  "cwd": string;
+  "errors": Array<HookErrorInfo>;
+  "hooks": Array<HookMetadata>;
+  "warnings": Array<string>;
+};
+
+export type HooksListParams = {
+  "cwds"?: Array<string>;
+};
+
+export type HooksListResponse = {
+  "data": Array<HooksListEntry>;
+};
 
 export type ImageDetail = "auto" | "low" | "high" | "original";
 

--- a/appserver/protocol/typescript/testdata/hook_metadata_list_contract.ts
+++ b/appserver/protocol/typescript/testdata/hook_metadata_list_contract.ts
@@ -1,0 +1,146 @@
+import type {
+  HookErrorInfo,
+  HookMetadata,
+  HooksListEntry,
+  HooksListParams,
+  HooksListResponse,
+  MethodParamsByName,
+  MethodResultsByName,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+
+type Metadata = {
+  key: string;
+  eventName: "preToolUse" | "permissionRequest" | "postToolUse" | "preCompact" | "postCompact" | "sessionStart" | "userPromptSubmit" | "subagentStart" | "subagentStop" | "stop";
+  handlerType: "command" | "prompt" | "agent";
+  matcher: string | null;
+  command: string | null;
+  timeoutSec: bigint;
+  statusMessage: string | null;
+  sourcePath: string;
+  source: "system" | "user" | "project" | "mdm" | "sessionFlags" | "plugin" | "cloudRequirements" | "cloudManagedConfig" | "legacyManagedConfigFile" | "legacyManagedConfigMdm" | "unknown";
+  pluginId: string | null;
+  displayOrder: bigint;
+  enabled: boolean;
+  isManaged: boolean;
+  currentHash: string;
+  trustStatus: "managed" | "untrusted" | "trusted" | "modified";
+};
+
+type Contracts = [
+  Expect<Equal<HookErrorInfo, { path: string; message: string }>>,
+  Expect<Equal<HookMetadata, Metadata>>,
+  Expect<Equal<HooksListEntry, {
+    cwd: string;
+    hooks: Array<HookMetadata>;
+    warnings: Array<string>;
+    errors: Array<HookErrorInfo>;
+  }>>,
+  Expect<Equal<HooksListParams, { cwds?: Array<string> }>>,
+  Expect<Equal<HooksListResponse, { data: Array<HooksListEntry> }>>,
+  Expect<Equal<Extract<keyof MethodParamsByName, "hooks/list">, never>>,
+  Expect<Equal<Extract<keyof MethodResultsByName, "hooks/list">, never>>,
+];
+declare const contracts: Contracts;
+void contracts;
+
+const metadata = {
+  key: "",
+  eventName: "preToolUse",
+  handlerType: "command",
+  matcher: null,
+  command: null,
+  timeoutSec: 18_446_744_073_709_551_615n,
+  statusMessage: null,
+  sourcePath: "/hooks.json",
+  source: "unknown",
+  pluginId: null,
+  displayOrder: -9_223_372_036_854_775_808n,
+  enabled: false,
+  isManaged: false,
+  currentHash: "",
+  trustStatus: "untrusted",
+} satisfies HookMetadata;
+({ path: "", message: "" }) satisfies HookErrorInfo;
+({ cwd: "", hooks: [metadata, metadata], warnings: ["", ""], errors: [] }) satisfies HooksListEntry;
+({}) satisfies HooksListParams;
+({ cwds: [] }) satisfies HooksListParams;
+({ cwds: ["", "repo/../repo", ""] }) satisfies HooksListParams;
+({ data: [] }) satisfies HooksListResponse;
+
+// @ts-expect-error path is required.
+({ message: "" }) satisfies HookErrorInfo;
+// @ts-expect-error message is non-null.
+({ path: "", message: null }) satisfies HookErrorInfo;
+// @ts-expect-error error records are closed.
+({ path: "", message: "", extra: true }) satisfies HookErrorInfo;
+// @ts-expect-error key is required.
+({ ...metadata, key: undefined }) satisfies HookMetadata;
+// @ts-expect-error eventName is closed.
+({ ...metadata, eventName: "other" }) satisfies HookMetadata;
+// @ts-expect-error handlerType is closed.
+({ ...metadata, handlerType: "shell" }) satisfies HookMetadata;
+// @ts-expect-error matcher is required by exact ts-rs output.
+({ ...metadata, matcher: undefined }) satisfies HookMetadata;
+// @ts-expect-error matcher is nullable string only.
+({ ...metadata, matcher: 1 }) satisfies HookMetadata;
+// @ts-expect-error command is required by exact ts-rs output.
+({ ...metadata, command: undefined }) satisfies HookMetadata;
+// @ts-expect-error timeoutSec is bigint.
+({ ...metadata, timeoutSec: 0 }) satisfies HookMetadata;
+// @ts-expect-error statusMessage is required by exact ts-rs output.
+({ ...metadata, statusMessage: undefined }) satisfies HookMetadata;
+// @ts-expect-error sourcePath is required.
+({ ...metadata, sourcePath: undefined }) satisfies HookMetadata;
+// @ts-expect-error source is required.
+({ ...metadata, source: undefined }) satisfies HookMetadata;
+// @ts-expect-error source is non-null.
+({ ...metadata, source: null }) satisfies HookMetadata;
+// @ts-expect-error pluginId is required by exact ts-rs output.
+({ ...metadata, pluginId: undefined }) satisfies HookMetadata;
+// @ts-expect-error displayOrder is bigint.
+({ ...metadata, displayOrder: 0 }) satisfies HookMetadata;
+// @ts-expect-error enabled is boolean.
+({ ...metadata, enabled: 0 }) satisfies HookMetadata;
+// @ts-expect-error isManaged is required.
+({ ...metadata, isManaged: undefined }) satisfies HookMetadata;
+// @ts-expect-error currentHash is required.
+({ ...metadata, currentHash: undefined }) satisfies HookMetadata;
+// @ts-expect-error trustStatus is closed.
+({ ...metadata, trustStatus: "other" }) satisfies HookMetadata;
+// @ts-expect-error snake-case aliases do not replace canonical fields.
+({ ...metadata, eventName: undefined, event_name: "preToolUse" }) satisfies HookMetadata;
+// @ts-expect-error metadata records are closed.
+({ ...metadata, extra: true }) satisfies HookMetadata;
+// @ts-expect-error cwd is required.
+({ hooks: [], warnings: [], errors: [] }) satisfies HooksListEntry;
+// @ts-expect-error hooks are required and non-null.
+({ cwd: "", hooks: null, warnings: [], errors: [] }) satisfies HooksListEntry;
+// @ts-expect-error nested metadata remains strict.
+({ cwd: "", hooks: [{ ...metadata, source: null }], warnings: [], errors: [] }) satisfies HooksListEntry;
+// @ts-expect-error warnings are string arrays.
+({ cwd: "", hooks: [], warnings: [1], errors: [] }) satisfies HooksListEntry;
+// @ts-expect-error nested errors remain strict.
+({ cwd: "", hooks: [], warnings: [], errors: [{ path: "" }] }) satisfies HooksListEntry;
+// @ts-expect-error entries are closed.
+({ cwd: "", hooks: [], warnings: [], errors: [], extra: true }) satisfies HooksListEntry;
+// @ts-expect-error cwds is non-null when present.
+({ cwds: null }) satisfies HooksListParams;
+// @ts-expect-error cwd elements are strings.
+({ cwds: [1] }) satisfies HooksListParams;
+// @ts-expect-error params are closed.
+({ extra: true }) satisfies HooksListParams;
+// @ts-expect-error data is required.
+({}) satisfies HooksListResponse;
+// @ts-expect-error data is non-null.
+({ data: null }) satisfies HooksListResponse;
+// @ts-expect-error response entries remain strict.
+({ data: [{ cwd: "", hooks: [], warnings: [], errors: null }] }) satisfies HooksListResponse;
+// @ts-expect-error responses are closed.
+({ data: [], extra: true }) satisfies HooksListResponse;

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 420 {
-		t.Fatalf("definition count = %d, want 420", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
+		t.Fatalf("definition count = %d, want 425", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- export exact standalone `HookErrorInfo`, `HookMetadata`, `HooksListEntry`, `HooksListParams`, and `HooksListResponse`
- preserve Rust serde defaults, nullable options, uint64/int64 bigint generation, required non-null arrays, and optional empty-omitted `cwds`
- keep `hooks/list`, hook lifecycle notifications, method maps, item bindings, and runtime behavior unchanged
- advance deterministic protocol generation from 420 to 425 definitions

## Verification
- deliberate-red Go and strict TypeScript failures on all five missing contracts
- focused tests: 30 repetitions, race, and 100% coverage for every new codec/schema function
- full protocol normal/race/coverage (97.2%)
- all 59 non-Monty packages normal/race; local Monty normal/race/coverage skipped per project direction
- `golangci-lint` (0 issues), non-Monty vet, tidy, deterministic generation, strict TypeScript
- configured pre-push and push-time pre-push gates
- exact normalized pinned-upstream schema and parsed TypeScript comparisons
- exact structural reversal to PR #196 tree
- byte-identical baseline/feature initialize/status output
- all five Slang stdio/Unix-socket/WebSocket workflows
