### PR TITLE
feat(protocol): export file change output delta

### DIFF
--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(defs); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/attestation_contract_test.go
+++ b/appserver/protocol/attestation_contract_test.go
@@ -133,8 +133,8 @@ func TestAttestationContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("attestation/generate = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,8 +217,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,8 +203,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -260,8 +260,8 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,8 +244,8 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -162,8 +162,8 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -175,8 +175,8 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_contract_test.go
+++ b/appserver/protocol/file_change_contract_test.go
@@ -108,8 +108,8 @@ func TestFileChangeRemainsStandalone(t *testing.T) {
 			t.Fatalf("FileChange unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_output_delta_notification_contract_test.go
+++ b/appserver/protocol/file_change_output_delta_notification_contract_test.go
@@ -1,0 +1,128 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestFileChangeOutputDeltaNotificationSchemaIsExact(t *testing.T) {
+	definition, ok := JSONSchema()["$defs"].(Schema)["FileChangeOutputDeltaNotification"].(Schema)
+	if !ok {
+		t.Fatal("$defs missing FileChangeOutputDeltaNotification")
+	}
+	want := Schema{
+		"type": "object",
+		"properties": Schema{
+			"threadId": Schema{"type": "string"},
+			"turnId":   Schema{"type": "string"},
+			"itemId":   Schema{"type": "string"},
+			"delta":    Schema{"type": "string"},
+		},
+		"required":             []string{"threadId", "turnId", "itemId", "delta"},
+		"additionalProperties": false,
+	}
+	if !reflect.DeepEqual(definition, want) {
+		t.Fatalf("FileChangeOutputDeltaNotification = %#v, want %#v", definition, want)
+	}
+}
+
+func TestFileChangeOutputDeltaNotificationAcceptsSerdeWireForms(t *testing.T) {
+	for _, test := range []struct {
+		input string
+		want  string
+	}{
+		{
+			input: `{"threadId":"","turnId":"","itemId":"","delta":""}`,
+			want:  `{"threadId":"","turnId":"","itemId":"","delta":""}`,
+		},
+		{
+			input: `{"future":true,"threadId":"thread","turnId":"turn","itemId":"item","delta":"patch\nline"}`,
+			want:  `{"threadId":"thread","turnId":"turn","itemId":"item","delta":"patch\nline"}`,
+		},
+		{
+			input: `{"threadId":"thread","turnId":"turn","itemId":"item","delta":"value","future":1,"future":2}`,
+			want:  `{"threadId":"thread","turnId":"turn","itemId":"item","delta":"value"}`,
+		},
+	} {
+		var notification FileChangeOutputDeltaNotification
+		if err := json.Unmarshal([]byte(test.input), &notification); err != nil {
+			t.Errorf("Unmarshal(%s): %v", test.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(notification)
+		if err != nil || string(encoded) != test.want {
+			t.Errorf("round trip %s = %s, %v; want %s", test.input, encoded, err, test.want)
+		}
+	}
+}
+
+func TestFileChangeOutputDeltaNotificationRejectsMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`, `{}`,
+		`{"turnId":"turn","itemId":"item","delta":"delta"}`,
+		`{"threadId":"thread","itemId":"item","delta":"delta"}`,
+		`{"threadId":"thread","turnId":"turn","delta":"delta"}`,
+		`{"threadId":"thread","turnId":"turn","itemId":"item"}`,
+		`{"threadId":null,"turnId":"turn","itemId":"item","delta":"delta"}`,
+		`{"threadId":"thread","turnId":1,"itemId":"item","delta":"delta"}`,
+		`{"threadId":"thread","turnId":"turn","itemId":[],"delta":"delta"}`,
+		`{"threadId":"thread","turnId":"turn","itemId":"item","delta":false}`,
+		`{"threadId":"one","threadId":"two","turnId":"turn","itemId":"item","delta":"delta"}`,
+		`{"threadId":"thread","turnId":"one","turnId":"two","itemId":"item","delta":"delta"}`,
+		`{"threadId":"thread","turnId":"turn","itemId":"one","itemId":"two","delta":"delta"}`,
+		`{"threadId":"thread","turnId":"turn","itemId":"item","delta":"one","delta":"two"}`,
+		`{"threadId":"thread","turnId":"turn","itemId":"item","delta":"delta"} {}`,
+		`{"threadId":"thread","turnId":"turn","itemId":"item","delta":"delta"} x`,
+	} {
+		assertJSONRejects[FileChangeOutputDeltaNotification](t, input)
+	}
+
+	var notification *FileChangeOutputDeltaNotification
+	if err := notification.UnmarshalJSON([]byte(`{"threadId":"thread","turnId":"turn","itemId":"item","delta":"delta"}`)); err == nil {
+		t.Fatal("nil FileChangeOutputDeltaNotification receiver succeeded")
+	}
+}
+
+func TestFileChangeOutputDeltaNotificationRemainsDeprecatedAndStandalone(t *testing.T) {
+	if reflect.TypeFor[FileChangeOutputDeltaNotification]() == reflect.TypeFor[CommandExecutionOutputDeltaNotification]() {
+		t.Fatal("legacy file delta unexpectedly aliases command delta")
+	}
+	for _, binding := range WireTypeBindings() {
+		if slices.Contains(binding.Params, "FileChangeOutputDeltaNotification") ||
+			slices.Contains(binding.Result, "FileChangeOutputDeltaNotification") {
+			t.Fatalf("FileChangeOutputDeltaNotification unexpectedly bound to %s", binding.Method)
+		}
+	}
+	info, ok := LookupMethod("item/fileChange/outputDelta")
+	if !ok || info.State != MethodBlocked {
+		t.Fatalf("item/fileChange/outputDelta = %#v, %v; want blocked", info, ok)
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestFileChangeOutputDeltaNotificationTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	want := "export type FileChangeOutputDeltaNotification = {\n" +
+		"  \"delta\": string;\n" +
+		"  \"itemId\": string;\n" +
+		"  \"threadId\": string;\n" +
+		"  \"turnId\": string;\n" +
+		"};"
+	if !strings.Contains(string(generated), want) {
+		t.Fatalf("generated TypeScript missing %q", want)
+	}
+}

--- a/appserver/protocol/file_change_output_delta_notification_types.go
+++ b/appserver/protocol/file_change_output_delta_notification_types.go
@@ -1,0 +1,54 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// FileChangeOutputDeltaNotification is the exact deprecated public textual
+// apply-patch output value. It remains standalone because the server no longer
+// emits item/fileChange/outputDelta.
+type FileChangeOutputDeltaNotification struct {
+	ThreadID string `json:"threadId"`
+	TurnID   string `json:"turnId"`
+	ItemID   string `json:"itemId"`
+	Delta    string `json:"delta"`
+}
+
+func (n *FileChangeOutputDeltaNotification) UnmarshalJSON(data []byte) error {
+	if n == nil {
+		return errors.New("decode file-change output delta into nil receiver")
+	}
+	const objectName = "file-change output delta"
+	payload, err := decodeRustSerdeObject(
+		data, objectName, "threadId", "turnId", "itemId", "delta",
+	)
+	if err != nil {
+		return err
+	}
+	threadID, err := decodeRequiredThreadItemValue[string](payload, objectName, "threadId")
+	if err != nil {
+		return err
+	}
+	turnID, err := decodeRequiredThreadItemValue[string](payload, objectName, "turnId")
+	if err != nil {
+		return err
+	}
+	itemID, err := decodeRequiredThreadItemValue[string](payload, objectName, "itemId")
+	if err != nil {
+		return err
+	}
+	delta, err := decodeRequiredThreadItemValue[string](payload, objectName, "delta")
+	if err != nil {
+		return err
+	}
+	*n = FileChangeOutputDeltaNotification{
+		ThreadID: threadID,
+		TurnID:   turnID,
+		ItemID:   itemID,
+		Delta:    delta,
+	}
+	return nil
+}
+
+var _ json.Unmarshaler = (*FileChangeOutputDeltaNotification)(nil)

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -381,8 +381,8 @@ func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_action_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_action_contract_test.go
@@ -226,8 +226,8 @@ func TestGuardianApprovalReviewActionRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReviewAction unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
@@ -164,8 +164,8 @@ func TestGuardianApprovalReviewCompletedNotificationRemainsStandalone(t *testing
 			t.Fatalf("completed notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_contract_test.go
@@ -139,8 +139,8 @@ func TestGuardianApprovalReviewRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReview unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
@@ -175,8 +175,8 @@ func TestGuardianApprovalReviewStartedNotificationRemainsStandalone(t *testing.T
 			t.Fatalf("started notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_enum_foundation_contract_test.go
+++ b/appserver/protocol/guardian_enum_foundation_contract_test.go
@@ -89,8 +89,8 @@ func TestGuardianEnumFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_metadata_list_contract_test.go
+++ b/appserver/protocol/hook_metadata_list_contract_test.go
@@ -352,8 +352,8 @@ func TestHookMetadataListContractsStayStandalone(t *testing.T) {
 			t.Errorf("standalone definition %s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Errorf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Errorf("definition count = %d, want 438", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 {
 		t.Errorf("wire binding count = %d, want 59", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_run_notification_contract_test.go
+++ b/appserver/protocol/hook_run_notification_contract_test.go
@@ -297,8 +297,8 @@ func TestHookRunNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("surface changed: %d methods, %d wire bindings, %d item bindings", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/hook_value_foundation_contract_test.go
+++ b/appserver/protocol/hook_value_foundation_contract_test.go
@@ -167,8 +167,8 @@ func TestHookValueFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 437 {
-		t.Fatalf("definition count = %d, want 437", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 438 {
+		t.Fatalf("definition count = %d, want 438", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 437 {
-		t.Fatalf("definition count = %d, want 437", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 438 {
+		t.Fatalf("definition count = %d, want 438", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 437 {
-		t.Fatalf("definition count = %d, want 437", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 438 {
+		t.Fatalf("definition count = %d, want 438", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 437 {
-		t.Fatalf("definition count = %d, want 437", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 438 {
+		t.Fatalf("definition count = %d, want 438", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 437 {
-		t.Fatalf("definition count = %d, want 437", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 438 {
+		t.Fatalf("definition count = %d, want 438", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 437 {
-		t.Fatalf("definition count = %d, want 437", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 438 {
+		t.Fatalf("definition count = %d, want 438", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -167,6 +167,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "ErrorNotification", Type: reflect.TypeFor[ErrorNotification]()},
 		{Name: "ExecPolicyAmendment", Type: reflect.TypeFor[ExecPolicyAmendment]()},
 		{Name: "FileChange", Type: reflect.TypeFor[FileChange]()},
+		{Name: "FileChangeOutputDeltaNotification", Type: reflect.TypeFor[FileChangeOutputDeltaNotification]()},
 		{Name: "FileChangeApprovalRequestParams", Type: reflect.TypeFor[FileChangeApprovalRequestParams]()},
 		{Name: "FileChangeApprovalDecision", Type: reflect.TypeFor[FileChangeApprovalDecision]()},
 		{Name: "FileChangeRequestApprovalResponse", Type: reflect.TypeFor[FileChangeRequestApprovalResponse]()},

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -3747,6 +3747,30 @@
       ],
       "type": "object"
     },
+    "FileChangeOutputDeltaNotification": {
+      "additionalProperties": false,
+      "properties": {
+        "delta": {
+          "type": "string"
+        },
+        "itemId": {
+          "type": "string"
+        },
+        "threadId": {
+          "type": "string"
+        },
+        "turnId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "threadId",
+        "turnId",
+        "itemId",
+        "delta"
+      ],
+      "type": "object"
+    },
     "FileChangePatchUpdatedNotification": {
       "additionalProperties": false,
       "properties": {

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 437 {
-		t.Fatalf("definition count = %d, want 437", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 438 {
+		t.Fatalf("definition count = %d, want 438", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 437 {
-		t.Fatalf("definition count = %d, want 437", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 438 {
+		t.Fatalf("definition count = %d, want 438", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 437 {
-		t.Fatalf("definition count = %d, want 437", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 438 {
+		t.Fatalf("definition count = %d, want 438", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -1259,6 +1259,13 @@ export type FileChangeItemStartedNotificationParams = {
   "turnId": string;
 };
 
+export type FileChangeOutputDeltaNotification = {
+  "delta": string;
+  "itemId": string;
+  "threadId": string;
+  "turnId": string;
+};
+
 export type FileChangePatchUpdatedNotification = {
   "changes": Array<FileUpdateChange>;
   "itemId": string;

--- a/appserver/protocol/typescript/testdata/file_change_output_delta_notification_contract.ts
+++ b/appserver/protocol/typescript/testdata/file_change_output_delta_notification_contract.ts
@@ -1,0 +1,49 @@
+import type {
+  FileChangeOutputDeltaNotification,
+  MethodParamsByName,
+  MethodResultsByName,
+} from "../gollem_appserver_protocol.js";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+
+type ExactNotification = {
+  threadId: string;
+  turnId: string;
+  itemId: string;
+  delta: string;
+};
+
+type Contracts = [
+  Expect<Equal<FileChangeOutputDeltaNotification, ExactNotification>>,
+  Expect<Equal<Extract<keyof MethodParamsByName, "item/fileChange/outputDelta">, never>>,
+  Expect<Equal<Extract<keyof MethodResultsByName, "item/fileChange/outputDelta">, never>>,
+];
+
+({ threadId: "", turnId: "", itemId: "", delta: "" }) satisfies FileChangeOutputDeltaNotification;
+({ threadId: "thread", turnId: "turn", itemId: "item", delta: "patch\nline" }) satisfies FileChangeOutputDeltaNotification;
+
+// @ts-expect-error threadId is required.
+({ turnId: "turn", itemId: "item", delta: "delta" }) satisfies FileChangeOutputDeltaNotification;
+// @ts-expect-error turnId is required.
+({ threadId: "thread", itemId: "item", delta: "delta" }) satisfies FileChangeOutputDeltaNotification;
+// @ts-expect-error itemId is required.
+({ threadId: "thread", turnId: "turn", delta: "delta" }) satisfies FileChangeOutputDeltaNotification;
+// @ts-expect-error delta is required.
+({ threadId: "thread", turnId: "turn", itemId: "item" }) satisfies FileChangeOutputDeltaNotification;
+// @ts-expect-error ids are non-null strings.
+({ threadId: null, turnId: "turn", itemId: "item", delta: "delta" }) satisfies FileChangeOutputDeltaNotification;
+// @ts-expect-error delta is a string.
+({ threadId: "thread", turnId: "turn", itemId: "item", delta: 1 }) satisfies FileChangeOutputDeltaNotification;
+// @ts-expect-error canonical records are closed.
+({ threadId: "thread", turnId: "turn", itemId: "item", delta: "delta", future: true }) satisfies FileChangeOutputDeltaNotification;
+// @ts-expect-error values are non-null objects.
+(null) satisfies FileChangeOutputDeltaNotification;
+// @ts-expect-error values are not arrays.
+([]) satisfies FileChangeOutputDeltaNotification;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 437 {
-		t.Fatalf("definition count = %d, want 437", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
+		t.Fatalf("definition count = %d, want 438", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- export the exact standalone `FileChangeOutputDeltaNotification` wire record
- generate the matching JSON Schema and TypeScript contract without adding a method, item, or runtime binding
- cover Rust-serde-compatible unknown-field handling and strict known-field validation

## Upstream contract
Pinned Codex app-server contract: `5c19155c`

The record requires four string fields: `threadId`, `turnId`, `itemId`, and `delta`. Unknown fields are accepted and discarded, while missing, null, wrong-typed, and duplicate known fields are rejected. The deprecated `item/fileChange/outputDelta` method remains blocked and unbound because the current server no longer emits it.

## Verification
- `go test ./appserver/protocol -run FileChangeOutputDeltaNotification -count=30`
- `go test ./appserver/protocol`
- focused race and coverage (`UnmarshalJSON`: 100%)
- all 59 non-Monty packages under normal and race runs
- `golangci-lint run ./...`
- non-Monty `go vet`
- `go mod tidy` clean
- deterministic schema and TypeScript generation, twice
- `tsc --project appserver/protocol/typescript/tsconfig.json`
- exact normalized upstream schema and bidirectional TypeScript assignability
- unchanged method, wire-type, and item-payload binding inventories
- deterministic binary and byte-identical neutral live transcript
- all five Slang integration workflows against the feature binary
- exact structural reversal to the parent tree

Local Monty race tests are skipped via `hooks.skipMontyRace=true`; hosted CI is unchanged.
