### PR TITLE
Export exact Guardian enum foundation

### DIFF
--- a/appserver/protocol/README.md
+++ b/appserver/protocol/README.md
@@ -517,6 +517,15 @@ and generate as TypeScript `bigint`. Both `hook/started` and `hook/completed`
 remain blocked and unbound. Their strict compile contract is
 `typescript/testdata/hook_run_notification_contract.ts`.
 
+Exact standalone Guardian approval review status, command source, risk level,
+user authorization, and network approval protocol enums establish the closed
+leaf layer needed by later Guardian review records. All literals are closed and
+case-sensitive, including camel-case `inProgress`, `timedOut`, `unifiedExec`,
+`socks5Tcp`, and `socks5Udp`. No Guardian review/action parent, notification,
+assessment, replay, approval, policy enforcement, method/item binding, or
+runtime behavior is added. Their strict compile contract is
+`typescript/testdata/guardian_enum_foundation_contract.ts`.
+
 Exact standalone warning, guardian-warning, and error notification records
 establish the fixed public warning/error value layer. Canonical warning output
 requires explicit nullable thread id, while decoding also accepts omission to

--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(defs); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,8 +217,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,8 +203,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -260,8 +260,8 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,8 +244,8 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -162,8 +162,8 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -175,8 +175,8 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -381,8 +381,8 @@ func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_enum_foundation_contract_test.go
+++ b/appserver/protocol/guardian_enum_foundation_contract_test.go
@@ -1,0 +1,156 @@
+package protocol
+
+import (
+	"encoding/json"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestGuardianEnumFoundationSchemasAreExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	assertStringEnum(t, defs["GuardianApprovalReviewStatus"],
+		"inProgress", "approved", "denied", "timedOut", "aborted")
+	assertStringEnum(t, defs["GuardianCommandSource"], "shell", "unifiedExec")
+	assertStringEnum(t, defs["GuardianRiskLevel"], "low", "medium", "high", "critical")
+	assertStringEnum(t, defs["GuardianUserAuthorization"], "unknown", "low", "medium", "high")
+	assertStringEnum(t, defs["NetworkApprovalProtocol"], "http", "https", "socks5Tcp", "socks5Udp")
+}
+
+func TestGuardianEnumFoundationAcceptsExactValues(t *testing.T) {
+	assertEnumRoundTrips(t, []GuardianApprovalReviewStatus{
+		GuardianApprovalReviewStatusInProgress, GuardianApprovalReviewStatusApproved,
+		GuardianApprovalReviewStatusDenied, GuardianApprovalReviewStatusTimedOut,
+		GuardianApprovalReviewStatusAborted,
+	})
+	assertEnumRoundTrips(t, []GuardianCommandSource{
+		GuardianCommandSourceShell, GuardianCommandSourceUnifiedExec,
+	})
+	assertEnumRoundTrips(t, []GuardianRiskLevel{
+		GuardianRiskLevelLow, GuardianRiskLevelMedium,
+		GuardianRiskLevelHigh, GuardianRiskLevelCritical,
+	})
+	assertEnumRoundTrips(t, []GuardianUserAuthorization{
+		GuardianUserAuthorizationUnknown, GuardianUserAuthorizationLow,
+		GuardianUserAuthorizationMedium, GuardianUserAuthorizationHigh,
+	})
+	assertEnumRoundTrips(t, []NetworkApprovalProtocol{
+		NetworkApprovalProtocolHTTP, NetworkApprovalProtocolHTTPS,
+		NetworkApprovalProtocolSocks5TCP, NetworkApprovalProtocolSocks5UDP,
+	})
+}
+
+func TestGuardianEnumFoundationRejectsMalformedWireForms(t *testing.T) {
+	common := []string{``, `null`, `""`, `1`, `true`, `{}`, `[]`, `"low" {}`, `"low" x`}
+	assertEnumRejects[GuardianApprovalReviewStatus](t,
+		append(common, `"in_progress"`, `"InProgress"`, `"other"`)...)
+	assertEnumRejects[GuardianCommandSource](t,
+		append(common, `"unified_exec"`, `"UnifiedExec"`, `"other"`)...)
+	assertEnumRejects[GuardianRiskLevel](t,
+		append(common, `"Low"`, `"other"`)...)
+	assertEnumRejects[GuardianUserAuthorization](t,
+		append(common, `"Unknown"`, `"other"`)...)
+	assertEnumRejects[NetworkApprovalProtocol](t,
+		append(common, `"socks5_tcp"`, `"Socks5Tcp"`, `"other"`)...)
+}
+
+func TestGuardianEnumFoundationNilReceiversAndInvalidValuesFailClosed(t *testing.T) {
+	receivers := []json.Unmarshaler{
+		(*GuardianApprovalReviewStatus)(nil), (*GuardianCommandSource)(nil),
+		(*GuardianRiskLevel)(nil), (*GuardianUserAuthorization)(nil),
+		(*NetworkApprovalProtocol)(nil),
+	}
+	for _, receiver := range receivers {
+		if err := receiver.UnmarshalJSON([]byte(`"low"`)); err == nil {
+			t.Fatalf("nil %T receiver succeeded", receiver)
+		}
+	}
+	invalid := []json.Marshaler{
+		GuardianApprovalReviewStatus("other"), GuardianCommandSource("other"),
+		GuardianRiskLevel("other"), GuardianUserAuthorization("other"),
+		NetworkApprovalProtocol("other"),
+	}
+	for _, value := range invalid {
+		if _, err := value.MarshalJSON(); err == nil {
+			t.Fatalf("invalid %T marshaled", value)
+		}
+	}
+}
+
+func TestGuardianEnumFoundationRemainsStandalone(t *testing.T) {
+	names := []string{
+		"GuardianApprovalReviewStatus", "GuardianCommandSource", "GuardianRiskLevel",
+		"GuardianUserAuthorization", "NetworkApprovalProtocol",
+	}
+	for _, binding := range WireTypeBindings() {
+		for _, name := range names {
+			if slices.Contains(binding.Params, name) || slices.Contains(binding.Result, name) {
+				t.Fatalf("%s unexpectedly bound to %s", name, binding.Method)
+			}
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestGuardianEnumFoundationTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	for _, want := range []string{
+		`export type GuardianApprovalReviewStatus = "inProgress" | "approved" | "denied" | "timedOut" | "aborted";`,
+		`export type GuardianCommandSource = "shell" | "unifiedExec";`,
+		`export type GuardianRiskLevel = "low" | "medium" | "high" | "critical";`,
+		`export type GuardianUserAuthorization = "unknown" | "low" | "medium" | "high";`,
+		`export type NetworkApprovalProtocol = "http" | "https" | "socks5Tcp" | "socks5Udp";`,
+	} {
+		if !strings.Contains(string(generated), want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}
+
+func assertEnumRoundTrips[T ~string](t *testing.T, values []T) {
+	t.Helper()
+	for _, want := range values {
+		data, err := json.Marshal(want)
+		if err != nil {
+			t.Fatalf("marshal %T(%q): %v", want, want, err)
+		}
+		var got T
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("unmarshal %T(%q): %v", want, want, err)
+		}
+		if got != want {
+			t.Fatalf("round trip %T = %q, want %q", want, got, want)
+		}
+	}
+}
+
+func assertEnumRejects[T ~string](t *testing.T, inputs ...string) {
+	t.Helper()
+	for _, input := range inputs {
+		assertJSONRejects[T](t, input)
+	}
+}
+
+var (
+	_ json.Marshaler   = GuardianApprovalReviewStatus("")
+	_ json.Unmarshaler = (*GuardianApprovalReviewStatus)(nil)
+	_ json.Marshaler   = GuardianCommandSource("")
+	_ json.Unmarshaler = (*GuardianCommandSource)(nil)
+	_ json.Marshaler   = GuardianRiskLevel("")
+	_ json.Unmarshaler = (*GuardianRiskLevel)(nil)
+	_ json.Marshaler   = GuardianUserAuthorization("")
+	_ json.Unmarshaler = (*GuardianUserAuthorization)(nil)
+	_ json.Marshaler   = NetworkApprovalProtocol("")
+	_ json.Unmarshaler = (*NetworkApprovalProtocol)(nil)
+)

--- a/appserver/protocol/guardian_enum_foundation_types.go
+++ b/appserver/protocol/guardian_enum_foundation_types.go
@@ -1,0 +1,155 @@
+package protocol
+
+import "encoding/json"
+
+// GuardianApprovalReviewStatus is the exact closed public lifecycle state for
+// an approval auto-review. It does not imply a live Guardian review producer.
+type GuardianApprovalReviewStatus string
+
+const (
+	GuardianApprovalReviewStatusInProgress GuardianApprovalReviewStatus = "inProgress"
+	GuardianApprovalReviewStatusApproved   GuardianApprovalReviewStatus = "approved"
+	GuardianApprovalReviewStatusDenied     GuardianApprovalReviewStatus = "denied"
+	GuardianApprovalReviewStatusTimedOut   GuardianApprovalReviewStatus = "timedOut"
+	GuardianApprovalReviewStatusAborted    GuardianApprovalReviewStatus = "aborted"
+)
+
+func (s GuardianApprovalReviewStatus) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(s, "Guardian approval review status", GuardianApprovalReviewStatus.valid)
+}
+
+func (s *GuardianApprovalReviewStatus) UnmarshalJSON(data []byte) error {
+	return unmarshalThreadTurnLeafEnum(data, s, "Guardian approval review status", GuardianApprovalReviewStatus.valid)
+}
+
+func (s GuardianApprovalReviewStatus) valid() bool {
+	switch s {
+	case GuardianApprovalReviewStatusInProgress, GuardianApprovalReviewStatusApproved,
+		GuardianApprovalReviewStatusDenied, GuardianApprovalReviewStatusTimedOut,
+		GuardianApprovalReviewStatusAborted:
+		return true
+	default:
+		return false
+	}
+}
+
+// GuardianCommandSource is the exact closed public source of a command under
+// Guardian review. It does not grant command execution authority.
+type GuardianCommandSource string
+
+const (
+	GuardianCommandSourceShell       GuardianCommandSource = "shell"
+	GuardianCommandSourceUnifiedExec GuardianCommandSource = "unifiedExec"
+)
+
+func (s GuardianCommandSource) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(s, "Guardian command source", GuardianCommandSource.valid)
+}
+
+func (s *GuardianCommandSource) UnmarshalJSON(data []byte) error {
+	return unmarshalThreadTurnLeafEnum(data, s, "Guardian command source", GuardianCommandSource.valid)
+}
+
+func (s GuardianCommandSource) valid() bool {
+	return s == GuardianCommandSourceShell || s == GuardianCommandSourceUnifiedExec
+}
+
+// GuardianRiskLevel is the exact closed public risk classification assigned by
+// an approval auto-review. It does not perform or authorize risk assessment.
+type GuardianRiskLevel string
+
+const (
+	GuardianRiskLevelLow      GuardianRiskLevel = "low"
+	GuardianRiskLevelMedium   GuardianRiskLevel = "medium"
+	GuardianRiskLevelHigh     GuardianRiskLevel = "high"
+	GuardianRiskLevelCritical GuardianRiskLevel = "critical"
+)
+
+func (l GuardianRiskLevel) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(l, "Guardian risk level", GuardianRiskLevel.valid)
+}
+
+func (l *GuardianRiskLevel) UnmarshalJSON(data []byte) error {
+	return unmarshalThreadTurnLeafEnum(data, l, "Guardian risk level", GuardianRiskLevel.valid)
+}
+
+func (l GuardianRiskLevel) valid() bool {
+	switch l {
+	case GuardianRiskLevelLow, GuardianRiskLevelMedium,
+		GuardianRiskLevelHigh, GuardianRiskLevelCritical:
+		return true
+	default:
+		return false
+	}
+}
+
+// GuardianUserAuthorization is the exact closed public user-authorization
+// classification. It does not infer or grant user authorization.
+type GuardianUserAuthorization string
+
+const (
+	GuardianUserAuthorizationUnknown GuardianUserAuthorization = "unknown"
+	GuardianUserAuthorizationLow     GuardianUserAuthorization = "low"
+	GuardianUserAuthorizationMedium  GuardianUserAuthorization = "medium"
+	GuardianUserAuthorizationHigh    GuardianUserAuthorization = "high"
+)
+
+func (a GuardianUserAuthorization) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(a, "Guardian user authorization", GuardianUserAuthorization.valid)
+}
+
+func (a *GuardianUserAuthorization) UnmarshalJSON(data []byte) error {
+	return unmarshalThreadTurnLeafEnum(data, a, "Guardian user authorization", GuardianUserAuthorization.valid)
+}
+
+func (a GuardianUserAuthorization) valid() bool {
+	switch a {
+	case GuardianUserAuthorizationUnknown, GuardianUserAuthorizationLow,
+		GuardianUserAuthorizationMedium, GuardianUserAuthorizationHigh:
+		return true
+	default:
+		return false
+	}
+}
+
+// NetworkApprovalProtocol is the exact closed public protocol classification
+// for network approval review. It does not grant or enforce network access.
+type NetworkApprovalProtocol string
+
+const (
+	NetworkApprovalProtocolHTTP      NetworkApprovalProtocol = "http"
+	NetworkApprovalProtocolHTTPS     NetworkApprovalProtocol = "https"
+	NetworkApprovalProtocolSocks5TCP NetworkApprovalProtocol = "socks5Tcp"
+	NetworkApprovalProtocolSocks5UDP NetworkApprovalProtocol = "socks5Udp"
+)
+
+func (p NetworkApprovalProtocol) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(p, "network approval protocol", NetworkApprovalProtocol.valid)
+}
+
+func (p *NetworkApprovalProtocol) UnmarshalJSON(data []byte) error {
+	return unmarshalThreadTurnLeafEnum(data, p, "network approval protocol", NetworkApprovalProtocol.valid)
+}
+
+func (p NetworkApprovalProtocol) valid() bool {
+	switch p {
+	case NetworkApprovalProtocolHTTP, NetworkApprovalProtocolHTTPS,
+		NetworkApprovalProtocolSocks5TCP, NetworkApprovalProtocolSocks5UDP:
+		return true
+	default:
+		return false
+	}
+}
+
+var (
+	_ json.Marshaler   = GuardianApprovalReviewStatus("")
+	_ json.Unmarshaler = (*GuardianApprovalReviewStatus)(nil)
+	_ json.Marshaler   = GuardianCommandSource("")
+	_ json.Unmarshaler = (*GuardianCommandSource)(nil)
+	_ json.Marshaler   = GuardianRiskLevel("")
+	_ json.Unmarshaler = (*GuardianRiskLevel)(nil)
+	_ json.Marshaler   = GuardianUserAuthorization("")
+	_ json.Unmarshaler = (*GuardianUserAuthorization)(nil)
+	_ json.Marshaler   = NetworkApprovalProtocol("")
+	_ json.Unmarshaler = (*NetworkApprovalProtocol)(nil)
+)

--- a/appserver/protocol/hook_metadata_list_contract_test.go
+++ b/appserver/protocol/hook_metadata_list_contract_test.go
@@ -352,8 +352,8 @@ func TestHookMetadataListContractsStayStandalone(t *testing.T) {
 			t.Errorf("standalone definition %s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Errorf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Errorf("definition count = %d, want 430", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 {
 		t.Errorf("wire binding count = %d, want 59", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_run_notification_contract_test.go
+++ b/appserver/protocol/hook_run_notification_contract_test.go
@@ -297,8 +297,8 @@ func TestHookRunNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("surface changed: %d methods, %d wire bindings, %d item bindings", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/hook_value_foundation_contract_test.go
+++ b/appserver/protocol/hook_value_foundation_contract_test.go
@@ -167,8 +167,8 @@ func TestHookValueFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 425 {
-		t.Fatalf("definition count = %d, want 425", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 430 {
+		t.Fatalf("definition count = %d, want 430", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 425 {
-		t.Fatalf("definition count = %d, want 425", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 430 {
+		t.Fatalf("definition count = %d, want 430", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 425 {
-		t.Fatalf("definition count = %d, want 425", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 430 {
+		t.Fatalf("definition count = %d, want 430", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 425 {
-		t.Fatalf("definition count = %d, want 425", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 430 {
+		t.Fatalf("definition count = %d, want 430", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 425 {
-		t.Fatalf("definition count = %d, want 425", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 430 {
+		t.Fatalf("definition count = %d, want 430", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 425 {
-		t.Fatalf("definition count = %d, want 425", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 430 {
+		t.Fatalf("definition count = %d, want 430", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -332,6 +332,10 @@ func wireSchemaDefinitions() Schema {
 		{Name: "FuzzyFileSearchResponse", Type: reflect.TypeFor[FuzzyFileSearchResponse]()},
 		{Name: "FuzzyFileSearchSessionUpdatedNotification", Type: reflect.TypeFor[FuzzyFileSearchSessionUpdatedNotification]()},
 		{Name: "FuzzyFileSearchSessionCompletedNotification", Type: reflect.TypeFor[FuzzyFileSearchSessionCompletedNotification]()},
+		{Name: "GuardianApprovalReviewStatus", Type: reflect.TypeFor[GuardianApprovalReviewStatus]()},
+		{Name: "GuardianCommandSource", Type: reflect.TypeFor[GuardianCommandSource]()},
+		{Name: "GuardianRiskLevel", Type: reflect.TypeFor[GuardianRiskLevel]()},
+		{Name: "GuardianUserAuthorization", Type: reflect.TypeFor[GuardianUserAuthorization]()},
 		{Name: "HookEventName", Type: reflect.TypeFor[HookEventName]()},
 		{Name: "HookExecutionMode", Type: reflect.TypeFor[HookExecutionMode]()},
 		{Name: "HookHandlerType", Type: reflect.TypeFor[HookHandlerType]()},
@@ -349,6 +353,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "HooksListEntry", Type: reflect.TypeFor[HooksListEntry]()},
 		{Name: "HooksListParams", Type: reflect.TypeFor[HooksListParams]()},
 		{Name: "HooksListResponse", Type: reflect.TypeFor[HooksListResponse]()},
+		{Name: "NetworkApprovalProtocol", Type: reflect.TypeFor[NetworkApprovalProtocol]()},
 		{Name: "PermissionGrantScope", Type: reflect.TypeFor[PermissionGrantScope]()},
 		{Name: "PermissionsApprovalRequestParams", Type: reflect.TypeFor[PermissionsApprovalRequestParams]()},
 		{Name: "PermissionsRequestApprovalParams", Type: reflect.TypeFor[PermissionsRequestApprovalParams]()},
@@ -616,6 +621,22 @@ func wireSchemaDefinitions() Schema {
 	schemas["FuzzyFileSearchResponse"] = fuzzyFileSearchResponseSchema()
 	schemas["FuzzyFileSearchSessionUpdatedNotification"] = fuzzyFileSearchSessionUpdatedNotificationSchema()
 	schemas["FuzzyFileSearchSessionCompletedNotification"] = fuzzyFileSearchSessionCompletedNotificationSchema()
+	schemas["GuardianApprovalReviewStatus"] = stringEnumSchema(
+		string(GuardianApprovalReviewStatusInProgress), string(GuardianApprovalReviewStatusApproved),
+		string(GuardianApprovalReviewStatusDenied), string(GuardianApprovalReviewStatusTimedOut),
+		string(GuardianApprovalReviewStatusAborted),
+	)
+	schemas["GuardianCommandSource"] = stringEnumSchema(
+		string(GuardianCommandSourceShell), string(GuardianCommandSourceUnifiedExec),
+	)
+	schemas["GuardianRiskLevel"] = stringEnumSchema(
+		string(GuardianRiskLevelLow), string(GuardianRiskLevelMedium),
+		string(GuardianRiskLevelHigh), string(GuardianRiskLevelCritical),
+	)
+	schemas["GuardianUserAuthorization"] = stringEnumSchema(
+		string(GuardianUserAuthorizationUnknown), string(GuardianUserAuthorizationLow),
+		string(GuardianUserAuthorizationMedium), string(GuardianUserAuthorizationHigh),
+	)
 	schemas["HookEventName"] = stringEnumSchema(
 		string(HookEventNamePreToolUse), string(HookEventNamePermissionRequest),
 		string(HookEventNamePostToolUse), string(HookEventNamePreCompact),
@@ -662,6 +683,10 @@ func wireSchemaDefinitions() Schema {
 	schemas["HooksListEntry"] = hooksListEntrySchema()
 	schemas["HooksListParams"] = hooksListParamsSchema()
 	schemas["HooksListResponse"] = hooksListResponseSchema()
+	schemas["NetworkApprovalProtocol"] = stringEnumSchema(
+		string(NetworkApprovalProtocolHTTP), string(NetworkApprovalProtocolHTTPS),
+		string(NetworkApprovalProtocolSocks5TCP), string(NetworkApprovalProtocolSocks5UDP),
+	)
 	schemas["McpServerToolCallParams"] = mcpServerToolCallParamsSchema()
 	schemas["McpServerToolCallResponse"] = mcpServerToolCallResponseSchema()
 	schemas["ResourceContent"] = resourceContentSchema()

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -4610,6 +4610,41 @@
       },
       "type": "object"
     },
+    "GuardianApprovalReviewStatus": {
+      "enum": [
+        "inProgress",
+        "approved",
+        "denied",
+        "timedOut",
+        "aborted"
+      ],
+      "type": "string"
+    },
+    "GuardianCommandSource": {
+      "enum": [
+        "shell",
+        "unifiedExec"
+      ],
+      "type": "string"
+    },
+    "GuardianRiskLevel": {
+      "enum": [
+        "low",
+        "medium",
+        "high",
+        "critical"
+      ],
+      "type": "string"
+    },
+    "GuardianUserAuthorization": {
+      "enum": [
+        "unknown",
+        "low",
+        "medium",
+        "high"
+      ],
+      "type": "string"
+    },
     "GuardianWarningNotification": {
       "additionalProperties": false,
       "properties": {
@@ -7650,6 +7685,15 @@
       "enum": [
         "restricted",
         "enabled"
+      ],
+      "type": "string"
+    },
+    "NetworkApprovalProtocol": {
+      "enum": [
+        "http",
+        "https",
+        "socks5Tcp",
+        "socks5Udp"
       ],
       "type": "string"
     },

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 425 {
-		t.Fatalf("definition count = %d, want 425", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 430 {
+		t.Fatalf("definition count = %d, want 430", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 425 {
-		t.Fatalf("definition count = %d, want 425", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 430 {
+		t.Fatalf("definition count = %d, want 430", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 425 {
-		t.Fatalf("definition count = %d, want 425", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 430 {
+		t.Fatalf("definition count = %d, want 430", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -1478,6 +1478,14 @@ export type GrantedPermissionProfile = {
   "network"?: AdditionalNetworkPermissions;
 };
 
+export type GuardianApprovalReviewStatus = "inProgress" | "approved" | "denied" | "timedOut" | "aborted";
+
+export type GuardianCommandSource = "shell" | "unifiedExec";
+
+export type GuardianRiskLevel = "low" | "medium" | "high" | "critical";
+
+export type GuardianUserAuthorization = "unknown" | "low" | "medium" | "high";
+
 export type GuardianWarningNotification = {
   "message": string;
   "threadId": string;
@@ -2145,6 +2153,8 @@ export type ModelsRequirements = {
 };
 
 export type NetworkAccess = "restricted" | "enabled";
+
+export type NetworkApprovalProtocol = "http" | "https" | "socks5Tcp" | "socks5Udp";
 
 export type NetworkDomainPermission = "allow" | "deny";
 

--- a/appserver/protocol/typescript/testdata/guardian_enum_foundation_contract.ts
+++ b/appserver/protocol/typescript/testdata/guardian_enum_foundation_contract.ts
@@ -1,0 +1,69 @@
+import type {
+  GuardianApprovalReviewStatus,
+  GuardianCommandSource,
+  GuardianRiskLevel,
+  GuardianUserAuthorization,
+  NetworkApprovalProtocol,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? (<T>() => T extends B ? 1 : 2) extends
+        (<T>() => T extends A ? 1 : 2)
+      ? true
+      : false
+    : false;
+type Expect<T extends true> = T;
+
+type Contracts = [
+  Expect<Equal<GuardianApprovalReviewStatus,
+    "inProgress" | "approved" | "denied" | "timedOut" | "aborted">>,
+  Expect<Equal<GuardianCommandSource, "shell" | "unifiedExec">>,
+  Expect<Equal<GuardianRiskLevel, "low" | "medium" | "high" | "critical">>,
+  Expect<Equal<GuardianUserAuthorization, "unknown" | "low" | "medium" | "high">>,
+  Expect<Equal<NetworkApprovalProtocol, "http" | "https" | "socks5Tcp" | "socks5Udp">>,
+];
+
+"inProgress" satisfies GuardianApprovalReviewStatus;
+"approved" satisfies GuardianApprovalReviewStatus;
+"denied" satisfies GuardianApprovalReviewStatus;
+"timedOut" satisfies GuardianApprovalReviewStatus;
+"aborted" satisfies GuardianApprovalReviewStatus;
+"shell" satisfies GuardianCommandSource;
+"unifiedExec" satisfies GuardianCommandSource;
+"low" satisfies GuardianRiskLevel;
+"medium" satisfies GuardianRiskLevel;
+"high" satisfies GuardianRiskLevel;
+"critical" satisfies GuardianRiskLevel;
+"unknown" satisfies GuardianUserAuthorization;
+"low" satisfies GuardianUserAuthorization;
+"medium" satisfies GuardianUserAuthorization;
+"high" satisfies GuardianUserAuthorization;
+"http" satisfies NetworkApprovalProtocol;
+"https" satisfies NetworkApprovalProtocol;
+"socks5Tcp" satisfies NetworkApprovalProtocol;
+"socks5Udp" satisfies NetworkApprovalProtocol;
+
+// @ts-expect-error review statuses are closed.
+"other" satisfies GuardianApprovalReviewStatus;
+// @ts-expect-error exact camel-case spelling is required.
+"in_progress" satisfies GuardianApprovalReviewStatus;
+// @ts-expect-error command sources are closed.
+"other" satisfies GuardianCommandSource;
+// @ts-expect-error exact camel-case spelling is required.
+"unified_exec" satisfies GuardianCommandSource;
+// @ts-expect-error risk levels are lowercase.
+"Low" satisfies GuardianRiskLevel;
+// @ts-expect-error authorization levels are closed.
+"other" satisfies GuardianUserAuthorization;
+// @ts-expect-error protocols are closed.
+"other" satisfies NetworkApprovalProtocol;
+// @ts-expect-error exact camel-case spelling is required.
+"socks5_tcp" satisfies NetworkApprovalProtocol;
+// @ts-expect-error enum values are non-null.
+null satisfies GuardianApprovalReviewStatus;
+// @ts-expect-error enum values are strings.
+1 satisfies NetworkApprovalProtocol;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 425 {
-		t.Fatalf("definition count = %d, want 425", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
+		t.Fatalf("definition count = %d, want 430", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- export exact standalone GuardianApprovalReviewStatus, GuardianCommandSource, GuardianRiskLevel, GuardianUserAuthorization, and NetworkApprovalProtocol contracts
- preserve all closed camel-case/lowercase literals with strict fail-closed Go codecs and generated TypeScript unions
- keep Guardian review/action parents, notifications, methods, item bindings, policy enforcement, and runtime behavior unchanged
- advance generated output to 430 definitions while retaining 224 methods, 59 wire bindings, and five item bindings

## Verification
- deliberate-red Go and strict TypeScript gates
- focused 30x, focused race, and 100% coverage for all 15 new codec functions
- full protocol normal/race and 97.3% aggregate coverage
- all 59 non-Monty packages normal/race; local Monty tests skipped by standing direction
- golangci-lint (0 issues), non-Monty vet, tidy, gofmt, deterministic generation, strict TypeScript
- configured pre-push before commit and at push time
- exact normalized upstream schema and TypeScript semantic comparison
- exact structural reversal to PR #197 tree b2dfa6403cc241fe110c771875e80112609c29fe
- byte-identical fixed live output and all five Slang workflows against reproducible binary 4d04979ebd1caea46eb28d72a935907754c61b99f8fe97cc8c8dcbb76c64eec4

## Notes
- The first manual repository race command passed a newline scalar under zsh and ran no tests; the corrected 59-element array command passed.
- The first live cleanup used an unmatched zsh glob; the fail-fast explicit-path rerun passed and is the recorded evidence.