### PR TITLE
feat(protocol): export review decision

### DIFF
--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(defs); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/attestation_contract_test.go
+++ b/appserver/protocol/attestation_contract_test.go
@@ -133,8 +133,8 @@ func TestAttestationContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("attestation/generate = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/exec_command_approval_params_contract_test.go
+++ b/appserver/protocol/exec_command_approval_params_contract_test.go
@@ -128,8 +128,8 @@ func TestExecCommandApprovalParamsRemainsStandalone(t *testing.T) {
 	if _, ok := defs["ExecCommandApprovalResponse"]; ok {
 		t.Fatal("blocked ExecCommandApprovalResponse unexpectedly exported")
 	}
-	if _, ok := defs["ReviewDecision"]; ok {
-		t.Fatal("blocked ReviewDecision unexpectedly exported")
+	if _, ok := defs["ReviewDecision"]; !ok {
+		t.Fatal("dependency-complete ReviewDecision missing")
 	}
 	for _, binding := range WireTypeBindings() {
 		if slices.Contains(binding.Params, "ExecCommandApprovalParams") ||
@@ -137,8 +137,8 @@ func TestExecCommandApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ExecCommandApprovalParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(defs); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,8 +217,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,8 +203,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -260,8 +260,8 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,8 +244,8 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -162,8 +162,8 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -175,8 +175,8 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_contract_test.go
+++ b/appserver/protocol/file_change_contract_test.go
@@ -108,8 +108,8 @@ func TestFileChangeRemainsStandalone(t *testing.T) {
 			t.Fatalf("FileChange unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_output_delta_notification_contract_test.go
+++ b/appserver/protocol/file_change_output_delta_notification_contract_test.go
@@ -100,8 +100,8 @@ func TestFileChangeOutputDeltaNotificationRemainsDeprecatedAndStandalone(t *test
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("item/fileChange/outputDelta = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -381,8 +381,8 @@ func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_action_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_action_contract_test.go
@@ -226,8 +226,8 @@ func TestGuardianApprovalReviewActionRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReviewAction unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
@@ -164,8 +164,8 @@ func TestGuardianApprovalReviewCompletedNotificationRemainsStandalone(t *testing
 			t.Fatalf("completed notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_contract_test.go
@@ -139,8 +139,8 @@ func TestGuardianApprovalReviewRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReview unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
@@ -175,8 +175,8 @@ func TestGuardianApprovalReviewStartedNotificationRemainsStandalone(t *testing.T
 			t.Fatalf("started notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_enum_foundation_contract_test.go
+++ b/appserver/protocol/guardian_enum_foundation_contract_test.go
@@ -89,8 +89,8 @@ func TestGuardianEnumFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_metadata_list_contract_test.go
+++ b/appserver/protocol/hook_metadata_list_contract_test.go
@@ -352,8 +352,8 @@ func TestHookMetadataListContractsStayStandalone(t *testing.T) {
 			t.Errorf("standalone definition %s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Errorf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Errorf("definition count = %d, want 442", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 {
 		t.Errorf("wire binding count = %d, want 59", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_run_notification_contract_test.go
+++ b/appserver/protocol/hook_run_notification_contract_test.go
@@ -297,8 +297,8 @@ func TestHookRunNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("surface changed: %d methods, %d wire bindings, %d item bindings", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/hook_value_foundation_contract_test.go
+++ b/appserver/protocol/hook_value_foundation_contract_test.go
@@ -167,8 +167,8 @@ func TestHookValueFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 441 {
-		t.Fatalf("definition count = %d, want 441", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 442 {
+		t.Fatalf("definition count = %d, want 442", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_approval_context_contract_test.go
+++ b/appserver/protocol/network_approval_context_contract_test.go
@@ -84,8 +84,8 @@ func TestNetworkApprovalContextRemainsStandalone(t *testing.T) {
 			t.Fatalf("NetworkApprovalContext unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/parsed_command_contract_test.go
+++ b/appserver/protocol/parsed_command_contract_test.go
@@ -120,8 +120,8 @@ func TestParsedCommandRemainsStandalone(t *testing.T) {
 			t.Fatalf("ParsedCommand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 441 {
-		t.Fatalf("definition count = %d, want 441", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 442 {
+		t.Fatalf("definition count = %d, want 442", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 441 {
-		t.Fatalf("definition count = %d, want 441", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 442 {
+		t.Fatalf("definition count = %d, want 442", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 441 {
-		t.Fatalf("definition count = %d, want 441", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 442 {
+		t.Fatalf("definition count = %d, want 442", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 441 {
-		t.Fatalf("definition count = %d, want 441", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 442 {
+		t.Fatalf("definition count = %d, want 442", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 441 {
-		t.Fatalf("definition count = %d, want 441", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 442 {
+		t.Fatalf("definition count = %d, want 442", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/review_decision_contract_test.go
+++ b/appserver/protocol/review_decision_contract_test.go
@@ -1,0 +1,237 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestReviewDecisionSchemaIsExact(t *testing.T) {
+	definition, ok := JSONSchema()["$defs"].(Schema)["ReviewDecision"].(Schema)
+	if !ok {
+		t.Fatal("$defs missing ReviewDecision")
+	}
+	if want := expectedReviewDecisionSchema(); !reflect.DeepEqual(definition, want) {
+		t.Fatalf("ReviewDecision = %#v, want %#v", definition, want)
+	}
+}
+
+func TestReviewDecisionAcceptsExactWireForms(t *testing.T) {
+	for _, test := range []struct {
+		input string
+		want  string
+	}{
+		{input: `"approved"`, want: `"approved"`},
+		{input: `"approved_for_session"`, want: `"approved_for_session"`},
+		{input: `"denied"`, want: `"denied"`},
+		{input: `"timed_out"`, want: `"timed_out"`},
+		{input: `"abort"`, want: `"abort"`},
+		{
+			input: `{"approved_execpolicy_amendment":{"proposed_execpolicy_amendment":[]}}`,
+			want:  `{"approved_execpolicy_amendment":{"proposed_execpolicy_amendment":[]}}`,
+		},
+		{
+			input: `{"approved_execpolicy_amendment":{"future":true,"proposed_execpolicy_amendment":["git","git",""]}}`,
+			want:  `{"approved_execpolicy_amendment":{"proposed_execpolicy_amendment":["git","git",""]}}`,
+		},
+		{
+			input: `{"network_policy_amendment":{"future":true,"network_policy_amendment":{"future":1,"host":"","action":"allow"}}}`,
+			want:  `{"network_policy_amendment":{"network_policy_amendment":{"host":"","action":"allow"}}}`,
+		},
+		{
+			input: `{"network_policy_amendment":{"network_policy_amendment":{"host":"example.invalid","action":"deny"}}}`,
+			want:  `{"network_policy_amendment":{"network_policy_amendment":{"host":"example.invalid","action":"deny"}}}`,
+		},
+	} {
+		var decision ReviewDecision
+		if err := json.Unmarshal([]byte(test.input), &decision); err != nil {
+			t.Errorf("Unmarshal(%s): %v", test.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(decision)
+		if err != nil || string(encoded) != test.want {
+			t.Errorf("round trip %s = %s, %v; want %s", test.input, encoded, err, test.want)
+		}
+	}
+}
+
+func TestReviewDecisionRejectsMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `[]`, `1`, `true`, `{}`, `{`,
+		`"accept"`, `"Approved"`, `"approve"`, `""`,
+		`{"approved":null}`,
+		`{"approved_execpolicy_amendment":null}`,
+		`{"approved_execpolicy_amendment":{}}`,
+		`{"approved_execpolicy_amendment":{"proposed_execpolicy_amendment":null}}`,
+		`{"approved_execpolicy_amendment":{"proposed_execpolicy_amendment":{}}}`,
+		`{"approved_execpolicy_amendment":{"proposed_execpolicy_amendment":[1]}}`,
+		`{"approved_execpolicy_amendment":{"proposed_execpolicy_amendment":[null]}}`,
+		`{"approved_execpolicy_amendment":{"proposed_execpolicy_amendment":[],"proposed_execpolicy_amendment":[]}}`,
+		`{"network_policy_amendment":null}`,
+		`{"network_policy_amendment":{}}`,
+		`{"network_policy_amendment":{"network_policy_amendment":null}}`,
+		`{"network_policy_amendment":{"network_policy_amendment":[]}}`,
+		`{"network_policy_amendment":{"network_policy_amendment":{}}}`,
+		`{"network_policy_amendment":{"network_policy_amendment":{"host":null,"action":"allow"}}}`,
+		`{"network_policy_amendment":{"network_policy_amendment":{"host":1,"action":"allow"}}}`,
+		`{"network_policy_amendment":{"network_policy_amendment":{"host":"host","action":null}}}`,
+		`{"network_policy_amendment":{"network_policy_amendment":{"host":"host","action":"prompt"}}}`,
+		`{"network_policy_amendment":{"network_policy_amendment":{"host":"one","host":"two","action":"allow"}}}`,
+		`{"network_policy_amendment":{"network_policy_amendment":{"host":"host","action":"allow","action":"deny"}}}`,
+		`{"network_policy_amendment":{"network_policy_amendment":{"host":"host","action":"allow"},"network_policy_amendment":{"host":"host","action":"deny"}}}`,
+		`{"other":{}}`,
+		`{"approved_execpolicy_amendment":{"proposed_execpolicy_amendment":[]},"network_policy_amendment":{"network_policy_amendment":{"host":"host","action":"allow"}}}`,
+		`{"approved_execpolicy_amendment":{"proposed_execpolicy_amendment":[]},"other":true}`,
+		`{"approved_execpolicy_amendment":{"proposed_execpolicy_amendment":[]}} {}`,
+		`{"approved_execpolicy_amendment":{"proposed_execpolicy_amendment":[]}} x`,
+	} {
+		assertJSONRejects[ReviewDecision](t, input)
+	}
+
+	if _, err := json.Marshal(ReviewDecision{}); err == nil {
+		t.Fatal("zero ReviewDecision marshal succeeded")
+	}
+	var decision *ReviewDecision
+	if err := decision.UnmarshalJSON([]byte(`"approved"`)); err == nil {
+		t.Fatal("nil ReviewDecision receiver succeeded")
+	}
+	if _, err := json.Marshal(ReviewDecision{raw: json.RawMessage(`"other"`)}); err == nil {
+		t.Fatal("invalid internal ReviewDecision marshal succeeded")
+	}
+}
+
+func TestReviewDecisionInternalDecoderErrors(t *testing.T) {
+	for _, input := range []string{
+		``,
+		`{"`,
+		`{"approved_execpolicy_amendment":`,
+		`{"approved_execpolicy_amendment":{}`,
+		`{"approved_execpolicy_amendment":{"proposed_execpolicy_amendment":[]}} {}`,
+		`{"approved_execpolicy_amendment":{"proposed_execpolicy_amendment":[]}} x`,
+	} {
+		if _, _, err := decodeReviewDecisionVariant([]byte(input)); err == nil {
+			t.Errorf("decodeReviewDecisionVariant(%q) succeeded", input)
+		}
+	}
+}
+
+func TestReviewDecisionRemainsStandalone(t *testing.T) {
+	if reflect.TypeFor[ReviewDecision]() == reflect.TypeFor[CommandExecutionApprovalDecision]() {
+		t.Fatal("legacy review decision aliases live command-execution approval decision")
+	}
+	defs := JSONSchema()["$defs"].(Schema)
+	for _, name := range []string{"ExecCommandApprovalResponse", "ApplyPatchApprovalResponse"} {
+		if _, ok := defs[name]; ok {
+			t.Fatalf("blocked %s unexpectedly exported", name)
+		}
+	}
+	if reflect.DeepEqual(defs["ReviewDecision"], defs["CommandExecutionApprovalDecision"]) {
+		t.Fatal("legacy and live decision schemas unexpectedly match")
+	}
+	for _, binding := range WireTypeBindings() {
+		if slices.Contains(binding.Params, "ReviewDecision") ||
+			slices.Contains(binding.Result, "ReviewDecision") {
+			t.Fatalf("ReviewDecision unexpectedly bound to %s", binding.Method)
+		}
+	}
+	if got := len(defs); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestReviewDecisionTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	want := `export type ReviewDecision = "approved" | {
+  "approved_execpolicy_amendment": {
+    "proposed_execpolicy_amendment": ExecPolicyAmendment;
+  };
+} | "approved_for_session" | {
+  "network_policy_amendment": {
+    "network_policy_amendment": NetworkPolicyAmendment;
+  };
+} | "denied" | "timed_out" | "abort";`
+	if !strings.Contains(string(generated), want) {
+		t.Fatalf("generated TypeScript missing %q", want)
+	}
+}
+
+func expectedReviewDecisionSchema() Schema {
+	return Schema{
+		"description": "User's decision in response to an ExecApprovalRequest.",
+		"oneOf": []any{
+			reviewDecisionLiteralSchema(
+				"approved",
+				"User has approved this command and the agent should execute it.",
+			),
+			Schema{
+				"type":                 "object",
+				"title":                "ApprovedExecpolicyAmendmentReviewDecision",
+				"description":          "User has approved this command and wants to apply the proposed execpolicy amendment so future matching commands are permitted.",
+				"additionalProperties": false,
+				"properties": Schema{
+					"approved_execpolicy_amendment": Schema{
+						"type":                 "object",
+						"additionalProperties": false,
+						"properties": Schema{
+							"proposed_execpolicy_amendment": Schema{"$ref": "#/$defs/ExecPolicyAmendment"},
+						},
+						"required": []string{"proposed_execpolicy_amendment"},
+					},
+				},
+				"required": []string{"approved_execpolicy_amendment"},
+			},
+			reviewDecisionLiteralSchema(
+				"approved_for_session",
+				"User has approved this request and wants future prompts in the same session-scoped approval cache to be automatically approved for the remainder of the session.",
+			),
+			Schema{
+				"type":                 "object",
+				"title":                "NetworkPolicyAmendmentReviewDecision",
+				"description":          "User chose to persist a network policy rule (allow/deny) for future requests to the same host.",
+				"additionalProperties": false,
+				"properties": Schema{
+					"network_policy_amendment": Schema{
+						"type":                 "object",
+						"additionalProperties": false,
+						"properties": Schema{
+							"network_policy_amendment": Schema{"$ref": "#/$defs/NetworkPolicyAmendment"},
+						},
+						"required": []string{"network_policy_amendment"},
+					},
+				},
+				"required": []string{"network_policy_amendment"},
+			},
+			reviewDecisionLiteralSchema(
+				"denied",
+				"User has denied this command and the agent should not execute it, but it should continue the session and try something else.",
+			),
+			reviewDecisionLiteralSchema(
+				"timed_out",
+				"Automatic approval review timed out before reaching a decision.",
+			),
+			reviewDecisionLiteralSchema(
+				"abort",
+				"User has denied this command and the agent should not do anything until the user's next command.",
+			),
+		},
+	}
+}
+
+func reviewDecisionLiteralSchema(value, description string) Schema {
+	return Schema{
+		"type":        "string",
+		"enum":        []any{value},
+		"description": description,
+	}
+}

--- a/appserver/protocol/review_decision_types.go
+++ b/appserver/protocol/review_decision_types.go
@@ -1,0 +1,285 @@
+package protocol
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+const (
+	ReviewDecisionApproved                    = "approved"
+	ReviewDecisionApprovedExecPolicyAmendment = "approved_execpolicy_amendment"
+	ReviewDecisionApprovedForSession          = "approved_for_session"
+	ReviewDecisionNetworkPolicyAmendment      = "network_policy_amendment"
+	ReviewDecisionDenied                      = "denied"
+	ReviewDecisionTimedOut                    = "timed_out"
+	ReviewDecisionAbort                       = "abort"
+)
+
+// ReviewDecision is the exact legacy public approval decision. It remains
+// separate from Gollem's live command-execution approval decision.
+type ReviewDecision struct {
+	raw json.RawMessage
+}
+
+func (d ReviewDecision) MarshalJSON() ([]byte, error) {
+	if len(d.raw) == 0 {
+		return nil, errors.New("review decision has no value")
+	}
+	return validateReviewDecisionJSON(d.raw)
+}
+
+func (d *ReviewDecision) UnmarshalJSON(data []byte) error {
+	if d == nil {
+		return errors.New("decode review decision into nil receiver")
+	}
+	canonical, err := validateReviewDecisionJSON(data)
+	if err != nil {
+		return err
+	}
+	d.raw = canonical
+	return nil
+}
+
+func validateReviewDecisionJSON(data []byte) (json.RawMessage, error) {
+	var literal string
+	if err := json.Unmarshal(data, &literal); err == nil {
+		switch literal {
+		case ReviewDecisionApproved,
+			ReviewDecisionApprovedForSession,
+			ReviewDecisionDenied,
+			ReviewDecisionTimedOut,
+			ReviewDecisionAbort:
+			return json.Marshal(literal)
+		default:
+			return nil, fmt.Errorf("unknown review decision %q", literal)
+		}
+	}
+
+	variant, payload, err := decodeReviewDecisionVariant(data)
+	if err != nil {
+		return nil, err
+	}
+	if variant == ReviewDecisionApprovedExecPolicyAmendment {
+		return canonicalReviewExecPolicyAmendment(payload)
+	}
+	return canonicalReviewNetworkPolicyAmendment(payload)
+}
+
+func decodeReviewDecisionVariant(data []byte) (string, json.RawMessage, error) {
+	const objectName = "review decision"
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	opening, err := decoder.Token()
+	if err != nil {
+		return "", nil, fmt.Errorf("decode %s: %w", objectName, err)
+	}
+	if opening != json.Delim('{') {
+		return "", nil, fmt.Errorf("%s must be a string or object", objectName)
+	}
+
+	var variant string
+	var payload json.RawMessage
+	for decoder.More() {
+		token, err := decoder.Token()
+		if err != nil {
+			return "", nil, fmt.Errorf("decode %s variant: %w", objectName, err)
+		}
+		name := token.(string)
+		switch name {
+		case ReviewDecisionApprovedExecPolicyAmendment,
+			ReviewDecisionNetworkPolicyAmendment:
+		default:
+			return "", nil, fmt.Errorf("unknown %s variant %q", objectName, name)
+		}
+		if variant != "" {
+			return "", nil, errors.New("review decision requires exactly one variant")
+		}
+		var raw json.RawMessage
+		if err := decoder.Decode(&raw); err != nil {
+			return "", nil, fmt.Errorf("decode %s variant %q: %w", objectName, name, err)
+		}
+		variant = name
+		payload = append(json.RawMessage(nil), raw...)
+	}
+	if _, err := decoder.Token(); err != nil {
+		return "", nil, fmt.Errorf("decode %s: %w", objectName, err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return "", nil, errors.New("review decision must contain one JSON value")
+		}
+		return "", nil, fmt.Errorf("decode review decision trailing value: %w", err)
+	}
+	if variant == "" {
+		return "", nil, errors.New("review decision requires exactly one variant")
+	}
+	return variant, payload, nil
+}
+
+func canonicalReviewExecPolicyAmendment(payloadRaw json.RawMessage) (json.RawMessage, error) {
+	const objectName = "approved exec-policy amendment review decision"
+	payload, err := decodeRustSerdeObject(
+		payloadRaw,
+		objectName,
+		"proposed_execpolicy_amendment",
+	)
+	if err != nil {
+		return nil, err
+	}
+	amendment, err := decodeRequiredThreadItemArray[string](
+		payload,
+		objectName,
+		"proposed_execpolicy_amendment",
+	)
+	if err != nil {
+		return nil, err
+	}
+	type payloadWire struct {
+		ProposedExecPolicyAmendment ExecPolicyAmendment `json:"proposed_execpolicy_amendment"`
+	}
+	return json.Marshal(struct {
+		ApprovedExecPolicyAmendment payloadWire `json:"approved_execpolicy_amendment"`
+	}{
+		ApprovedExecPolicyAmendment: payloadWire{
+			ProposedExecPolicyAmendment: ExecPolicyAmendment(amendment),
+		},
+	})
+}
+
+func canonicalReviewNetworkPolicyAmendment(payloadRaw json.RawMessage) (json.RawMessage, error) {
+	const objectName = "network-policy amendment review decision"
+	payload, err := decodeRustSerdeObject(
+		payloadRaw,
+		objectName,
+		"network_policy_amendment",
+	)
+	if err != nil {
+		return nil, err
+	}
+	amendmentRaw, ok := payload["network_policy_amendment"]
+	if !ok || isJSONNull(amendmentRaw) {
+		return nil, errors.New("network-policy amendment review decision requires network_policy_amendment")
+	}
+	amendmentObject, err := decodeRustSerdeObject(
+		amendmentRaw,
+		"network policy amendment",
+		"host",
+		"action",
+	)
+	if err != nil {
+		return nil, err
+	}
+	host, err := decodeRequiredThreadItemValue[string](
+		amendmentObject,
+		"network policy amendment",
+		"host",
+	)
+	if err != nil {
+		return nil, err
+	}
+	action, err := decodeRequiredThreadItemValue[NetworkPolicyRuleAction](
+		amendmentObject,
+		"network policy amendment",
+		"action",
+	)
+	if err != nil {
+		return nil, err
+	}
+	if action != NetworkPolicyRuleAllow && action != NetworkPolicyRuleDeny {
+		return nil, fmt.Errorf("unknown network-policy action %q", action)
+	}
+	type payloadWire struct {
+		Amendment NetworkPolicyAmendment `json:"network_policy_amendment"`
+	}
+	return json.Marshal(struct {
+		NetworkPolicyAmendment payloadWire `json:"network_policy_amendment"`
+	}{
+		NetworkPolicyAmendment: payloadWire{
+			Amendment: NetworkPolicyAmendment{Host: host, Action: action},
+		},
+	})
+}
+
+func reviewDecisionSchema() Schema {
+	return Schema{
+		"description": "User's decision in response to an ExecApprovalRequest.",
+		"oneOf": []any{
+			reviewDecisionStringSchema(
+				ReviewDecisionApproved,
+				"User has approved this command and the agent should execute it.",
+			),
+			reviewDecisionObjectSchema(
+				ReviewDecisionApprovedExecPolicyAmendment,
+				"ApprovedExecpolicyAmendmentReviewDecision",
+				"User has approved this command and wants to apply the proposed execpolicy amendment so future matching commands are permitted.",
+				"proposed_execpolicy_amendment",
+				"ExecPolicyAmendment",
+			),
+			reviewDecisionStringSchema(
+				ReviewDecisionApprovedForSession,
+				"User has approved this request and wants future prompts in the same session-scoped approval cache to be automatically approved for the remainder of the session.",
+			),
+			reviewDecisionObjectSchema(
+				ReviewDecisionNetworkPolicyAmendment,
+				"NetworkPolicyAmendmentReviewDecision",
+				"User chose to persist a network policy rule (allow/deny) for future requests to the same host.",
+				"network_policy_amendment",
+				"NetworkPolicyAmendment",
+			),
+			reviewDecisionStringSchema(
+				ReviewDecisionDenied,
+				"User has denied this command and the agent should not execute it, but it should continue the session and try something else.",
+			),
+			reviewDecisionStringSchema(
+				ReviewDecisionTimedOut,
+				"Automatic approval review timed out before reaching a decision.",
+			),
+			reviewDecisionStringSchema(
+				ReviewDecisionAbort,
+				"User has denied this command and the agent should not do anything until the user's next command.",
+			),
+		},
+	}
+}
+
+func reviewDecisionStringSchema(value, description string) Schema {
+	return Schema{
+		"type":        "string",
+		"enum":        []any{value},
+		"description": description,
+	}
+}
+
+func reviewDecisionObjectSchema(
+	variant,
+	title,
+	description,
+	payloadField,
+	payloadType string,
+) Schema {
+	return Schema{
+		"type":                 "object",
+		"title":                title,
+		"description":          description,
+		"additionalProperties": false,
+		"properties": Schema{
+			variant: Schema{
+				"type":                 "object",
+				"additionalProperties": false,
+				"properties": Schema{
+					payloadField: Schema{"$ref": "#/$defs/" + payloadType},
+				},
+				"required": []string{payloadField},
+			},
+		},
+		"required": []string{variant},
+	}
+}
+
+var (
+	_ json.Marshaler   = ReviewDecision{}
+	_ json.Unmarshaler = (*ReviewDecision)(nil)
+)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -382,6 +382,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "RawResponseItemCompletedNotification", Type: reflect.TypeFor[RawResponseItemCompletedNotification]()},
 		{Name: "ResourceContent", Type: reflect.TypeFor[ResourceContent]()},
 		{Name: "ResponseItem", Type: reflect.TypeFor[ResponseItem]()},
+		{Name: "ReviewDecision", Type: reflect.TypeFor[ReviewDecision]()},
 		{Name: "ResponsesApiWebSearchAction", Type: reflect.TypeFor[ResponsesApiWebSearchAction]()},
 		{Name: "SandboxMode", Type: reflect.TypeFor[SandboxMode]()},
 		{Name: "SandboxPolicy", Type: reflect.TypeFor[SandboxPolicy]()},
@@ -818,6 +819,7 @@ func wireSchemaDefinitions() Schema {
 	schemas["AgentMessageInputContent"] = rawResponseContentSchema(agentMessageInputContentVariants)
 	schemas["ReasoningItemContent"] = rawResponseContentSchema(reasoningItemContentVariants)
 	schemas["ReasoningItemReasoningSummary"] = rawResponseContentSchema(reasoningItemSummaryVariants)
+	schemas["ReviewDecision"] = reviewDecisionSchema()
 	schemas["ResponsesApiWebSearchAction"] = responsesAPIWebSearchActionSchema()
 	schemas["ContentItem"] = contentItemSchema(contentItemVariants)
 	schemas["FunctionCallOutputContentItem"] = contentItemSchema(functionCallOutputContentItemVariants)

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -10075,6 +10075,92 @@
         }
       ]
     },
+    "ReviewDecision": {
+      "description": "User's decision in response to an ExecApprovalRequest.",
+      "oneOf": [
+        {
+          "description": "User has approved this command and the agent should execute it.",
+          "enum": [
+            "approved"
+          ],
+          "type": "string"
+        },
+        {
+          "additionalProperties": false,
+          "description": "User has approved this command and wants to apply the proposed execpolicy amendment so future matching commands are permitted.",
+          "properties": {
+            "approved_execpolicy_amendment": {
+              "additionalProperties": false,
+              "properties": {
+                "proposed_execpolicy_amendment": {
+                  "$ref": "#/$defs/ExecPolicyAmendment"
+                }
+              },
+              "required": [
+                "proposed_execpolicy_amendment"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "approved_execpolicy_amendment"
+          ],
+          "title": "ApprovedExecpolicyAmendmentReviewDecision",
+          "type": "object"
+        },
+        {
+          "description": "User has approved this request and wants future prompts in the same session-scoped approval cache to be automatically approved for the remainder of the session.",
+          "enum": [
+            "approved_for_session"
+          ],
+          "type": "string"
+        },
+        {
+          "additionalProperties": false,
+          "description": "User chose to persist a network policy rule (allow/deny) for future requests to the same host.",
+          "properties": {
+            "network_policy_amendment": {
+              "additionalProperties": false,
+              "properties": {
+                "network_policy_amendment": {
+                  "$ref": "#/$defs/NetworkPolicyAmendment"
+                }
+              },
+              "required": [
+                "network_policy_amendment"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "network_policy_amendment"
+          ],
+          "title": "NetworkPolicyAmendmentReviewDecision",
+          "type": "object"
+        },
+        {
+          "description": "User has denied this command and the agent should not execute it, but it should continue the session and try something else.",
+          "enum": [
+            "denied"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Automatic approval review timed out before reaching a decision.",
+          "enum": [
+            "timed_out"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "User has denied this command and the agent should not do anything until the user's next command.",
+          "enum": [
+            "abort"
+          ],
+          "type": "string"
+        }
+      ]
+    },
     "SandboxMode": {
       "enum": [
         "read-only",

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 441 {
-		t.Fatalf("definition count = %d, want 441", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 442 {
+		t.Fatalf("definition count = %d, want 442", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 441 {
-		t.Fatalf("definition count = %d, want 441", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 442 {
+		t.Fatalf("definition count = %d, want 442", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 441 {
-		t.Fatalf("definition count = %d, want 441", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 442 {
+		t.Fatalf("definition count = %d, want 442", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -2593,6 +2593,16 @@ export type ResponsesApiWebSearchAction = {
   "type": "other";
 };
 
+export type ReviewDecision = "approved" | {
+  "approved_execpolicy_amendment": {
+    "proposed_execpolicy_amendment": ExecPolicyAmendment;
+  };
+} | "approved_for_session" | {
+  "network_policy_amendment": {
+    "network_policy_amendment": NetworkPolicyAmendment;
+  };
+} | "denied" | "timed_out" | "abort";
+
 export type SandboxMode = "read-only" | "workspace-write" | "danger-full-access";
 
 export type SandboxPolicy = {

--- a/appserver/protocol/typescript/testdata/review_decision_contract.ts
+++ b/appserver/protocol/typescript/testdata/review_decision_contract.ts
@@ -1,0 +1,79 @@
+import type {
+  CommandExecutionApprovalDecision,
+  ExecPolicyAmendment,
+  MethodParamsByName,
+  MethodResultsByName,
+  NetworkPolicyAmendment,
+  ReviewDecision,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+type ExpectFalse<T extends false> = T;
+
+type ExactDecision =
+  | "approved"
+  | {
+      approved_execpolicy_amendment: {
+        proposed_execpolicy_amendment: ExecPolicyAmendment;
+      };
+    }
+  | "approved_for_session"
+  | {
+      network_policy_amendment: {
+        network_policy_amendment: NetworkPolicyAmendment;
+      };
+    }
+  | "denied"
+  | "timed_out"
+  | "abort";
+
+export type ReviewDecisionContract = [
+  Expect<Equal<ReviewDecision, ExactDecision>>,
+  ExpectFalse<Equal<ReviewDecision, CommandExecutionApprovalDecision>>,
+  ExpectFalse<"execCommandApproval" extends keyof MethodParamsByName ? true : false>,
+  ExpectFalse<"execCommandApproval" extends keyof MethodResultsByName ? true : false>,
+  ExpectFalse<"applyPatchApproval" extends keyof MethodParamsByName ? true : false>,
+  ExpectFalse<"applyPatchApproval" extends keyof MethodResultsByName ? true : false>,
+  Expect<Equal<Extract<MethodParamsByName[keyof MethodParamsByName], ReviewDecision>, never>>,
+  Expect<Equal<Extract<MethodResultsByName[keyof MethodResultsByName], ReviewDecision>, never>>,
+];
+
+export const approved = "approved" satisfies ReviewDecision;
+export const approvedForSession = "approved_for_session" satisfies ReviewDecision;
+export const denied = "denied" satisfies ReviewDecision;
+export const timedOut = "timed_out" satisfies ReviewDecision;
+export const abort = "abort" satisfies ReviewDecision;
+export const execAmendment = {
+  approved_execpolicy_amendment: {
+    proposed_execpolicy_amendment: ["git", "status"],
+  },
+} satisfies ReviewDecision;
+export const networkAmendment = {
+  network_policy_amendment: {
+    network_policy_amendment: { host: "example.invalid", action: "allow" },
+  },
+} satisfies ReviewDecision;
+
+// @ts-expect-error live literals are not legacy review decisions.
+export const rejectLiveLiteral = "accept" satisfies ReviewDecision;
+// @ts-expect-error snake-case discriminant is exact.
+export const rejectCase = "approvedForSession" satisfies ReviewDecision;
+// @ts-expect-error proposed amendment is required.
+export const rejectMissingExecAmendment = { approved_execpolicy_amendment: {} } satisfies ReviewDecision;
+// @ts-expect-error proposed amendment elements are strings.
+export const rejectExecElement = { approved_execpolicy_amendment: { proposed_execpolicy_amendment: [1] } } satisfies ReviewDecision;
+// @ts-expect-error network amendment wrapper is required.
+export const rejectMissingNetworkAmendment = { network_policy_amendment: {} } satisfies ReviewDecision;
+// @ts-expect-error network policy action is closed.
+export const rejectNetworkAction = { network_policy_amendment: { network_policy_amendment: { host: "h", action: "prompt" } } } satisfies ReviewDecision;
+// @ts-expect-error object variants are closed.
+export const rejectOuterExtra = { approved_execpolicy_amendment: { proposed_execpolicy_amendment: [] }, future: true } satisfies ReviewDecision;
+// @ts-expect-error nested canonical objects are closed.
+export const rejectNestedExtra = { approved_execpolicy_amendment: { proposed_execpolicy_amendment: [], future: true } } satisfies ReviewDecision;
+// @ts-expect-error null is not a review decision.
+export const rejectNull = null satisfies ReviewDecision;

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 441 {
-		t.Fatalf("definition count = %d, want 441", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 442 {
+		t.Fatalf("definition count = %d, want 442", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- export the exact seven-variant public `ReviewDecision` union in Go, JSON Schema, and generated TypeScript
- preserve Rust serde-compatible input behavior while emitting deterministic canonical JSON
- keep the legacy decision standalone from Gollem's live `CommandExecutionApprovalDecision` and from still-blocked legacy approval responses

## Contract
Pinned against public Codex commit `5c19155cbd93bfa099016e7487259f61669823ff`.

The exported union is:
- `"approved"`
- `{ approved_execpolicy_amendment: { proposed_execpolicy_amendment: ExecPolicyAmendment } }`
- `"approved_for_session"`
- `{ network_policy_amendment: { network_policy_amendment: NetworkPolicyAmendment } }`
- `"denied"`
- `"timed_out"`
- `"abort"`

This adds one definition (441 -> 442) without changing methods or bindings (224 methods, 59 method bindings, 5 item bindings).

## Verification
- focused protocol contract tests, including malformed and duplicate-field cases
- focused tests x30 and focused race tests
- all non-Monty packages, normal and race
- `golangci-lint run ./...`
- `go vet` across non-Monty packages
- `go mod tidy` / `go mod verify`
- deterministic schema and TypeScript generation twice
- strict TypeScript 7.0.2 contract fixture
- exact normalized pinned-upstream schema comparison
- generated-artifact and full-commit structural reversal to the parent
- reproducible `-trimpath -buildvcs=false` binary
- byte-identical parent/feature initialize + MCP transcript
- Slang real-binary stdio, direct file approval, direct command approval, Unix socket, and WebSocket workflows

Local Monty normal/race/coverage suites were intentionally skipped due runtime cost. Hosted CI remains unchanged.