### PR TITLE
feat(protocol): export attestation contracts

### DIFF
--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(defs); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/attestation_contract_test.go
+++ b/appserver/protocol/attestation_contract_test.go
@@ -1,0 +1,160 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestAttestationContractsSchemaIsExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	wantParams := Schema{
+		"type":                 "object",
+		"additionalProperties": false,
+	}
+	if got := defs["AttestationGenerateParams"]; !reflect.DeepEqual(got, wantParams) {
+		t.Fatalf("AttestationGenerateParams = %#v, want %#v", got, wantParams)
+	}
+	wantResponse := Schema{
+		"type": "object",
+		"properties": Schema{
+			"token": Schema{
+				"type":        "string",
+				"description": "Opaque client attestation token.",
+			},
+		},
+		"required":             []string{"token"},
+		"additionalProperties": false,
+	}
+	if got := defs["AttestationGenerateResponse"]; !reflect.DeepEqual(got, wantResponse) {
+		t.Fatalf("AttestationGenerateResponse = %#v, want %#v", got, wantResponse)
+	}
+}
+
+func TestAttestationGenerateParamsAcceptsSerdeObjects(t *testing.T) {
+	for _, input := range []string{
+		`{}`,
+		`{"future":true}`,
+		`{"nested":{"value":[1,null,"two"]}}`,
+		`{"future":1,"future":2}`,
+	} {
+		var params AttestationGenerateParams
+		if err := json.Unmarshal([]byte(input), &params); err != nil {
+			t.Errorf("Unmarshal(%s): %v", input, err)
+			continue
+		}
+		encoded, err := json.Marshal(params)
+		if err != nil {
+			t.Errorf("Marshal(%s): %v", input, err)
+			continue
+		}
+		if string(encoded) != `{}` {
+			t.Errorf("round trip %s = %s, want {}", input, encoded)
+		}
+	}
+}
+
+func TestAttestationGenerateParamsRejectsMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`, `{} {}`, `{} x`,
+	} {
+		assertJSONRejects[AttestationGenerateParams](t, input)
+	}
+
+	var params *AttestationGenerateParams
+	if err := params.UnmarshalJSON([]byte(`{}`)); err == nil {
+		t.Fatal("nil AttestationGenerateParams receiver succeeded")
+	}
+}
+
+func TestAttestationGenerateResponseAcceptsSerdeWireForms(t *testing.T) {
+	for _, test := range []struct {
+		input string
+		want  string
+	}{
+		{input: `{"token":""}`, want: `{"token":""}`},
+		{input: `{"future":true,"token":"opaque token"}`, want: `{"token":"opaque token"}`},
+		{input: `{"token":"line\nvalue","nested":{"value":1}}`, want: `{"token":"line\nvalue"}`},
+		{input: `{"token":"value","future":1,"future":2}`, want: `{"token":"value"}`},
+	} {
+		var response AttestationGenerateResponse
+		if err := json.Unmarshal([]byte(test.input), &response); err != nil {
+			t.Errorf("Unmarshal(%s): %v", test.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(response)
+		if err != nil {
+			t.Errorf("Marshal(%s): %v", test.input, err)
+			continue
+		}
+		if string(encoded) != test.want {
+			t.Errorf("round trip %s = %s, want %s", test.input, encoded, test.want)
+		}
+	}
+}
+
+func TestAttestationGenerateResponseRejectsMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		``, `{}`, `null`, `[]`, `"value"`, `1`, `true`, `{`,
+		`{"token":null}`,
+		`{"token":1}`,
+		`{"token":true}`,
+		`{"token":[]}`,
+		`{"token":{}}`,
+		`{"token":"one","token":"two"}`,
+		`{"token":"value"} {}`,
+		`{"token":"value"} x`,
+	} {
+		assertJSONRejects[AttestationGenerateResponse](t, input)
+	}
+
+	var response *AttestationGenerateResponse
+	if err := response.UnmarshalJSON([]byte(`{"token":"value"}`)); err == nil {
+		t.Fatal("nil AttestationGenerateResponse receiver succeeded")
+	}
+}
+
+func TestAttestationContractsRemainStandalone(t *testing.T) {
+	for _, typeName := range []string{"AttestationGenerateParams", "AttestationGenerateResponse"} {
+		for _, binding := range WireTypeBindings() {
+			if slices.Contains(binding.Params, typeName) || slices.Contains(binding.Result, typeName) {
+				t.Fatalf("%s unexpectedly bound to %s", typeName, binding.Method)
+			}
+		}
+		for _, binding := range ItemPayloadBindings() {
+			if binding.Type == typeName {
+				t.Fatalf("%s unexpectedly bound to item %s", typeName, binding.Kind)
+			}
+		}
+	}
+	info, ok := LookupMethod("attestation/generate")
+	if !ok || info.State != MethodBlocked {
+		t.Fatalf("attestation/generate = %#v, %v; want blocked", info, ok)
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestAttestationContractsTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	for _, want := range []string{
+		`export type AttestationGenerateParams = Record<string, never>;`,
+		"export type AttestationGenerateResponse = {\n  \"token\": string;\n};",
+	} {
+		if !strings.Contains(string(generated), want) {
+			t.Fatalf("generated TypeScript missing %q", want)
+		}
+	}
+}

--- a/appserver/protocol/attestation_types.go
+++ b/appserver/protocol/attestation_types.go
@@ -1,0 +1,58 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// AttestationGenerateParams is the exact empty public attestation request. It
+// remains standalone until Slang owns an attestation provider and threat model.
+type AttestationGenerateParams struct{}
+
+func (p *AttestationGenerateParams) UnmarshalJSON(data []byte) error {
+	if p == nil {
+		return errors.New("decode attestation generation params into nil receiver")
+	}
+
+	// Serde ignores unknown fields for this empty struct. Decode through a map
+	// to preserve that input compatibility while still requiring one object.
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(data, &object); err != nil {
+		return fmt.Errorf("decode attestation generation params: %w", err)
+	}
+	if object == nil {
+		return errors.New("attestation generation params must be an object")
+	}
+
+	*p = AttestationGenerateParams{}
+	return nil
+}
+
+// AttestationGenerateResponse is the exact public opaque-token response. It
+// describes wire data only and does not generate, validate, or trust a token.
+type AttestationGenerateResponse struct {
+	Token string `json:"token" jsonschema:"description=Opaque client attestation token."`
+}
+
+func (r *AttestationGenerateResponse) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("decode attestation generation response into nil receiver")
+	}
+	const objectName = "attestation generation response"
+	payload, err := decodeRustSerdeObject(data, objectName, "token")
+	if err != nil {
+		return err
+	}
+	token, err := decodeRequiredThreadItemValue[string](payload, objectName, "token")
+	if err != nil {
+		return err
+	}
+	*r = AttestationGenerateResponse{Token: token}
+	return nil
+}
+
+var (
+	_ json.Unmarshaler = (*AttestationGenerateParams)(nil)
+	_ json.Unmarshaler = (*AttestationGenerateResponse)(nil)
+)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,8 +217,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,8 +203,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -260,8 +260,8 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,8 +244,8 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -162,8 +162,8 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -175,8 +175,8 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -381,8 +381,8 @@ func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_action_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_action_contract_test.go
@@ -226,8 +226,8 @@ func TestGuardianApprovalReviewActionRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReviewAction unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
@@ -164,8 +164,8 @@ func TestGuardianApprovalReviewCompletedNotificationRemainsStandalone(t *testing
 			t.Fatalf("completed notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_contract_test.go
@@ -139,8 +139,8 @@ func TestGuardianApprovalReviewRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReview unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
@@ -175,8 +175,8 @@ func TestGuardianApprovalReviewStartedNotificationRemainsStandalone(t *testing.T
 			t.Fatalf("started notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_enum_foundation_contract_test.go
+++ b/appserver/protocol/guardian_enum_foundation_contract_test.go
@@ -89,8 +89,8 @@ func TestGuardianEnumFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_metadata_list_contract_test.go
+++ b/appserver/protocol/hook_metadata_list_contract_test.go
@@ -352,8 +352,8 @@ func TestHookMetadataListContractsStayStandalone(t *testing.T) {
 			t.Errorf("standalone definition %s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Errorf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Errorf("definition count = %d, want 436", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 {
 		t.Errorf("wire binding count = %d, want 59", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_run_notification_contract_test.go
+++ b/appserver/protocol/hook_run_notification_contract_test.go
@@ -297,8 +297,8 @@ func TestHookRunNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("surface changed: %d methods, %d wire bindings, %d item bindings", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/hook_value_foundation_contract_test.go
+++ b/appserver/protocol/hook_value_foundation_contract_test.go
@@ -167,8 +167,8 @@ func TestHookValueFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 434 {
-		t.Fatalf("definition count = %d, want 434", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 436 {
+		t.Fatalf("definition count = %d, want 436", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 434 {
-		t.Fatalf("definition count = %d, want 434", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 436 {
+		t.Fatalf("definition count = %d, want 436", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 434 {
-		t.Fatalf("definition count = %d, want 434", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 436 {
+		t.Fatalf("definition count = %d, want 436", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 434 {
-		t.Fatalf("definition count = %d, want 434", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 436 {
+		t.Fatalf("definition count = %d, want 436", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 434 {
-		t.Fatalf("definition count = %d, want 434", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 436 {
+		t.Fatalf("definition count = %d, want 436", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 434 {
-		t.Fatalf("definition count = %d, want 434", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 436 {
+		t.Fatalf("definition count = %d, want 436", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -93,6 +93,8 @@ func wireSchemaDefinitions() Schema {
 		{Name: "AdditionalPermissionProfile", Type: reflect.TypeFor[AdditionalPermissionProfile]()},
 		{Name: "AmazonBedrockCredentialSource", Type: reflect.TypeFor[AmazonBedrockCredentialSource]()},
 		{Name: "AnalyticsConfig", Type: reflect.TypeFor[AnalyticsConfig]()},
+		{Name: "AttestationGenerateParams", Type: reflect.TypeFor[AttestationGenerateParams]()},
+		{Name: "AttestationGenerateResponse", Type: reflect.TypeFor[AttestationGenerateResponse]()},
 		{Name: "AuthMode", Type: reflect.TypeFor[AuthMode]()},
 		{Name: "ApprovalRequestBase", Type: reflect.TypeFor[ApprovalRequestBase]()},
 		{Name: "ApprovalRespondParams", Type: reflect.TypeFor[ApprovalRespondParams]()},

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -382,6 +382,23 @@
         }
       ]
     },
+    "AttestationGenerateParams": {
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "AttestationGenerateResponse": {
+      "additionalProperties": false,
+      "properties": {
+        "token": {
+          "description": "Opaque client attestation token.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "token"
+      ],
+      "type": "object"
+    },
     "AuthMode": {
       "enum": [
         "apikey",

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 434 {
-		t.Fatalf("definition count = %d, want 434", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 436 {
+		t.Fatalf("definition count = %d, want 436", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 434 {
-		t.Fatalf("definition count = %d, want 434", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 436 {
+		t.Fatalf("definition count = %d, want 436", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 434 {
-		t.Fatalf("definition count = %d, want 434", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 436 {
+		t.Fatalf("definition count = %d, want 436", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -578,6 +578,12 @@ export type AskForApproval = "untrusted" | "on-request" | {
   };
 } | "never";
 
+export type AttestationGenerateParams = Record<string, never>;
+
+export type AttestationGenerateResponse = {
+  "token": string;
+};
+
 export type AuthMode = "apikey" | "chatgpt" | "chatgptAuthTokens" | "headers" | "agentIdentity" | "personalAccessToken" | "bedrockApiKey";
 
 export type AutoCompactTokenLimitScope = "total" | "body_after_prefix";

--- a/appserver/protocol/typescript/testdata/attestation_contract.ts
+++ b/appserver/protocol/typescript/testdata/attestation_contract.ts
@@ -1,0 +1,50 @@
+import type {
+  AttestationGenerateParams,
+  AttestationGenerateResponse,
+  MethodParamsByName,
+  MethodResultsByName,
+} from "../gollem_appserver_protocol.js";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+
+type Contracts = [
+  Expect<Equal<AttestationGenerateParams, Record<string, never>>>,
+  Expect<Equal<AttestationGenerateResponse, { token: string }>>,
+  Expect<Equal<Extract<keyof MethodParamsByName, "attestation/generate">, never>>,
+  Expect<Equal<Extract<keyof MethodResultsByName, "attestation/generate">, never>>,
+];
+
+({}) satisfies AttestationGenerateParams;
+({ token: "" }) satisfies AttestationGenerateResponse;
+({ token: "opaque token" }) satisfies AttestationGenerateResponse;
+
+// @ts-expect-error empty params have no known fields.
+({ future: true }) satisfies AttestationGenerateParams;
+// @ts-expect-error params are non-null objects.
+(null) satisfies AttestationGenerateParams;
+// @ts-expect-error params are not arrays.
+([]) satisfies AttestationGenerateParams;
+// @ts-expect-error params are not strings.
+("") satisfies AttestationGenerateParams;
+// @ts-expect-error params are not numbers.
+(0) satisfies AttestationGenerateParams;
+// @ts-expect-error params are not booleans.
+(false) satisfies AttestationGenerateParams;
+
+// @ts-expect-error token is required.
+({}) satisfies AttestationGenerateResponse;
+// @ts-expect-error token is non-null.
+({ token: null }) satisfies AttestationGenerateResponse;
+// @ts-expect-error token is a string.
+({ token: 1 }) satisfies AttestationGenerateResponse;
+// @ts-expect-error responses have no extra fields.
+({ token: "value", extra: true }) satisfies AttestationGenerateResponse;
+// @ts-expect-error responses are non-null objects.
+(null) satisfies AttestationGenerateResponse;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 434 {
-		t.Fatalf("definition count = %d, want 434", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
+		t.Fatalf("definition count = %d, want 436", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- export exact standalone `AttestationGenerateParams` and `AttestationGenerateResponse`
- preserve serde-compatible empty-object and unknown-field input while enforcing strict known fields
- keep `attestation/generate` blocked and unbound with no token generation or trust authority
- regenerate the deterministic 436-definition schema and TypeScript binding

## Verification
- focused 30x, race, and 100% decoder coverage
- full protocol normal/race and 97.3% aggregate coverage
- normal/race/vet across 59 non-Monty packages; full lint; tidy/verify
- strict TypeScript and exact pinned-upstream schema/type comparison
- deterministic generation and exact structural reversal
- all five Slang real-process workflows and byte-identical live transcript
