### PR TITLE
feat(protocol): export guardian review action

### DIFF
--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(defs); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,8 +217,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,8 +203,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -260,8 +260,8 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,8 +244,8 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -162,8 +162,8 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -175,8 +175,8 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -381,8 +381,8 @@ func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_action_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_action_contract_test.go
@@ -1,0 +1,300 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestGuardianApprovalReviewActionSchemaIsExact(t *testing.T) {
+	definition := JSONSchema()["$defs"].(Schema)["GuardianApprovalReviewAction"].(Schema)
+	variants, ok := definition["oneOf"].([]any)
+	if !ok || len(variants) != 6 {
+		t.Fatalf("GuardianApprovalReviewAction oneOf = %#v, want six variants", definition["oneOf"])
+	}
+	want := map[string]struct {
+		required []string
+		refs     map[string]string
+	}{
+		"command":            {required: []string{"type", "source", "command", "cwd"}, refs: map[string]string{"source": "GuardianCommandSource", "cwd": "AbsolutePathBuf"}},
+		"execve":             {required: []string{"type", "source", "program", "argv", "cwd"}, refs: map[string]string{"source": "GuardianCommandSource", "cwd": "AbsolutePathBuf"}},
+		"applyPatch":         {required: []string{"type", "cwd", "files"}, refs: map[string]string{"cwd": "AbsolutePathBuf"}},
+		"networkAccess":      {required: []string{"type", "target", "host", "protocol", "port"}, refs: map[string]string{"protocol": "NetworkApprovalProtocol"}},
+		"mcpToolCall":        {required: []string{"type", "server", "toolName"}},
+		"requestPermissions": {required: []string{"type", "permissions"}, refs: map[string]string{"permissions": "RequestPermissionProfile"}},
+	}
+	seen := map[string]bool{}
+	for _, raw := range variants {
+		variant := raw.(Schema)
+		if variant["type"] != "object" || variant["additionalProperties"] != false {
+			t.Fatalf("GuardianApprovalReviewAction variant is not closed: %#v", variant)
+		}
+		properties := variant["properties"].(Schema)
+		typeSchema := properties["type"].(Schema)
+		tags := typeSchema["enum"].([]any)
+		if len(tags) != 1 {
+			t.Fatalf("GuardianApprovalReviewAction tag = %#v", typeSchema)
+		}
+		tag := tags[0].(string)
+		expected, found := want[tag]
+		if !found {
+			t.Fatalf("unexpected GuardianApprovalReviewAction variant %q", tag)
+		}
+		seen[tag] = true
+		gotRequired := append([]string(nil), variant["required"].([]string)...)
+		slices.Sort(gotRequired)
+		wantRequired := append([]string(nil), expected.required...)
+		slices.Sort(wantRequired)
+		if !reflect.DeepEqual(gotRequired, wantRequired) {
+			t.Errorf("%s required = %v, want %v", tag, gotRequired, wantRequired)
+		}
+		for field, ref := range expected.refs {
+			if got := properties[field].(Schema)["$ref"]; got != "#/$defs/"+ref {
+				t.Errorf("%s.%s ref = %v, want %s", tag, field, got, ref)
+			}
+		}
+		switch tag {
+		case "execve":
+			assertGuardianActionArraySchema(t, properties["argv"], Schema{"type": "string"})
+		case "applyPatch":
+			assertGuardianActionArraySchema(t, properties["files"], Schema{"$ref": "#/$defs/AbsolutePathBuf"})
+		case "networkAccess":
+			if got := properties["port"]; !reflect.DeepEqual(got, Schema{"type": "integer", "minimum": 0, "maximum": 65535}) {
+				t.Errorf("networkAccess.port = %#v", got)
+			}
+		case "mcpToolCall":
+			for _, field := range []string{"connectorId", "connectorName", "toolTitle"} {
+				assertGuardianActionNullableStringSchema(t, properties[field])
+			}
+		case "requestPermissions":
+			assertGuardianActionNullableStringSchema(t, properties["reason"])
+		}
+	}
+	if len(seen) != len(want) {
+		t.Fatalf("GuardianApprovalReviewAction variants = %v, want %v", seen, want)
+	}
+}
+
+func TestGuardianApprovalReviewActionAcceptsSerdeWireForms(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		canonical string
+		kind      string
+	}{
+		{
+			name:      "command normalizes cwd and discards unknown fields",
+			input:     `{"unknown":true,"type":"command","source":"shell","command":"","cwd":"/workspace/../workspace","port":7}`,
+			canonical: `{"type":"command","source":"shell","command":"","cwd":"/workspace"}`,
+			kind:      "command",
+		},
+		{
+			name:      "execve preserves ordered duplicate arguments",
+			input:     `{"type":"execve","source":"unifiedExec","program":"","argv":["-x","-x",""],"cwd":"/workspace"}`,
+			canonical: `{"type":"execve","source":"unifiedExec","program":"","argv":["-x","-x",""],"cwd":"/workspace"}`,
+			kind:      "execve",
+		},
+		{
+			name:      "apply patch preserves empty files",
+			input:     `{"type":"applyPatch","cwd":"/workspace","files":[]}`,
+			canonical: `{"type":"applyPatch","cwd":"/workspace","files":[]}`,
+			kind:      "applyPatch",
+		},
+		{
+			name:      "apply patch normalizes duplicate paths",
+			input:     `{"type":"applyPatch","cwd":"/workspace/./","files":["/tmp/a/../b","/tmp/b"]}`,
+			canonical: `{"type":"applyPatch","cwd":"/workspace","files":["/tmp/b","/tmp/b"]}`,
+			kind:      "applyPatch",
+		},
+		{
+			name:      "network access accepts uint16 maximum and empty strings",
+			input:     `{"type":"networkAccess","target":"","host":"","protocol":"socks5Udp","port":65535}`,
+			canonical: `{"type":"networkAccess","target":"","host":"","protocol":"socks5Udp","port":65535}`,
+			kind:      "networkAccess",
+		},
+		{
+			name:      "MCP omitted options become explicit null output",
+			input:     `{"type":"mcpToolCall","server":"server","toolName":"tool"}`,
+			canonical: `{"type":"mcpToolCall","server":"server","toolName":"tool","connectorId":null,"connectorName":null,"toolTitle":null}`,
+			kind:      "mcpToolCall",
+		},
+		{
+			name:      "MCP explicit options",
+			input:     `{"type":"mcpToolCall","server":"","toolName":"","connectorId":"","connectorName":"name","toolTitle":null}`,
+			canonical: `{"type":"mcpToolCall","server":"","toolName":"","connectorId":"","connectorName":"name","toolTitle":null}`,
+			kind:      "mcpToolCall",
+		},
+		{
+			name:      "permission omitted reason becomes explicit null output",
+			input:     `{"type":"requestPermissions","permissions":{}}`,
+			canonical: `{"type":"requestPermissions","reason":null,"permissions":{"network":null,"fileSystem":null}}`,
+			kind:      "requestPermissions",
+		},
+		{
+			name:      "permission explicit empty reason",
+			input:     `{"type":"requestPermissions","reason":"","permissions":{"network":null,"fileSystem":null}}`,
+			canonical: `{"type":"requestPermissions","reason":"","permissions":{"network":null,"fileSystem":null}}`,
+			kind:      "requestPermissions",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var action GuardianApprovalReviewAction
+			if err := json.Unmarshal([]byte(test.input), &action); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if action.Type() != test.kind {
+				t.Errorf("Type() = %q, want %q", action.Type(), test.kind)
+			}
+			encoded, err := json.Marshal(action)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if string(encoded) != test.canonical {
+				t.Errorf("canonical = %s, want %s", encoded, test.canonical)
+			}
+		})
+	}
+}
+
+func TestGuardianApprovalReviewActionRejectsMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `[]`, `1`, `true`, `"value"`, `{`, `{}`,
+		`{"type":null}`, `{"type":"other"}`, `{"type":"Command"}`, `{"type":1}`,
+		`{"type":"command","source":"shell","command":"c"}`,
+		`{"type":"command","source":null,"command":"c","cwd":"/w"}`,
+		`{"type":"command","source":"other","command":"c","cwd":"/w"}`,
+		`{"type":"command","source":"shell","command":null,"cwd":"/w"}`,
+		`{"type":"command","source":"shell","command":"c","cwd":"relative"}`,
+		`{"type":"execve","source":"other","program":"p","argv":[],"cwd":"/w"}`,
+		`{"type":"execve","source":"shell","program":null,"argv":[],"cwd":"/w"}`,
+		`{"type":"execve","source":"shell","program":"p","argv":null,"cwd":"/w"}`,
+		`{"type":"execve","source":"shell","program":"p","argv":[null],"cwd":"/w"}`,
+		`{"type":"execve","source":"shell","program":"p","argv":[1],"cwd":"/w"}`,
+		`{"type":"execve","source":"shell","program":"p","argv":[],"cwd":"relative"}`,
+		`{"type":"applyPatch","cwd":"relative","files":[]}`,
+		`{"type":"applyPatch","cwd":"/w","files":null}`,
+		`{"type":"applyPatch","cwd":"/w","files":["relative"]}`,
+		`{"type":"applyPatch","cwd":"/w","files":[null]}`,
+		`{"type":"networkAccess","target":"t","host":"h","protocol":"http"}`,
+		`{"type":"networkAccess","target":null,"host":"h","protocol":"http","port":1}`,
+		`{"type":"networkAccess","target":"t","host":false,"protocol":"http","port":1}`,
+		`{"type":"networkAccess","target":"t","host":"h","protocol":"other","port":1}`,
+		`{"type":"networkAccess","target":"t","host":"h","protocol":"http","port":-1}`,
+		`{"type":"networkAccess","target":"t","host":"h","protocol":"http","port":65536}`,
+		`{"type":"networkAccess","target":"t","host":"h","protocol":"http","port":1.5}`,
+		`{"type":"mcpToolCall","server":"s"}`,
+		`{"type":"mcpToolCall","server":null,"toolName":"t"}`,
+		`{"type":"mcpToolCall","server":"s","toolName":"t","connectorId":1}`,
+		`{"type":"mcpToolCall","server":"s","toolName":"t","connectorName":false}`,
+		`{"type":"mcpToolCall","server":"s","toolName":"t","toolTitle":[]}`,
+		`{"type":"requestPermissions","permissions":null}`,
+		`{"type":"requestPermissions","permissions":[]}`,
+		`{"type":"requestPermissions","reason":1,"permissions":{}}`,
+		`{"type":"command","type":"execve","source":"shell","command":"c","cwd":"/w"}`,
+		`{"type":"command","source":"shell","source":"unifiedExec","command":"c","cwd":"/w"}`,
+		`{"type":"mcpToolCall","server":"s","toolName":"t","connectorId":null,"connectorId":"id"}`,
+		`{"type":"requestPermissions","reason":null,"reason":"r","permissions":{}}`,
+		`{"type":"command","source":"shell","command":"c","cwd":"/w"} {}`,
+		`{"type":"command","source":"shell","command":"c","cwd":"/w"} x`,
+	} {
+		assertJSONRejects[GuardianApprovalReviewAction](t, input)
+	}
+}
+
+func TestGuardianApprovalReviewActionNilReceiverAndEmptyMarshalFailClosed(t *testing.T) {
+	var action *GuardianApprovalReviewAction
+	if err := action.UnmarshalJSON([]byte(`{"type":"applyPatch","cwd":"/w","files":[]}`)); err == nil {
+		t.Fatal("nil GuardianApprovalReviewAction receiver succeeded")
+	}
+	if _, err := json.Marshal(GuardianApprovalReviewAction{}); err == nil {
+		t.Fatal("empty GuardianApprovalReviewAction marshaled")
+	}
+}
+
+func TestGuardianApprovalReviewActionRemainsStandalone(t *testing.T) {
+	for _, binding := range WireTypeBindings() {
+		if slices.Contains(binding.Params, "GuardianApprovalReviewAction") ||
+			slices.Contains(binding.Result, "GuardianApprovalReviewAction") {
+			t.Fatalf("GuardianApprovalReviewAction unexpectedly bound to %s", binding.Method)
+		}
+	}
+	for _, binding := range ItemPayloadBindings() {
+		if binding.Type == "GuardianApprovalReviewAction" {
+			t.Fatalf("GuardianApprovalReviewAction unexpectedly bound to item %s", binding.Kind)
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestGuardianApprovalReviewActionTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	source := string(generated)
+	start := strings.Index(source, "export type GuardianApprovalReviewAction =")
+	if start < 0 {
+		t.Fatal("generated TypeScript action declaration start is missing")
+	}
+	end := strings.Index(source[start:], "\n\nexport type GuardianApprovalReviewStatus =")
+	if end < 0 {
+		t.Fatal("generated TypeScript action declaration end is missing")
+	}
+	actionSource := source[start : start+end]
+	for _, want := range []string{
+		`export type GuardianApprovalReviewAction =`,
+		`"type": "command";`, `"source": GuardianCommandSource;`,
+		`"command": string;`, `"cwd": AbsolutePathBuf;`,
+		`"type": "execve";`, `"program": string;`, `"argv": Array<string>;`,
+		`"type": "applyPatch";`, `"files": Array<AbsolutePathBuf>;`,
+		`"type": "networkAccess";`, `"target": string;`, `"host": string;`,
+		`"protocol": NetworkApprovalProtocol;`, `"port": number;`,
+		`"type": "mcpToolCall";`, `"server": string;`, `"toolName": string;`,
+		`"connectorId": string | null;`, `"connectorName": string | null;`,
+		`"toolTitle": string | null;`, `"type": "requestPermissions";`,
+		`"reason": string | null;`, `"permissions": RequestPermissionProfile;`,
+	} {
+		if !strings.Contains(actionSource, want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+	for _, forbidden := range []string{
+		`"connectorId"?:`, `"connectorName"?:`, `"toolTitle"?:`, `"reason"?:`,
+	} {
+		if strings.Contains(actionSource, forbidden) {
+			t.Errorf("generated TypeScript unexpectedly contains %q", forbidden)
+		}
+	}
+}
+
+func assertGuardianActionArraySchema(t *testing.T, got any, items Schema) {
+	t.Helper()
+	want := Schema{"type": "array", "items": items}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("array schema = %#v, want %#v", got, want)
+	}
+}
+
+func assertGuardianActionNullableStringSchema(t *testing.T, got any) {
+	t.Helper()
+	want := Schema{"type": []any{"string", "null"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("nullable string schema = %#v, want %#v", got, want)
+	}
+}
+
+var (
+	_ json.Marshaler   = GuardianApprovalReviewAction{}
+	_ json.Unmarshaler = (*GuardianApprovalReviewAction)(nil)
+)

--- a/appserver/protocol/guardian_approval_review_action_types.go
+++ b/appserver/protocol/guardian_approval_review_action_types.go
@@ -1,0 +1,313 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// GuardianApprovalReviewAction is the exact unstable public description of an
+// action under approval review. It does not execute or authorize the action.
+type GuardianApprovalReviewAction struct {
+	raw json.RawMessage
+}
+
+func (a GuardianApprovalReviewAction) MarshalJSON() ([]byte, error) {
+	if len(a.raw) == 0 {
+		return nil, errors.New("guardian approval review action has no value")
+	}
+	return validateGuardianApprovalReviewActionJSON(a.raw)
+}
+
+func (a *GuardianApprovalReviewAction) UnmarshalJSON(data []byte) error {
+	if a == nil {
+		return errors.New("decode Guardian approval review action into nil receiver")
+	}
+	canonical, err := validateGuardianApprovalReviewActionJSON(data)
+	if err != nil {
+		return err
+	}
+	a.raw = canonical
+	return nil
+}
+
+// Type returns the exact public action discriminant.
+func (a GuardianApprovalReviewAction) Type() string {
+	return permissionUnionDiscriminant(a.raw, "type")
+}
+
+func validateGuardianApprovalReviewActionJSON(data []byte) (json.RawMessage, error) {
+	const objectName = "Guardian approval review action"
+	payload, err := decodeRustSerdeObject(
+		data,
+		objectName,
+		"type",
+		"source",
+		"command",
+		"cwd",
+		"program",
+		"argv",
+		"files",
+		"target",
+		"host",
+		"protocol",
+		"port",
+		"server",
+		"toolName",
+		"connectorId",
+		"connectorName",
+		"toolTitle",
+		"reason",
+		"permissions",
+	)
+	if err != nil {
+		return nil, err
+	}
+	actionType, err := decodeRequiredThreadItemValue[string](payload, objectName, "type")
+	if err != nil {
+		return nil, err
+	}
+	switch actionType {
+	case "command":
+		return canonicalGuardianCommandReviewAction(payload, actionType)
+	case "execve":
+		return canonicalGuardianExecveReviewAction(payload, actionType)
+	case "applyPatch":
+		return canonicalGuardianApplyPatchReviewAction(payload, actionType)
+	case "networkAccess":
+		return canonicalGuardianNetworkAccessReviewAction(payload, actionType)
+	case "mcpToolCall":
+		return canonicalGuardianMCPToolCallReviewAction(payload, actionType)
+	case "requestPermissions":
+		return canonicalGuardianRequestPermissionsReviewAction(payload, actionType)
+	default:
+		return nil, fmt.Errorf("unsupported Guardian approval review action type %q", actionType)
+	}
+}
+
+func canonicalGuardianCommandReviewAction(
+	payload map[string]json.RawMessage,
+	actionType string,
+) (json.RawMessage, error) {
+	const objectName = "Guardian command review action"
+	source, err := decodeRequiredThreadItemValue[GuardianCommandSource](payload, objectName, "source")
+	if err != nil {
+		return nil, err
+	}
+	command, err := decodeRequiredThreadItemValue[string](payload, objectName, "command")
+	if err != nil {
+		return nil, err
+	}
+	cwd, err := decodeRequiredThreadItemValue[AbsolutePathBuf](payload, objectName, "cwd")
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(struct {
+		Type    string                `json:"type"`
+		Source  GuardianCommandSource `json:"source"`
+		Command string                `json:"command"`
+		CWD     AbsolutePathBuf       `json:"cwd"`
+	}{Type: actionType, Source: source, Command: command, CWD: cwd})
+}
+
+func canonicalGuardianExecveReviewAction(
+	payload map[string]json.RawMessage,
+	actionType string,
+) (json.RawMessage, error) {
+	const objectName = "Guardian execve review action"
+	source, err := decodeRequiredThreadItemValue[GuardianCommandSource](payload, objectName, "source")
+	if err != nil {
+		return nil, err
+	}
+	program, err := decodeRequiredThreadItemValue[string](payload, objectName, "program")
+	if err != nil {
+		return nil, err
+	}
+	argv, err := decodeRequiredThreadItemArray[string](payload, objectName, "argv")
+	if err != nil {
+		return nil, err
+	}
+	cwd, err := decodeRequiredThreadItemValue[AbsolutePathBuf](payload, objectName, "cwd")
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(struct {
+		Type    string                `json:"type"`
+		Source  GuardianCommandSource `json:"source"`
+		Program string                `json:"program"`
+		Argv    []string              `json:"argv"`
+		CWD     AbsolutePathBuf       `json:"cwd"`
+	}{Type: actionType, Source: source, Program: program, Argv: argv, CWD: cwd})
+}
+
+func canonicalGuardianApplyPatchReviewAction(
+	payload map[string]json.RawMessage,
+	actionType string,
+) (json.RawMessage, error) {
+	const objectName = "Guardian apply-patch review action"
+	cwd, err := decodeRequiredThreadItemValue[AbsolutePathBuf](payload, objectName, "cwd")
+	if err != nil {
+		return nil, err
+	}
+	files, err := decodeRequiredThreadItemArray[AbsolutePathBuf](payload, objectName, "files")
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(struct {
+		Type  string            `json:"type"`
+		CWD   AbsolutePathBuf   `json:"cwd"`
+		Files []AbsolutePathBuf `json:"files"`
+	}{Type: actionType, CWD: cwd, Files: files})
+}
+
+func canonicalGuardianNetworkAccessReviewAction(
+	payload map[string]json.RawMessage,
+	actionType string,
+) (json.RawMessage, error) {
+	const objectName = "Guardian network-access review action"
+	target, err := decodeRequiredThreadItemValue[string](payload, objectName, "target")
+	if err != nil {
+		return nil, err
+	}
+	host, err := decodeRequiredThreadItemValue[string](payload, objectName, "host")
+	if err != nil {
+		return nil, err
+	}
+	protocol, err := decodeRequiredThreadItemValue[NetworkApprovalProtocol](payload, objectName, "protocol")
+	if err != nil {
+		return nil, err
+	}
+	port, err := decodeRequiredThreadItemValue[uint16](payload, objectName, "port")
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(struct {
+		Type     string                  `json:"type"`
+		Target   string                  `json:"target"`
+		Host     string                  `json:"host"`
+		Protocol NetworkApprovalProtocol `json:"protocol"`
+		Port     uint16                  `json:"port"`
+	}{Type: actionType, Target: target, Host: host, Protocol: protocol, Port: port})
+}
+
+func canonicalGuardianMCPToolCallReviewAction(
+	payload map[string]json.RawMessage,
+	actionType string,
+) (json.RawMessage, error) {
+	const objectName = "Guardian MCP tool-call review action"
+	server, err := decodeRequiredThreadItemValue[string](payload, objectName, "server")
+	if err != nil {
+		return nil, err
+	}
+	toolName, err := decodeRequiredThreadItemValue[string](payload, objectName, "toolName")
+	if err != nil {
+		return nil, err
+	}
+	connectorID, err := decodeOptionalNullableConfigValue[string](payload, objectName, "connectorId")
+	if err != nil {
+		return nil, err
+	}
+	connectorName, err := decodeOptionalNullableConfigValue[string](payload, objectName, "connectorName")
+	if err != nil {
+		return nil, err
+	}
+	toolTitle, err := decodeOptionalNullableConfigValue[string](payload, objectName, "toolTitle")
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(struct {
+		Type          string  `json:"type"`
+		Server        string  `json:"server"`
+		ToolName      string  `json:"toolName"`
+		ConnectorID   *string `json:"connectorId"`
+		ConnectorName *string `json:"connectorName"`
+		ToolTitle     *string `json:"toolTitle"`
+	}{
+		Type: actionType, Server: server, ToolName: toolName,
+		ConnectorID: connectorID, ConnectorName: connectorName, ToolTitle: toolTitle,
+	})
+}
+
+func canonicalGuardianRequestPermissionsReviewAction(
+	payload map[string]json.RawMessage,
+	actionType string,
+) (json.RawMessage, error) {
+	const objectName = "Guardian request-permissions review action"
+	reason, err := decodeOptionalNullableConfigValue[string](payload, objectName, "reason")
+	if err != nil {
+		return nil, err
+	}
+	permissions, err := decodeRequiredThreadItemValue[RequestPermissionProfile](
+		payload, objectName, "permissions",
+	)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(struct {
+		Type        string                   `json:"type"`
+		Reason      *string                  `json:"reason"`
+		Permissions RequestPermissionProfile `json:"permissions"`
+	}{Type: actionType, Reason: reason, Permissions: permissions})
+}
+
+func guardianApprovalReviewActionSchema() Schema {
+	nullableString := Schema{"type": []any{"string", "null"}}
+	return Schema{"oneOf": []any{
+		guardianApprovalReviewActionVariantSchema("command", []string{"source", "command", "cwd"}, Schema{
+			"source":  Schema{"$ref": "#/$defs/GuardianCommandSource"},
+			"command": Schema{"type": "string"},
+			"cwd":     Schema{"$ref": "#/$defs/AbsolutePathBuf"},
+		}),
+		guardianApprovalReviewActionVariantSchema("execve", []string{"source", "program", "argv", "cwd"}, Schema{
+			"source":  Schema{"$ref": "#/$defs/GuardianCommandSource"},
+			"program": Schema{"type": "string"},
+			"argv":    Schema{"type": "array", "items": Schema{"type": "string"}},
+			"cwd":     Schema{"$ref": "#/$defs/AbsolutePathBuf"},
+		}),
+		guardianApprovalReviewActionVariantSchema("applyPatch", []string{"cwd", "files"}, Schema{
+			"cwd":   Schema{"$ref": "#/$defs/AbsolutePathBuf"},
+			"files": Schema{"type": "array", "items": Schema{"$ref": "#/$defs/AbsolutePathBuf"}},
+		}),
+		guardianApprovalReviewActionVariantSchema("networkAccess", []string{"target", "host", "protocol", "port"}, Schema{
+			"target":   Schema{"type": "string"},
+			"host":     Schema{"type": "string"},
+			"protocol": Schema{"$ref": "#/$defs/NetworkApprovalProtocol"},
+			"port":     Schema{"type": "integer", "minimum": 0, "maximum": 65535},
+		}),
+		guardianApprovalReviewActionVariantSchema("mcpToolCall", []string{"server", "toolName"}, Schema{
+			"server":        Schema{"type": "string"},
+			"toolName":      Schema{"type": "string"},
+			"connectorId":   nullableString,
+			"connectorName": nullableString,
+			"toolTitle":     nullableString,
+		}),
+		guardianApprovalReviewActionVariantSchema("requestPermissions", []string{"permissions"}, Schema{
+			"reason":      nullableString,
+			"permissions": Schema{"$ref": "#/$defs/RequestPermissionProfile"},
+		}),
+	}}
+}
+
+func guardianApprovalReviewActionVariantSchema(
+	actionType string,
+	requiredFields []string,
+	fields Schema,
+) Schema {
+	properties := Schema{"type": Schema{"type": "string", "enum": []any{actionType}}}
+	for name, schema := range fields {
+		properties[name] = schema
+	}
+	required := []string{"type"}
+	required = append(required, requiredFields...)
+	return Schema{
+		"type":                 "object",
+		"properties":           properties,
+		"required":             required,
+		"additionalProperties": false,
+	}
+}
+
+var (
+	_ json.Marshaler   = GuardianApprovalReviewAction{}
+	_ json.Unmarshaler = (*GuardianApprovalReviewAction)(nil)
+)

--- a/appserver/protocol/guardian_approval_review_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_contract_test.go
@@ -139,8 +139,8 @@ func TestGuardianApprovalReviewRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReview unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_enum_foundation_contract_test.go
+++ b/appserver/protocol/guardian_enum_foundation_contract_test.go
@@ -89,8 +89,8 @@ func TestGuardianEnumFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_metadata_list_contract_test.go
+++ b/appserver/protocol/hook_metadata_list_contract_test.go
@@ -352,8 +352,8 @@ func TestHookMetadataListContractsStayStandalone(t *testing.T) {
 			t.Errorf("standalone definition %s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Errorf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Errorf("definition count = %d, want 432", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 {
 		t.Errorf("wire binding count = %d, want 59", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_run_notification_contract_test.go
+++ b/appserver/protocol/hook_run_notification_contract_test.go
@@ -297,8 +297,8 @@ func TestHookRunNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("surface changed: %d methods, %d wire bindings, %d item bindings", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/hook_value_foundation_contract_test.go
+++ b/appserver/protocol/hook_value_foundation_contract_test.go
@@ -167,8 +167,8 @@ func TestHookValueFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 431 {
-		t.Fatalf("definition count = %d, want 431", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 432 {
+		t.Fatalf("definition count = %d, want 432", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 431 {
-		t.Fatalf("definition count = %d, want 431", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 432 {
+		t.Fatalf("definition count = %d, want 432", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 431 {
-		t.Fatalf("definition count = %d, want 431", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 432 {
+		t.Fatalf("definition count = %d, want 432", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 431 {
-		t.Fatalf("definition count = %d, want 431", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 432 {
+		t.Fatalf("definition count = %d, want 432", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 431 {
-		t.Fatalf("definition count = %d, want 431", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 432 {
+		t.Fatalf("definition count = %d, want 432", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 431 {
-		t.Fatalf("definition count = %d, want 431", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 432 {
+		t.Fatalf("definition count = %d, want 432", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -333,6 +333,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "FuzzyFileSearchSessionUpdatedNotification", Type: reflect.TypeFor[FuzzyFileSearchSessionUpdatedNotification]()},
 		{Name: "FuzzyFileSearchSessionCompletedNotification", Type: reflect.TypeFor[FuzzyFileSearchSessionCompletedNotification]()},
 		{Name: "GuardianApprovalReview", Type: reflect.TypeFor[GuardianApprovalReview]()},
+		{Name: "GuardianApprovalReviewAction", Type: reflect.TypeFor[GuardianApprovalReviewAction]()},
 		{Name: "GuardianApprovalReviewStatus", Type: reflect.TypeFor[GuardianApprovalReviewStatus]()},
 		{Name: "GuardianCommandSource", Type: reflect.TypeFor[GuardianCommandSource]()},
 		{Name: "GuardianRiskLevel", Type: reflect.TypeFor[GuardianRiskLevel]()},
@@ -623,6 +624,7 @@ func wireSchemaDefinitions() Schema {
 	schemas["FuzzyFileSearchSessionUpdatedNotification"] = fuzzyFileSearchSessionUpdatedNotificationSchema()
 	schemas["FuzzyFileSearchSessionCompletedNotification"] = fuzzyFileSearchSessionCompletedNotificationSchema()
 	schemas["GuardianApprovalReview"] = guardianApprovalReviewSchema()
+	schemas["GuardianApprovalReviewAction"] = guardianApprovalReviewActionSchema()
 	schemas["GuardianApprovalReviewStatus"] = stringEnumSchema(
 		string(GuardianApprovalReviewStatusInProgress), string(GuardianApprovalReviewStatusApproved),
 		string(GuardianApprovalReviewStatusDenied), string(GuardianApprovalReviewStatusTimedOut),

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -4648,6 +4648,196 @@
       ],
       "type": "object"
     },
+    "GuardianApprovalReviewAction": {
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "command": {
+              "type": "string"
+            },
+            "cwd": {
+              "$ref": "#/$defs/AbsolutePathBuf"
+            },
+            "source": {
+              "$ref": "#/$defs/GuardianCommandSource"
+            },
+            "type": {
+              "enum": [
+                "command"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "source",
+            "command",
+            "cwd"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "argv": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "cwd": {
+              "$ref": "#/$defs/AbsolutePathBuf"
+            },
+            "program": {
+              "type": "string"
+            },
+            "source": {
+              "$ref": "#/$defs/GuardianCommandSource"
+            },
+            "type": {
+              "enum": [
+                "execve"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "source",
+            "program",
+            "argv",
+            "cwd"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "cwd": {
+              "$ref": "#/$defs/AbsolutePathBuf"
+            },
+            "files": {
+              "items": {
+                "$ref": "#/$defs/AbsolutePathBuf"
+              },
+              "type": "array"
+            },
+            "type": {
+              "enum": [
+                "applyPatch"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "cwd",
+            "files"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "host": {
+              "type": "string"
+            },
+            "port": {
+              "maximum": 65535,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "protocol": {
+              "$ref": "#/$defs/NetworkApprovalProtocol"
+            },
+            "target": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "networkAccess"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "target",
+            "host",
+            "protocol",
+            "port"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "connectorId": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "connectorName": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "server": {
+              "type": "string"
+            },
+            "toolName": {
+              "type": "string"
+            },
+            "toolTitle": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": {
+              "enum": [
+                "mcpToolCall"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "server",
+            "toolName"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "permissions": {
+              "$ref": "#/$defs/RequestPermissionProfile"
+            },
+            "reason": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": {
+              "enum": [
+                "requestPermissions"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "permissions"
+          ],
+          "type": "object"
+        }
+      ]
+    },
     "GuardianApprovalReviewStatus": {
       "enum": [
         "inProgress",

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 431 {
-		t.Fatalf("definition count = %d, want 431", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 432 {
+		t.Fatalf("definition count = %d, want 432", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 431 {
-		t.Fatalf("definition count = %d, want 431", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 432 {
+		t.Fatalf("definition count = %d, want 432", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 431 {
-		t.Fatalf("definition count = %d, want 431", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 432 {
+		t.Fatalf("definition count = %d, want 432", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -134,6 +134,9 @@ func MarshalTypeScript() ([]byte, error) {
 				"rationale": Schema{"anyOf": []any{Schema{"type": "string"}, Schema{"type": "null"}}},
 			})
 		}
+		if name == "GuardianApprovalReviewAction" {
+			definition = guardianApprovalReviewActionTypeScriptSchema(definition)
+		}
 		typeName, err := typeScriptType(definition, 0)
 		if err != nil {
 			return nil, fmt.Errorf("generate TypeScript definition %s: %w", name, err)
@@ -345,6 +348,51 @@ func typeScriptDefinitionWithPropertySchemas(definition any, replacements Schema
 		renderProperties[name] = replacement
 	}
 	renderSchema["properties"] = renderProperties
+	return renderSchema
+}
+
+func guardianApprovalReviewActionTypeScriptSchema(definition any) Schema {
+	schema, _ := typeScriptSchema(definition)
+	renderSchema := make(Schema, len(schema))
+	for key, value := range schema {
+		renderSchema[key] = value
+	}
+	variants, _ := typeScriptAnySlice(schema["oneOf"])
+	renderVariants := make([]any, 0, len(variants))
+	for _, rawVariant := range variants {
+		variant, _ := typeScriptSchema(rawVariant)
+		renderVariant := make(Schema, len(variant))
+		for key, value := range variant {
+			renderVariant[key] = value
+		}
+		properties, _ := typeScriptSchema(variant["properties"])
+		renderProperties := make(Schema, len(properties))
+		for key, value := range properties {
+			renderProperties[key] = value
+		}
+		typeSchema, _ := typeScriptSchema(properties["type"])
+		tags, _ := typeScriptAnySlice(typeSchema["enum"])
+		required := append([]string(nil), variant["required"].([]string)...)
+		var nullableFields []string
+		if len(tags) == 1 {
+			switch tags[0] {
+			case "mcpToolCall":
+				nullableFields = []string{"connectorId", "connectorName", "toolTitle"}
+			case "requestPermissions":
+				nullableFields = []string{"reason"}
+			}
+		}
+		for _, field := range nullableFields {
+			required = append(required, field)
+			renderProperties[field] = Schema{"anyOf": []any{
+				Schema{"type": "string"}, Schema{"type": "null"},
+			}}
+		}
+		renderVariant["properties"] = renderProperties
+		renderVariant["required"] = required
+		renderVariants = append(renderVariants, renderVariant)
+	}
+	renderSchema["oneOf"] = renderVariants
 	return renderSchema
 }
 

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -1485,6 +1485,40 @@ export type GuardianApprovalReview = {
   "userAuthorization": GuardianUserAuthorization | null;
 };
 
+export type GuardianApprovalReviewAction = {
+  "command": string;
+  "cwd": AbsolutePathBuf;
+  "source": GuardianCommandSource;
+  "type": "command";
+} | {
+  "argv": Array<string>;
+  "cwd": AbsolutePathBuf;
+  "program": string;
+  "source": GuardianCommandSource;
+  "type": "execve";
+} | {
+  "cwd": AbsolutePathBuf;
+  "files": Array<AbsolutePathBuf>;
+  "type": "applyPatch";
+} | {
+  "host": string;
+  "port": number;
+  "protocol": NetworkApprovalProtocol;
+  "target": string;
+  "type": "networkAccess";
+} | {
+  "connectorId": string | null;
+  "connectorName": string | null;
+  "server": string;
+  "toolName": string;
+  "toolTitle": string | null;
+  "type": "mcpToolCall";
+} | {
+  "permissions": RequestPermissionProfile;
+  "reason": string | null;
+  "type": "requestPermissions";
+};
+
 export type GuardianApprovalReviewStatus = "inProgress" | "approved" | "denied" | "timedOut" | "aborted";
 
 export type GuardianCommandSource = "shell" | "unifiedExec";

--- a/appserver/protocol/typescript/testdata/guardian_approval_review_action_contract.ts
+++ b/appserver/protocol/typescript/testdata/guardian_approval_review_action_contract.ts
@@ -1,0 +1,70 @@
+import type {
+  AbsolutePathBuf,
+  GuardianApprovalReviewAction,
+  GuardianCommandSource,
+  MethodParamsByName,
+  MethodResultsByName,
+  NetworkApprovalProtocol,
+  RequestPermissionProfile,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+
+type ExactAction =
+  | { type: "command"; source: GuardianCommandSource; command: string; cwd: AbsolutePathBuf }
+  | { type: "execve"; source: GuardianCommandSource; program: string; argv: Array<string>; cwd: AbsolutePathBuf }
+  | { type: "applyPatch"; cwd: AbsolutePathBuf; files: Array<AbsolutePathBuf> }
+  | { type: "networkAccess"; target: string; host: string; protocol: NetworkApprovalProtocol; port: number }
+  | { type: "mcpToolCall"; server: string; toolName: string; connectorId: string | null; connectorName: string | null; toolTitle: string | null }
+  | { type: "requestPermissions"; reason: string | null; permissions: RequestPermissionProfile };
+
+type GuardianNotificationMethod =
+  | "item/autoApprovalReview/started"
+  | "item/autoApprovalReview/completed";
+
+type Contracts = [
+  Expect<Equal<GuardianApprovalReviewAction, ExactAction>>,
+  Expect<Equal<Extract<keyof MethodParamsByName, GuardianNotificationMethod>, never>>,
+  Expect<Equal<Extract<keyof MethodResultsByName, GuardianNotificationMethod>, never>>,
+];
+
+({ type: "command", source: "shell", command: "", cwd: "/workspace" }) satisfies GuardianApprovalReviewAction;
+({ type: "execve", source: "unifiedExec", program: "", argv: ["-x", "-x"], cwd: "/workspace" }) satisfies GuardianApprovalReviewAction;
+({ type: "applyPatch", cwd: "/workspace", files: [] }) satisfies GuardianApprovalReviewAction;
+({ type: "networkAccess", target: "", host: "", protocol: "socks5Udp", port: 65535 }) satisfies GuardianApprovalReviewAction;
+({ type: "mcpToolCall", server: "", toolName: "", connectorId: null, connectorName: "", toolTitle: null }) satisfies GuardianApprovalReviewAction;
+({ type: "requestPermissions", reason: null, permissions: { network: null, fileSystem: null } }) satisfies GuardianApprovalReviewAction;
+
+// @ts-expect-error action tags are closed.
+({ type: "other" }) satisfies GuardianApprovalReviewAction;
+// @ts-expect-error tags are case-sensitive.
+({ type: "Command", source: "shell", command: "", cwd: "/workspace" }) satisfies GuardianApprovalReviewAction;
+// @ts-expect-error command source is required.
+({ type: "command", command: "", cwd: "/workspace" }) satisfies GuardianApprovalReviewAction;
+// @ts-expect-error command sources are closed.
+({ type: "command", source: "other", command: "", cwd: "/workspace" }) satisfies GuardianApprovalReviewAction;
+// @ts-expect-error argv is required and non-null.
+({ type: "execve", source: "shell", program: "p", argv: null, cwd: "/workspace" }) satisfies GuardianApprovalReviewAction;
+// @ts-expect-error applyPatch files are required.
+({ type: "applyPatch", cwd: "/workspace" }) satisfies GuardianApprovalReviewAction;
+// @ts-expect-error network protocols are closed.
+({ type: "networkAccess", target: "", host: "", protocol: "tcp", port: 1 }) satisfies GuardianApprovalReviewAction;
+// @ts-expect-error network port is a number.
+({ type: "networkAccess", target: "", host: "", protocol: "http", port: "1" }) satisfies GuardianApprovalReviewAction;
+// @ts-expect-error canonical MCP actions require nullable connectorId.
+({ type: "mcpToolCall", server: "", toolName: "", connectorName: null, toolTitle: null }) satisfies GuardianApprovalReviewAction;
+// @ts-expect-error canonical MCP actions require nullable connectorName.
+({ type: "mcpToolCall", server: "", toolName: "", connectorId: null, toolTitle: null }) satisfies GuardianApprovalReviewAction;
+// @ts-expect-error canonical MCP actions require nullable toolTitle.
+({ type: "mcpToolCall", server: "", toolName: "", connectorId: null, connectorName: null }) satisfies GuardianApprovalReviewAction;
+// @ts-expect-error canonical permission actions require nullable reason.
+({ type: "requestPermissions", permissions: { network: null, fileSystem: null } }) satisfies GuardianApprovalReviewAction;
+// @ts-expect-error variants cannot cross fields.
+({ type: "command", source: "shell", command: "", cwd: "/workspace", port: 1 }) satisfies GuardianApprovalReviewAction;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 431 {
-		t.Fatalf("definition count = %d, want 431", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
+		t.Fatalf("definition count = %d, want 432", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary

- export exact standalone GuardianApprovalReviewAction as the six public tagged variants
- reuse existing exact path, Guardian enum, network protocol, and permission-profile dependencies
- preserve serde input behavior and canonical ts-rs nullable option fields
- keep Guardian notifications, assessment/replay, enforcement, bindings, producers, persistence, and runtime unchanged

## Verification

- deliberate-red Go and strict TypeScript boundaries
- focused tests 30x, focused race, and 100% statement coverage for every new production function
- full protocol normal/race at 97.3% aggregate coverage
- exactly 59 non-Monty packages passed normal and race suites
- golangci-lint: 0 issues; vet; tidy; module verification
- deterministic 432-definition generation and strict TypeScript
- normalized schema and parsed TypeScript semantics match pinned public Codex 5c19155c
- schema/TypeScript differ from PR #199 only by GuardianApprovalReviewAction; 224 methods and 59/5 bindings unchanged
- structural reversal restores exact PR #199 tree f0bd95cfb120b14f457afec48773d8be4a20e1dd
- all five existing Slang stdio/Unix-socket/WebSocket workflows pass
- baseline/feature live transcript byte-identical at 37,893 bytes with empty stderr
- configured pre-push passed before commit and on push with local Monty race skipped

Generated SHA-256: schema 68340a846b6eb2be52bcc10df0d2f94df654c5571c85253eefe03423b8ef97fd; TypeScript 1d9f7277bf72010e3b78d239d81214346a12dd2ddd86ca515abf85a152a7d3fb; strict fixture 78a4cf49059ca55de241d9d6d7006b354e32e474528a91186866312d2d0b5ac3.