### PR TITLE
appserver/protocol: add exact ParsedCommand contract

### DIFF
--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(defs); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/attestation_contract_test.go
+++ b/appserver/protocol/attestation_contract_test.go
@@ -133,8 +133,8 @@ func TestAttestationContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("attestation/generate = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,8 +217,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,8 +203,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -260,8 +260,8 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,8 +244,8 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -162,8 +162,8 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -175,8 +175,8 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_contract_test.go
+++ b/appserver/protocol/file_change_contract_test.go
@@ -108,8 +108,8 @@ func TestFileChangeRemainsStandalone(t *testing.T) {
 			t.Fatalf("FileChange unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_output_delta_notification_contract_test.go
+++ b/appserver/protocol/file_change_output_delta_notification_contract_test.go
@@ -100,8 +100,8 @@ func TestFileChangeOutputDeltaNotificationRemainsDeprecatedAndStandalone(t *test
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("item/fileChange/outputDelta = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -381,8 +381,8 @@ func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_action_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_action_contract_test.go
@@ -226,8 +226,8 @@ func TestGuardianApprovalReviewActionRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReviewAction unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
@@ -164,8 +164,8 @@ func TestGuardianApprovalReviewCompletedNotificationRemainsStandalone(t *testing
 			t.Fatalf("completed notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_contract_test.go
@@ -139,8 +139,8 @@ func TestGuardianApprovalReviewRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReview unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
@@ -175,8 +175,8 @@ func TestGuardianApprovalReviewStartedNotificationRemainsStandalone(t *testing.T
 			t.Fatalf("started notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_enum_foundation_contract_test.go
+++ b/appserver/protocol/guardian_enum_foundation_contract_test.go
@@ -89,8 +89,8 @@ func TestGuardianEnumFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_metadata_list_contract_test.go
+++ b/appserver/protocol/hook_metadata_list_contract_test.go
@@ -352,8 +352,8 @@ func TestHookMetadataListContractsStayStandalone(t *testing.T) {
 			t.Errorf("standalone definition %s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Errorf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Errorf("definition count = %d, want 440", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 {
 		t.Errorf("wire binding count = %d, want 59", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_run_notification_contract_test.go
+++ b/appserver/protocol/hook_run_notification_contract_test.go
@@ -297,8 +297,8 @@ func TestHookRunNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("surface changed: %d methods, %d wire bindings, %d item bindings", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/hook_value_foundation_contract_test.go
+++ b/appserver/protocol/hook_value_foundation_contract_test.go
@@ -167,8 +167,8 @@ func TestHookValueFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 439 {
-		t.Fatalf("definition count = %d, want 439", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 440 {
+		t.Fatalf("definition count = %d, want 440", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_approval_context_contract_test.go
+++ b/appserver/protocol/network_approval_context_contract_test.go
@@ -84,8 +84,8 @@ func TestNetworkApprovalContextRemainsStandalone(t *testing.T) {
 			t.Fatalf("NetworkApprovalContext unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/parsed_command_contract_test.go
+++ b/appserver/protocol/parsed_command_contract_test.go
@@ -1,0 +1,163 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestParsedCommandSchemaIsExact(t *testing.T) {
+	definition, ok := JSONSchema()["$defs"].(Schema)["ParsedCommand"].(Schema)
+	if !ok {
+		t.Fatal("$defs missing ParsedCommand")
+	}
+	want := Schema{"oneOf": []any{
+		parsedCommandVariantSchema("read", []string{"cmd", "name", "path"}, Schema{
+			"cmd":  Schema{"type": "string"},
+			"name": Schema{"type": "string"},
+			"path": Schema{
+				"type": "string",
+				"description": "(Best effort) Path to the file being read by the command. When " +
+					"possible, this is an absolute path, though when relative, it should " +
+					"be resolved against the `cwd`` that will be used to run the command " +
+					"to derive the absolute path.",
+			},
+		}),
+		parsedCommandVariantSchema("list_files", []string{"cmd"}, Schema{
+			"cmd": Schema{"type": "string"}, "path": nullableStringSchema(),
+		}),
+		parsedCommandVariantSchema("search", []string{"cmd"}, Schema{
+			"cmd": Schema{"type": "string"}, "query": nullableStringSchema(), "path": nullableStringSchema(),
+		}),
+		parsedCommandVariantSchema("unknown", []string{"cmd"}, Schema{
+			"cmd": Schema{"type": "string"},
+		}),
+	}}
+	if !reflect.DeepEqual(definition, want) {
+		t.Fatalf("ParsedCommand = %#v, want %#v", definition, want)
+	}
+}
+
+func TestParsedCommandAcceptsSerdeWireForms(t *testing.T) {
+	for _, test := range []struct {
+		input string
+		want  string
+	}{
+		{input: `{"type":"read","cmd":"","name":"","path":""}`, want: `{"type":"read","cmd":"","name":"","path":""}`},
+		{input: `{"type":"read","cmd":"cat file","name":"cat","path":"relative/../file"}`, want: `{"type":"read","cmd":"cat file","name":"cat","path":"relative/../file"}`},
+		{input: `{"type":"list_files","cmd":"ls"}`, want: `{"type":"list_files","cmd":"ls","path":null}`},
+		{input: `{"type":"list_files","cmd":"ls","path":null}`, want: `{"type":"list_files","cmd":"ls","path":null}`},
+		{input: `{"type":"list_files","cmd":"ls src","path":"relative/src"}`, want: `{"type":"list_files","cmd":"ls src","path":"relative/src"}`},
+		{input: `{"type":"search","cmd":"rg"}`, want: `{"type":"search","cmd":"rg","query":null,"path":null}`},
+		{input: `{"type":"search","cmd":"rg","query":null,"path":null}`, want: `{"type":"search","cmd":"rg","query":null,"path":null}`},
+		{input: `{"type":"search","cmd":"rg needle","query":"needle","path":null}`, want: `{"type":"search","cmd":"rg needle","query":"needle","path":null}`},
+		{input: `{"type":"unknown","cmd":"custom --flag"}`, want: `{"type":"unknown","cmd":"custom --flag"}`},
+		{input: `{"future":true,"type":"unknown","cmd":"run","path":"discarded"}`, want: `{"type":"unknown","cmd":"run"}`},
+		{input: `{"type":"unknown","cmd":"run","path":"one","path":"two"}`, want: `{"type":"unknown","cmd":"run"}`},
+		{input: `{"type":"read","cmd":"cat","name":"cat","path":"file","query":"discarded","future":1,"future":2}`, want: `{"type":"read","cmd":"cat","name":"cat","path":"file"}`},
+		{input: `{"type":"read","cmd":"cat","name":"cat","path":"file","query":"one","query":"two"}`, want: `{"type":"read","cmd":"cat","name":"cat","path":"file"}`},
+	} {
+		var command ParsedCommand
+		if err := json.Unmarshal([]byte(test.input), &command); err != nil {
+			t.Errorf("Unmarshal(%s): %v", test.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(command)
+		if err != nil || string(encoded) != test.want {
+			t.Errorf("round trip %s = %s, %v; want %s", test.input, encoded, err, test.want)
+		}
+	}
+}
+
+func TestParsedCommandRejectsMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`, `{}`,
+		`{"cmd":"run"}`,
+		`{"type":null,"cmd":"run"}`,
+		`{"type":1,"cmd":"run"}`,
+		`{"type":"execute","cmd":"run"}`,
+		`{"type":"read","cmd":"cat","name":"cat"}`,
+		`{"type":"read","cmd":"cat","name":"cat","path":null}`,
+		`{"type":"read","cmd":null,"name":"cat","path":"file"}`,
+		`{"type":"read","cmd":"cat","name":null,"path":"file"}`,
+		`{"type":"list_files"}`,
+		`{"type":"list_files","cmd":"ls","path":1}`,
+		`{"type":"search"}`,
+		`{"type":"search","cmd":"rg","query":1}`,
+		`{"type":"search","cmd":"rg","path":false}`,
+		`{"type":"unknown"}`,
+		`{"type":"unknown","cmd":null}`,
+		`{"type":"unknown","type":"read","cmd":"run"}`,
+		`{"type":"unknown","cmd":"one","cmd":"two"}`,
+		`{"type":"read","cmd":"cat","name":"one","name":"two","path":"file"}`,
+		`{"type":"list_files","cmd":"ls","path":null,"path":"src"}`,
+		`{"type":"search","cmd":"rg","query":null,"query":"q"}`,
+		`{"type":"search","cmd":"rg","path":null,"path":"src"}`,
+		`{"type":"unknown","cmd":"run"} {}`,
+		`{"type":"unknown","cmd":"run"} x`,
+	} {
+		assertJSONRejects[ParsedCommand](t, input)
+	}
+
+	if _, err := json.Marshal(ParsedCommand{}); err == nil {
+		t.Fatal("Marshal empty ParsedCommand succeeded")
+	}
+	var command *ParsedCommand
+	if err := command.UnmarshalJSON([]byte(`{"type":"unknown","cmd":"run"}`)); err == nil {
+		t.Fatal("nil ParsedCommand receiver succeeded")
+	}
+}
+
+func TestParsedCommandRemainsStandalone(t *testing.T) {
+	if _, ok := JSONSchema()["$defs"].(Schema)["ExecCommandApprovalParams"]; ok {
+		t.Fatal("blocked ExecCommandApprovalParams unexpectedly exported")
+	}
+	if reflect.TypeFor[ParsedCommand]() == reflect.TypeFor[CommandAction]() ||
+		reflect.TypeFor[ParsedCommand]() == reflect.TypeFor[CommandExecutionAction]() {
+		t.Fatal("ParsedCommand aliases a distinct live command-action type")
+	}
+	for _, binding := range WireTypeBindings() {
+		if slices.Contains(binding.Params, "ParsedCommand") || slices.Contains(binding.Result, "ParsedCommand") {
+			t.Fatalf("ParsedCommand unexpectedly bound to %s", binding.Method)
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestParsedCommandTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	want := "export type ParsedCommand = {\n" +
+		"  \"cmd\": string;\n" +
+		"  \"name\": string;\n" +
+		"  \"path\": string;\n" +
+		"  \"type\": \"read\";\n" +
+		"} | {\n" +
+		"  \"cmd\": string;\n" +
+		"  \"path\": string | null;\n" +
+		"  \"type\": \"list_files\";\n" +
+		"} | {\n" +
+		"  \"cmd\": string;\n" +
+		"  \"path\": string | null;\n" +
+		"  \"query\": string | null;\n" +
+		"  \"type\": \"search\";\n" +
+		"} | {\n" +
+		"  \"cmd\": string;\n" +
+		"  \"type\": \"unknown\";\n" +
+		"};"
+	if !strings.Contains(string(generated), want) {
+		t.Fatalf("generated TypeScript missing %q", want)
+	}
+}

--- a/appserver/protocol/parsed_command_types.go
+++ b/appserver/protocol/parsed_command_types.go
@@ -1,0 +1,145 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// ParsedCommand retains one exact public parsed-command variant without
+// aliasing Gollem's distinct live command-action types.
+type ParsedCommand struct {
+	raw json.RawMessage
+}
+
+func (c ParsedCommand) MarshalJSON() ([]byte, error) {
+	if len(c.raw) == 0 {
+		return nil, errors.New("parsed command has no value")
+	}
+	return validateParsedCommandJSON(c.raw)
+}
+
+func (c *ParsedCommand) UnmarshalJSON(data []byte) error {
+	if c == nil {
+		return errors.New("decode parsed command into nil receiver")
+	}
+	canonical, err := validateParsedCommandJSON(data)
+	if err != nil {
+		return err
+	}
+	c.raw = canonical
+	return nil
+}
+
+func validateParsedCommandJSON(data []byte) (json.RawMessage, error) {
+	const objectName = "parsed command"
+	discriminator, err := decodeRustSerdeObject(data, objectName, "type")
+	if err != nil {
+		return nil, err
+	}
+	commandType, err := decodeRequiredThreadItemValue[string](discriminator, objectName, "type")
+	if err != nil {
+		return nil, err
+	}
+
+	switch commandType {
+	case "read":
+		payload, err := decodeRustSerdeObject(data, "read parsed command", "type", "cmd", "name", "path")
+		if err != nil {
+			return nil, err
+		}
+		cmd, err := decodeRequiredThreadItemValue[string](payload, "read parsed command", "cmd")
+		if err != nil {
+			return nil, err
+		}
+		name, err := decodeRequiredThreadItemValue[string](payload, "read parsed command", "name")
+		if err != nil {
+			return nil, err
+		}
+		path, err := decodeRequiredThreadItemValue[string](payload, "read parsed command", "path")
+		if err != nil {
+			return nil, err
+		}
+		return json.Marshal(struct {
+			Type string `json:"type"`
+			Cmd  string `json:"cmd"`
+			Name string `json:"name"`
+			Path string `json:"path"`
+		}{Type: commandType, Cmd: cmd, Name: name, Path: path})
+	case "list_files":
+		payload, err := decodeRustSerdeObject(data, "list_files parsed command", "type", "cmd", "path")
+		if err != nil {
+			return nil, err
+		}
+		cmd, err := decodeRequiredThreadItemValue[string](payload, "list_files parsed command", "cmd")
+		if err != nil {
+			return nil, err
+		}
+		path, err := decodeOptionalNullableParsedCommandString(payload, "list_files parsed command", "path")
+		if err != nil {
+			return nil, err
+		}
+		return json.Marshal(struct {
+			Type string  `json:"type"`
+			Cmd  string  `json:"cmd"`
+			Path *string `json:"path"`
+		}{Type: commandType, Cmd: cmd, Path: path})
+	case "search":
+		payload, err := decodeRustSerdeObject(data, "search parsed command", "type", "cmd", "query", "path")
+		if err != nil {
+			return nil, err
+		}
+		cmd, err := decodeRequiredThreadItemValue[string](payload, "search parsed command", "cmd")
+		if err != nil {
+			return nil, err
+		}
+		query, err := decodeOptionalNullableParsedCommandString(payload, "search parsed command", "query")
+		if err != nil {
+			return nil, err
+		}
+		path, err := decodeOptionalNullableParsedCommandString(payload, "search parsed command", "path")
+		if err != nil {
+			return nil, err
+		}
+		return json.Marshal(struct {
+			Type  string  `json:"type"`
+			Cmd   string  `json:"cmd"`
+			Query *string `json:"query"`
+			Path  *string `json:"path"`
+		}{Type: commandType, Cmd: cmd, Query: query, Path: path})
+	case "unknown":
+		payload, err := decodeRustSerdeObject(data, "unknown parsed command", "type", "cmd")
+		if err != nil {
+			return nil, err
+		}
+		cmd, err := decodeRequiredThreadItemValue[string](payload, "unknown parsed command", "cmd")
+		if err != nil {
+			return nil, err
+		}
+		return json.Marshal(struct {
+			Type string `json:"type"`
+			Cmd  string `json:"cmd"`
+		}{Type: commandType, Cmd: cmd})
+	default:
+		return nil, fmt.Errorf("unknown parsed command type %q", commandType)
+	}
+}
+
+func decodeOptionalNullableParsedCommandString(
+	payload map[string]json.RawMessage,
+	objectName string,
+	fieldName string,
+) (*string, error) {
+	raw, ok := payload[fieldName]
+	if !ok || isJSONNull(raw) {
+		return nil, nil
+	}
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return nil, fmt.Errorf("decode %s %s: %w", objectName, fieldName, err)
+	}
+	return &value, nil
+}
+
+var _ json.Marshaler = ParsedCommand{}
+var _ json.Unmarshaler = (*ParsedCommand)(nil)

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 439 {
-		t.Fatalf("definition count = %d, want 439", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 440 {
+		t.Fatalf("definition count = %d, want 440", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 439 {
-		t.Fatalf("definition count = %d, want 439", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 440 {
+		t.Fatalf("definition count = %d, want 440", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 439 {
-		t.Fatalf("definition count = %d, want 439", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 440 {
+		t.Fatalf("definition count = %d, want 440", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 439 {
-		t.Fatalf("definition count = %d, want 439", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 440 {
+		t.Fatalf("definition count = %d, want 440", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 439 {
-		t.Fatalf("definition count = %d, want 439", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 440 {
+		t.Fatalf("definition count = %d, want 440", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -363,6 +363,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "ItemGuardianApprovalReviewStartedNotification", Type: reflect.TypeFor[ItemGuardianApprovalReviewStartedNotification]()},
 		{Name: "NetworkApprovalContext", Type: reflect.TypeFor[NetworkApprovalContext]()},
 		{Name: "NetworkApprovalProtocol", Type: reflect.TypeFor[NetworkApprovalProtocol]()},
+		{Name: "ParsedCommand", Type: reflect.TypeFor[ParsedCommand]()},
 		{Name: "PermissionGrantScope", Type: reflect.TypeFor[PermissionGrantScope]()},
 		{Name: "PermissionsApprovalRequestParams", Type: reflect.TypeFor[PermissionsApprovalRequestParams]()},
 		{Name: "PermissionsRequestApprovalParams", Type: reflect.TypeFor[PermissionsRequestApprovalParams]()},
@@ -704,6 +705,7 @@ func wireSchemaDefinitions() Schema {
 		string(NetworkApprovalProtocolHTTP), string(NetworkApprovalProtocolHTTPS),
 		string(NetworkApprovalProtocolSocks5TCP), string(NetworkApprovalProtocolSocks5UDP),
 	)
+	schemas["ParsedCommand"] = parsedCommandSchema()
 	schemas["McpServerToolCallParams"] = mcpServerToolCallParamsSchema()
 	schemas["McpServerToolCallResponse"] = mcpServerToolCallResponseSchema()
 	schemas["ResourceContent"] = resourceContentSchema()
@@ -1270,6 +1272,48 @@ func commandActionSchema() Schema {
 			"command": Schema{"type": "string"},
 		}),
 	}}
+}
+
+func parsedCommandSchema() Schema {
+	return Schema{"oneOf": []any{
+		parsedCommandVariantSchema("read", []string{"cmd", "name", "path"}, Schema{
+			"cmd":  Schema{"type": "string"},
+			"name": Schema{"type": "string"},
+			"path": Schema{
+				"type": "string",
+				"description": "(Best effort) Path to the file being read by the command. When " +
+					"possible, this is an absolute path, though when relative, it should " +
+					"be resolved against the `cwd`` that will be used to run the command " +
+					"to derive the absolute path.",
+			},
+		}),
+		parsedCommandVariantSchema("list_files", []string{"cmd"}, Schema{
+			"cmd": Schema{"type": "string"}, "path": nullableStringSchema(),
+		}),
+		parsedCommandVariantSchema("search", []string{"cmd"}, Schema{
+			"cmd": Schema{"type": "string"}, "query": nullableStringSchema(), "path": nullableStringSchema(),
+		}),
+		parsedCommandVariantSchema("unknown", []string{"cmd"}, Schema{
+			"cmd": Schema{"type": "string"},
+		}),
+	}}
+}
+
+func parsedCommandVariantSchema(commandType string, requiredFields []string, fields Schema) Schema {
+	properties := Schema{
+		"type": Schema{"type": "string", "enum": []any{commandType}},
+	}
+	for name, schema := range fields {
+		properties[name] = schema
+	}
+	required := []string{"type"}
+	required = append(required, requiredFields...)
+	return Schema{
+		"type":                 "object",
+		"properties":           properties,
+		"required":             required,
+		"additionalProperties": false,
+	}
 }
 
 func collabAgentStateSchema() Schema {

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -8496,6 +8496,125 @@
       ],
       "type": "object"
     },
+    "ParsedCommand": {
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "cmd": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "path": {
+              "description": "(Best effort) Path to the file being read by the command. When possible, this is an absolute path, though when relative, it should be resolved against the `cwd`` that will be used to run the command to derive the absolute path.",
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "read"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "cmd",
+            "name",
+            "path"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "cmd": {
+              "type": "string"
+            },
+            "path": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "type": {
+              "enum": [
+                "list_files"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "cmd"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "cmd": {
+              "type": "string"
+            },
+            "path": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "query": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "type": {
+              "enum": [
+                "search"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "cmd"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "cmd": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "unknown"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "cmd"
+          ],
+          "type": "object"
+        }
+      ]
+    },
     "PatchApplyStatus": {
       "enum": [
         "inProgress",

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 439 {
-		t.Fatalf("definition count = %d, want 439", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 440 {
+		t.Fatalf("definition count = %d, want 440", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 439 {
-		t.Fatalf("definition count = %d, want 439", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 440 {
+		t.Fatalf("definition count = %d, want 440", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 439 {
-		t.Fatalf("definition count = %d, want 439", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 440 {
+		t.Fatalf("definition count = %d, want 440", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -45,7 +45,7 @@ func MarshalTypeScript() ([]byte, error) {
 			name == "FuzzyFileSearchParams" || name == "FuzzyFileSearchResult" ||
 			name == "HookRunSummary" || name == "HookStartedNotification" ||
 			name == "HookCompletedNotification" || name == "HookMetadata" ||
-			name == "GuardianApprovalReview" ||
+			name == "GuardianApprovalReview" || name == "ParsedCommand" ||
 			name == "ItemGuardianApprovalReviewCompletedNotification" ||
 			name == "ItemGuardianApprovalReviewStartedNotification" {
 			// Rust accepts omitted serde default/Option fields while generated
@@ -92,6 +92,22 @@ func MarshalTypeScript() ([]byte, error) {
 			case "GuardianApprovalReview":
 				schema["required"] = []string{
 					"status", "riskLevel", "userAuthorization", "rationale",
+				}
+			case "ParsedCommand":
+				variants := schema["oneOf"].([]any)
+				for index, required := range [][]string{
+					{"type", "cmd", "name", "path"},
+					{"type", "cmd", "path"},
+					{"type", "cmd", "query", "path"},
+					{"type", "cmd"},
+				} {
+					variant := variants[index].(Schema)
+					copy := make(Schema, len(variant))
+					for key, value := range variant {
+						copy[key] = value
+					}
+					copy["required"] = required
+					variants[index] = copy
 				}
 			case "ItemGuardianApprovalReviewCompletedNotification":
 				schema["required"] = []string{

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -2295,6 +2295,25 @@ export type OverriddenMetadata = {
   "overridingLayer": ConfigLayerMetadata;
 };
 
+export type ParsedCommand = {
+  "cmd": string;
+  "name": string;
+  "path": string;
+  "type": "read";
+} | {
+  "cmd": string;
+  "path": string | null;
+  "type": "list_files";
+} | {
+  "cmd": string;
+  "path": string | null;
+  "query": string | null;
+  "type": "search";
+} | {
+  "cmd": string;
+  "type": "unknown";
+};
+
 export type PatchApplyStatus = "inProgress" | "completed" | "failed" | "declined";
 
 export type PatchChangeKind = {

--- a/appserver/protocol/typescript/testdata/parsed_command_contract.ts
+++ b/appserver/protocol/typescript/testdata/parsed_command_contract.ts
@@ -1,0 +1,49 @@
+import type {
+  CommandAction,
+  CommandExecutionAction,
+  MethodParamsByName,
+  MethodResultsByName,
+  ParsedCommand,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2) ? true : false;
+type Expect<T extends true> = T;
+
+type ExactParsedCommand =
+  | { type: "read"; cmd: string; name: string; path: string }
+  | { type: "list_files"; cmd: string; path: string | null }
+  | { type: "search"; cmd: string; query: string | null; path: string | null }
+  | { type: "unknown"; cmd: string };
+
+export type ParsedCommandContract = [
+  Expect<Equal<ParsedCommand, ExactParsedCommand>>,
+  Expect<Equal<Extract<ParsedCommand, CommandAction>, never>>,
+  Expect<Equal<Extract<ParsedCommand, CommandExecutionAction>, never>>,
+  Expect<Equal<Extract<MethodParamsByName[keyof MethodParamsByName], ParsedCommand>, never>>,
+  Expect<Equal<Extract<MethodResultsByName[keyof MethodResultsByName], ParsedCommand>, never>>,
+];
+
+({ type: "read", cmd: "", name: "", path: "" }) satisfies ParsedCommand;
+({ type: "read", cmd: "cat", name: "cat", path: "relative/../file" }) satisfies ParsedCommand;
+({ type: "list_files", cmd: "ls", path: null }) satisfies ParsedCommand;
+({ type: "list_files", cmd: "ls src", path: "relative/src" }) satisfies ParsedCommand;
+({ type: "search", cmd: "rg", query: null, path: null }) satisfies ParsedCommand;
+({ type: "search", cmd: "rg q", query: "q", path: "src" }) satisfies ParsedCommand;
+({ type: "unknown", cmd: "custom --flag" }) satisfies ParsedCommand;
+
+// @ts-expect-error read requires path.
+({ type: "read", cmd: "cat", name: "cat" }) satisfies ParsedCommand;
+// @ts-expect-error list_files path is canonical-required nullable.
+({ type: "list_files", cmd: "ls" }) satisfies ParsedCommand;
+// @ts-expect-error search query is canonical-required nullable.
+({ type: "search", cmd: "rg", path: null }) satisfies ParsedCommand;
+// @ts-expect-error search path is canonical-required nullable.
+({ type: "search", cmd: "rg", query: null }) satisfies ParsedCommand;
+// @ts-expect-error canonical variants are closed.
+({ type: "unknown", cmd: "run", path: null }) satisfies ParsedCommand;
+// @ts-expect-error discriminants are closed and snake-case.
+({ type: "listFiles", cmd: "ls", path: null }) satisfies ParsedCommand;
+// @ts-expect-error cmd is required.
+({ type: "unknown" }) satisfies ParsedCommand;

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 439 {
-		t.Fatalf("definition count = %d, want 439", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
+		t.Fatalf("definition count = %d, want 440", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- export the exact standalone four-variant `ParsedCommand` public protocol union from pinned Codex `5c19155c`
- preserve serde input behavior while emitting closed canonical JSON and required nullable TypeScript fields
- keep the blocked legacy approval parent, live command actions, methods, bindings, and runtime behavior unchanged

## Verification
- deliberate-red Go and strict TypeScript boundaries
- focused tests x30, focused race, and 100% coverage for all new production functions
- full protocol normal/race and 97.4% aggregate coverage
- all 59 non-Monty packages under normal/race; local Monty tests skipped per configuration
- exact normalized pinned schema and compiler-level TypeScript identity
- deterministic generation, structural reversal, lint, vet, tidy/verify, and configured pre-push
- all five real Slang stdio/Unix-socket/WebSocket workflows
- reproducible no-VCS binary SHA-256 `80716e3dd8dcfeff3b47da86c4f72a1694509c435167d5ad7caec515918b2e23`