### PR TITLE
feat(appserver): export network approval context

### DIFF
--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(defs); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/attestation_contract_test.go
+++ b/appserver/protocol/attestation_contract_test.go
@@ -133,8 +133,8 @@ func TestAttestationContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("attestation/generate = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,8 +217,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,8 +203,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -260,8 +260,8 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,8 +244,8 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -162,8 +162,8 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -175,8 +175,8 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_contract_test.go
+++ b/appserver/protocol/file_change_contract_test.go
@@ -108,8 +108,8 @@ func TestFileChangeRemainsStandalone(t *testing.T) {
 			t.Fatalf("FileChange unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_output_delta_notification_contract_test.go
+++ b/appserver/protocol/file_change_output_delta_notification_contract_test.go
@@ -100,8 +100,8 @@ func TestFileChangeOutputDeltaNotificationRemainsDeprecatedAndStandalone(t *test
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("item/fileChange/outputDelta = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -381,8 +381,8 @@ func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_action_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_action_contract_test.go
@@ -226,8 +226,8 @@ func TestGuardianApprovalReviewActionRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReviewAction unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
@@ -164,8 +164,8 @@ func TestGuardianApprovalReviewCompletedNotificationRemainsStandalone(t *testing
 			t.Fatalf("completed notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_contract_test.go
@@ -139,8 +139,8 @@ func TestGuardianApprovalReviewRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReview unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
@@ -175,8 +175,8 @@ func TestGuardianApprovalReviewStartedNotificationRemainsStandalone(t *testing.T
 			t.Fatalf("started notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_enum_foundation_contract_test.go
+++ b/appserver/protocol/guardian_enum_foundation_contract_test.go
@@ -89,8 +89,8 @@ func TestGuardianEnumFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_metadata_list_contract_test.go
+++ b/appserver/protocol/hook_metadata_list_contract_test.go
@@ -352,8 +352,8 @@ func TestHookMetadataListContractsStayStandalone(t *testing.T) {
 			t.Errorf("standalone definition %s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Errorf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Errorf("definition count = %d, want 439", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 {
 		t.Errorf("wire binding count = %d, want 59", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_run_notification_contract_test.go
+++ b/appserver/protocol/hook_run_notification_contract_test.go
@@ -297,8 +297,8 @@ func TestHookRunNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("surface changed: %d methods, %d wire bindings, %d item bindings", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/hook_value_foundation_contract_test.go
+++ b/appserver/protocol/hook_value_foundation_contract_test.go
@@ -167,8 +167,8 @@ func TestHookValueFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 438 {
-		t.Fatalf("definition count = %d, want 438", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 439 {
+		t.Fatalf("definition count = %d, want 439", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_approval_context_contract_test.go
+++ b/appserver/protocol/network_approval_context_contract_test.go
@@ -1,0 +1,110 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestNetworkApprovalContextSchemaIsExact(t *testing.T) {
+	definition, ok := JSONSchema()["$defs"].(Schema)["NetworkApprovalContext"].(Schema)
+	if !ok {
+		t.Fatal("$defs missing NetworkApprovalContext")
+	}
+	want := Schema{
+		"type": "object",
+		"properties": Schema{
+			"host":     Schema{"type": "string"},
+			"protocol": Schema{"$ref": "#/$defs/NetworkApprovalProtocol"},
+		},
+		"required":             []string{"host", "protocol"},
+		"additionalProperties": false,
+	}
+	if !reflect.DeepEqual(definition, want) {
+		t.Fatalf("NetworkApprovalContext = %#v, want %#v", definition, want)
+	}
+}
+
+func TestNetworkApprovalContextAcceptsSerdeWireForms(t *testing.T) {
+	for _, test := range []struct {
+		input string
+		want  string
+	}{
+		{input: `{"host":"","protocol":"http"}`, want: `{"host":"","protocol":"http"}`},
+		{input: `{"host":"example.com:443","protocol":"https"}`, want: `{"host":"example.com:443","protocol":"https"}`},
+		{input: `{"host":"[::1]","protocol":"socks5Tcp"}`, want: `{"host":"[::1]","protocol":"socks5Tcp"}`},
+		{input: `{"future":true,"host":"arbitrary host","protocol":"socks5Udp"}`, want: `{"host":"arbitrary host","protocol":"socks5Udp"}`},
+		{input: `{"host":"host","protocol":"http","future":1,"future":2}`, want: `{"host":"host","protocol":"http"}`},
+	} {
+		var context NetworkApprovalContext
+		if err := json.Unmarshal([]byte(test.input), &context); err != nil {
+			t.Errorf("Unmarshal(%s): %v", test.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(context)
+		if err != nil || string(encoded) != test.want {
+			t.Errorf("round trip %s = %s, %v; want %s", test.input, encoded, err, test.want)
+		}
+	}
+}
+
+func TestNetworkApprovalContextRejectsMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`, `{}`,
+		`{"protocol":"http"}`,
+		`{"host":"host"}`,
+		`{"host":null,"protocol":"http"}`,
+		`{"host":1,"protocol":"http"}`,
+		`{"host":"host","protocol":null}`,
+		`{"host":"host","protocol":true}`,
+		`{"host":"host","protocol":"ftp"}`,
+		`{"host":"one","host":"two","protocol":"http"}`,
+		`{"host":"host","protocol":"http","protocol":"https"}`,
+		`{"host":"host","protocol":"http"} {}`,
+		`{"host":"host","protocol":"http"} x`,
+	} {
+		assertJSONRejects[NetworkApprovalContext](t, input)
+	}
+
+	var context *NetworkApprovalContext
+	if err := context.UnmarshalJSON([]byte(`{"host":"host","protocol":"http"}`)); err == nil {
+		t.Fatal("nil NetworkApprovalContext receiver succeeded")
+	}
+}
+
+func TestNetworkApprovalContextRemainsStandalone(t *testing.T) {
+	if _, ok := reflect.TypeFor[CommandExecutionApprovalRequestParams]().FieldByName("NetworkApprovalContext"); ok {
+		t.Fatal("live command approval request unexpectedly embeds NetworkApprovalContext")
+	}
+	for _, binding := range WireTypeBindings() {
+		if slices.Contains(binding.Params, "NetworkApprovalContext") ||
+			slices.Contains(binding.Result, "NetworkApprovalContext") {
+			t.Fatalf("NetworkApprovalContext unexpectedly bound to %s", binding.Method)
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestNetworkApprovalContextTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	want := "export type NetworkApprovalContext = {\n" +
+		"  \"host\": string;\n" +
+		"  \"protocol\": NetworkApprovalProtocol;\n" +
+		"};"
+	if !strings.Contains(string(generated), want) {
+		t.Fatalf("generated TypeScript missing %q", want)
+	}
+}

--- a/appserver/protocol/network_approval_context_types.go
+++ b/appserver/protocol/network_approval_context_types.go
@@ -1,0 +1,36 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// NetworkApprovalContext is the exact standalone public context for a network
+// approval. It describes protocol data only and does not grant network access.
+type NetworkApprovalContext struct {
+	Host     string                  `json:"host"`
+	Protocol NetworkApprovalProtocol `json:"protocol"`
+}
+
+func (c *NetworkApprovalContext) UnmarshalJSON(data []byte) error {
+	if c == nil {
+		return errors.New("decode network approval context into nil receiver")
+	}
+	const objectName = "network approval context"
+	payload, err := decodeRustSerdeObject(data, objectName, "host", "protocol")
+	if err != nil {
+		return err
+	}
+	host, err := decodeRequiredThreadItemValue[string](payload, objectName, "host")
+	if err != nil {
+		return err
+	}
+	protocol, err := decodeRequiredThreadItemValue[NetworkApprovalProtocol](payload, objectName, "protocol")
+	if err != nil {
+		return err
+	}
+	*c = NetworkApprovalContext{Host: host, Protocol: protocol}
+	return nil
+}
+
+var _ json.Unmarshaler = (*NetworkApprovalContext)(nil)

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 438 {
-		t.Fatalf("definition count = %d, want 438", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 439 {
+		t.Fatalf("definition count = %d, want 439", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 438 {
-		t.Fatalf("definition count = %d, want 438", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 439 {
+		t.Fatalf("definition count = %d, want 439", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 438 {
-		t.Fatalf("definition count = %d, want 438", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 439 {
+		t.Fatalf("definition count = %d, want 439", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 438 {
-		t.Fatalf("definition count = %d, want 438", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 439 {
+		t.Fatalf("definition count = %d, want 439", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 438 {
-		t.Fatalf("definition count = %d, want 438", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 439 {
+		t.Fatalf("definition count = %d, want 439", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -361,6 +361,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "HooksListResponse", Type: reflect.TypeFor[HooksListResponse]()},
 		{Name: "ItemGuardianApprovalReviewCompletedNotification", Type: reflect.TypeFor[ItemGuardianApprovalReviewCompletedNotification]()},
 		{Name: "ItemGuardianApprovalReviewStartedNotification", Type: reflect.TypeFor[ItemGuardianApprovalReviewStartedNotification]()},
+		{Name: "NetworkApprovalContext", Type: reflect.TypeFor[NetworkApprovalContext]()},
 		{Name: "NetworkApprovalProtocol", Type: reflect.TypeFor[NetworkApprovalProtocol]()},
 		{Name: "PermissionGrantScope", Type: reflect.TypeFor[PermissionGrantScope]()},
 		{Name: "PermissionsApprovalRequestParams", Type: reflect.TypeFor[PermissionsApprovalRequestParams]()},
@@ -695,6 +696,10 @@ func wireSchemaDefinitions() Schema {
 	schemas["HooksListResponse"] = hooksListResponseSchema()
 	schemas["ItemGuardianApprovalReviewCompletedNotification"] = guardianApprovalReviewCompletedNotificationSchema()
 	schemas["ItemGuardianApprovalReviewStartedNotification"] = guardianApprovalReviewStartedNotificationSchema()
+	schemas["NetworkApprovalContext"] = closedThreadSessionParamSchema(Schema{
+		"host":     Schema{"type": "string"},
+		"protocol": Schema{"$ref": "#/$defs/NetworkApprovalProtocol"},
+	}, []string{"host", "protocol"})
 	schemas["NetworkApprovalProtocol"] = stringEnumSchema(
 		string(NetworkApprovalProtocolHTTP), string(NetworkApprovalProtocolHTTPS),
 		string(NetworkApprovalProtocolSocks5TCP), string(NetworkApprovalProtocolSocks5UDP),

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -8108,6 +8108,22 @@
       ],
       "type": "string"
     },
+    "NetworkApprovalContext": {
+      "additionalProperties": false,
+      "properties": {
+        "host": {
+          "type": "string"
+        },
+        "protocol": {
+          "$ref": "#/$defs/NetworkApprovalProtocol"
+        }
+      },
+      "required": [
+        "host",
+        "protocol"
+      ],
+      "type": "object"
+    },
     "NetworkApprovalProtocol": {
       "enum": [
         "http",

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 438 {
-		t.Fatalf("definition count = %d, want 438", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 439 {
+		t.Fatalf("definition count = %d, want 439", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 438 {
-		t.Fatalf("definition count = %d, want 438", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 439 {
+		t.Fatalf("definition count = %d, want 439", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 438 {
-		t.Fatalf("definition count = %d, want 438", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 439 {
+		t.Fatalf("definition count = %d, want 439", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -2242,6 +2242,11 @@ export type ModelsRequirements = {
 
 export type NetworkAccess = "restricted" | "enabled";
 
+export type NetworkApprovalContext = {
+  "host": string;
+  "protocol": NetworkApprovalProtocol;
+};
+
 export type NetworkApprovalProtocol = "http" | "https" | "socks5Tcp" | "socks5Udp";
 
 export type NetworkDomainPermission = "allow" | "deny";

--- a/appserver/protocol/typescript/testdata/network_approval_context_contract.ts
+++ b/appserver/protocol/typescript/testdata/network_approval_context_contract.ts
@@ -1,0 +1,48 @@
+import type {
+  CommandExecutionApprovalRequestParams,
+  MethodParamsByName,
+  MethodResultsByName,
+  NetworkApprovalContext,
+  NetworkApprovalProtocol,
+} from "../gollem_appserver_protocol.js";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+
+type ExactContext = {
+  host: string;
+  protocol: NetworkApprovalProtocol;
+};
+
+type Contracts = [
+  Expect<Equal<NetworkApprovalContext, ExactContext>>,
+  Expect<Equal<NetworkApprovalProtocol, "http" | "https" | "socks5Tcp" | "socks5Udp">>,
+  Expect<Equal<Extract<keyof CommandExecutionApprovalRequestParams, "networkApprovalContext">, never>>,
+  Expect<Equal<Extract<MethodParamsByName[keyof MethodParamsByName], NetworkApprovalContext>, never>>,
+  Expect<Equal<Extract<MethodResultsByName[keyof MethodResultsByName], NetworkApprovalContext>, never>>,
+];
+
+({ host: "", protocol: "http" }) satisfies NetworkApprovalContext;
+({ host: "example.com:443", protocol: "https" }) satisfies NetworkApprovalContext;
+({ host: "arbitrary host", protocol: "socks5Udp" }) satisfies NetworkApprovalContext;
+
+// @ts-expect-error host is required.
+({ protocol: "http" }) satisfies NetworkApprovalContext;
+// @ts-expect-error protocol is required.
+({ host: "host" }) satisfies NetworkApprovalContext;
+// @ts-expect-error host is a non-null string.
+({ host: null, protocol: "http" }) satisfies NetworkApprovalContext;
+// @ts-expect-error protocol is closed.
+({ host: "host", protocol: "ftp" }) satisfies NetworkApprovalContext;
+// @ts-expect-error canonical records are closed.
+({ host: "host", protocol: "http", future: true }) satisfies NetworkApprovalContext;
+// @ts-expect-error values are non-null objects.
+(null) satisfies NetworkApprovalContext;
+// @ts-expect-error values are not arrays.
+([]) satisfies NetworkApprovalContext;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 438 {
-		t.Fatalf("definition count = %d, want 438", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
+		t.Fatalf("definition count = %d, want 439", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary

- export exact standalone `NetworkApprovalContext` with required `host` and `protocol` fields
- preserve Rust serde-compatible unknown-field handling while rejecting malformed and duplicate known fields
- generate the 439th schema definition and exact TypeScript contract without changing runtime approval bindings

## Verification

- deliberate-red Go and strict TypeScript provenance
- 30 focused repetitions, focused race, and 100% decoder coverage
- full protocol normal/race (97.4% aggregate coverage)
- normal and race tests across all 59 non-Monty packages
- `golangci-lint run ./...`, non-Monty `go vet`, tidy verification
- configured pre-push hook with `hooks.skipMontyRace=true`
- deterministic generation and strict TypeScript compilation
- normalized pinned-upstream schema identity and structural reversal to PR #205
