### PR TITLE
feat(protocol): export legacy apply-patch approval params

### DIFF
--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(defs); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/apply_patch_approval_params_contract_test.go
+++ b/appserver/protocol/apply_patch_approval_params_contract_test.go
@@ -1,0 +1,168 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestApplyPatchApprovalParamsSchemaIsExact(t *testing.T) {
+	definition, ok := JSONSchema()["$defs"].(Schema)["ApplyPatchApprovalParams"].(Schema)
+	if !ok {
+		t.Fatal("$defs missing ApplyPatchApprovalParams")
+	}
+	want := closedThreadSessionParamSchema(Schema{
+		"conversationId": Schema{"$ref": "#/$defs/ThreadId"},
+		"callId": Schema{
+			"type": "string",
+			"description": "Use to correlate this with [codex_protocol::protocol::PatchApplyBeginEvent] " +
+				"and [codex_protocol::protocol::PatchApplyEndEvent].",
+		},
+		"fileChanges": Schema{
+			"type":                 "object",
+			"additionalProperties": Schema{"$ref": "#/$defs/FileChange"},
+		},
+		"reason": Schema{
+			"anyOf":       []any{Schema{"type": "string"}, Schema{"type": "null"}},
+			"description": "Optional explanatory reason (e.g. request for extra write access).",
+		},
+		"grantRoot": Schema{
+			"anyOf": []any{Schema{"type": "string"}, Schema{"type": "null"}},
+			"description": "When set, the agent is asking the user to allow writes under this root " +
+				"for the remainder of the session (unclear if this is honored today).",
+		},
+	}, []string{"callId", "conversationId", "fileChanges"})
+	if !reflect.DeepEqual(definition, want) {
+		t.Fatalf("ApplyPatchApprovalParams = %#v, want %#v", definition, want)
+	}
+}
+
+func TestApplyPatchApprovalParamsAcceptsSerdeWireForms(t *testing.T) {
+	for _, test := range []struct {
+		input string
+		want  string
+	}{
+		{
+			input: `{"conversationId":"","callId":"","fileChanges":{}}`,
+			want:  `{"conversationId":"","callId":"","fileChanges":{},"reason":null,"grantRoot":null}`,
+		},
+		{
+			input: `{"conversationId":"thread","callId":"call","fileChanges":{"relative path":{"type":"add","content":""},"/absolute":{"type":"delete","content":"old"}},"reason":null,"grantRoot":null}`,
+			want:  `{"conversationId":"thread","callId":"call","fileChanges":{"/absolute":{"type":"delete","content":"old"},"relative path":{"type":"add","content":""}},"reason":null,"grantRoot":null}`,
+		},
+		{
+			input: `{"conversationId":"thread-2","callId":"call-2","fileChanges":{"":{"type":"update","unified_diff":"diff","move_path":"next path"}},"reason":"","grantRoot":"relative/root"}`,
+			want:  `{"conversationId":"thread-2","callId":"call-2","fileChanges":{"":{"type":"update","unified_diff":"diff","move_path":"next path"}},"reason":"","grantRoot":"relative/root"}`,
+		},
+		{
+			input: `{"future":1,"future":2,"conversationId":"thread","callId":"call","fileChanges":{"same":{"type":"add","content":"first"},"same":{"type":"delete","content":"last"}},"other":{"ignored":true}}`,
+			want:  `{"conversationId":"thread","callId":"call","fileChanges":{"same":{"type":"delete","content":"last"}},"reason":null,"grantRoot":null}`,
+		},
+	} {
+		var params ApplyPatchApprovalParams
+		if err := json.Unmarshal([]byte(test.input), &params); err != nil {
+			t.Errorf("Unmarshal(%s): %v", test.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(params)
+		if err != nil || string(encoded) != test.want {
+			t.Errorf("round trip %s = %s, %v; want %s", test.input, encoded, err, test.want)
+		}
+	}
+
+	encoded, err := json.Marshal(ApplyPatchApprovalParams{})
+	want := `{"conversationId":"","callId":"","fileChanges":{},"reason":null,"grantRoot":null}`
+	if err != nil || string(encoded) != want {
+		t.Fatalf("marshal zero params = %s, %v; want %s", encoded, err, want)
+	}
+}
+
+func TestApplyPatchApprovalParamsRejectsMalformedWireForms(t *testing.T) {
+	valid := `"conversationId":"thread","callId":"call","fileChanges":{}`
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`, `{}`,
+		`{"callId":"call","fileChanges":{}}`,
+		`{"conversationId":"thread","fileChanges":{}}`,
+		`{"conversationId":"thread","callId":"call"}`,
+		`{"conversationId":null,"callId":"call","fileChanges":{}}`,
+		`{"conversationId":1,"callId":"call","fileChanges":{}}`,
+		`{"conversationId":"thread","callId":null,"fileChanges":{}}`,
+		`{"conversationId":"thread","callId":1,"fileChanges":{}}`,
+		`{"conversationId":"thread","callId":"call","fileChanges":null}`,
+		`{"conversationId":"thread","callId":"call","fileChanges":[]}`,
+		`{"conversationId":"thread","callId":"call","fileChanges":{"path":null}}`,
+		`{"conversationId":"thread","callId":"call","fileChanges":{"path":{"type":"add"}}}`,
+		`{"conversationId":"thread","callId":"call","fileChanges":{},"reason":1}`,
+		`{"conversationId":"thread","callId":"call","fileChanges":{},"grantRoot":1}`,
+		`{"conversationId":"one","conversationId":"two","callId":"call","fileChanges":{}}`,
+		`{"conversationId":"thread","callId":"one","callId":"two","fileChanges":{}}`,
+		`{"conversationId":"thread","callId":"call","fileChanges":{},"fileChanges":{}}`,
+		`{"conversationId":"thread","callId":"call","fileChanges":{},"reason":null,"reason":"why"}`,
+		`{"conversationId":"thread","callId":"call","fileChanges":{},"grantRoot":null,"grantRoot":"root"}`,
+		`{` + valid + `} {}`,
+		`{` + valid + `} x`,
+	} {
+		assertJSONRejects[ApplyPatchApprovalParams](t, input)
+	}
+
+	var params *ApplyPatchApprovalParams
+	if err := params.UnmarshalJSON([]byte(`{` + valid + `}`)); err == nil {
+		t.Fatal("nil ApplyPatchApprovalParams receiver succeeded")
+	}
+	if _, err := json.Marshal(ApplyPatchApprovalParams{
+		FileChanges: map[string]FileChange{"path": {}},
+	}); err == nil {
+		t.Fatal("invalid nested FileChange marshaled")
+	}
+}
+
+func TestApplyPatchApprovalParamsRemainsStandalone(t *testing.T) {
+	if reflect.TypeFor[ApplyPatchApprovalParams]() == reflect.TypeFor[FileChangeApprovalRequestParams]() {
+		t.Fatal("legacy apply-patch params alias live file-change approval params")
+	}
+	defs := JSONSchema()["$defs"].(Schema)
+	for _, name := range []string{"ThreadId", "FileChange", "ApplyPatchApprovalResponse"} {
+		if _, ok := defs[name]; !ok {
+			t.Fatalf("dependency-complete %s missing", name)
+		}
+	}
+	for _, binding := range WireTypeBindings() {
+		if slices.Contains(binding.Params, "ApplyPatchApprovalParams") ||
+			slices.Contains(binding.Result, "ApplyPatchApprovalParams") {
+			t.Fatalf("ApplyPatchApprovalParams unexpectedly bound to %s", binding.Method)
+		}
+	}
+	for _, binding := range ItemPayloadBindings() {
+		if binding.Type == "ApplyPatchApprovalParams" {
+			t.Fatalf("ApplyPatchApprovalParams unexpectedly bound to item %s", binding.Kind)
+		}
+	}
+	if got := len(defs); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestApplyPatchApprovalParamsTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	want := "export type ApplyPatchApprovalParams = {\n" +
+		"  \"callId\": string;\n" +
+		"  \"conversationId\": ThreadId;\n" +
+		"  \"fileChanges\": { [key in string]?: FileChange };\n" +
+		"  \"grantRoot\": string | null;\n" +
+		"  \"reason\": string | null;\n" +
+		"};"
+	if !strings.Contains(string(generated), want) {
+		t.Fatalf("generated TypeScript missing %q", want)
+	}
+}

--- a/appserver/protocol/apply_patch_approval_params_types.go
+++ b/appserver/protocol/apply_patch_approval_params_types.go
@@ -1,0 +1,93 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// ApplyPatchApprovalParams is the exact legacy public patch-approval request
+// data. It remains separate from Gollem's live file-change approval request.
+type ApplyPatchApprovalParams struct {
+	ConversationID ThreadId              `json:"conversationId"`
+	CallID         string                `json:"callId"`
+	FileChanges    map[string]FileChange `json:"fileChanges"`
+	Reason         *string               `json:"reason,omitempty"`
+	GrantRoot      *string               `json:"grantRoot,omitempty"`
+}
+
+func (p ApplyPatchApprovalParams) MarshalJSON() ([]byte, error) {
+	type wire struct {
+		ConversationID ThreadId              `json:"conversationId"`
+		CallID         string                `json:"callId"`
+		FileChanges    map[string]FileChange `json:"fileChanges"`
+		Reason         *string               `json:"reason"`
+		GrantRoot      *string               `json:"grantRoot"`
+	}
+	fileChanges := p.FileChanges
+	if fileChanges == nil {
+		fileChanges = map[string]FileChange{}
+	}
+	return json.Marshal(wire{
+		ConversationID: p.ConversationID,
+		CallID:         p.CallID,
+		FileChanges:    fileChanges,
+		Reason:         p.Reason,
+		GrantRoot:      p.GrantRoot,
+	})
+}
+
+func (p *ApplyPatchApprovalParams) UnmarshalJSON(data []byte) error {
+	if p == nil {
+		return errors.New("decode apply-patch approval params into nil receiver")
+	}
+	const objectName = "apply-patch approval params"
+	payload, err := decodeRustSerdeObject(
+		data,
+		objectName,
+		"conversationId",
+		"callId",
+		"fileChanges",
+		"reason",
+		"grantRoot",
+	)
+	if err != nil {
+		return err
+	}
+	conversationID, err := decodeRequiredThreadItemValue[ThreadId](
+		payload, objectName, "conversationId",
+	)
+	if err != nil {
+		return err
+	}
+	callID, err := decodeRequiredThreadItemValue[string](payload, objectName, "callId")
+	if err != nil {
+		return err
+	}
+	fileChanges, err := decodeRequiredThreadItemValue[map[string]FileChange](
+		payload, objectName, "fileChanges",
+	)
+	if err != nil {
+		return err
+	}
+	reason, err := decodeOptionalNullableConfigValue[string](payload, objectName, "reason")
+	if err != nil {
+		return err
+	}
+	grantRoot, err := decodeOptionalNullableConfigValue[string](payload, objectName, "grantRoot")
+	if err != nil {
+		return err
+	}
+	*p = ApplyPatchApprovalParams{
+		ConversationID: conversationID,
+		CallID:         callID,
+		FileChanges:    fileChanges,
+		Reason:         reason,
+		GrantRoot:      grantRoot,
+	}
+	return nil
+}
+
+var (
+	_ json.Marshaler   = ApplyPatchApprovalParams{}
+	_ json.Unmarshaler = (*ApplyPatchApprovalParams)(nil)
+)

--- a/appserver/protocol/attestation_contract_test.go
+++ b/appserver/protocol/attestation_contract_test.go
@@ -133,8 +133,8 @@ func TestAttestationContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("attestation/generate = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/exec_command_approval_params_contract_test.go
+++ b/appserver/protocol/exec_command_approval_params_contract_test.go
@@ -137,8 +137,8 @@ func TestExecCommandApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ExecCommandApprovalParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(defs); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,8 +217,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,8 +203,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -260,8 +260,8 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,8 +244,8 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -162,8 +162,8 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -175,8 +175,8 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_contract_test.go
+++ b/appserver/protocol/file_change_contract_test.go
@@ -108,8 +108,8 @@ func TestFileChangeRemainsStandalone(t *testing.T) {
 			t.Fatalf("FileChange unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_output_delta_notification_contract_test.go
+++ b/appserver/protocol/file_change_output_delta_notification_contract_test.go
@@ -100,8 +100,8 @@ func TestFileChangeOutputDeltaNotificationRemainsDeprecatedAndStandalone(t *test
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("item/fileChange/outputDelta = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -381,8 +381,8 @@ func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_action_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_action_contract_test.go
@@ -226,8 +226,8 @@ func TestGuardianApprovalReviewActionRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReviewAction unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
@@ -164,8 +164,8 @@ func TestGuardianApprovalReviewCompletedNotificationRemainsStandalone(t *testing
 			t.Fatalf("completed notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_contract_test.go
@@ -139,8 +139,8 @@ func TestGuardianApprovalReviewRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReview unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
@@ -175,8 +175,8 @@ func TestGuardianApprovalReviewStartedNotificationRemainsStandalone(t *testing.T
 			t.Fatalf("started notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_enum_foundation_contract_test.go
+++ b/appserver/protocol/guardian_enum_foundation_contract_test.go
@@ -89,8 +89,8 @@ func TestGuardianEnumFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_metadata_list_contract_test.go
+++ b/appserver/protocol/hook_metadata_list_contract_test.go
@@ -352,8 +352,8 @@ func TestHookMetadataListContractsStayStandalone(t *testing.T) {
 			t.Errorf("standalone definition %s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Errorf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Errorf("definition count = %d, want 445", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 {
 		t.Errorf("wire binding count = %d, want 59", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_run_notification_contract_test.go
+++ b/appserver/protocol/hook_run_notification_contract_test.go
@@ -297,8 +297,8 @@ func TestHookRunNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("surface changed: %d methods, %d wire bindings, %d item bindings", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/hook_value_foundation_contract_test.go
+++ b/appserver/protocol/hook_value_foundation_contract_test.go
@@ -167,8 +167,8 @@ func TestHookValueFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 444 {
-		t.Fatalf("definition count = %d, want 444", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 445 {
+		t.Fatalf("definition count = %d, want 445", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/legacy_approval_response_contract_test.go
+++ b/appserver/protocol/legacy_approval_response_contract_test.go
@@ -98,8 +98,8 @@ func TestLegacyApprovalResponsesRemainStandaloneAndNominal(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_approval_context_contract_test.go
+++ b/appserver/protocol/network_approval_context_contract_test.go
@@ -84,8 +84,8 @@ func TestNetworkApprovalContextRemainsStandalone(t *testing.T) {
 			t.Fatalf("NetworkApprovalContext unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/parsed_command_contract_test.go
+++ b/appserver/protocol/parsed_command_contract_test.go
@@ -120,8 +120,8 @@ func TestParsedCommandRemainsStandalone(t *testing.T) {
 			t.Fatalf("ParsedCommand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 444 {
-		t.Fatalf("definition count = %d, want 444", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 445 {
+		t.Fatalf("definition count = %d, want 445", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 444 {
-		t.Fatalf("definition count = %d, want 444", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 445 {
+		t.Fatalf("definition count = %d, want 445", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 444 {
-		t.Fatalf("definition count = %d, want 444", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 445 {
+		t.Fatalf("definition count = %d, want 445", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 444 {
-		t.Fatalf("definition count = %d, want 444", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 445 {
+		t.Fatalf("definition count = %d, want 445", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 444 {
-		t.Fatalf("definition count = %d, want 444", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 445 {
+		t.Fatalf("definition count = %d, want 445", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/review_decision_contract_test.go
+++ b/appserver/protocol/review_decision_contract_test.go
@@ -136,8 +136,8 @@ func TestReviewDecisionRemainsStandalone(t *testing.T) {
 			t.Fatalf("ReviewDecision unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(defs); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -100,6 +100,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "ApprovalRespondParams", Type: reflect.TypeFor[ApprovalRespondParams]()},
 		{Name: "ApprovalRespondResult", Type: reflect.TypeFor[ApprovalRespondResult]()},
 		{Name: "ApprovalsReviewer", Type: reflect.TypeFor[ApprovalsReviewer]()},
+		{Name: "ApplyPatchApprovalParams", Type: reflect.TypeFor[ApplyPatchApprovalParams]()},
 		{Name: "ApplyPatchApprovalResponse", Type: reflect.TypeFor[ApplyPatchApprovalResponse]()},
 		{Name: "AskForApproval", Type: reflect.TypeFor[AskForApproval]()},
 		{Name: "AutoCompactTokenLimitScope", Type: reflect.TypeFor[AutoCompactTokenLimitScope]()},
@@ -701,6 +702,27 @@ func wireSchemaDefinitions() Schema {
 	schemas["HooksListResponse"] = hooksListResponseSchema()
 	schemas["ItemGuardianApprovalReviewCompletedNotification"] = guardianApprovalReviewCompletedNotificationSchema()
 	schemas["ItemGuardianApprovalReviewStartedNotification"] = guardianApprovalReviewStartedNotificationSchema()
+	schemas["ApplyPatchApprovalParams"] = closedThreadSessionParamSchema(Schema{
+		"conversationId": Schema{"$ref": "#/$defs/ThreadId"},
+		"callId": Schema{
+			"type": "string",
+			"description": "Use to correlate this with [codex_protocol::protocol::PatchApplyBeginEvent] " +
+				"and [codex_protocol::protocol::PatchApplyEndEvent].",
+		},
+		"fileChanges": Schema{
+			"type":                 "object",
+			"additionalProperties": Schema{"$ref": "#/$defs/FileChange"},
+		},
+		"reason": Schema{
+			"anyOf":       []any{Schema{"type": "string"}, Schema{"type": "null"}},
+			"description": "Optional explanatory reason (e.g. request for extra write access).",
+		},
+		"grantRoot": Schema{
+			"anyOf": []any{Schema{"type": "string"}, Schema{"type": "null"}},
+			"description": "When set, the agent is asking the user to allow writes under this root " +
+				"for the remainder of the session (unclear if this is honored today).",
+		},
+	}, []string{"callId", "conversationId", "fileChanges"})
 	schemas["ExecCommandApprovalParams"] = closedThreadSessionParamSchema(Schema{
 		"conversationId": Schema{"$ref": "#/$defs/ThreadId"},
 		"callId": Schema{

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -246,6 +246,52 @@
       "type": "object",
       "x-gollem-typescript-optional-map": true
     },
+    "ApplyPatchApprovalParams": {
+      "additionalProperties": false,
+      "properties": {
+        "callId": {
+          "description": "Use to correlate this with [codex_protocol::protocol::PatchApplyBeginEvent] and [codex_protocol::protocol::PatchApplyEndEvent].",
+          "type": "string"
+        },
+        "conversationId": {
+          "$ref": "#/$defs/ThreadId"
+        },
+        "fileChanges": {
+          "additionalProperties": {
+            "$ref": "#/$defs/FileChange"
+          },
+          "type": "object"
+        },
+        "grantRoot": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "When set, the agent is asking the user to allow writes under this root for the remainder of the session (unclear if this is honored today)."
+        },
+        "reason": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional explanatory reason (e.g. request for extra write access)."
+        }
+      },
+      "required": [
+        "callId",
+        "conversationId",
+        "fileChanges"
+      ],
+      "type": "object"
+    },
     "ApplyPatchApprovalResponse": {
       "additionalProperties": false,
       "properties": {

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 444 {
-		t.Fatalf("definition count = %d, want 444", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 445 {
+		t.Fatalf("definition count = %d, want 445", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 444 {
-		t.Fatalf("definition count = %d, want 444", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 445 {
+		t.Fatalf("definition count = %d, want 445", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 444 {
-		t.Fatalf("definition count = %d, want 444", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 445 {
+		t.Fatalf("definition count = %d, want 445", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -39,7 +39,8 @@ func MarshalTypeScript() ([]byte, error) {
 	sort.Strings(names)
 	for _, name := range names {
 		definition := defs[name]
-		if name == "MigrationDetails" || name == "ExternalAgentConfigMigrationItem" ||
+		if name == "ApplyPatchApprovalParams" || name == "MigrationDetails" ||
+			name == "ExternalAgentConfigMigrationItem" ||
 			name == "ExternalAgentConfigImportItemTypeFailure" ||
 			name == "ExternalAgentConfigImportItemTypeSuccess" ||
 			name == "ExecCommandApprovalParams" ||
@@ -58,6 +59,10 @@ func MarshalTypeScript() ([]byte, error) {
 			}
 			schema = renderSchema
 			switch name {
+			case "ApplyPatchApprovalParams":
+				schema["required"] = []string{
+					"conversationId", "callId", "fileChanges", "reason", "grantRoot",
+				}
 			case "ExecCommandApprovalParams":
 				schema["required"] = []string{
 					"conversationId", "callId", "approvalId", "command", "cwd", "reason", "parsedCmd",
@@ -125,6 +130,17 @@ func MarshalTypeScript() ([]byte, error) {
 				}
 			}
 			definition = schema
+		}
+		if name == "ApplyPatchApprovalParams" {
+			// ts-rs models HashMap values with optional mapped keys. Keep this
+			// render-only hint out of the exact public JSON Schema.
+			definition = typeScriptDefinitionWithPropertySchemas(definition, Schema{
+				"fileChanges": Schema{
+					"type":                             "object",
+					"additionalProperties":             Schema{"$ref": "#/$defs/FileChange"},
+					"x-gollem-typescript-optional-map": true,
+				},
+			})
 		}
 		if name == "ExternalAgentConfigImportHistory" {
 			// ts-rs maps this Rust i64 to bigint. Apply the hint only to a

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -545,6 +545,14 @@ export type AnalyticsConfig = ({
   "enabled": boolean | null;
 } & { [key in string]?: JsonValue });
 
+export type ApplyPatchApprovalParams = {
+  "callId": string;
+  "conversationId": ThreadId;
+  "fileChanges": { [key in string]?: FileChange };
+  "grantRoot": string | null;
+  "reason": string | null;
+};
+
 export type ApplyPatchApprovalResponse = {
   "decision": ReviewDecision;
 };

--- a/appserver/protocol/typescript/testdata/apply_patch_approval_params_contract.ts
+++ b/appserver/protocol/typescript/testdata/apply_patch_approval_params_contract.ts
@@ -1,0 +1,67 @@
+import type {
+  ApplyPatchApprovalParams,
+  FileChange,
+  FileChangeApprovalRequestParams,
+  MethodParamsByName,
+  MethodResultsByName,
+  ThreadId,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+type ExpectFalse<T extends false> = T;
+
+type ExactParams = {
+  conversationId: ThreadId;
+  callId: string;
+  fileChanges: { [key in string]?: FileChange };
+  reason: string | null;
+  grantRoot: string | null;
+};
+
+export type ApplyPatchApprovalParamsContract = [
+  Expect<Equal<ApplyPatchApprovalParams, ExactParams>>,
+  ExpectFalse<Equal<ApplyPatchApprovalParams, FileChangeApprovalRequestParams>>,
+  ExpectFalse<"applyPatchApproval" extends keyof MethodParamsByName ? true : false>,
+  ExpectFalse<"applyPatchApproval" extends keyof MethodResultsByName ? true : false>,
+  Expect<Equal<Extract<MethodParamsByName[keyof MethodParamsByName], ApplyPatchApprovalParams>, never>>,
+  Expect<Equal<Extract<MethodResultsByName[keyof MethodResultsByName], ApplyPatchApprovalParams>, never>>,
+];
+
+({
+  conversationId: "",
+  callId: "",
+  fileChanges: {},
+  reason: null,
+  grantRoot: null,
+}) satisfies ApplyPatchApprovalParams;
+
+({
+  conversationId: "thread",
+  callId: "call",
+  fileChanges: {
+    "relative path": { type: "add", content: "" },
+    "/absolute": { type: "update", unified_diff: "diff", move_path: null },
+  },
+  reason: "inspect",
+  grantRoot: "relative/root",
+}) satisfies ApplyPatchApprovalParams;
+
+// @ts-expect-error conversationId is required.
+({ callId: "call", fileChanges: {}, reason: null, grantRoot: null }) satisfies ApplyPatchApprovalParams;
+// @ts-expect-error callId is required.
+({ conversationId: "thread", fileChanges: {}, reason: null, grantRoot: null }) satisfies ApplyPatchApprovalParams;
+// @ts-expect-error fileChanges is required.
+({ conversationId: "thread", callId: "call", reason: null, grantRoot: null }) satisfies ApplyPatchApprovalParams;
+// @ts-expect-error nested file changes remain strict.
+({ conversationId: "thread", callId: "call", fileChanges: { path: { type: "add" } }, reason: null, grantRoot: null }) satisfies ApplyPatchApprovalParams;
+// @ts-expect-error reason is canonical-required nullable.
+({ conversationId: "thread", callId: "call", fileChanges: {}, grantRoot: null }) satisfies ApplyPatchApprovalParams;
+// @ts-expect-error grantRoot is canonical-required nullable.
+({ conversationId: "thread", callId: "call", fileChanges: {}, reason: null }) satisfies ApplyPatchApprovalParams;
+// @ts-expect-error canonical records are closed.
+({ conversationId: "thread", callId: "call", fileChanges: {}, reason: null, grantRoot: null, future: true }) satisfies ApplyPatchApprovalParams;

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 444 {
-		t.Fatalf("definition count = %d, want 444", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
+		t.Fatalf("definition count = %d, want 445", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary

- export the exact standalone legacy `ApplyPatchApprovalParams` contract
- preserve serde-compatible optional nullable fields and strict canonical output
- keep `applyPatchApproval`, live approval requests, bindings, and runtime behavior unchanged

## Verification

- deliberate-red Go and TypeScript boundaries
- focused x30, focused race, and 100% codec coverage
- full protocol coverage 97.5%
- all 59 non-Monty packages in normal and race modes
- lint, vet, tidy/verify, deterministic generation, TypeScript 7.0.2
- exact normalized pinned Codex schema and compiler-level TypeScript identity
- exact structural reversal to PR #210 artifacts
- configured pre-push and all five Slang real-binary workflows

Local Monty normal/race/coverage tests remain skipped per project direction; hosted CI is unchanged.