### PR TITLE
Export exact ExecCommandApprovalParams contract

### DIFF
--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(defs); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/attestation_contract_test.go
+++ b/appserver/protocol/attestation_contract_test.go
@@ -133,8 +133,8 @@ func TestAttestationContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("attestation/generate = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/exec_command_approval_params_contract_test.go
+++ b/appserver/protocol/exec_command_approval_params_contract_test.go
@@ -1,0 +1,168 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestExecCommandApprovalParamsSchemaIsExact(t *testing.T) {
+	definition, ok := JSONSchema()["$defs"].(Schema)["ExecCommandApprovalParams"].(Schema)
+	if !ok {
+		t.Fatal("$defs missing ExecCommandApprovalParams")
+	}
+	want := closedThreadSessionParamSchema(Schema{
+		"conversationId": Schema{"$ref": "#/$defs/ThreadId"},
+		"callId": Schema{
+			"type": "string",
+			"description": "Use to correlate this with [codex_protocol::protocol::ExecCommandBeginEvent] " +
+				"and [codex_protocol::protocol::ExecCommandEndEvent].",
+		},
+		"approvalId": Schema{
+			"anyOf":       []any{Schema{"type": "string"}, Schema{"type": "null"}},
+			"description": "Identifier for this specific approval callback.",
+		},
+		"command": Schema{"type": "array", "items": Schema{"type": "string"}},
+		"cwd":     Schema{"type": "string"},
+		"reason":  nullableStringSchema(),
+		"parsedCmd": Schema{
+			"type":  "array",
+			"items": Schema{"$ref": "#/$defs/ParsedCommand"},
+		},
+	}, []string{"callId", "command", "conversationId", "cwd", "parsedCmd"})
+	if !reflect.DeepEqual(definition, want) {
+		t.Fatalf("ExecCommandApprovalParams = %#v, want %#v", definition, want)
+	}
+}
+
+func TestExecCommandApprovalParamsAcceptsSerdeWireForms(t *testing.T) {
+	for _, test := range []struct {
+		input string
+		want  string
+	}{
+		{
+			input: `{"conversationId":"","callId":"","command":[],"cwd":"","parsedCmd":[]}`,
+			want:  `{"conversationId":"","callId":"","approvalId":null,"command":[],"cwd":"","reason":null,"parsedCmd":[]}`,
+		},
+		{
+			input: `{"conversationId":"thread-1","callId":"call-1","approvalId":null,"command":["sh","-lc","pwd"],"cwd":"relative/worktree","reason":null,"parsedCmd":[{"type":"unknown","cmd":"pwd"}]}`,
+			want:  `{"conversationId":"thread-1","callId":"call-1","approvalId":null,"command":["sh","-lc","pwd"],"cwd":"relative/worktree","reason":null,"parsedCmd":[{"type":"unknown","cmd":"pwd"}]}`,
+		},
+		{
+			input: `{"conversationId":"thread-2","callId":"call-2","approvalId":"approval-2","command":["rg","q","q"],"cwd":"/workspace","reason":"inspect","parsedCmd":[{"type":"read","cmd":"cat f","name":"cat","path":"relative/f"},{"type":"list_files","cmd":"ls"},{"type":"search","cmd":"rg q","query":"q","path":null}]}`,
+			want:  `{"conversationId":"thread-2","callId":"call-2","approvalId":"approval-2","command":["rg","q","q"],"cwd":"/workspace","reason":"inspect","parsedCmd":[{"type":"read","cmd":"cat f","name":"cat","path":"relative/f"},{"type":"list_files","cmd":"ls","path":null},{"type":"search","cmd":"rg q","query":"q","path":null}]}`,
+		},
+		{
+			input: `{"future":1,"future":2,"conversationId":"thread","callId":"call","command":["echo"],"cwd":".","parsedCmd":[],"other":{"ignored":true}}`,
+			want:  `{"conversationId":"thread","callId":"call","approvalId":null,"command":["echo"],"cwd":".","reason":null,"parsedCmd":[]}`,
+		},
+	} {
+		var params ExecCommandApprovalParams
+		if err := json.Unmarshal([]byte(test.input), &params); err != nil {
+			t.Errorf("Unmarshal(%s): %v", test.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(params)
+		if err != nil || string(encoded) != test.want {
+			t.Errorf("round trip %s = %s, %v; want %s", test.input, encoded, err, test.want)
+		}
+	}
+
+	encoded, err := json.Marshal(ExecCommandApprovalParams{})
+	want := `{"conversationId":"","callId":"","approvalId":null,"command":[],"cwd":"","reason":null,"parsedCmd":[]}`
+	if err != nil || string(encoded) != want {
+		t.Fatalf("marshal zero params = %s, %v; want %s", encoded, err, want)
+	}
+}
+
+func TestExecCommandApprovalParamsRejectsMalformedWireForms(t *testing.T) {
+	valid := `"conversationId":"thread","callId":"call","command":[],"cwd":".","parsedCmd":[]`
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`, `{}`,
+		`{"callId":"call","command":[],"cwd":".","parsedCmd":[]}`,
+		`{"conversationId":"thread","command":[],"cwd":".","parsedCmd":[]}`,
+		`{"conversationId":"thread","callId":"call","cwd":".","parsedCmd":[]}`,
+		`{"conversationId":"thread","callId":"call","command":[],"parsedCmd":[]}`,
+		`{"conversationId":"thread","callId":"call","command":[],"cwd":"."}`,
+		`{"conversationId":null,"callId":"call","command":[],"cwd":".","parsedCmd":[]}`,
+		`{"conversationId":1,"callId":"call","command":[],"cwd":".","parsedCmd":[]}`,
+		`{"conversationId":"thread","callId":null,"command":[],"cwd":".","parsedCmd":[]}`,
+		`{"conversationId":"thread","callId":1,"command":[],"cwd":".","parsedCmd":[]}`,
+		`{"conversationId":"thread","callId":"call","approvalId":1,"command":[],"cwd":".","parsedCmd":[]}`,
+		`{"conversationId":"thread","callId":"call","command":null,"cwd":".","parsedCmd":[]}`,
+		`{"conversationId":"thread","callId":"call","command":{},"cwd":".","parsedCmd":[]}`,
+		`{"conversationId":"thread","callId":"call","command":[1],"cwd":".","parsedCmd":[]}`,
+		`{"conversationId":"thread","callId":"call","command":[],"cwd":null,"parsedCmd":[]}`,
+		`{"conversationId":"thread","callId":"call","command":[],"cwd":1,"parsedCmd":[]}`,
+		`{"conversationId":"thread","callId":"call","command":[],"cwd":".","reason":1,"parsedCmd":[]}`,
+		`{"conversationId":"thread","callId":"call","command":[],"cwd":".","parsedCmd":null}`,
+		`{"conversationId":"thread","callId":"call","command":[],"cwd":".","parsedCmd":{}}`,
+		`{"conversationId":"thread","callId":"call","command":[],"cwd":".","parsedCmd":[null]}`,
+		`{"conversationId":"thread","callId":"call","command":[],"cwd":".","parsedCmd":[{"type":"unknown"}]}`,
+		`{"conversationId":"one","conversationId":"two","callId":"call","command":[],"cwd":".","parsedCmd":[]}`,
+		`{"conversationId":"thread","callId":"one","callId":"two","command":[],"cwd":".","parsedCmd":[]}`,
+		`{"conversationId":"thread","callId":"call","approvalId":null,"approvalId":"id","command":[],"cwd":".","parsedCmd":[]}`,
+		`{"conversationId":"thread","callId":"call","command":[],"command":[],"cwd":".","parsedCmd":[]}`,
+		`{"conversationId":"thread","callId":"call","command":[],"cwd":"one","cwd":"two","parsedCmd":[]}`,
+		`{"conversationId":"thread","callId":"call","command":[],"cwd":".","reason":null,"reason":"why","parsedCmd":[]}`,
+		`{"conversationId":"thread","callId":"call","command":[],"cwd":".","parsedCmd":[],"parsedCmd":[]}`,
+		`{` + valid + `} {}`,
+		`{` + valid + `} x`,
+	} {
+		assertJSONRejects[ExecCommandApprovalParams](t, input)
+	}
+
+	var params *ExecCommandApprovalParams
+	if err := params.UnmarshalJSON([]byte(`{` + valid + `}`)); err == nil {
+		t.Fatal("nil ExecCommandApprovalParams receiver succeeded")
+	}
+}
+
+func TestExecCommandApprovalParamsRemainsStandalone(t *testing.T) {
+	if reflect.TypeFor[ExecCommandApprovalParams]() == reflect.TypeFor[CommandExecutionApprovalRequestParams]() {
+		t.Fatal("legacy exec-command params alias live command-execution approval params")
+	}
+	defs := JSONSchema()["$defs"].(Schema)
+	if _, ok := defs["ExecCommandApprovalResponse"]; ok {
+		t.Fatal("blocked ExecCommandApprovalResponse unexpectedly exported")
+	}
+	if _, ok := defs["ReviewDecision"]; ok {
+		t.Fatal("blocked ReviewDecision unexpectedly exported")
+	}
+	for _, binding := range WireTypeBindings() {
+		if slices.Contains(binding.Params, "ExecCommandApprovalParams") ||
+			slices.Contains(binding.Result, "ExecCommandApprovalParams") {
+			t.Fatalf("ExecCommandApprovalParams unexpectedly bound to %s", binding.Method)
+		}
+	}
+	if got := len(defs); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestExecCommandApprovalParamsTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	want := "export type ExecCommandApprovalParams = {\n" +
+		"  \"approvalId\": string | null;\n" +
+		"  \"callId\": string;\n" +
+		"  \"command\": Array<string>;\n" +
+		"  \"conversationId\": ThreadId;\n" +
+		"  \"cwd\": string;\n" +
+		"  \"parsedCmd\": Array<ParsedCommand>;\n" +
+		"  \"reason\": string | null;\n" +
+		"};"
+	if !strings.Contains(string(generated), want) {
+		t.Fatalf("generated TypeScript missing %q", want)
+	}
+}

--- a/appserver/protocol/exec_command_approval_params_types.go
+++ b/appserver/protocol/exec_command_approval_params_types.go
@@ -1,0 +1,127 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// ExecCommandApprovalParams is the exact legacy public approval request data.
+// It remains separate from Gollem's live command-execution approval request.
+type ExecCommandApprovalParams struct {
+	ConversationID ThreadId        `json:"conversationId"`
+	CallID         string          `json:"callId"`
+	ApprovalID     *string         `json:"approvalId,omitempty"`
+	Command        []string        `json:"command"`
+	CWD            string          `json:"cwd"`
+	Reason         *string         `json:"reason,omitempty"`
+	ParsedCmd      []ParsedCommand `json:"parsedCmd"`
+}
+
+func (p ExecCommandApprovalParams) MarshalJSON() ([]byte, error) {
+	type wire struct {
+		ConversationID ThreadId        `json:"conversationId"`
+		CallID         string          `json:"callId"`
+		ApprovalID     *string         `json:"approvalId"`
+		Command        []string        `json:"command"`
+		CWD            string          `json:"cwd"`
+		Reason         *string         `json:"reason"`
+		ParsedCmd      []ParsedCommand `json:"parsedCmd"`
+	}
+	command := p.Command
+	if command == nil {
+		command = []string{}
+	}
+	parsedCmd := p.ParsedCmd
+	if parsedCmd == nil {
+		parsedCmd = []ParsedCommand{}
+	}
+	return json.Marshal(wire{
+		ConversationID: p.ConversationID,
+		CallID:         p.CallID,
+		ApprovalID:     p.ApprovalID,
+		Command:        command,
+		CWD:            p.CWD,
+		Reason:         p.Reason,
+		ParsedCmd:      parsedCmd,
+	})
+}
+
+func (p *ExecCommandApprovalParams) UnmarshalJSON(data []byte) error {
+	if p == nil {
+		return errors.New("decode exec-command approval params into nil receiver")
+	}
+	const objectName = "exec-command approval params"
+	payload, err := decodeRustSerdeObject(
+		data,
+		objectName,
+		"conversationId",
+		"callId",
+		"approvalId",
+		"command",
+		"cwd",
+		"reason",
+		"parsedCmd",
+	)
+	if err != nil {
+		return err
+	}
+	conversationID, err := decodeRequiredThreadItemValue[ThreadId](payload, objectName, "conversationId")
+	if err != nil {
+		return err
+	}
+	callID, err := decodeRequiredThreadItemValue[string](payload, objectName, "callId")
+	if err != nil {
+		return err
+	}
+	approvalID, err := decodeOptionalNullableExecCommandApprovalParam[string](payload, "approvalId")
+	if err != nil {
+		return err
+	}
+	command, err := decodeRequiredThreadItemValue[[]string](payload, objectName, "command")
+	if err != nil {
+		return err
+	}
+	cwd, err := decodeRequiredThreadItemValue[string](payload, objectName, "cwd")
+	if err != nil {
+		return err
+	}
+	reason, err := decodeOptionalNullableExecCommandApprovalParam[string](payload, "reason")
+	if err != nil {
+		return err
+	}
+	parsedCmd, err := decodeRequiredThreadItemValue[[]ParsedCommand](payload, objectName, "parsedCmd")
+	if err != nil {
+		return err
+	}
+	*p = ExecCommandApprovalParams{
+		ConversationID: conversationID,
+		CallID:         callID,
+		ApprovalID:     approvalID,
+		Command:        command,
+		CWD:            cwd,
+		Reason:         reason,
+		ParsedCmd:      parsedCmd,
+	}
+	return nil
+}
+
+func decodeOptionalNullableExecCommandApprovalParam[T any](
+	payload map[string]json.RawMessage,
+	fieldName string,
+) (*T, error) {
+	raw, ok := payload[fieldName]
+	if !ok || isJSONNull(raw) {
+		return nil, nil
+	}
+	var value T
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return nil, fmt.Errorf("decode exec-command approval %s: %w", fieldName, err)
+	}
+	return &value, nil
+}
+
+var (
+	_ json.Marshaler   = ExecCommandApprovalParams{}
+	_ json.Unmarshaler = (*ExecCommandApprovalParams)(nil)
+)

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,8 +217,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,8 +203,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -260,8 +260,8 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,8 +244,8 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -162,8 +162,8 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -175,8 +175,8 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_contract_test.go
+++ b/appserver/protocol/file_change_contract_test.go
@@ -108,8 +108,8 @@ func TestFileChangeRemainsStandalone(t *testing.T) {
 			t.Fatalf("FileChange unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_output_delta_notification_contract_test.go
+++ b/appserver/protocol/file_change_output_delta_notification_contract_test.go
@@ -100,8 +100,8 @@ func TestFileChangeOutputDeltaNotificationRemainsDeprecatedAndStandalone(t *test
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("item/fileChange/outputDelta = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -381,8 +381,8 @@ func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_action_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_action_contract_test.go
@@ -226,8 +226,8 @@ func TestGuardianApprovalReviewActionRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReviewAction unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
@@ -164,8 +164,8 @@ func TestGuardianApprovalReviewCompletedNotificationRemainsStandalone(t *testing
 			t.Fatalf("completed notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_contract_test.go
@@ -139,8 +139,8 @@ func TestGuardianApprovalReviewRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReview unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
@@ -175,8 +175,8 @@ func TestGuardianApprovalReviewStartedNotificationRemainsStandalone(t *testing.T
 			t.Fatalf("started notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_enum_foundation_contract_test.go
+++ b/appserver/protocol/guardian_enum_foundation_contract_test.go
@@ -89,8 +89,8 @@ func TestGuardianEnumFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_metadata_list_contract_test.go
+++ b/appserver/protocol/hook_metadata_list_contract_test.go
@@ -352,8 +352,8 @@ func TestHookMetadataListContractsStayStandalone(t *testing.T) {
 			t.Errorf("standalone definition %s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Errorf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Errorf("definition count = %d, want 441", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 {
 		t.Errorf("wire binding count = %d, want 59", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_run_notification_contract_test.go
+++ b/appserver/protocol/hook_run_notification_contract_test.go
@@ -297,8 +297,8 @@ func TestHookRunNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("surface changed: %d methods, %d wire bindings, %d item bindings", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/hook_value_foundation_contract_test.go
+++ b/appserver/protocol/hook_value_foundation_contract_test.go
@@ -167,8 +167,8 @@ func TestHookValueFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 440 {
-		t.Fatalf("definition count = %d, want 440", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 441 {
+		t.Fatalf("definition count = %d, want 441", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_approval_context_contract_test.go
+++ b/appserver/protocol/network_approval_context_contract_test.go
@@ -84,8 +84,8 @@ func TestNetworkApprovalContextRemainsStandalone(t *testing.T) {
 			t.Fatalf("NetworkApprovalContext unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/parsed_command_contract_test.go
+++ b/appserver/protocol/parsed_command_contract_test.go
@@ -111,9 +111,6 @@ func TestParsedCommandRejectsMalformedWireForms(t *testing.T) {
 }
 
 func TestParsedCommandRemainsStandalone(t *testing.T) {
-	if _, ok := JSONSchema()["$defs"].(Schema)["ExecCommandApprovalParams"]; ok {
-		t.Fatal("blocked ExecCommandApprovalParams unexpectedly exported")
-	}
 	if reflect.TypeFor[ParsedCommand]() == reflect.TypeFor[CommandAction]() ||
 		reflect.TypeFor[ParsedCommand]() == reflect.TypeFor[CommandExecutionAction]() {
 		t.Fatal("ParsedCommand aliases a distinct live command-action type")
@@ -123,8 +120,8 @@ func TestParsedCommandRemainsStandalone(t *testing.T) {
 			t.Fatalf("ParsedCommand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 440 {
-		t.Fatalf("definition count = %d, want 440", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 441 {
+		t.Fatalf("definition count = %d, want 441", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 440 {
-		t.Fatalf("definition count = %d, want 440", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 441 {
+		t.Fatalf("definition count = %d, want 441", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 440 {
-		t.Fatalf("definition count = %d, want 440", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 441 {
+		t.Fatalf("definition count = %d, want 441", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 440 {
-		t.Fatalf("definition count = %d, want 440", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 441 {
+		t.Fatalf("definition count = %d, want 441", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 440 {
-		t.Fatalf("definition count = %d, want 440", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 441 {
+		t.Fatalf("definition count = %d, want 441", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -330,6 +330,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "ExternalAgentConfigImportHistoriesReadResponse", Type: reflect.TypeFor[ExternalAgentConfigImportHistoriesReadResponse]()},
 		{Name: "ExternalAgentConfigImportProgressNotification", Type: reflect.TypeFor[ExternalAgentConfigImportProgressNotification]()},
 		{Name: "ExternalAgentConfigImportCompletedNotification", Type: reflect.TypeFor[ExternalAgentConfigImportCompletedNotification]()},
+		{Name: "ExecCommandApprovalParams", Type: reflect.TypeFor[ExecCommandApprovalParams]()},
 		{Name: "FuzzyFileSearchMatchType", Type: reflect.TypeFor[FuzzyFileSearchMatchType]()},
 		{Name: "FuzzyFileSearchParams", Type: reflect.TypeFor[FuzzyFileSearchParams]()},
 		{Name: "FuzzyFileSearchResult", Type: reflect.TypeFor[FuzzyFileSearchResult]()},
@@ -697,6 +698,25 @@ func wireSchemaDefinitions() Schema {
 	schemas["HooksListResponse"] = hooksListResponseSchema()
 	schemas["ItemGuardianApprovalReviewCompletedNotification"] = guardianApprovalReviewCompletedNotificationSchema()
 	schemas["ItemGuardianApprovalReviewStartedNotification"] = guardianApprovalReviewStartedNotificationSchema()
+	schemas["ExecCommandApprovalParams"] = closedThreadSessionParamSchema(Schema{
+		"conversationId": Schema{"$ref": "#/$defs/ThreadId"},
+		"callId": Schema{
+			"type": "string",
+			"description": "Use to correlate this with [codex_protocol::protocol::ExecCommandBeginEvent] " +
+				"and [codex_protocol::protocol::ExecCommandEndEvent].",
+		},
+		"approvalId": Schema{
+			"anyOf":       []any{Schema{"type": "string"}, Schema{"type": "null"}},
+			"description": "Identifier for this specific approval callback.",
+		},
+		"command": Schema{"type": "array", "items": Schema{"type": "string"}},
+		"cwd":     Schema{"type": "string"},
+		"reason":  nullableStringSchema(),
+		"parsedCmd": Schema{
+			"type":  "array",
+			"items": Schema{"$ref": "#/$defs/ParsedCommand"},
+		},
+	}, []string{"callId", "command", "conversationId", "cwd", "parsedCmd"})
 	schemas["NetworkApprovalContext"] = closedThreadSessionParamSchema(Schema{
 		"host":     Schema{"type": "string"},
 		"protocol": Schema{"$ref": "#/$defs/NetworkApprovalProtocol"},

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -3148,6 +3148,62 @@
       ],
       "type": "object"
     },
+    "ExecCommandApprovalParams": {
+      "additionalProperties": false,
+      "properties": {
+        "approvalId": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Identifier for this specific approval callback."
+        },
+        "callId": {
+          "description": "Use to correlate this with [codex_protocol::protocol::ExecCommandBeginEvent] and [codex_protocol::protocol::ExecCommandEndEvent].",
+          "type": "string"
+        },
+        "command": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "conversationId": {
+          "$ref": "#/$defs/ThreadId"
+        },
+        "cwd": {
+          "type": "string"
+        },
+        "parsedCmd": {
+          "items": {
+            "$ref": "#/$defs/ParsedCommand"
+          },
+          "type": "array"
+        },
+        "reason": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "callId",
+        "command",
+        "conversationId",
+        "cwd",
+        "parsedCmd"
+      ],
+      "type": "object"
+    },
     "ExecPolicyAmendment": {
       "items": {
         "type": "string"

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 440 {
-		t.Fatalf("definition count = %d, want 440", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 441 {
+		t.Fatalf("definition count = %d, want 441", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 440 {
-		t.Fatalf("definition count = %d, want 440", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 441 {
+		t.Fatalf("definition count = %d, want 441", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 440 {
-		t.Fatalf("definition count = %d, want 440", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 441 {
+		t.Fatalf("definition count = %d, want 441", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -42,6 +42,7 @@ func MarshalTypeScript() ([]byte, error) {
 		if name == "MigrationDetails" || name == "ExternalAgentConfigMigrationItem" ||
 			name == "ExternalAgentConfigImportItemTypeFailure" ||
 			name == "ExternalAgentConfigImportItemTypeSuccess" ||
+			name == "ExecCommandApprovalParams" ||
 			name == "FuzzyFileSearchParams" || name == "FuzzyFileSearchResult" ||
 			name == "HookRunSummary" || name == "HookStartedNotification" ||
 			name == "HookCompletedNotification" || name == "HookMetadata" ||
@@ -57,6 +58,10 @@ func MarshalTypeScript() ([]byte, error) {
 			}
 			schema = renderSchema
 			switch name {
+			case "ExecCommandApprovalParams":
+				schema["required"] = []string{
+					"conversationId", "callId", "approvalId", "command", "cwd", "reason", "parsedCmd",
+				}
 			case "MigrationDetails":
 				schema["required"] = []string{
 					"plugins", "skills", "sessions", "mcpServers", "hooks", "subagents", "commands",

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -1125,6 +1125,16 @@ export type ErrorNotification = {
   "willRetry": boolean;
 };
 
+export type ExecCommandApprovalParams = {
+  "approvalId": string | null;
+  "callId": string;
+  "command": Array<string>;
+  "conversationId": ThreadId;
+  "cwd": string;
+  "parsedCmd": Array<ParsedCommand>;
+  "reason": string | null;
+};
+
 export type ExecPolicyAmendment = Array<string>;
 
 export type ExternalAgentConfigDetectParams = {

--- a/appserver/protocol/typescript/testdata/exec_command_approval_params_contract.ts
+++ b/appserver/protocol/typescript/testdata/exec_command_approval_params_contract.ts
@@ -1,0 +1,76 @@
+import type {
+  CommandExecutionApprovalRequestParams,
+  ExecCommandApprovalParams,
+  MethodParamsByName,
+  MethodResultsByName,
+  ParsedCommand,
+  ThreadId,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+type ExpectFalse<T extends false> = T;
+
+type ExactParams = {
+  conversationId: ThreadId;
+  callId: string;
+  approvalId: string | null;
+  command: Array<string>;
+  cwd: string;
+  reason: string | null;
+  parsedCmd: Array<ParsedCommand>;
+};
+
+export type ExecCommandApprovalParamsContract = [
+  Expect<Equal<ExecCommandApprovalParams, ExactParams>>,
+  ExpectFalse<Equal<ExecCommandApprovalParams, CommandExecutionApprovalRequestParams>>,
+  ExpectFalse<"execCommandApproval" extends keyof MethodParamsByName ? true : false>,
+  ExpectFalse<"execCommandApproval" extends keyof MethodResultsByName ? true : false>,
+  Expect<Equal<Extract<MethodParamsByName[keyof MethodParamsByName], ExecCommandApprovalParams>, never>>,
+  Expect<Equal<Extract<MethodResultsByName[keyof MethodResultsByName], ExecCommandApprovalParams>, never>>,
+];
+
+({
+  conversationId: "",
+  callId: "",
+  approvalId: null,
+  command: [],
+  cwd: "",
+  reason: null,
+  parsedCmd: [],
+}) satisfies ExecCommandApprovalParams;
+
+({
+  conversationId: "thread",
+  callId: "call",
+  approvalId: "approval",
+  command: ["rg", "q"],
+  cwd: "relative/worktree",
+  reason: "inspect",
+  parsedCmd: [{ type: "search", cmd: "rg q", query: "q", path: null }],
+}) satisfies ExecCommandApprovalParams;
+
+// @ts-expect-error conversationId is required.
+({ callId: "call", approvalId: null, command: [], cwd: ".", reason: null, parsedCmd: [] }) satisfies ExecCommandApprovalParams;
+// @ts-expect-error callId is required.
+({ conversationId: "thread", approvalId: null, command: [], cwd: ".", reason: null, parsedCmd: [] }) satisfies ExecCommandApprovalParams;
+// @ts-expect-error approvalId is canonical-required nullable.
+({ conversationId: "thread", callId: "call", command: [], cwd: ".", reason: null, parsedCmd: [] }) satisfies ExecCommandApprovalParams;
+// @ts-expect-error command is required.
+({ conversationId: "thread", callId: "call", approvalId: null, cwd: ".", reason: null, parsedCmd: [] }) satisfies ExecCommandApprovalParams;
+// @ts-expect-error command elements are strings.
+({ conversationId: "thread", callId: "call", approvalId: null, command: [1], cwd: ".", reason: null, parsedCmd: [] }) satisfies ExecCommandApprovalParams;
+// @ts-expect-error cwd is required.
+({ conversationId: "thread", callId: "call", approvalId: null, command: [], reason: null, parsedCmd: [] }) satisfies ExecCommandApprovalParams;
+// @ts-expect-error reason is canonical-required nullable.
+({ conversationId: "thread", callId: "call", approvalId: null, command: [], cwd: ".", parsedCmd: [] }) satisfies ExecCommandApprovalParams;
+// @ts-expect-error parsedCmd is required.
+({ conversationId: "thread", callId: "call", approvalId: null, command: [], cwd: ".", reason: null }) satisfies ExecCommandApprovalParams;
+// @ts-expect-error nested parsed commands remain strict.
+({ conversationId: "thread", callId: "call", approvalId: null, command: [], cwd: ".", reason: null, parsedCmd: [{ type: "unknown" }] }) satisfies ExecCommandApprovalParams;
+// @ts-expect-error canonical records are closed.
+({ conversationId: "thread", callId: "call", approvalId: null, command: [], cwd: ".", reason: null, parsedCmd: [], future: true }) satisfies ExecCommandApprovalParams;

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 440 {
-		t.Fatalf("definition count = %d, want 440", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
+		t.Fatalf("definition count = %d, want 441", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- export exact standalone legacy `ExecCommandApprovalParams` with strict serde-compatible decoding and canonical nullable/non-null-array output
- reference existing exact `ThreadId` and `ParsedCommand` dependencies without binding the deferred `execCommandApproval` method
- keep Gollem's live `CommandExecutionApprovalRequestParams`, approval authority, parsing, path handling, methods, and runtime unchanged
- regenerate the deterministic 441-definition schema and TypeScript binding

## Verification
- deliberate-red Go and strict TypeScript boundaries
- focused x30, focused race, and 100% statement coverage for all new production functions
- full protocol normal/race at 97.4% aggregate coverage
- fresh normal/race across exactly 59 non-Monty packages
- package/full lint: 0 issues; non-Monty vet; tidy unchanged
- deterministic generation twice and strict TypeScript
- exact normalized pinned-upstream schema and compiler-level TypeScript identity
- unchanged 224 methods, 59 method bindings, five item bindings, and exact structural reversal to PR #207
- byte-identical baseline/feature live transcript and all five Slang workflows
- configured pre-push passed before commit and during push

Local Monty normal/race/coverage remains skipped per standing direction; hosted CI is unchanged.