### PR TITLE
feat(protocol): export guardian approval review

### DIFF
--- a/appserver/protocol/README.md
+++ b/appserver/protocol/README.md
@@ -521,10 +521,13 @@ Exact standalone Guardian approval review status, command source, risk level,
 user authorization, and network approval protocol enums establish the closed
 leaf layer needed by later Guardian review records. All literals are closed and
 case-sensitive, including camel-case `inProgress`, `timedOut`, `unifiedExec`,
-`socks5Tcp`, and `socks5Udp`. No Guardian review/action parent, notification,
-assessment, replay, approval, policy enforcement, method/item binding, or
-runtime behavior is added. Their strict compile contract is
-`typescript/testdata/guardian_enum_foundation_contract.ts`.
+`socks5Tcp`, and `socks5Udp`. The standalone unstable
+`GuardianApprovalReview` record accepts omitted nullable options like serde but
+emits them explicitly like ts-rs. No Guardian action union, notification,
+assessment, replay, approval, policy enforcement, method/item binding,
+producer, persistence, or runtime behavior is added. Their strict compile
+contracts are `typescript/testdata/guardian_enum_foundation_contract.ts` and
+`typescript/testdata/guardian_approval_review_contract.ts`.
 
 Exact standalone warning, guardian-warning, and error notification records
 establish the fixed public warning/error value layer. Canonical warning output

--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(defs); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,8 +217,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,8 +203,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -260,8 +260,8 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,8 +244,8 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -162,8 +162,8 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -175,8 +175,8 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -381,8 +381,8 @@ func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_contract_test.go
@@ -1,0 +1,181 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestGuardianApprovalReviewSchemaIsExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	want := Schema{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties": Schema{
+			"status": Schema{"$ref": "#/$defs/GuardianApprovalReviewStatus"},
+			"riskLevel": Schema{"anyOf": []any{
+				Schema{"$ref": "#/$defs/GuardianRiskLevel"}, Schema{"type": "null"},
+			}},
+			"userAuthorization": Schema{"anyOf": []any{
+				Schema{"$ref": "#/$defs/GuardianUserAuthorization"}, Schema{"type": "null"},
+			}},
+			"rationale": Schema{"type": []any{"string", "null"}},
+		},
+		"required": []string{"status"},
+	}
+	if got := defs["GuardianApprovalReview"]; !reflect.DeepEqual(got, want) {
+		t.Fatalf("GuardianApprovalReview schema = %#v, want %#v", got, want)
+	}
+}
+
+func TestGuardianApprovalReviewAcceptsSerdeWireForms(t *testing.T) {
+	risk := GuardianRiskLevelCritical
+	authorization := GuardianUserAuthorizationUnknown
+	rationale := "\nopaque rationale \u2603\n"
+	tests := []struct {
+		name      string
+		input     string
+		want      GuardianApprovalReview
+		canonical string
+	}{
+		{
+			name:      "omitted options become explicit null output",
+			input:     `{"status":"inProgress"}`,
+			want:      GuardianApprovalReview{Status: GuardianApprovalReviewStatusInProgress},
+			canonical: `{"status":"inProgress","riskLevel":null,"userAuthorization":null,"rationale":null}`,
+		},
+		{
+			name:      "explicit null options",
+			input:     `{"status":"approved","riskLevel":null,"userAuthorization":null,"rationale":null}`,
+			want:      GuardianApprovalReview{Status: GuardianApprovalReviewStatusApproved},
+			canonical: `{"status":"approved","riskLevel":null,"userAuthorization":null,"rationale":null}`,
+		},
+		{
+			name:  "all values and unknown fields",
+			input: `{"unknown":{"nested":true},"status":"denied","riskLevel":"critical","userAuthorization":"unknown","rationale":"\nopaque rationale \u2603\n"}`,
+			want: GuardianApprovalReview{
+				Status: GuardianApprovalReviewStatusDenied, RiskLevel: &risk,
+				UserAuthorization: &authorization, Rationale: &rationale,
+			},
+			canonical: `{"status":"denied","riskLevel":"critical","userAuthorization":"unknown","rationale":"\nopaque rationale ` + "\u2603" + `\n"}`,
+		},
+		{
+			name:      "empty rationale",
+			input:     `{"status":"aborted","rationale":""}`,
+			want:      GuardianApprovalReview{Status: GuardianApprovalReviewStatusAborted, Rationale: ptr("")},
+			canonical: `{"status":"aborted","riskLevel":null,"userAuthorization":null,"rationale":""}`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var got GuardianApprovalReview
+			if err := json.Unmarshal([]byte(test.input), &got); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("decoded = %#v, want %#v", got, test.want)
+			}
+			encoded, err := json.Marshal(got)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if string(encoded) != test.canonical {
+				t.Fatalf("canonical = %s, want %s", encoded, test.canonical)
+			}
+		})
+	}
+}
+
+func TestGuardianApprovalReviewRejectsMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `[]`, `1`, `true`, `"value"`, `{`,
+		`{}`, `{"riskLevel":"low"}`, `{"status":null}`,
+		`{"status":"other"}`, `{"status":"InProgress"}`, `{"status":1}`,
+		`{"status":"approved","riskLevel":"other"}`,
+		`{"status":"approved","riskLevel":1}`,
+		`{"status":"approved","userAuthorization":"other"}`,
+		`{"status":"approved","userAuthorization":false}`,
+		`{"status":"approved","rationale":1}`,
+		`{"status":"approved","status":"denied"}`,
+		`{"status":"approved","riskLevel":null,"riskLevel":"low"}`,
+		`{"status":"approved","userAuthorization":null,"userAuthorization":"high"}`,
+		`{"status":"approved","rationale":null,"rationale":"value"}`,
+		`{"status":"approved"} {}`, `{"status":"approved"} x`,
+	} {
+		assertJSONRejects[GuardianApprovalReview](t, input)
+	}
+}
+
+func TestGuardianApprovalReviewNilReceiverAndInvalidValuesFailClosed(t *testing.T) {
+	var review *GuardianApprovalReview
+	if err := review.UnmarshalJSON([]byte(`{"status":"approved"}`)); err == nil {
+		t.Fatal("nil GuardianApprovalReview receiver succeeded")
+	}
+	invalidRisk := GuardianRiskLevel("other")
+	invalidAuthorization := GuardianUserAuthorization("other")
+	for _, review := range []GuardianApprovalReview{
+		{},
+		{Status: GuardianApprovalReviewStatus("other")},
+		{Status: GuardianApprovalReviewStatusApproved, RiskLevel: &invalidRisk},
+		{Status: GuardianApprovalReviewStatusApproved, UserAuthorization: &invalidAuthorization},
+	} {
+		if _, err := json.Marshal(review); err == nil {
+			t.Fatalf("invalid review marshaled: %#v", review)
+		}
+	}
+}
+
+func TestGuardianApprovalReviewRemainsStandalone(t *testing.T) {
+	for _, binding := range WireTypeBindings() {
+		if slices.Contains(binding.Params, "GuardianApprovalReview") ||
+			slices.Contains(binding.Result, "GuardianApprovalReview") {
+			t.Fatalf("GuardianApprovalReview unexpectedly bound to %s", binding.Method)
+		}
+	}
+	for _, binding := range ItemPayloadBindings() {
+		if binding.Type == "GuardianApprovalReview" {
+			t.Fatalf("GuardianApprovalReview unexpectedly bound to item %s", binding.Kind)
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestGuardianApprovalReviewTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	want := `export type GuardianApprovalReview = {
+  "rationale": string | null;
+  "riskLevel": GuardianRiskLevel | null;
+  "status": GuardianApprovalReviewStatus;
+  "userAuthorization": GuardianUserAuthorization | null;
+};`
+	if !strings.Contains(string(generated), want) {
+		t.Errorf("generated TypeScript missing %q", want)
+	}
+	for _, forbidden := range []string{
+		`"rationale"?:`, `"riskLevel"?:`, `"userAuthorization"?:`,
+	} {
+		if strings.Contains(string(generated), forbidden) {
+			t.Errorf("generated TypeScript unexpectedly contains %q", forbidden)
+		}
+	}
+}
+
+func ptr[T any](value T) *T { return &value }
+
+var (
+	_ json.Marshaler   = GuardianApprovalReview{}
+	_ json.Unmarshaler = (*GuardianApprovalReview)(nil)
+)

--- a/appserver/protocol/guardian_approval_review_types.go
+++ b/appserver/protocol/guardian_approval_review_types.go
@@ -1,0 +1,85 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// GuardianApprovalReview is the exact unstable public result of one approval
+// auto-review. It is descriptive and does not perform or authorize a review.
+type GuardianApprovalReview struct {
+	Status            GuardianApprovalReviewStatus `json:"status"`
+	RiskLevel         *GuardianRiskLevel           `json:"riskLevel"`
+	UserAuthorization *GuardianUserAuthorization   `json:"userAuthorization"`
+	Rationale         *string                      `json:"rationale"`
+}
+
+func (r GuardianApprovalReview) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Status            GuardianApprovalReviewStatus `json:"status"`
+		RiskLevel         *GuardianRiskLevel           `json:"riskLevel"`
+		UserAuthorization *GuardianUserAuthorization   `json:"userAuthorization"`
+		Rationale         *string                      `json:"rationale"`
+	}{
+		Status: r.Status, RiskLevel: r.RiskLevel,
+		UserAuthorization: r.UserAuthorization, Rationale: r.Rationale,
+	})
+}
+
+func (r *GuardianApprovalReview) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("decode Guardian approval review into nil receiver")
+	}
+	const objectName = "Guardian approval review"
+	payload, err := decodeRustSerdeObject(
+		data, objectName, "status", "riskLevel", "userAuthorization", "rationale",
+	)
+	if err != nil {
+		return err
+	}
+	status, err := decodeRequiredThreadItemValue[GuardianApprovalReviewStatus](
+		payload, objectName, "status",
+	)
+	if err != nil {
+		return err
+	}
+	riskLevel, err := decodeOptionalNullableConfigValue[GuardianRiskLevel](
+		payload, objectName, "riskLevel",
+	)
+	if err != nil {
+		return err
+	}
+	userAuthorization, err := decodeOptionalNullableConfigValue[GuardianUserAuthorization](
+		payload, objectName, "userAuthorization",
+	)
+	if err != nil {
+		return err
+	}
+	rationale, err := decodeOptionalNullableConfigValue[string](payload, objectName, "rationale")
+	if err != nil {
+		return err
+	}
+	*r = GuardianApprovalReview{
+		Status: status, RiskLevel: riskLevel,
+		UserAuthorization: userAuthorization, Rationale: rationale,
+	}
+	return nil
+}
+
+func guardianApprovalReviewSchema() Schema {
+	return closedThreadSessionParamSchema(Schema{
+		"status": Schema{"$ref": "#/$defs/GuardianApprovalReviewStatus"},
+		"riskLevel": Schema{"anyOf": []any{
+			Schema{"$ref": "#/$defs/GuardianRiskLevel"}, Schema{"type": "null"},
+		}},
+		"userAuthorization": Schema{"anyOf": []any{
+			Schema{"$ref": "#/$defs/GuardianUserAuthorization"}, Schema{"type": "null"},
+		}},
+		"rationale": Schema{"type": []any{"string", "null"}},
+	}, []string{"status"})
+}
+
+var (
+	_ json.Marshaler   = GuardianApprovalReview{}
+	_ json.Unmarshaler = (*GuardianApprovalReview)(nil)
+)

--- a/appserver/protocol/guardian_enum_foundation_contract_test.go
+++ b/appserver/protocol/guardian_enum_foundation_contract_test.go
@@ -89,8 +89,8 @@ func TestGuardianEnumFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_metadata_list_contract_test.go
+++ b/appserver/protocol/hook_metadata_list_contract_test.go
@@ -352,8 +352,8 @@ func TestHookMetadataListContractsStayStandalone(t *testing.T) {
 			t.Errorf("standalone definition %s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Errorf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Errorf("definition count = %d, want 431", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 {
 		t.Errorf("wire binding count = %d, want 59", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_run_notification_contract_test.go
+++ b/appserver/protocol/hook_run_notification_contract_test.go
@@ -297,8 +297,8 @@ func TestHookRunNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("surface changed: %d methods, %d wire bindings, %d item bindings", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/hook_value_foundation_contract_test.go
+++ b/appserver/protocol/hook_value_foundation_contract_test.go
@@ -167,8 +167,8 @@ func TestHookValueFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 430 {
-		t.Fatalf("definition count = %d, want 430", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 431 {
+		t.Fatalf("definition count = %d, want 431", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 430 {
-		t.Fatalf("definition count = %d, want 430", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 431 {
+		t.Fatalf("definition count = %d, want 431", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 430 {
-		t.Fatalf("definition count = %d, want 430", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 431 {
+		t.Fatalf("definition count = %d, want 431", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 430 {
-		t.Fatalf("definition count = %d, want 430", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 431 {
+		t.Fatalf("definition count = %d, want 431", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 430 {
-		t.Fatalf("definition count = %d, want 430", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 431 {
+		t.Fatalf("definition count = %d, want 431", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 430 {
-		t.Fatalf("definition count = %d, want 430", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 431 {
+		t.Fatalf("definition count = %d, want 431", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -332,6 +332,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "FuzzyFileSearchResponse", Type: reflect.TypeFor[FuzzyFileSearchResponse]()},
 		{Name: "FuzzyFileSearchSessionUpdatedNotification", Type: reflect.TypeFor[FuzzyFileSearchSessionUpdatedNotification]()},
 		{Name: "FuzzyFileSearchSessionCompletedNotification", Type: reflect.TypeFor[FuzzyFileSearchSessionCompletedNotification]()},
+		{Name: "GuardianApprovalReview", Type: reflect.TypeFor[GuardianApprovalReview]()},
 		{Name: "GuardianApprovalReviewStatus", Type: reflect.TypeFor[GuardianApprovalReviewStatus]()},
 		{Name: "GuardianCommandSource", Type: reflect.TypeFor[GuardianCommandSource]()},
 		{Name: "GuardianRiskLevel", Type: reflect.TypeFor[GuardianRiskLevel]()},
@@ -621,6 +622,7 @@ func wireSchemaDefinitions() Schema {
 	schemas["FuzzyFileSearchResponse"] = fuzzyFileSearchResponseSchema()
 	schemas["FuzzyFileSearchSessionUpdatedNotification"] = fuzzyFileSearchSessionUpdatedNotificationSchema()
 	schemas["FuzzyFileSearchSessionCompletedNotification"] = fuzzyFileSearchSessionCompletedNotificationSchema()
+	schemas["GuardianApprovalReview"] = guardianApprovalReviewSchema()
 	schemas["GuardianApprovalReviewStatus"] = stringEnumSchema(
 		string(GuardianApprovalReviewStatusInProgress), string(GuardianApprovalReviewStatusApproved),
 		string(GuardianApprovalReviewStatusDenied), string(GuardianApprovalReviewStatusTimedOut),

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -4610,6 +4610,44 @@
       },
       "type": "object"
     },
+    "GuardianApprovalReview": {
+      "additionalProperties": false,
+      "properties": {
+        "rationale": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "riskLevel": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GuardianRiskLevel"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "status": {
+          "$ref": "#/$defs/GuardianApprovalReviewStatus"
+        },
+        "userAuthorization": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GuardianUserAuthorization"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "status"
+      ],
+      "type": "object"
+    },
     "GuardianApprovalReviewStatus": {
       "enum": [
         "inProgress",

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 430 {
-		t.Fatalf("definition count = %d, want 430", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 431 {
+		t.Fatalf("definition count = %d, want 431", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 430 {
-		t.Fatalf("definition count = %d, want 430", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 431 {
+		t.Fatalf("definition count = %d, want 431", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 430 {
-		t.Fatalf("definition count = %d, want 430", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 431 {
+		t.Fatalf("definition count = %d, want 431", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -44,7 +44,8 @@ func MarshalTypeScript() ([]byte, error) {
 			name == "ExternalAgentConfigImportItemTypeSuccess" ||
 			name == "FuzzyFileSearchParams" || name == "FuzzyFileSearchResult" ||
 			name == "HookRunSummary" || name == "HookStartedNotification" ||
-			name == "HookCompletedNotification" || name == "HookMetadata" {
+			name == "HookCompletedNotification" || name == "HookMetadata" ||
+			name == "GuardianApprovalReview" {
 			// Rust accepts omitted serde default/Option fields while generated
 			// TypeScript requires callers to provide their canonical values.
 			schema, _ := typeScriptSchema(definition)
@@ -86,6 +87,10 @@ func MarshalTypeScript() ([]byte, error) {
 					"statusMessage", "sourcePath", "source", "pluginId", "displayOrder",
 					"enabled", "isManaged", "currentHash", "trustStatus",
 				}
+			case "GuardianApprovalReview":
+				schema["required"] = []string{
+					"status", "riskLevel", "userAuthorization", "rationale",
+				}
 			}
 			definition = schema
 		}
@@ -122,6 +127,11 @@ func MarshalTypeScript() ([]byte, error) {
 		if name == "HookStartedNotification" || name == "HookCompletedNotification" {
 			definition = typeScriptDefinitionWithPropertySchemas(definition, Schema{
 				"turnId": Schema{"anyOf": []any{Schema{"type": "string"}, Schema{"type": "null"}}},
+			})
+		}
+		if name == "GuardianApprovalReview" {
+			definition = typeScriptDefinitionWithPropertySchemas(definition, Schema{
+				"rationale": Schema{"anyOf": []any{Schema{"type": "string"}, Schema{"type": "null"}}},
 			})
 		}
 		typeName, err := typeScriptType(definition, 0)

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -1478,6 +1478,13 @@ export type GrantedPermissionProfile = {
   "network"?: AdditionalNetworkPermissions;
 };
 
+export type GuardianApprovalReview = {
+  "rationale": string | null;
+  "riskLevel": GuardianRiskLevel | null;
+  "status": GuardianApprovalReviewStatus;
+  "userAuthorization": GuardianUserAuthorization | null;
+};
+
 export type GuardianApprovalReviewStatus = "inProgress" | "approved" | "denied" | "timedOut" | "aborted";
 
 export type GuardianCommandSource = "shell" | "unifiedExec";

--- a/appserver/protocol/typescript/testdata/guardian_approval_review_contract.ts
+++ b/appserver/protocol/typescript/testdata/guardian_approval_review_contract.ts
@@ -1,0 +1,69 @@
+import type {
+  GuardianApprovalReview,
+  GuardianApprovalReviewStatus,
+  GuardianRiskLevel,
+  GuardianUserAuthorization,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? (<T>() => T extends B ? 1 : 2) extends
+        (<T>() => T extends A ? 1 : 2)
+      ? true
+      : false
+    : false;
+type Expect<T extends true> = T;
+
+type Contracts = [
+  Expect<Equal<GuardianApprovalReview, {
+    status: GuardianApprovalReviewStatus;
+    riskLevel: GuardianRiskLevel | null;
+    userAuthorization: GuardianUserAuthorization | null;
+    rationale: string | null;
+  }>>,
+];
+
+({
+  status: "inProgress",
+  riskLevel: null,
+  userAuthorization: null,
+  rationale: null,
+}) satisfies GuardianApprovalReview;
+({
+  status: "denied",
+  riskLevel: "critical",
+  userAuthorization: "unknown",
+  rationale: "",
+}) satisfies GuardianApprovalReview;
+({
+  status: "timedOut",
+  riskLevel: "low",
+  userAuthorization: "high",
+  rationale: "opaque\nvalue",
+}) satisfies GuardianApprovalReview;
+
+// @ts-expect-error status is required.
+({ riskLevel: null, userAuthorization: null, rationale: null }) satisfies GuardianApprovalReview;
+// @ts-expect-error status is non-null.
+({ status: null, riskLevel: null, userAuthorization: null, rationale: null }) satisfies GuardianApprovalReview;
+// @ts-expect-error statuses are closed.
+({ status: "other", riskLevel: null, userAuthorization: null, rationale: null }) satisfies GuardianApprovalReview;
+// @ts-expect-error riskLevel is required by exact ts-rs output.
+({ status: "approved", userAuthorization: null, rationale: null }) satisfies GuardianApprovalReview;
+// @ts-expect-error risk levels are closed.
+({ status: "approved", riskLevel: "other", userAuthorization: null, rationale: null }) satisfies GuardianApprovalReview;
+// @ts-expect-error userAuthorization is required by exact ts-rs output.
+({ status: "approved", riskLevel: null, rationale: null }) satisfies GuardianApprovalReview;
+// @ts-expect-error authorization levels are closed.
+({ status: "approved", riskLevel: null, userAuthorization: "other", rationale: null }) satisfies GuardianApprovalReview;
+// @ts-expect-error rationale is required by exact ts-rs output.
+({ status: "approved", riskLevel: null, userAuthorization: null }) satisfies GuardianApprovalReview;
+// @ts-expect-error rationale is nullable string only.
+({ status: "approved", riskLevel: null, userAuthorization: null, rationale: 1 }) satisfies GuardianApprovalReview;
+// @ts-expect-error snake-case aliases do not replace canonical fields.
+({ status: "approved", risk_level: null, userAuthorization: null, rationale: null }) satisfies GuardianApprovalReview;
+// @ts-expect-error review records are closed.
+({ status: "approved", riskLevel: null, userAuthorization: null, rationale: null, extra: true }) satisfies GuardianApprovalReview;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 430 {
-		t.Fatalf("definition count = %d, want 430", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
+		t.Fatalf("definition count = %d, want 431", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary

- export the exact standalone `GuardianApprovalReview` record
- preserve serde input semantics while emitting all nullable fields canonically
- generate the strict ts-rs-compatible TypeScript shape without adding runtime or method bindings

## Scope

`status` is required and closed. `riskLevel`, `userAuthorization`, and `rationale` accept omitted or null input and emit explicit null values. Unknown input fields are discarded, duplicate known fields are rejected, and the unstable review remains standalone from Guardian actions, notifications, assessment, replay, policy enforcement, persistence, and runtime behavior.

## Verification

- deliberate-red Go and strict TypeScript boundaries
- 30 focused repetitions, focused race, and 100% statement coverage for all three new production functions
- full protocol coverage: 97.3%
- all 59 non-Monty packages, normal and race
- `golangci-lint`, `go vet`, `go mod tidy`, `go mod verify`, and configured pre-push gate
- deterministic 431-definition schema and TypeScript generation
- exact normalized schema and parsed TypeScript parity with pinned Codex `5c19155c`
- unchanged 224 methods, 59 method bindings, and five item bindings
- structural reversal to exact PR #198 tree `895f64ac45e577b25864be8f0c13da52c8cd633d`
- byte-identical baseline/feature initialize and MCP status transcript
- reproducible binary and all five real Slang transport workflows

Local Monty normal, race, and coverage tests remain intentionally skipped; hosted CI is unchanged.
