### PR TITLE
feat(protocol): export guardian review started notification

### DIFF
--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(defs); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,8 +217,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,8 +203,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -260,8 +260,8 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,8 +244,8 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -162,8 +162,8 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -175,8 +175,8 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -381,8 +381,8 @@ func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_action_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_action_contract_test.go
@@ -226,8 +226,8 @@ func TestGuardianApprovalReviewActionRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReviewAction unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_contract_test.go
@@ -139,8 +139,8 @@ func TestGuardianApprovalReviewRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReview unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
@@ -1,0 +1,230 @@
+package protocol
+
+import (
+	"encoding/json"
+	"math"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestGuardianApprovalReviewStartedNotificationSchemaIsExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	want := Schema{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties": Schema{
+			"threadId":     Schema{"type": "string"},
+			"turnId":       Schema{"type": "string"},
+			"startedAtMs":  Schema{"type": "integer"},
+			"reviewId":     Schema{"type": "string"},
+			"targetItemId": Schema{"type": []any{"string", "null"}},
+			"review":       Schema{"$ref": "#/$defs/GuardianApprovalReview"},
+			"action":       Schema{"$ref": "#/$defs/GuardianApprovalReviewAction"},
+		},
+		"required": []string{
+			"threadId", "turnId", "startedAtMs", "reviewId", "review", "action",
+		},
+	}
+	if got := defs["ItemGuardianApprovalReviewStartedNotification"]; !reflect.DeepEqual(got, want) {
+		t.Fatalf("started-notification schema = %#v, want %#v", got, want)
+	}
+}
+
+func TestGuardianApprovalReviewStartedNotificationAcceptsSerdeWireForms(t *testing.T) {
+	validReview := `{"status":"inProgress"}`
+	validAction := `{"type":"command","source":"shell","command":"","cwd":"/workspace"}`
+	tests := []struct {
+		name      string
+		input     string
+		want      ItemGuardianApprovalReviewStartedNotification
+		canonical string
+	}{
+		{
+			name: "omitted target becomes explicit null",
+			input: `{"threadId":"","turnId":"","startedAtMs":-9223372036854775808,` +
+				`"reviewId":"","review":` + validReview + `,"action":` + validAction + `}`,
+			want: ItemGuardianApprovalReviewStartedNotification{
+				StartedAtMS: math.MinInt64,
+				Review:      GuardianApprovalReview{Status: GuardianApprovalReviewStatusInProgress},
+				Action:      mustGuardianApprovalReviewAction(t, validAction),
+			},
+			canonical: `{"threadId":"","turnId":"","startedAtMs":-9223372036854775808,` +
+				`"reviewId":"","targetItemId":null,` +
+				`"review":{"status":"inProgress","riskLevel":null,"userAuthorization":null,"rationale":null},` +
+				`"action":{"type":"command","source":"shell","command":"","cwd":"/workspace"}}`,
+		},
+		{
+			name: "explicit null target and unknown fields",
+			input: `{"unknown":{"nested":true},"action":` + validAction + `,"review":` + validReview +
+				`,"targetItemId":null,"reviewId":"review-1","startedAtMs":0,"turnId":"turn-1","threadId":"thread-1"}`,
+			want: ItemGuardianApprovalReviewStartedNotification{
+				ThreadID: "thread-1", TurnID: "turn-1", ReviewID: "review-1",
+				Review: GuardianApprovalReview{Status: GuardianApprovalReviewStatusInProgress},
+				Action: mustGuardianApprovalReviewAction(t, validAction),
+			},
+			canonical: `{"threadId":"thread-1","turnId":"turn-1","startedAtMs":0,` +
+				`"reviewId":"review-1","targetItemId":null,` +
+				`"review":{"status":"inProgress","riskLevel":null,"userAuthorization":null,"rationale":null},` +
+				`"action":{"type":"command","source":"shell","command":"","cwd":"/workspace"}}`,
+		},
+		{
+			name: "maximum timestamp and target",
+			input: `{"threadId":"thread-2","turnId":"turn-2","startedAtMs":9223372036854775807,` +
+				`"reviewId":"review-2","targetItemId":"item-2",` +
+				`"review":{"status":"denied","riskLevel":"critical","userAuthorization":"unknown","rationale":"why"},` +
+				`"action":{"type":"networkAccess","target":"","host":"","protocol":"https","port":65535}}`,
+			want: ItemGuardianApprovalReviewStartedNotification{
+				ThreadID: "thread-2", TurnID: "turn-2", StartedAtMS: math.MaxInt64,
+				ReviewID: "review-2", TargetItemID: ptr("item-2"),
+				Review: GuardianApprovalReview{
+					Status:            GuardianApprovalReviewStatusDenied,
+					RiskLevel:         ptr(GuardianRiskLevelCritical),
+					UserAuthorization: ptr(GuardianUserAuthorizationUnknown), Rationale: ptr("why"),
+				},
+				Action: mustGuardianApprovalReviewAction(t,
+					`{"type":"networkAccess","target":"","host":"","protocol":"https","port":65535}`),
+			},
+			canonical: `{"threadId":"thread-2","turnId":"turn-2","startedAtMs":9223372036854775807,` +
+				`"reviewId":"review-2","targetItemId":"item-2",` +
+				`"review":{"status":"denied","riskLevel":"critical","userAuthorization":"unknown","rationale":"why"},` +
+				`"action":{"type":"networkAccess","target":"","host":"","protocol":"https","port":65535}}`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var got ItemGuardianApprovalReviewStartedNotification
+			if err := json.Unmarshal([]byte(test.input), &got); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("decoded = %#v, want %#v", got, test.want)
+			}
+			encoded, err := json.Marshal(got)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if string(encoded) != test.canonical {
+				t.Fatalf("canonical = %s, want %s", encoded, test.canonical)
+			}
+		})
+	}
+}
+
+func TestGuardianApprovalReviewStartedNotificationRejectsMalformedWireForms(t *testing.T) {
+	valid := `{"threadId":"thread","turnId":"turn","startedAtMs":1,"reviewId":"review",` +
+		`"review":{"status":"approved"},` +
+		`"action":{"type":"applyPatch","cwd":"/workspace","files":[]}}`
+	for _, input := range []string{
+		``, `null`, `[]`, `1`, `true`, `"value"`, `{`, `{}`,
+		`{"turnId":"turn","startedAtMs":1,"reviewId":"review","review":{"status":"approved"},"action":{"type":"applyPatch","cwd":"/workspace","files":[]}}`,
+		`{"threadId":"thread","startedAtMs":1,"reviewId":"review","review":{"status":"approved"},"action":{"type":"applyPatch","cwd":"/workspace","files":[]}}`,
+		`{"threadId":"thread","turnId":"turn","reviewId":"review","review":{"status":"approved"},"action":{"type":"applyPatch","cwd":"/workspace","files":[]}}`,
+		`{"threadId":"thread","turnId":"turn","startedAtMs":1,"review":{"status":"approved"},"action":{"type":"applyPatch","cwd":"/workspace","files":[]}}`,
+		`{"threadId":"thread","turnId":"turn","startedAtMs":1,"reviewId":"review","action":{"type":"applyPatch","cwd":"/workspace","files":[]}}`,
+		`{"threadId":"thread","turnId":"turn","startedAtMs":1,"reviewId":"review","review":{"status":"approved"}}`,
+		strings.Replace(valid, `"threadId":"thread"`, `"threadId":null`, 1),
+		strings.Replace(valid, `"turnId":"turn"`, `"turnId":null`, 1),
+		strings.Replace(valid, `"startedAtMs":1`, `"startedAtMs":null`, 1),
+		strings.Replace(valid, `"startedAtMs":1`, `"startedAtMs":1.5`, 1),
+		strings.Replace(valid, `"startedAtMs":1`, `"startedAtMs":"1"`, 1),
+		strings.Replace(valid, `"startedAtMs":1`, `"startedAtMs":9223372036854775808`, 1),
+		strings.Replace(valid, `"startedAtMs":1`, `"startedAtMs":-9223372036854775809`, 1),
+		strings.Replace(valid, `"reviewId":"review"`, `"reviewId":null`, 1),
+		strings.Replace(valid, `"review":{"status":"approved"}`, `"review":null`, 1),
+		strings.Replace(valid, `"review":{"status":"approved"}`, `"review":{"status":"other"}`, 1),
+		strings.Replace(valid, `"action":{"type":"applyPatch","cwd":"/workspace","files":[]}`, `"action":null`, 1),
+		strings.Replace(valid, `"action":{"type":"applyPatch","cwd":"/workspace","files":[]}`, `"action":{"type":"other"}`, 1),
+		strings.Replace(valid, `"reviewId":"review"`, `"targetItemId":1,"reviewId":"review"`, 1),
+		strings.Replace(valid, `"threadId":"thread"`, `"threadId":"thread","threadId":"other"`, 1),
+		strings.Replace(valid, `"reviewId":"review"`, `"targetItemId":null,"targetItemId":"item","reviewId":"review"`, 1),
+		valid + ` {}`,
+		valid + ` x`,
+	} {
+		assertJSONRejects[ItemGuardianApprovalReviewStartedNotification](t, input)
+	}
+}
+
+func TestGuardianApprovalReviewStartedNotificationNilReceiverAndInvalidValuesFailClosed(t *testing.T) {
+	var notification *ItemGuardianApprovalReviewStartedNotification
+	if err := notification.UnmarshalJSON([]byte(`{}`)); err == nil {
+		t.Fatal("nil started-notification receiver succeeded")
+	}
+	validAction := mustGuardianApprovalReviewAction(t,
+		`{"type":"command","source":"shell","command":"","cwd":"/workspace"}`)
+	for _, notification := range []ItemGuardianApprovalReviewStartedNotification{
+		{},
+		{Review: GuardianApprovalReview{Status: GuardianApprovalReviewStatus("other")}, Action: validAction},
+	} {
+		if _, err := json.Marshal(notification); err == nil {
+			t.Fatalf("invalid notification marshaled: %#v", notification)
+		}
+	}
+}
+
+func TestGuardianApprovalReviewStartedNotificationRemainsStandalone(t *testing.T) {
+	const typeName = "ItemGuardianApprovalReviewStartedNotification"
+	for _, binding := range WireTypeBindings() {
+		if slices.Contains(binding.Params, typeName) || slices.Contains(binding.Result, typeName) {
+			t.Fatalf("started notification unexpectedly bound to %s", binding.Method)
+		}
+	}
+	for _, binding := range ItemPayloadBindings() {
+		if binding.Type == typeName {
+			t.Fatalf("started notification unexpectedly bound to item %s", binding.Kind)
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+	for _, method := range Methods() {
+		if method.Method == "item/autoApprovalReview/started" && method.State != MethodBlocked {
+			t.Fatalf("started method state = %s, want blocked", method.State)
+		}
+	}
+}
+
+func TestGuardianApprovalReviewStartedNotificationTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	want := `export type ItemGuardianApprovalReviewStartedNotification = {
+  "action": GuardianApprovalReviewAction;
+  "review": GuardianApprovalReview;
+  "reviewId": string;
+  "startedAtMs": number;
+  "targetItemId": string | null;
+  "threadId": string;
+  "turnId": string;
+};`
+	if !strings.Contains(string(generated), want) {
+		t.Errorf("generated TypeScript missing %q", want)
+	}
+	for _, forbidden := range []string{`"targetItemId"?:`, `"startedAtMs": bigint`} {
+		if strings.Contains(string(generated), forbidden) {
+			t.Errorf("generated TypeScript unexpectedly contains %q", forbidden)
+		}
+	}
+}
+
+func mustGuardianApprovalReviewAction(t *testing.T, input string) GuardianApprovalReviewAction {
+	t.Helper()
+	var action GuardianApprovalReviewAction
+	if err := json.Unmarshal([]byte(input), &action); err != nil {
+		t.Fatalf("decode action fixture: %v", err)
+	}
+	return action
+}
+
+var (
+	_ json.Marshaler   = ItemGuardianApprovalReviewStartedNotification{}
+	_ json.Unmarshaler = (*ItemGuardianApprovalReviewStartedNotification)(nil)
+)

--- a/appserver/protocol/guardian_approval_review_started_notification_types.go
+++ b/appserver/protocol/guardian_approval_review_started_notification_types.go
@@ -1,0 +1,98 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// ItemGuardianApprovalReviewStartedNotification is the exact unstable public
+// description of a Guardian review start. It does not produce or authorize a review.
+type ItemGuardianApprovalReviewStartedNotification struct {
+	ThreadID     string                       `json:"threadId"`
+	TurnID       string                       `json:"turnId"`
+	StartedAtMS  int64                        `json:"startedAtMs"`
+	ReviewID     string                       `json:"reviewId"`
+	TargetItemID *string                      `json:"targetItemId"`
+	Review       GuardianApprovalReview       `json:"review"`
+	Action       GuardianApprovalReviewAction `json:"action"`
+}
+
+func (n ItemGuardianApprovalReviewStartedNotification) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		ThreadID     string                       `json:"threadId"`
+		TurnID       string                       `json:"turnId"`
+		StartedAtMS  int64                        `json:"startedAtMs"`
+		ReviewID     string                       `json:"reviewId"`
+		TargetItemID *string                      `json:"targetItemId"`
+		Review       GuardianApprovalReview       `json:"review"`
+		Action       GuardianApprovalReviewAction `json:"action"`
+	}{
+		ThreadID: n.ThreadID, TurnID: n.TurnID, StartedAtMS: n.StartedAtMS,
+		ReviewID: n.ReviewID, TargetItemID: n.TargetItemID,
+		Review: n.Review, Action: n.Action,
+	})
+}
+
+func (n *ItemGuardianApprovalReviewStartedNotification) UnmarshalJSON(data []byte) error {
+	if n == nil {
+		return errors.New("decode Guardian approval-review-started notification into nil receiver")
+	}
+	const objectName = "Guardian approval-review-started notification"
+	payload, err := decodeRustSerdeObject(
+		data, objectName,
+		"threadId", "turnId", "startedAtMs", "reviewId", "targetItemId", "review", "action",
+	)
+	if err != nil {
+		return err
+	}
+	threadID, err := decodeRequiredThreadItemValue[string](payload, objectName, "threadId")
+	if err != nil {
+		return err
+	}
+	turnID, err := decodeRequiredThreadItemValue[string](payload, objectName, "turnId")
+	if err != nil {
+		return err
+	}
+	startedAtMS, err := decodeRequiredThreadItemValue[int64](payload, objectName, "startedAtMs")
+	if err != nil {
+		return err
+	}
+	reviewID, err := decodeRequiredThreadItemValue[string](payload, objectName, "reviewId")
+	if err != nil {
+		return err
+	}
+	targetItemID, err := decodeOptionalNullableConfigValue[string](payload, objectName, "targetItemId")
+	if err != nil {
+		return err
+	}
+	review, err := decodeRequiredThreadItemValue[GuardianApprovalReview](payload, objectName, "review")
+	if err != nil {
+		return err
+	}
+	action, err := decodeRequiredThreadItemValue[GuardianApprovalReviewAction](payload, objectName, "action")
+	if err != nil {
+		return err
+	}
+	*n = ItemGuardianApprovalReviewStartedNotification{
+		ThreadID: threadID, TurnID: turnID, StartedAtMS: startedAtMS,
+		ReviewID: reviewID, TargetItemID: targetItemID, Review: review, Action: action,
+	}
+	return nil
+}
+
+func guardianApprovalReviewStartedNotificationSchema() Schema {
+	return closedThreadSessionParamSchema(Schema{
+		"threadId":     Schema{"type": "string"},
+		"turnId":       Schema{"type": "string"},
+		"startedAtMs":  Schema{"type": "integer"},
+		"reviewId":     Schema{"type": "string"},
+		"targetItemId": Schema{"type": []any{"string", "null"}},
+		"review":       Schema{"$ref": "#/$defs/GuardianApprovalReview"},
+		"action":       Schema{"$ref": "#/$defs/GuardianApprovalReviewAction"},
+	}, []string{"threadId", "turnId", "startedAtMs", "reviewId", "review", "action"})
+}
+
+var (
+	_ json.Marshaler   = ItemGuardianApprovalReviewStartedNotification{}
+	_ json.Unmarshaler = (*ItemGuardianApprovalReviewStartedNotification)(nil)
+)

--- a/appserver/protocol/guardian_enum_foundation_contract_test.go
+++ b/appserver/protocol/guardian_enum_foundation_contract_test.go
@@ -89,8 +89,8 @@ func TestGuardianEnumFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_metadata_list_contract_test.go
+++ b/appserver/protocol/hook_metadata_list_contract_test.go
@@ -352,8 +352,8 @@ func TestHookMetadataListContractsStayStandalone(t *testing.T) {
 			t.Errorf("standalone definition %s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Errorf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Errorf("definition count = %d, want 433", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 {
 		t.Errorf("wire binding count = %d, want 59", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_run_notification_contract_test.go
+++ b/appserver/protocol/hook_run_notification_contract_test.go
@@ -297,8 +297,8 @@ func TestHookRunNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("surface changed: %d methods, %d wire bindings, %d item bindings", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/hook_value_foundation_contract_test.go
+++ b/appserver/protocol/hook_value_foundation_contract_test.go
@@ -167,8 +167,8 @@ func TestHookValueFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 432 {
-		t.Fatalf("definition count = %d, want 432", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 433 {
+		t.Fatalf("definition count = %d, want 433", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 432 {
-		t.Fatalf("definition count = %d, want 432", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 433 {
+		t.Fatalf("definition count = %d, want 433", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 432 {
-		t.Fatalf("definition count = %d, want 432", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 433 {
+		t.Fatalf("definition count = %d, want 433", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 432 {
-		t.Fatalf("definition count = %d, want 432", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 433 {
+		t.Fatalf("definition count = %d, want 433", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 432 {
-		t.Fatalf("definition count = %d, want 432", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 433 {
+		t.Fatalf("definition count = %d, want 433", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 432 {
-		t.Fatalf("definition count = %d, want 432", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 433 {
+		t.Fatalf("definition count = %d, want 433", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -355,6 +355,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "HooksListEntry", Type: reflect.TypeFor[HooksListEntry]()},
 		{Name: "HooksListParams", Type: reflect.TypeFor[HooksListParams]()},
 		{Name: "HooksListResponse", Type: reflect.TypeFor[HooksListResponse]()},
+		{Name: "ItemGuardianApprovalReviewStartedNotification", Type: reflect.TypeFor[ItemGuardianApprovalReviewStartedNotification]()},
 		{Name: "NetworkApprovalProtocol", Type: reflect.TypeFor[NetworkApprovalProtocol]()},
 		{Name: "PermissionGrantScope", Type: reflect.TypeFor[PermissionGrantScope]()},
 		{Name: "PermissionsApprovalRequestParams", Type: reflect.TypeFor[PermissionsApprovalRequestParams]()},
@@ -687,6 +688,7 @@ func wireSchemaDefinitions() Schema {
 	schemas["HooksListEntry"] = hooksListEntrySchema()
 	schemas["HooksListParams"] = hooksListParamsSchema()
 	schemas["HooksListResponse"] = hooksListResponseSchema()
+	schemas["ItemGuardianApprovalReviewStartedNotification"] = guardianApprovalReviewStartedNotificationSchema()
 	schemas["NetworkApprovalProtocol"] = stringEnumSchema(
 		string(NetworkApprovalProtocolHTTP), string(NetworkApprovalProtocolHTTPS),
 		string(NetworkApprovalProtocolSocks5TCP), string(NetworkApprovalProtocolSocks5UDP),

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -5506,6 +5506,44 @@
       ],
       "type": "object"
     },
+    "ItemGuardianApprovalReviewStartedNotification": {
+      "additionalProperties": false,
+      "properties": {
+        "action": {
+          "$ref": "#/$defs/GuardianApprovalReviewAction"
+        },
+        "review": {
+          "$ref": "#/$defs/GuardianApprovalReview"
+        },
+        "reviewId": {
+          "type": "string"
+        },
+        "startedAtMs": {
+          "type": "integer"
+        },
+        "targetItemId": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "threadId": {
+          "type": "string"
+        },
+        "turnId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "threadId",
+        "turnId",
+        "startedAtMs",
+        "reviewId",
+        "review",
+        "action"
+      ],
+      "type": "object"
+    },
     "ItemLifecycleNotificationParams": {
       "additionalProperties": false,
       "properties": {

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 432 {
-		t.Fatalf("definition count = %d, want 432", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 433 {
+		t.Fatalf("definition count = %d, want 433", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 432 {
-		t.Fatalf("definition count = %d, want 432", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 433 {
+		t.Fatalf("definition count = %d, want 433", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 432 {
-		t.Fatalf("definition count = %d, want 432", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 433 {
+		t.Fatalf("definition count = %d, want 433", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -45,7 +45,8 @@ func MarshalTypeScript() ([]byte, error) {
 			name == "FuzzyFileSearchParams" || name == "FuzzyFileSearchResult" ||
 			name == "HookRunSummary" || name == "HookStartedNotification" ||
 			name == "HookCompletedNotification" || name == "HookMetadata" ||
-			name == "GuardianApprovalReview" {
+			name == "GuardianApprovalReview" ||
+			name == "ItemGuardianApprovalReviewStartedNotification" {
 			// Rust accepts omitted serde default/Option fields while generated
 			// TypeScript requires callers to provide their canonical values.
 			schema, _ := typeScriptSchema(definition)
@@ -90,6 +91,10 @@ func MarshalTypeScript() ([]byte, error) {
 			case "GuardianApprovalReview":
 				schema["required"] = []string{
 					"status", "riskLevel", "userAuthorization", "rationale",
+				}
+			case "ItemGuardianApprovalReviewStartedNotification":
+				schema["required"] = []string{
+					"threadId", "turnId", "startedAtMs", "reviewId", "targetItemId", "review", "action",
 				}
 			}
 			definition = schema
@@ -136,6 +141,13 @@ func MarshalTypeScript() ([]byte, error) {
 		}
 		if name == "GuardianApprovalReviewAction" {
 			definition = guardianApprovalReviewActionTypeScriptSchema(definition)
+		}
+		if name == "ItemGuardianApprovalReviewStartedNotification" {
+			definition = typeScriptDefinitionWithPropertySchemas(definition, Schema{
+				"targetItemId": Schema{
+					"anyOf": []any{Schema{"type": "string"}, Schema{"type": "null"}},
+				},
+			})
 		}
 		typeName, err := typeScriptType(definition, 0)
 		if err != nil {

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -1681,6 +1681,16 @@ export type ItemCompletedNotification = {
   "turnId": string;
 };
 
+export type ItemGuardianApprovalReviewStartedNotification = {
+  "action": GuardianApprovalReviewAction;
+  "review": GuardianApprovalReview;
+  "reviewId": string;
+  "startedAtMs": number;
+  "targetItemId": string | null;
+  "threadId": string;
+  "turnId": string;
+};
+
 export type ItemLifecycleNotificationParams = {
   "at": string;
   "item"?: TimelineItem | null;

--- a/appserver/protocol/typescript/testdata/guardian_approval_review_started_notification_contract.ts
+++ b/appserver/protocol/typescript/testdata/guardian_approval_review_started_notification_contract.ts
@@ -1,0 +1,82 @@
+import type {
+  GuardianApprovalReview,
+  GuardianApprovalReviewAction,
+  ItemGuardianApprovalReviewStartedNotification,
+  MethodParamsByName,
+  MethodResultsByName,
+} from "../gollem_appserver_protocol.js";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+type StartedMethod = "item/autoApprovalReview/started";
+
+type Contracts = [
+  Expect<Equal<ItemGuardianApprovalReviewStartedNotification, {
+    threadId: string;
+    turnId: string;
+    startedAtMs: number;
+    reviewId: string;
+    targetItemId: string | null;
+    review: GuardianApprovalReview;
+    action: GuardianApprovalReviewAction;
+  }>>,
+  Expect<Equal<Extract<keyof MethodParamsByName, StartedMethod>, never>>,
+  Expect<Equal<Extract<keyof MethodResultsByName, StartedMethod>, never>>,
+];
+
+const review: GuardianApprovalReview = {
+  status: "inProgress",
+  riskLevel: null,
+  userAuthorization: null,
+  rationale: null,
+};
+const action: GuardianApprovalReviewAction = {
+  type: "command",
+  source: "shell",
+  command: "",
+  cwd: "/workspace",
+};
+
+({
+  threadId: "",
+  turnId: "",
+  startedAtMs: Number.MIN_SAFE_INTEGER,
+  reviewId: "",
+  targetItemId: null,
+  review,
+  action,
+}) satisfies ItemGuardianApprovalReviewStartedNotification;
+({
+  threadId: "thread",
+  turnId: "turn",
+  startedAtMs: Number.MAX_SAFE_INTEGER,
+  reviewId: "review",
+  targetItemId: "item",
+  review,
+  action,
+}) satisfies ItemGuardianApprovalReviewStartedNotification;
+
+// @ts-expect-error threadId is required.
+({ turnId: "", startedAtMs: 0, reviewId: "", targetItemId: null, review, action }) satisfies ItemGuardianApprovalReviewStartedNotification;
+// @ts-expect-error turnId is required.
+({ threadId: "", startedAtMs: 0, reviewId: "", targetItemId: null, review, action }) satisfies ItemGuardianApprovalReviewStartedNotification;
+// @ts-expect-error startedAtMs is required.
+({ threadId: "", turnId: "", reviewId: "", targetItemId: null, review, action }) satisfies ItemGuardianApprovalReviewStartedNotification;
+// @ts-expect-error startedAtMs is a number, not bigint.
+({ threadId: "", turnId: "", startedAtMs: 0n, reviewId: "", targetItemId: null, review, action }) satisfies ItemGuardianApprovalReviewStartedNotification;
+// @ts-expect-error reviewId is required.
+({ threadId: "", turnId: "", startedAtMs: 0, targetItemId: null, review, action }) satisfies ItemGuardianApprovalReviewStartedNotification;
+// @ts-expect-error targetItemId is required nullable output.
+({ threadId: "", turnId: "", startedAtMs: 0, reviewId: "", review, action }) satisfies ItemGuardianApprovalReviewStartedNotification;
+// @ts-expect-error review is required and non-null.
+({ threadId: "", turnId: "", startedAtMs: 0, reviewId: "", targetItemId: null, review: null, action }) satisfies ItemGuardianApprovalReviewStartedNotification;
+// @ts-expect-error action is required and non-null.
+({ threadId: "", turnId: "", startedAtMs: 0, reviewId: "", targetItemId: null, review, action: null }) satisfies ItemGuardianApprovalReviewStartedNotification;
+// @ts-expect-error records are closed.
+({ threadId: "", turnId: "", startedAtMs: 0, reviewId: "", targetItemId: null, review, action, extra: true }) satisfies ItemGuardianApprovalReviewStartedNotification;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 432 {
-		t.Fatalf("definition count = %d, want 432", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
+		t.Fatalf("definition count = %d, want 433", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- export exact standalone `ItemGuardianApprovalReviewStartedNotification` over the existing Guardian review/action contracts
- preserve serde input optionality for `targetItemId` while requiring canonical nullable TypeScript output and ts-rs `number` timestamp semantics
- leave `item/autoApprovalReview/started` blocked and unbound with no producer, replay, approval, execution, persistence, or runtime authority

## Verification
- deliberate-red Go and strict TypeScript boundaries
- focused 30x, focused race, and 100% coverage for all three new production functions
- full protocol normal/race at 97.3% aggregate coverage
- fresh normal/race across exactly 59 non-Monty packages
- zero-issue lint, non-Monty vet, tidy/verify, configured pre-push before commit and push
- deterministic 433-definition/59-method/5-item generation and strict TypeScript
- exact normalized pinned-upstream schema and parsed TypeScript semantics
- unchanged 224 methods and all method/item bindings; exact structural reversal to PR #200
- reproducible binary, all five prior Slang workflows, and byte-identical fixed live transcript

Local Monty normal/race/coverage tests remain intentionally skipped per project direction; hosted CI is unchanged.