### PR TITLE
feat(protocol): export file change contract

### DIFF
--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(defs); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/attestation_contract_test.go
+++ b/appserver/protocol/attestation_contract_test.go
@@ -133,8 +133,8 @@ func TestAttestationContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("attestation/generate = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,8 +217,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,8 +203,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -260,8 +260,8 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,8 +244,8 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -162,8 +162,8 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -175,8 +175,8 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_contract_test.go
+++ b/appserver/protocol/file_change_contract_test.go
@@ -1,0 +1,141 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestFileChangeSchemaIsExact(t *testing.T) {
+	definition := JSONSchema()["$defs"].(Schema)["FileChange"].(Schema)
+	want := Schema{"oneOf": []any{
+		fileChangeVariantSchema("add", []string{"content", "type"}, Schema{
+			"content": Schema{"type": "string"},
+		}),
+		fileChangeVariantSchema("delete", []string{"content", "type"}, Schema{
+			"content": Schema{"type": "string"},
+		}),
+		fileChangeVariantSchema("update", []string{"type", "unified_diff"}, Schema{
+			"unified_diff": Schema{"type": "string"},
+			"move_path":    Schema{"type": []any{"string", "null"}},
+		}),
+	}}
+	if !reflect.DeepEqual(definition, want) {
+		t.Fatalf("FileChange = %#v, want %#v", definition, want)
+	}
+}
+
+func TestFileChangeAcceptsSerdeWireForms(t *testing.T) {
+	for _, test := range []struct {
+		input    string
+		want     string
+		wantType string
+	}{
+		{input: `{"type":"add","content":""}`, want: `{"type":"add","content":""}`, wantType: "add"},
+		{input: `{"future":true,"type":"delete","content":"old"}`, want: `{"type":"delete","content":"old"}`, wantType: "delete"},
+		{input: `{"type":"update","unified_diff":"diff"}`, want: `{"type":"update","unified_diff":"diff","move_path":null}`, wantType: "update"},
+		{input: `{"type":"update","unified_diff":"","move_path":null}`, want: `{"type":"update","unified_diff":"","move_path":null}`, wantType: "update"},
+		{input: `{"type":"update","unified_diff":"diff","move_path":"next path"}`, want: `{"type":"update","unified_diff":"diff","move_path":"next path"}`, wantType: "update"},
+		{input: `{"type":"add","content":"new","unified_diff":"ignored","move_path":"ignored"}`, want: `{"type":"add","content":"new"}`, wantType: "add"},
+		{input: `{"type":"delete","content":"old","unified_diff":1,"unified_diff":2}`, want: `{"type":"delete","content":"old"}`, wantType: "delete"},
+		{input: `{"type":"update","content":"ignored","unified_diff":"diff","future":1,"future":2}`, want: `{"type":"update","unified_diff":"diff","move_path":null}`, wantType: "update"},
+		{input: `{"type":"update","content":1,"content":2,"unified_diff":"diff"}`, want: `{"type":"update","unified_diff":"diff","move_path":null}`, wantType: "update"},
+	} {
+		var change FileChange
+		if err := json.Unmarshal([]byte(test.input), &change); err != nil {
+			t.Errorf("Unmarshal(%s): %v", test.input, err)
+			continue
+		}
+		if change.Type() != test.wantType {
+			t.Errorf("Type(%s) = %q, want %q", test.input, change.Type(), test.wantType)
+		}
+		encoded, err := json.Marshal(change)
+		if err != nil {
+			t.Errorf("Marshal(%s): %v", test.input, err)
+			continue
+		}
+		if string(encoded) != test.want {
+			t.Errorf("round trip %s = %s, want %s", test.input, encoded, test.want)
+		}
+	}
+}
+
+func TestFileChangeRejectsMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`,
+		`{}`,
+		`{"type":null}`,
+		`{"type":1}`,
+		`{"type":"other"}`,
+		`{"type":"add"}`,
+		`{"type":"add","content":null}`,
+		`{"type":"add","content":1}`,
+		`{"type":"add","content":"one","content":"two"}`,
+		`{"type":"delete"}`,
+		`{"type":"delete","content":[]}`,
+		`{"type":"update"}`,
+		`{"type":"update","unified_diff":null}`,
+		`{"type":"update","unified_diff":1}`,
+		`{"type":"update","unified_diff":"diff","move_path":1}`,
+		`{"type":"update","unified_diff":"one","unified_diff":"two"}`,
+		`{"type":"update","unified_diff":"diff","move_path":null,"move_path":"next"}`,
+		`{"type":"add","type":"delete","content":"value"}`,
+		`{"type":"add","content":"value"} {}`,
+		`{"type":"add","content":"value"} x`,
+	} {
+		assertJSONRejects[FileChange](t, input)
+	}
+
+	var change *FileChange
+	if err := change.UnmarshalJSON([]byte(`{"type":"add","content":"value"}`)); err == nil {
+		t.Fatal("nil FileChange receiver succeeded")
+	}
+	if _, err := json.Marshal(FileChange{}); err == nil {
+		t.Fatal("zero FileChange marshaled")
+	}
+}
+
+func TestFileChangeRemainsStandalone(t *testing.T) {
+	for _, binding := range WireTypeBindings() {
+		if slices.Contains(binding.Params, "FileChange") || slices.Contains(binding.Result, "FileChange") {
+			t.Fatalf("FileChange unexpectedly bound to %s", binding.Method)
+		}
+	}
+	for _, binding := range ItemPayloadBindings() {
+		if binding.Type == "FileChange" {
+			t.Fatalf("FileChange unexpectedly bound to item %s", binding.Kind)
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestFileChangeTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	want := "export type FileChange = {\n" +
+		"  \"content\": string;\n" +
+		"  \"type\": \"add\";\n" +
+		"} | {\n" +
+		"  \"content\": string;\n" +
+		"  \"type\": \"delete\";\n" +
+		"} | {\n" +
+		"  \"move_path\": string | null;\n" +
+		"  \"type\": \"update\";\n" +
+		"  \"unified_diff\": string;\n" +
+		"};"
+	if !strings.Contains(string(generated), want) {
+		t.Fatalf("generated TypeScript missing %q", want)
+	}
+}

--- a/appserver/protocol/file_change_types.go
+++ b/appserver/protocol/file_change_types.go
@@ -1,0 +1,107 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// FileChange is the exact legacy public description of one file update. It is
+// standalone and distinct from the live FileUpdateChange item payload.
+type FileChange struct {
+	raw json.RawMessage
+}
+
+func (c FileChange) MarshalJSON() ([]byte, error) {
+	if len(c.raw) == 0 {
+		return nil, errors.New("file change has no value")
+	}
+	return validateFileChangeJSON(c.raw)
+}
+
+func (c *FileChange) UnmarshalJSON(data []byte) error {
+	if c == nil {
+		return errors.New("decode file change into nil receiver")
+	}
+	canonical, err := validateFileChangeJSON(data)
+	if err != nil {
+		return err
+	}
+	c.raw = canonical
+	return nil
+}
+
+// Type returns the exact public file-change discriminant.
+func (c FileChange) Type() string {
+	return permissionUnionDiscriminant(c.raw, "type")
+}
+
+func validateFileChangeJSON(data []byte) (json.RawMessage, error) {
+	const objectName = "file change"
+	discriminant, err := decodeRustSerdeObject(data, objectName, "type")
+	if err != nil {
+		return nil, err
+	}
+	changeType, err := decodeRequiredThreadItemValue[string](
+		discriminant, objectName, "type",
+	)
+	if err != nil {
+		return nil, err
+	}
+	switch changeType {
+	case "add", "delete":
+		return canonicalFileChangeContentVariant(data, changeType)
+	case "update":
+		return canonicalFileChangeUpdate(data)
+	default:
+		return nil, fmt.Errorf("unsupported file change type %q", changeType)
+	}
+}
+
+func canonicalFileChangeContentVariant(data []byte, changeType string) (json.RawMessage, error) {
+	const objectName = "file change"
+	payload, err := decodeRustSerdeObject(data, objectName, "type", "content")
+	if err != nil {
+		return nil, err
+	}
+	content, err := decodeRequiredThreadItemValue[string](payload, objectName, "content")
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(struct {
+		Type    string `json:"type"`
+		Content string `json:"content"`
+	}{Type: changeType, Content: content})
+}
+
+func canonicalFileChangeUpdate(data []byte) (json.RawMessage, error) {
+	const objectName = "file change update"
+	payload, err := decodeRustSerdeObject(
+		data, objectName, "type", "unified_diff", "move_path",
+	)
+	if err != nil {
+		return nil, err
+	}
+	unifiedDiff, err := decodeRequiredThreadItemValue[string](
+		payload, objectName, "unified_diff",
+	)
+	if err != nil {
+		return nil, err
+	}
+	movePath, err := decodeOptionalNullableConfigValue[string](
+		payload, objectName, "move_path",
+	)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(struct {
+		Type        string  `json:"type"`
+		UnifiedDiff string  `json:"unified_diff"`
+		MovePath    *string `json:"move_path"`
+	}{Type: "update", UnifiedDiff: unifiedDiff, MovePath: movePath})
+}
+
+var (
+	_ json.Marshaler   = FileChange{}
+	_ json.Unmarshaler = (*FileChange)(nil)
+)

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -381,8 +381,8 @@ func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_action_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_action_contract_test.go
@@ -226,8 +226,8 @@ func TestGuardianApprovalReviewActionRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReviewAction unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
@@ -164,8 +164,8 @@ func TestGuardianApprovalReviewCompletedNotificationRemainsStandalone(t *testing
 			t.Fatalf("completed notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_contract_test.go
@@ -139,8 +139,8 @@ func TestGuardianApprovalReviewRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReview unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
@@ -175,8 +175,8 @@ func TestGuardianApprovalReviewStartedNotificationRemainsStandalone(t *testing.T
 			t.Fatalf("started notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_enum_foundation_contract_test.go
+++ b/appserver/protocol/guardian_enum_foundation_contract_test.go
@@ -89,8 +89,8 @@ func TestGuardianEnumFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_metadata_list_contract_test.go
+++ b/appserver/protocol/hook_metadata_list_contract_test.go
@@ -352,8 +352,8 @@ func TestHookMetadataListContractsStayStandalone(t *testing.T) {
 			t.Errorf("standalone definition %s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Errorf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Errorf("definition count = %d, want 437", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 {
 		t.Errorf("wire binding count = %d, want 59", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_run_notification_contract_test.go
+++ b/appserver/protocol/hook_run_notification_contract_test.go
@@ -297,8 +297,8 @@ func TestHookRunNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("surface changed: %d methods, %d wire bindings, %d item bindings", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/hook_value_foundation_contract_test.go
+++ b/appserver/protocol/hook_value_foundation_contract_test.go
@@ -167,8 +167,8 @@ func TestHookValueFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 436 {
-		t.Fatalf("definition count = %d, want 436", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 437 {
+		t.Fatalf("definition count = %d, want 437", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 436 {
-		t.Fatalf("definition count = %d, want 436", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 437 {
+		t.Fatalf("definition count = %d, want 437", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 436 {
-		t.Fatalf("definition count = %d, want 436", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 437 {
+		t.Fatalf("definition count = %d, want 437", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 436 {
-		t.Fatalf("definition count = %d, want 436", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 437 {
+		t.Fatalf("definition count = %d, want 437", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 436 {
-		t.Fatalf("definition count = %d, want 436", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 437 {
+		t.Fatalf("definition count = %d, want 437", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 436 {
-		t.Fatalf("definition count = %d, want 436", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 437 {
+		t.Fatalf("definition count = %d, want 437", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -166,6 +166,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "DynamicToolCallItemStartedNotificationParams", Type: reflect.TypeFor[DynamicToolCallItemStartedNotificationParams]()},
 		{Name: "ErrorNotification", Type: reflect.TypeFor[ErrorNotification]()},
 		{Name: "ExecPolicyAmendment", Type: reflect.TypeFor[ExecPolicyAmendment]()},
+		{Name: "FileChange", Type: reflect.TypeFor[FileChange]()},
 		{Name: "FileChangeApprovalRequestParams", Type: reflect.TypeFor[FileChangeApprovalRequestParams]()},
 		{Name: "FileChangeApprovalDecision", Type: reflect.TypeFor[FileChangeApprovalDecision]()},
 		{Name: "FileChangeRequestApprovalResponse", Type: reflect.TypeFor[FileChangeRequestApprovalResponse]()},
@@ -915,6 +916,7 @@ func wireSchemaDefinitions() Schema {
 		string(FileChangeApprovalDecline),
 		string(FileChangeApprovalCancel),
 	)
+	schemas["FileChange"] = fileChangeSchema()
 	schemas["PatchApplyStatus"] = stringEnumSchema(
 		string(PatchApplyStatusInProgress), string(PatchApplyStatusCompleted),
 		string(PatchApplyStatusFailed), string(PatchApplyStatusDeclined),
@@ -2099,6 +2101,34 @@ func patchChangeKindSchema() Schema {
 		patchChangeKindVariantSchema("update", "move_path"),
 		patchChangeKindVariantSchema("update", "movePath"),
 	}}
+}
+
+func fileChangeSchema() Schema {
+	return Schema{"oneOf": []any{
+		fileChangeVariantSchema("add", []string{"content", "type"}, Schema{
+			"content": Schema{"type": "string"},
+		}),
+		fileChangeVariantSchema("delete", []string{"content", "type"}, Schema{
+			"content": Schema{"type": "string"},
+		}),
+		fileChangeVariantSchema("update", []string{"type", "unified_diff"}, Schema{
+			"unified_diff": Schema{"type": "string"},
+			"move_path":    Schema{"type": []any{"string", "null"}},
+		}),
+	}}
+}
+
+func fileChangeVariantSchema(changeType string, requiredFields []string, fields Schema) Schema {
+	properties := Schema{"type": Schema{"type": "string", "enum": []any{changeType}}}
+	for name, schema := range fields {
+		properties[name] = schema
+	}
+	return Schema{
+		"type":                 "object",
+		"properties":           properties,
+		"required":             append([]string(nil), requiredFields...),
+		"additionalProperties": false,
+	}
 }
 
 func dynamicToolCallOutputContentItemSchema() Schema {

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -3483,6 +3483,73 @@
       ],
       "type": "string"
     },
+    "FileChange": {
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "content": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "add"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "content",
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "content": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "delete"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "content",
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "move_path": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": {
+              "enum": [
+                "update"
+              ],
+              "type": "string"
+            },
+            "unified_diff": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "unified_diff"
+          ],
+          "type": "object"
+        }
+      ]
+    },
     "FileChangeApprovalDecision": {
       "enum": [
         "accept",

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 436 {
-		t.Fatalf("definition count = %d, want 436", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 437 {
+		t.Fatalf("definition count = %d, want 437", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 436 {
-		t.Fatalf("definition count = %d, want 436", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 437 {
+		t.Fatalf("definition count = %d, want 437", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 436 {
-		t.Fatalf("definition count = %d, want 436", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 437 {
+		t.Fatalf("definition count = %d, want 437", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -148,6 +148,9 @@ func MarshalTypeScript() ([]byte, error) {
 		if name == "GuardianApprovalReviewAction" {
 			definition = guardianApprovalReviewActionTypeScriptSchema(definition)
 		}
+		if name == "FileChange" {
+			definition = fileChangeTypeScriptSchema(definition)
+		}
 		if name == "ItemGuardianApprovalReviewCompletedNotification" ||
 			name == "ItemGuardianApprovalReviewStartedNotification" {
 			definition = typeScriptDefinitionWithPropertySchemas(definition, Schema{
@@ -409,6 +412,42 @@ func guardianApprovalReviewActionTypeScriptSchema(definition any) Schema {
 		}
 		renderVariant["properties"] = renderProperties
 		renderVariant["required"] = required
+		renderVariants = append(renderVariants, renderVariant)
+	}
+	renderSchema["oneOf"] = renderVariants
+	return renderSchema
+}
+
+func fileChangeTypeScriptSchema(definition any) Schema {
+	schema, _ := typeScriptSchema(definition)
+	renderSchema := make(Schema, len(schema))
+	for key, value := range schema {
+		renderSchema[key] = value
+	}
+	variants, _ := typeScriptAnySlice(schema["oneOf"])
+	renderVariants := make([]any, 0, len(variants))
+	for _, rawVariant := range variants {
+		variant, _ := typeScriptSchema(rawVariant)
+		renderVariant := make(Schema, len(variant))
+		for key, value := range variant {
+			renderVariant[key] = value
+		}
+		properties, _ := typeScriptSchema(variant["properties"])
+		typeSchema, _ := typeScriptSchema(properties["type"])
+		tags, _ := typeScriptAnySlice(typeSchema["enum"])
+		if len(tags) == 1 && tags[0] == "update" {
+			renderProperties := make(Schema, len(properties))
+			for key, value := range properties {
+				renderProperties[key] = value
+			}
+			renderProperties["move_path"] = Schema{"anyOf": []any{
+				Schema{"type": "string"}, Schema{"type": "null"},
+			}}
+			required := append([]string(nil), variant["required"].([]string)...)
+			required = append(required, "move_path")
+			renderVariant["properties"] = renderProperties
+			renderVariant["required"] = required
+		}
 		renderVariants = append(renderVariants, renderVariant)
 	}
 	renderSchema["oneOf"] = renderVariants

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -1197,6 +1197,18 @@ export type ExternalAgentConfigMigrationItem = {
 
 export type ExternalAgentConfigMigrationItemType = "AGENTS_MD" | "CONFIG" | "SKILLS" | "PLUGINS" | "MCP_SERVER_CONFIG" | "SUBAGENTS" | "HOOKS" | "COMMANDS" | "SESSIONS";
 
+export type FileChange = {
+  "content": string;
+  "type": "add";
+} | {
+  "content": string;
+  "type": "delete";
+} | {
+  "move_path": string | null;
+  "type": "update";
+  "unified_diff": string;
+};
+
 export type FileChangeApprovalDecision = "accept" | "acceptForSession" | "decline" | "cancel";
 
 export type FileChangeApprovalRequestParams = {

--- a/appserver/protocol/typescript/testdata/file_change_contract.ts
+++ b/appserver/protocol/typescript/testdata/file_change_contract.ts
@@ -1,0 +1,41 @@
+import type { FileChange } from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+
+type ExactFileChange =
+  | { type: "add"; content: string }
+  | { type: "delete"; content: string }
+  | { type: "update"; unified_diff: string; move_path: string | null };
+
+type Contract = Expect<Equal<FileChange, ExactFileChange>>;
+
+({ type: "add", content: "" }) satisfies FileChange;
+({ type: "delete", content: "old" }) satisfies FileChange;
+({ type: "update", unified_diff: "", move_path: null }) satisfies FileChange;
+({ type: "update", unified_diff: "diff", move_path: "next path" }) satisfies FileChange;
+
+// @ts-expect-error variants are closed.
+({ type: "other" }) satisfies FileChange;
+// @ts-expect-error tags are case-sensitive.
+({ type: "Add", content: "value" }) satisfies FileChange;
+// @ts-expect-error add content is required.
+({ type: "add" }) satisfies FileChange;
+// @ts-expect-error delete content is a string.
+({ type: "delete", content: null }) satisfies FileChange;
+// @ts-expect-error canonical update move_path is required.
+({ type: "update", unified_diff: "diff" }) satisfies FileChange;
+// @ts-expect-error update move_path is string or null.
+({ type: "update", unified_diff: "diff", move_path: 1 }) satisfies FileChange;
+// @ts-expect-error canonical updates use snake_case.
+({ type: "update", unified_diff: "diff", movePath: null }) satisfies FileChange;
+// @ts-expect-error variants cannot cross fields.
+({ type: "add", content: "value", unified_diff: "diff" }) satisfies FileChange;
+// @ts-expect-error values are non-null objects.
+(null) satisfies FileChange;
+
+void (null as unknown as Contract);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 436 {
-		t.Fatalf("definition count = %d, want 436", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
+		t.Fatalf("definition count = %d, want 437", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary

- export the exact standalone public `FileChange` add/delete/update union
- preserve serde unknown-field behavior while rejecting duplicate selected-variant fields and malformed wire values
- canonicalize omitted update `move_path` to explicit null
- generate the exact closed TypeScript union without changing live file items, methods, bindings, or runtime behavior

## Verification

- deliberate-red Go and strict TypeScript boundaries
- focused tests 30x, focused race, and 100% coverage for all six new production functions
- full protocol coverage 97.4%
- normal and race gates across exactly 59 non-Monty packages
- package/full lint (0 issues), vet, tidy, module verification, and configured pre-push
- deterministic 437-definition/224-method/59-method-binding/5-item-binding generation
- exact normalized pinned-upstream schema hash and compiler-level bidirectional TypeScript identity
- exact structural reversal to PR #203 tree
- all five Slang stdio/Unix-socket/WebSocket workflows
- byte-identical baseline/feature live transcript with empty stderr

Local Monty normal/race/coverage tests were intentionally skipped via `hooks.skipMontyRace=true`; hosted CI remains unchanged.