### PR TITLE
feat(protocol): export guardian review completed notification

### DIFF
--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(defs); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,8 +217,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,8 +203,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -260,8 +260,8 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,8 +244,8 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -162,8 +162,8 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -175,8 +175,8 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -381,8 +381,8 @@ func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_action_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_action_contract_test.go
@@ -226,8 +226,8 @@ func TestGuardianApprovalReviewActionRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReviewAction unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
@@ -1,0 +1,213 @@
+package protocol
+
+import (
+	"encoding/json"
+	"math"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestGuardianApprovalReviewCompletedNotificationSchemaIsExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	want := Schema{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties": Schema{
+			"threadId":       Schema{"type": "string"},
+			"turnId":         Schema{"type": "string"},
+			"startedAtMs":    Schema{"type": "integer"},
+			"completedAtMs":  Schema{"type": "integer"},
+			"reviewId":       Schema{"type": "string"},
+			"targetItemId":   Schema{"type": []any{"string", "null"}},
+			"decisionSource": Schema{"$ref": "#/$defs/AutoReviewDecisionSource"},
+			"review":         Schema{"$ref": "#/$defs/GuardianApprovalReview"},
+			"action":         Schema{"$ref": "#/$defs/GuardianApprovalReviewAction"},
+		},
+		"required": []string{
+			"threadId", "turnId", "startedAtMs", "completedAtMs", "reviewId",
+			"decisionSource", "review", "action",
+		},
+	}
+	if got := defs["ItemGuardianApprovalReviewCompletedNotification"]; !reflect.DeepEqual(got, want) {
+		t.Fatalf("completed-notification schema = %#v, want %#v", got, want)
+	}
+}
+
+func TestGuardianApprovalReviewCompletedNotificationAcceptsSerdeWireForms(t *testing.T) {
+	validReview := `{"status":"approved"}`
+	validAction := `{"type":"command","source":"shell","command":"","cwd":"/workspace"}`
+	tests := []struct {
+		name      string
+		input     string
+		want      ItemGuardianApprovalReviewCompletedNotification
+		canonical string
+	}{
+		{
+			name: "omitted target becomes explicit null",
+			input: `{"threadId":"","turnId":"","startedAtMs":-9223372036854775808,` +
+				`"completedAtMs":9223372036854775807,"reviewId":"","decisionSource":"agent",` +
+				`"review":` + validReview + `,"action":` + validAction + `}`,
+			want: ItemGuardianApprovalReviewCompletedNotification{
+				StartedAtMS: math.MinInt64, CompletedAtMS: math.MaxInt64,
+				DecisionSource: AutoReviewDecisionSourceAgent,
+				Review:         GuardianApprovalReview{Status: GuardianApprovalReviewStatusApproved},
+				Action:         mustGuardianApprovalReviewAction(t, validAction),
+			},
+			canonical: `{"threadId":"","turnId":"","startedAtMs":-9223372036854775808,` +
+				`"completedAtMs":9223372036854775807,"reviewId":"","targetItemId":null,` +
+				`"decisionSource":"agent",` +
+				`"review":{"status":"approved","riskLevel":null,"userAuthorization":null,"rationale":null},` +
+				`"action":{"type":"command","source":"shell","command":"","cwd":"/workspace"}}`,
+		},
+		{
+			name: "target and unknown field",
+			input: `{"unknown":true,"threadId":"thread","turnId":"turn","startedAtMs":2,` +
+				`"completedAtMs":1,"reviewId":"review","targetItemId":"item",` +
+				`"decisionSource":"agent","review":` + validReview + `,"action":` + validAction + `}`,
+			want: ItemGuardianApprovalReviewCompletedNotification{
+				ThreadID: "thread", TurnID: "turn", StartedAtMS: 2, CompletedAtMS: 1,
+				ReviewID: "review", TargetItemID: ptr("item"),
+				DecisionSource: AutoReviewDecisionSourceAgent,
+				Review:         GuardianApprovalReview{Status: GuardianApprovalReviewStatusApproved},
+				Action:         mustGuardianApprovalReviewAction(t, validAction),
+			},
+			canonical: `{"threadId":"thread","turnId":"turn","startedAtMs":2,"completedAtMs":1,` +
+				`"reviewId":"review","targetItemId":"item","decisionSource":"agent",` +
+				`"review":{"status":"approved","riskLevel":null,"userAuthorization":null,"rationale":null},` +
+				`"action":{"type":"command","source":"shell","command":"","cwd":"/workspace"}}`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var got ItemGuardianApprovalReviewCompletedNotification
+			if err := json.Unmarshal([]byte(test.input), &got); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("decoded = %#v, want %#v", got, test.want)
+			}
+			encoded, err := json.Marshal(got)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if string(encoded) != test.canonical {
+				t.Fatalf("canonical = %s, want %s", encoded, test.canonical)
+			}
+		})
+	}
+}
+
+func TestGuardianApprovalReviewCompletedNotificationRejectsMalformedWireForms(t *testing.T) {
+	valid := `{"threadId":"thread","turnId":"turn","startedAtMs":1,"completedAtMs":2,` +
+		`"reviewId":"review","decisionSource":"agent","review":{"status":"approved"},` +
+		`"action":{"type":"applyPatch","cwd":"/workspace","files":[]}}`
+	for _, input := range []string{
+		``, `null`, `[]`, `1`, `true`, `"value"`, `{`, `{}`,
+		strings.Replace(valid, `"threadId":"thread",`, ``, 1),
+		strings.Replace(valid, `"turnId":"turn",`, ``, 1),
+		strings.Replace(valid, `"startedAtMs":1,`, ``, 1),
+		strings.Replace(valid, `"completedAtMs":2,`, ``, 1),
+		strings.Replace(valid, `"reviewId":"review",`, ``, 1),
+		strings.Replace(valid, `"decisionSource":"agent",`, ``, 1),
+		strings.Replace(valid, `"review":{"status":"approved"},`, ``, 1),
+		strings.Replace(valid, `,"action":{"type":"applyPatch","cwd":"/workspace","files":[]}`, ``, 1),
+		strings.Replace(valid, `"threadId":"thread"`, `"threadId":null`, 1),
+		strings.Replace(valid, `"startedAtMs":1`, `"startedAtMs":1.5`, 1),
+		strings.Replace(valid, `"startedAtMs":1`, `"startedAtMs":9223372036854775808`, 1),
+		strings.Replace(valid, `"completedAtMs":2`, `"completedAtMs":null`, 1),
+		strings.Replace(valid, `"completedAtMs":2`, `"completedAtMs":-9223372036854775809`, 1),
+		strings.Replace(valid, `"decisionSource":"agent"`, `"decisionSource":"other"`, 1),
+		strings.Replace(valid, `"review":{"status":"approved"}`, `"review":null`, 1),
+		strings.Replace(valid, `"action":{"type":"applyPatch","cwd":"/workspace","files":[]}`, `"action":null`, 1),
+		strings.Replace(valid, `"reviewId":"review"`, `"targetItemId":1,"reviewId":"review"`, 1),
+		strings.Replace(valid, `"threadId":"thread"`, `"threadId":"thread","threadId":"other"`, 1),
+		strings.Replace(valid, `"completedAtMs":2`, `"completedAtMs":2,"completedAtMs":3`, 1),
+		valid + ` {}`,
+		valid + ` x`,
+	} {
+		assertJSONRejects[ItemGuardianApprovalReviewCompletedNotification](t, input)
+	}
+}
+
+func TestGuardianApprovalReviewCompletedNotificationNilReceiverAndInvalidValuesFailClosed(t *testing.T) {
+	var notification *ItemGuardianApprovalReviewCompletedNotification
+	if err := notification.UnmarshalJSON([]byte(`{}`)); err == nil {
+		t.Fatal("nil completed-notification receiver succeeded")
+	}
+	validAction := mustGuardianApprovalReviewAction(t,
+		`{"type":"command","source":"shell","command":"","cwd":"/workspace"}`)
+	for _, notification := range []ItemGuardianApprovalReviewCompletedNotification{
+		{},
+		{
+			DecisionSource: AutoReviewDecisionSource("other"),
+			Review:         GuardianApprovalReview{Status: GuardianApprovalReviewStatusApproved},
+			Action:         validAction,
+		},
+	} {
+		if _, err := json.Marshal(notification); err == nil {
+			t.Fatalf("invalid notification marshaled: %#v", notification)
+		}
+	}
+}
+
+func TestGuardianApprovalReviewCompletedNotificationRemainsStandalone(t *testing.T) {
+	const typeName = "ItemGuardianApprovalReviewCompletedNotification"
+	for _, binding := range WireTypeBindings() {
+		if slices.Contains(binding.Params, typeName) || slices.Contains(binding.Result, typeName) {
+			t.Fatalf("completed notification unexpectedly bound to %s", binding.Method)
+		}
+	}
+	for _, binding := range ItemPayloadBindings() {
+		if binding.Type == typeName {
+			t.Fatalf("completed notification unexpectedly bound to item %s", binding.Kind)
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+	for _, method := range Methods() {
+		if (method.Method == "item/autoApprovalReview/started" ||
+			method.Method == "item/autoApprovalReview/completed") && method.State != MethodBlocked {
+			t.Fatalf("%s state = %s, want blocked", method.Method, method.State)
+		}
+	}
+}
+
+func TestGuardianApprovalReviewCompletedNotificationTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	want := `export type ItemGuardianApprovalReviewCompletedNotification = {
+  "action": GuardianApprovalReviewAction;
+  "completedAtMs": number;
+  "decisionSource": AutoReviewDecisionSource;
+  "review": GuardianApprovalReview;
+  "reviewId": string;
+  "startedAtMs": number;
+  "targetItemId": string | null;
+  "threadId": string;
+  "turnId": string;
+};`
+	if !strings.Contains(string(generated), want) {
+		t.Errorf("generated TypeScript missing %q", want)
+	}
+	for _, forbidden := range []string{`"targetItemId"?:`, `"startedAtMs": bigint`} {
+		if strings.Contains(string(generated), forbidden) {
+			t.Errorf("generated TypeScript unexpectedly contains %q", forbidden)
+		}
+	}
+}
+
+var (
+	_ json.Marshaler   = ItemGuardianApprovalReviewCompletedNotification{}
+	_ json.Unmarshaler = (*ItemGuardianApprovalReviewCompletedNotification)(nil)
+)

--- a/appserver/protocol/guardian_approval_review_completed_notification_types.go
+++ b/appserver/protocol/guardian_approval_review_completed_notification_types.go
@@ -1,0 +1,121 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// ItemGuardianApprovalReviewCompletedNotification is the exact unstable public
+// description of a Guardian review completion. It does not produce or authorize a review.
+type ItemGuardianApprovalReviewCompletedNotification struct {
+	ThreadID       string                       `json:"threadId"`
+	TurnID         string                       `json:"turnId"`
+	StartedAtMS    int64                        `json:"startedAtMs"`
+	CompletedAtMS  int64                        `json:"completedAtMs"`
+	ReviewID       string                       `json:"reviewId"`
+	TargetItemID   *string                      `json:"targetItemId"`
+	DecisionSource AutoReviewDecisionSource     `json:"decisionSource"`
+	Review         GuardianApprovalReview       `json:"review"`
+	Action         GuardianApprovalReviewAction `json:"action"`
+}
+
+func (n ItemGuardianApprovalReviewCompletedNotification) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		ThreadID       string                       `json:"threadId"`
+		TurnID         string                       `json:"turnId"`
+		StartedAtMS    int64                        `json:"startedAtMs"`
+		CompletedAtMS  int64                        `json:"completedAtMs"`
+		ReviewID       string                       `json:"reviewId"`
+		TargetItemID   *string                      `json:"targetItemId"`
+		DecisionSource AutoReviewDecisionSource     `json:"decisionSource"`
+		Review         GuardianApprovalReview       `json:"review"`
+		Action         GuardianApprovalReviewAction `json:"action"`
+	}{
+		ThreadID: n.ThreadID, TurnID: n.TurnID,
+		StartedAtMS: n.StartedAtMS, CompletedAtMS: n.CompletedAtMS,
+		ReviewID: n.ReviewID, TargetItemID: n.TargetItemID,
+		DecisionSource: n.DecisionSource, Review: n.Review, Action: n.Action,
+	})
+}
+
+func (n *ItemGuardianApprovalReviewCompletedNotification) UnmarshalJSON(data []byte) error {
+	if n == nil {
+		return errors.New("decode Guardian approval-review-completed notification into nil receiver")
+	}
+	const objectName = "Guardian approval-review-completed notification"
+	payload, err := decodeRustSerdeObject(
+		data, objectName,
+		"threadId", "turnId", "startedAtMs", "completedAtMs", "reviewId",
+		"targetItemId", "decisionSource", "review", "action",
+	)
+	if err != nil {
+		return err
+	}
+	threadID, err := decodeRequiredThreadItemValue[string](payload, objectName, "threadId")
+	if err != nil {
+		return err
+	}
+	turnID, err := decodeRequiredThreadItemValue[string](payload, objectName, "turnId")
+	if err != nil {
+		return err
+	}
+	startedAtMS, err := decodeRequiredThreadItemValue[int64](payload, objectName, "startedAtMs")
+	if err != nil {
+		return err
+	}
+	completedAtMS, err := decodeRequiredThreadItemValue[int64](payload, objectName, "completedAtMs")
+	if err != nil {
+		return err
+	}
+	reviewID, err := decodeRequiredThreadItemValue[string](payload, objectName, "reviewId")
+	if err != nil {
+		return err
+	}
+	targetItemID, err := decodeOptionalNullableConfigValue[string](payload, objectName, "targetItemId")
+	if err != nil {
+		return err
+	}
+	decisionSource, err := decodeRequiredThreadItemValue[AutoReviewDecisionSource](
+		payload, objectName, "decisionSource",
+	)
+	if err != nil {
+		return err
+	}
+	review, err := decodeRequiredThreadItemValue[GuardianApprovalReview](payload, objectName, "review")
+	if err != nil {
+		return err
+	}
+	action, err := decodeRequiredThreadItemValue[GuardianApprovalReviewAction](payload, objectName, "action")
+	if err != nil {
+		return err
+	}
+	*n = ItemGuardianApprovalReviewCompletedNotification{
+		ThreadID: threadID, TurnID: turnID,
+		StartedAtMS: startedAtMS, CompletedAtMS: completedAtMS,
+		ReviewID: reviewID, TargetItemID: targetItemID,
+		DecisionSource: decisionSource, Review: review, Action: action,
+	}
+	return nil
+}
+
+func guardianApprovalReviewCompletedNotificationSchema() Schema {
+	return closedThreadSessionParamSchema(Schema{
+		"threadId":       Schema{"type": "string"},
+		"turnId":         Schema{"type": "string"},
+		"startedAtMs":    Schema{"type": "integer"},
+		"completedAtMs":  Schema{"type": "integer"},
+		"reviewId":       Schema{"type": "string"},
+		"targetItemId":   Schema{"type": []any{"string", "null"}},
+		"decisionSource": Schema{"$ref": "#/$defs/AutoReviewDecisionSource"},
+		"review":         Schema{"$ref": "#/$defs/GuardianApprovalReview"},
+		"action":         Schema{"$ref": "#/$defs/GuardianApprovalReviewAction"},
+	}, []string{
+		"threadId", "turnId", "startedAtMs", "completedAtMs", "reviewId",
+		"decisionSource", "review", "action",
+	})
+}
+
+var (
+	_ json.Marshaler   = ItemGuardianApprovalReviewCompletedNotification{}
+	_ json.Unmarshaler = (*ItemGuardianApprovalReviewCompletedNotification)(nil)
+)

--- a/appserver/protocol/guardian_approval_review_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_contract_test.go
@@ -139,8 +139,8 @@ func TestGuardianApprovalReviewRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReview unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
@@ -175,8 +175,8 @@ func TestGuardianApprovalReviewStartedNotificationRemainsStandalone(t *testing.T
 			t.Fatalf("started notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_enum_foundation_contract_test.go
+++ b/appserver/protocol/guardian_enum_foundation_contract_test.go
@@ -89,8 +89,8 @@ func TestGuardianEnumFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_metadata_list_contract_test.go
+++ b/appserver/protocol/hook_metadata_list_contract_test.go
@@ -352,8 +352,8 @@ func TestHookMetadataListContractsStayStandalone(t *testing.T) {
 			t.Errorf("standalone definition %s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Errorf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Errorf("definition count = %d, want 434", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 {
 		t.Errorf("wire binding count = %d, want 59", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_run_notification_contract_test.go
+++ b/appserver/protocol/hook_run_notification_contract_test.go
@@ -297,8 +297,8 @@ func TestHookRunNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("surface changed: %d methods, %d wire bindings, %d item bindings", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/hook_value_foundation_contract_test.go
+++ b/appserver/protocol/hook_value_foundation_contract_test.go
@@ -167,8 +167,8 @@ func TestHookValueFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 433 {
-		t.Fatalf("definition count = %d, want 433", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 434 {
+		t.Fatalf("definition count = %d, want 434", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 433 {
-		t.Fatalf("definition count = %d, want 433", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 434 {
+		t.Fatalf("definition count = %d, want 434", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 433 {
-		t.Fatalf("definition count = %d, want 433", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 434 {
+		t.Fatalf("definition count = %d, want 434", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 433 {
-		t.Fatalf("definition count = %d, want 433", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 434 {
+		t.Fatalf("definition count = %d, want 434", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 433 {
-		t.Fatalf("definition count = %d, want 433", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 434 {
+		t.Fatalf("definition count = %d, want 434", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 433 {
-		t.Fatalf("definition count = %d, want 433", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 434 {
+		t.Fatalf("definition count = %d, want 434", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -355,6 +355,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "HooksListEntry", Type: reflect.TypeFor[HooksListEntry]()},
 		{Name: "HooksListParams", Type: reflect.TypeFor[HooksListParams]()},
 		{Name: "HooksListResponse", Type: reflect.TypeFor[HooksListResponse]()},
+		{Name: "ItemGuardianApprovalReviewCompletedNotification", Type: reflect.TypeFor[ItemGuardianApprovalReviewCompletedNotification]()},
 		{Name: "ItemGuardianApprovalReviewStartedNotification", Type: reflect.TypeFor[ItemGuardianApprovalReviewStartedNotification]()},
 		{Name: "NetworkApprovalProtocol", Type: reflect.TypeFor[NetworkApprovalProtocol]()},
 		{Name: "PermissionGrantScope", Type: reflect.TypeFor[PermissionGrantScope]()},
@@ -688,6 +689,7 @@ func wireSchemaDefinitions() Schema {
 	schemas["HooksListEntry"] = hooksListEntrySchema()
 	schemas["HooksListParams"] = hooksListParamsSchema()
 	schemas["HooksListResponse"] = hooksListResponseSchema()
+	schemas["ItemGuardianApprovalReviewCompletedNotification"] = guardianApprovalReviewCompletedNotificationSchema()
 	schemas["ItemGuardianApprovalReviewStartedNotification"] = guardianApprovalReviewStartedNotificationSchema()
 	schemas["NetworkApprovalProtocol"] = stringEnumSchema(
 		string(NetworkApprovalProtocolHTTP), string(NetworkApprovalProtocolHTTPS),

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -5506,6 +5506,52 @@
       ],
       "type": "object"
     },
+    "ItemGuardianApprovalReviewCompletedNotification": {
+      "additionalProperties": false,
+      "properties": {
+        "action": {
+          "$ref": "#/$defs/GuardianApprovalReviewAction"
+        },
+        "completedAtMs": {
+          "type": "integer"
+        },
+        "decisionSource": {
+          "$ref": "#/$defs/AutoReviewDecisionSource"
+        },
+        "review": {
+          "$ref": "#/$defs/GuardianApprovalReview"
+        },
+        "reviewId": {
+          "type": "string"
+        },
+        "startedAtMs": {
+          "type": "integer"
+        },
+        "targetItemId": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "threadId": {
+          "type": "string"
+        },
+        "turnId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "threadId",
+        "turnId",
+        "startedAtMs",
+        "completedAtMs",
+        "reviewId",
+        "decisionSource",
+        "review",
+        "action"
+      ],
+      "type": "object"
+    },
     "ItemGuardianApprovalReviewStartedNotification": {
       "additionalProperties": false,
       "properties": {

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 433 {
-		t.Fatalf("definition count = %d, want 433", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 434 {
+		t.Fatalf("definition count = %d, want 434", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 433 {
-		t.Fatalf("definition count = %d, want 433", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 434 {
+		t.Fatalf("definition count = %d, want 434", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 433 {
-		t.Fatalf("definition count = %d, want 433", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 434 {
+		t.Fatalf("definition count = %d, want 434", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -46,6 +46,7 @@ func MarshalTypeScript() ([]byte, error) {
 			name == "HookRunSummary" || name == "HookStartedNotification" ||
 			name == "HookCompletedNotification" || name == "HookMetadata" ||
 			name == "GuardianApprovalReview" ||
+			name == "ItemGuardianApprovalReviewCompletedNotification" ||
 			name == "ItemGuardianApprovalReviewStartedNotification" {
 			// Rust accepts omitted serde default/Option fields while generated
 			// TypeScript requires callers to provide their canonical values.
@@ -91,6 +92,11 @@ func MarshalTypeScript() ([]byte, error) {
 			case "GuardianApprovalReview":
 				schema["required"] = []string{
 					"status", "riskLevel", "userAuthorization", "rationale",
+				}
+			case "ItemGuardianApprovalReviewCompletedNotification":
+				schema["required"] = []string{
+					"threadId", "turnId", "startedAtMs", "completedAtMs", "reviewId",
+					"targetItemId", "decisionSource", "review", "action",
 				}
 			case "ItemGuardianApprovalReviewStartedNotification":
 				schema["required"] = []string{
@@ -142,7 +148,8 @@ func MarshalTypeScript() ([]byte, error) {
 		if name == "GuardianApprovalReviewAction" {
 			definition = guardianApprovalReviewActionTypeScriptSchema(definition)
 		}
-		if name == "ItemGuardianApprovalReviewStartedNotification" {
+		if name == "ItemGuardianApprovalReviewCompletedNotification" ||
+			name == "ItemGuardianApprovalReviewStartedNotification" {
 			definition = typeScriptDefinitionWithPropertySchemas(definition, Schema{
 				"targetItemId": Schema{
 					"anyOf": []any{Schema{"type": "string"}, Schema{"type": "null"}},

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -1681,6 +1681,18 @@ export type ItemCompletedNotification = {
   "turnId": string;
 };
 
+export type ItemGuardianApprovalReviewCompletedNotification = {
+  "action": GuardianApprovalReviewAction;
+  "completedAtMs": number;
+  "decisionSource": AutoReviewDecisionSource;
+  "review": GuardianApprovalReview;
+  "reviewId": string;
+  "startedAtMs": number;
+  "targetItemId": string | null;
+  "threadId": string;
+  "turnId": string;
+};
+
 export type ItemGuardianApprovalReviewStartedNotification = {
   "action": GuardianApprovalReviewAction;
   "review": GuardianApprovalReview;

--- a/appserver/protocol/typescript/testdata/guardian_approval_review_completed_notification_contract.ts
+++ b/appserver/protocol/typescript/testdata/guardian_approval_review_completed_notification_contract.ts
@@ -1,0 +1,95 @@
+import type {
+  AutoReviewDecisionSource,
+  GuardianApprovalReview,
+  GuardianApprovalReviewAction,
+  ItemGuardianApprovalReviewCompletedNotification,
+  MethodParamsByName,
+  MethodResultsByName,
+} from "../gollem_appserver_protocol.js";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+type GuardianNotificationMethod =
+  | "item/autoApprovalReview/started"
+  | "item/autoApprovalReview/completed";
+
+type Contracts = [
+  Expect<Equal<ItemGuardianApprovalReviewCompletedNotification, {
+    threadId: string;
+    turnId: string;
+    startedAtMs: number;
+    completedAtMs: number;
+    reviewId: string;
+    targetItemId: string | null;
+    decisionSource: AutoReviewDecisionSource;
+    review: GuardianApprovalReview;
+    action: GuardianApprovalReviewAction;
+  }>>,
+  Expect<Equal<Extract<keyof MethodParamsByName, GuardianNotificationMethod>, never>>,
+  Expect<Equal<Extract<keyof MethodResultsByName, GuardianNotificationMethod>, never>>,
+];
+
+const review: GuardianApprovalReview = {
+  status: "approved",
+  riskLevel: null,
+  userAuthorization: null,
+  rationale: null,
+};
+const action: GuardianApprovalReviewAction = {
+  type: "command",
+  source: "shell",
+  command: "",
+  cwd: "/workspace",
+};
+
+({
+  threadId: "",
+  turnId: "",
+  startedAtMs: Number.MIN_SAFE_INTEGER,
+  completedAtMs: Number.MAX_SAFE_INTEGER,
+  reviewId: "",
+  targetItemId: null,
+  decisionSource: "agent",
+  review,
+  action,
+}) satisfies ItemGuardianApprovalReviewCompletedNotification;
+({
+  threadId: "thread",
+  turnId: "turn",
+  startedAtMs: 2,
+  completedAtMs: 1,
+  reviewId: "review",
+  targetItemId: "item",
+  decisionSource: "agent",
+  review,
+  action,
+}) satisfies ItemGuardianApprovalReviewCompletedNotification;
+
+// @ts-expect-error threadId is required.
+({ turnId: "", startedAtMs: 0, completedAtMs: 0, reviewId: "", targetItemId: null, decisionSource: "agent", review, action }) satisfies ItemGuardianApprovalReviewCompletedNotification;
+// @ts-expect-error turnId is required.
+({ threadId: "", startedAtMs: 0, completedAtMs: 0, reviewId: "", targetItemId: null, decisionSource: "agent", review, action }) satisfies ItemGuardianApprovalReviewCompletedNotification;
+// @ts-expect-error startedAtMs is required.
+({ threadId: "", turnId: "", completedAtMs: 0, reviewId: "", targetItemId: null, decisionSource: "agent", review, action }) satisfies ItemGuardianApprovalReviewCompletedNotification;
+// @ts-expect-error completedAtMs is required.
+({ threadId: "", turnId: "", startedAtMs: 0, reviewId: "", targetItemId: null, decisionSource: "agent", review, action }) satisfies ItemGuardianApprovalReviewCompletedNotification;
+// @ts-expect-error timestamps are numbers, not bigint.
+({ threadId: "", turnId: "", startedAtMs: 0n, completedAtMs: 0n, reviewId: "", targetItemId: null, decisionSource: "agent", review, action }) satisfies ItemGuardianApprovalReviewCompletedNotification;
+// @ts-expect-error reviewId is required.
+({ threadId: "", turnId: "", startedAtMs: 0, completedAtMs: 0, targetItemId: null, decisionSource: "agent", review, action }) satisfies ItemGuardianApprovalReviewCompletedNotification;
+// @ts-expect-error targetItemId is required nullable output.
+({ threadId: "", turnId: "", startedAtMs: 0, completedAtMs: 0, reviewId: "", decisionSource: "agent", review, action }) satisfies ItemGuardianApprovalReviewCompletedNotification;
+// @ts-expect-error decisionSource is required and closed.
+({ threadId: "", turnId: "", startedAtMs: 0, completedAtMs: 0, reviewId: "", targetItemId: null, decisionSource: "other", review, action }) satisfies ItemGuardianApprovalReviewCompletedNotification;
+// @ts-expect-error review is required and non-null.
+({ threadId: "", turnId: "", startedAtMs: 0, completedAtMs: 0, reviewId: "", targetItemId: null, decisionSource: "agent", review: null, action }) satisfies ItemGuardianApprovalReviewCompletedNotification;
+// @ts-expect-error action is required and non-null.
+({ threadId: "", turnId: "", startedAtMs: 0, completedAtMs: 0, reviewId: "", targetItemId: null, decisionSource: "agent", review, action: null }) satisfies ItemGuardianApprovalReviewCompletedNotification;
+// @ts-expect-error records are closed.
+({ threadId: "", turnId: "", startedAtMs: 0, completedAtMs: 0, reviewId: "", targetItemId: null, decisionSource: "agent", review, action, extra: true }) satisfies ItemGuardianApprovalReviewCompletedNotification;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 433 {
-		t.Fatalf("definition count = %d, want 433", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
+		t.Fatalf("definition count = %d, want 434", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary

- export the exact standalone unstable `ItemGuardianApprovalReviewCompletedNotification`
- preserve serde-compatible omitted/null target input while generating canonical required-nullable TypeScript
- enforce strict signed-int64 timestamps, closed decision source, nested review/action contracts, duplicate rejection, and trailing-input rejection
- keep both Guardian notification methods and every method/item binding unchanged
- advance global schema-definition invariants from 433 to 434

## Boundary

This record is descriptive data only. The change adds no dispatcher, producer, lifecycle ordering, replay, persistence, assessment, approval, action execution, policy enforcement, item binding, or runtime/security authority.

## Verification

- deliberate-red Go and strict TypeScript boundaries
- 30 focused repetitions and focused race
- 100% focused statement coverage for all three new production functions
- full protocol normal/race and 97.3% aggregate coverage
- normal/race suites across exactly 59 non-Monty packages
- zero-issue lint, non-Monty vet, tidy, module verify, and configured pre-push gates
- deterministic 434-definition/59-method/5-item generation with 224 methods unchanged
- exact normalized pinned-upstream schema and compiler-parsed TypeScript semantics
- exact structural reversal to PR #201 tree `4bf2172f725742984e1ba2d319340a36367a07e8`
- all five existing Slang real-process workflows and byte-identical fixed live transcript
- reproducible binary SHA-256 `d8f286023a504b51c7fe5537b8f63c429afd2f6697641378f639dd421169ee8e`

Local Monty normal/race/coverage tests remain skipped per project direction; hosted CI is unchanged.
