### PR TITLE
appserver/protocol: add auth token refresh contracts

### DIFF
--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(defs); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/apply_patch_approval_params_contract_test.go
+++ b/appserver/protocol/apply_patch_approval_params_contract_test.go
@@ -139,8 +139,8 @@ func TestApplyPatchApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ApplyPatchApprovalParams unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(defs); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(defs); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/attestation_contract_test.go
+++ b/appserver/protocol/attestation_contract_test.go
@@ -133,8 +133,8 @@ func TestAttestationContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("attestation/generate = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
+++ b/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
@@ -1,0 +1,214 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestChatgptAuthTokensRefreshSchemasAreExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	assertStringEnum(t, defs["ChatgptAuthTokensRefreshReason"], "unauthorized")
+
+	params := closedThreadSessionParamSchema(Schema{
+		"reason": Schema{"$ref": "#/$defs/ChatgptAuthTokensRefreshReason"},
+		"previousAccountId": Schema{
+			"anyOf": []any{Schema{"type": "string"}, Schema{"type": "null"}},
+			"description": "Workspace/account identifier that Codex was previously using.\n\n" +
+				"Clients that manage multiple accounts/workspaces can use this as a hint to " +
+				"refresh the token for the correct workspace.\n\n" +
+				"This may be `null` when the prior auth state did not include a workspace " +
+				"identifier (`chatgpt_account_id`).",
+		},
+	}, []string{"reason"})
+	if !reflect.DeepEqual(defs["ChatgptAuthTokensRefreshParams"], params) {
+		t.Fatalf("ChatgptAuthTokensRefreshParams = %#v, want %#v", defs["ChatgptAuthTokensRefreshParams"], params)
+	}
+
+	response := closedThreadSessionParamSchema(Schema{
+		"accessToken":      Schema{"type": "string"},
+		"chatgptAccountId": Schema{"type": "string"},
+		"chatgptPlanType":  nullableStringSchema(),
+	}, []string{"accessToken", "chatgptAccountId"})
+	if !reflect.DeepEqual(defs["ChatgptAuthTokensRefreshResponse"], response) {
+		t.Fatalf("ChatgptAuthTokensRefreshResponse = %#v, want %#v", defs["ChatgptAuthTokensRefreshResponse"], response)
+	}
+}
+
+func TestChatgptAuthTokensRefreshReasonAcceptsExactValue(t *testing.T) {
+	var reason ChatgptAuthTokensRefreshReason
+	if err := json.Unmarshal([]byte(`"unauthorized"`), &reason); err != nil {
+		t.Fatalf("unmarshal reason: %v", err)
+	}
+	if reason != ChatgptAuthTokensRefreshReasonUnauthorized {
+		t.Fatalf("reason = %q, want unauthorized", reason)
+	}
+	encoded, err := json.Marshal(reason)
+	if err != nil || string(encoded) != `"unauthorized"` {
+		t.Fatalf("marshal reason = %s, %v", encoded, err)
+	}
+}
+
+func TestChatgptAuthTokensRefreshRecordsAcceptSerdeWireForms(t *testing.T) {
+	for _, tc := range []struct {
+		input string
+		want  string
+	}{
+		{`{"reason":"unauthorized"}`, `{"previousAccountId":null,"reason":"unauthorized"}`},
+		{`{"reason":"unauthorized","previousAccountId":null}`, `{"previousAccountId":null,"reason":"unauthorized"}`},
+		{`{"reason":"unauthorized","previousAccountId":""}`, `{"previousAccountId":"","reason":"unauthorized"}`},
+		{`{"unknown":"ignored","reason":"unauthorized","previousAccountId":" workspace "}`, `{"previousAccountId":" workspace ","reason":"unauthorized"}`},
+	} {
+		var params ChatgptAuthTokensRefreshParams
+		if err := json.Unmarshal([]byte(tc.input), &params); err != nil {
+			t.Errorf("unmarshal params %s: %v", tc.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(params)
+		if err != nil || string(encoded) != tc.want {
+			t.Errorf("params round trip %s = %s, %v; want %s", tc.input, encoded, err, tc.want)
+		}
+	}
+
+	for _, tc := range []struct {
+		input string
+		want  string
+	}{
+		{`{"accessToken":"","chatgptAccountId":""}`, `{"accessToken":"","chatgptAccountId":"","chatgptPlanType":null}`},
+		{`{"accessToken":"token","chatgptAccountId":"account","chatgptPlanType":null}`, `{"accessToken":"token","chatgptAccountId":"account","chatgptPlanType":null}`},
+		{`{"accessToken":" token ","chatgptAccountId":" workspace ","chatgptPlanType":" pro "}`, `{"accessToken":" token ","chatgptAccountId":" workspace ","chatgptPlanType":" pro "}`},
+		{`{"future":true,"accessToken":"token","chatgptAccountId":"account"}`, `{"accessToken":"token","chatgptAccountId":"account","chatgptPlanType":null}`},
+	} {
+		var response ChatgptAuthTokensRefreshResponse
+		if err := json.Unmarshal([]byte(tc.input), &response); err != nil {
+			t.Errorf("unmarshal response %s: %v", tc.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(response)
+		if err != nil || string(encoded) != tc.want {
+			t.Errorf("response round trip %s = %s, %v; want %s", tc.input, encoded, err, tc.want)
+		}
+	}
+}
+
+func TestChatgptAuthTokensRefreshRejectsMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `""`, `"other"`, `1`, `true`, `{}`, `[]`,
+		`"Unauthorized"`, `"unauthorized" {}`, `"unauthorized" x`,
+	} {
+		assertJSONRejects[ChatgptAuthTokensRefreshReason](t, input)
+	}
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`, `{}`,
+		`{"reason":null}`, `{"reason":"other"}`, `{"reason":1}`,
+		`{"reason":"unauthorized","previousAccountId":1}`,
+		`{"reason":"unauthorized","reason":"unauthorized"}`,
+		`{"reason":"unauthorized","previousAccountId":null,"previousAccountId":"account"}`,
+		`{"reason":"unauthorized"} {}`, `{"reason":"unauthorized"} x`,
+	} {
+		assertJSONRejects[ChatgptAuthTokensRefreshParams](t, input)
+	}
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`, `{}`,
+		`{"chatgptAccountId":"account"}`, `{"accessToken":"token"}`,
+		`{"accessToken":null,"chatgptAccountId":"account"}`,
+		`{"accessToken":"token","chatgptAccountId":null}`,
+		`{"accessToken":1,"chatgptAccountId":"account"}`,
+		`{"accessToken":"token","chatgptAccountId":1}`,
+		`{"accessToken":"token","chatgptAccountId":"account","chatgptPlanType":1}`,
+		`{"accessToken":"one","accessToken":"two","chatgptAccountId":"account"}`,
+		`{"accessToken":"token","chatgptAccountId":"one","chatgptAccountId":"two"}`,
+		`{"accessToken":"token","chatgptAccountId":"account","chatgptPlanType":null,"chatgptPlanType":"pro"}`,
+		`{"accessToken":"token","chatgptAccountId":"account"} {}`,
+		`{"accessToken":"token","chatgptAccountId":"account"} x`,
+	} {
+		assertJSONRejects[ChatgptAuthTokensRefreshResponse](t, input)
+	}
+}
+
+func TestChatgptAuthTokensRefreshNilReceiversAndInvalidMarshalFailClosed(t *testing.T) {
+	var reason *ChatgptAuthTokensRefreshReason
+	if err := reason.UnmarshalJSON([]byte(`"unauthorized"`)); err == nil {
+		t.Fatal("nil reason receiver succeeded")
+	}
+	var params *ChatgptAuthTokensRefreshParams
+	if err := params.UnmarshalJSON([]byte(`{"reason":"unauthorized"}`)); err == nil {
+		t.Fatal("nil params receiver succeeded")
+	}
+	var response *ChatgptAuthTokensRefreshResponse
+	if err := response.UnmarshalJSON([]byte(`{"accessToken":"token","chatgptAccountId":"account"}`)); err == nil {
+		t.Fatal("nil response receiver succeeded")
+	}
+	if _, err := json.Marshal(ChatgptAuthTokensRefreshReason("other")); err == nil {
+		t.Fatal("invalid reason marshaled")
+	}
+	if _, err := json.Marshal(ChatgptAuthTokensRefreshParams{}); err == nil {
+		t.Fatal("params with invalid zero reason marshaled")
+	}
+}
+
+func TestChatgptAuthTokensRefreshRemainsStandaloneAndDeferred(t *testing.T) {
+	names := []string{
+		"ChatgptAuthTokensRefreshReason",
+		"ChatgptAuthTokensRefreshParams",
+		"ChatgptAuthTokensRefreshResponse",
+	}
+	for _, binding := range WireTypeBindings() {
+		for _, name := range names {
+			if slices.Contains(binding.Params, name) || slices.Contains(binding.Result, name) {
+				t.Fatalf("%s unexpectedly bound to %s", name, binding.Method)
+			}
+		}
+	}
+	for _, binding := range ItemPayloadBindings() {
+		if slices.Contains(names, binding.Type) {
+			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
+		}
+	}
+	var found bool
+	for _, method := range Methods() {
+		if method.Method == "account/chatgptAuthTokens/refresh" {
+			found = true
+			if method.Surface != SurfaceServerRequest || method.State != MethodDeferredStub {
+				t.Fatalf("refresh method = %#v, want deferred server request", method)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("refresh method inventory entry missing")
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestChatgptAuthTokensRefreshTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	for _, want := range []string{
+		`export type ChatgptAuthTokensRefreshReason = "unauthorized";`,
+		"export type ChatgptAuthTokensRefreshParams = {\n" +
+			"  \"previousAccountId\"?: string | null;\n" +
+			"  \"reason\": ChatgptAuthTokensRefreshReason;\n" +
+			"};",
+		"export type ChatgptAuthTokensRefreshResponse = {\n" +
+			"  \"accessToken\": string;\n" +
+			"  \"chatgptAccountId\": string;\n" +
+			"  \"chatgptPlanType\": string | null;\n" +
+			"};",
+	} {
+		if !strings.Contains(string(generated), want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}

--- a/appserver/protocol/chatgpt_auth_tokens_refresh_types.go
+++ b/appserver/protocol/chatgpt_auth_tokens_refresh_types.go
@@ -1,0 +1,124 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// ChatgptAuthTokensRefreshReason is the exact closed public reason for a
+// client-managed ChatGPT token refresh. It carries no authentication authority.
+type ChatgptAuthTokensRefreshReason string
+
+const (
+	ChatgptAuthTokensRefreshReasonUnauthorized ChatgptAuthTokensRefreshReason = "unauthorized"
+)
+
+func (r ChatgptAuthTokensRefreshReason) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(r, "ChatGPT auth-tokens refresh reason", ChatgptAuthTokensRefreshReason.valid)
+}
+
+func (r *ChatgptAuthTokensRefreshReason) UnmarshalJSON(data []byte) error {
+	return unmarshalThreadTurnLeafEnum(data, r, "ChatGPT auth-tokens refresh reason", ChatgptAuthTokensRefreshReason.valid)
+}
+
+func (r ChatgptAuthTokensRefreshReason) valid() bool {
+	return r == ChatgptAuthTokensRefreshReasonUnauthorized
+}
+
+// ChatgptAuthTokensRefreshParams is exact standalone public refresh-request
+// data. The corresponding sensitive server request remains deferred and unbound.
+type ChatgptAuthTokensRefreshParams struct {
+	Reason            ChatgptAuthTokensRefreshReason `json:"reason"`
+	PreviousAccountID *string                        `json:"previousAccountId,omitempty"`
+}
+
+func (p ChatgptAuthTokensRefreshParams) MarshalJSON() ([]byte, error) {
+	return json.Marshal(map[string]any{
+		"reason":            p.Reason,
+		"previousAccountId": p.PreviousAccountID,
+	})
+}
+
+func (p *ChatgptAuthTokensRefreshParams) UnmarshalJSON(data []byte) error {
+	if p == nil {
+		return errors.New("decode ChatGPT auth-tokens refresh params into nil receiver")
+	}
+	const objectName = "ChatGPT auth-tokens refresh params"
+	payload, err := decodeRustSerdeObject(data, objectName, "reason", "previousAccountId")
+	if err != nil {
+		return err
+	}
+	reason, err := decodeRequiredThreadItemValue[ChatgptAuthTokensRefreshReason](
+		payload, objectName, "reason",
+	)
+	if err != nil {
+		return err
+	}
+	previousAccountID, err := decodeOptionalNullableConfigValue[string](
+		payload, objectName, "previousAccountId",
+	)
+	if err != nil {
+		return err
+	}
+	*p = ChatgptAuthTokensRefreshParams{
+		Reason:            reason,
+		PreviousAccountID: previousAccountID,
+	}
+	return nil
+}
+
+// ChatgptAuthTokensRefreshResponse is exact standalone public refresh-response
+// data. Gollem does not receive, store, log, validate, or return these tokens.
+type ChatgptAuthTokensRefreshResponse struct {
+	AccessToken      string  `json:"accessToken"` //nolint:gosec // Exact standalone protocol field; no runtime consumes it.
+	ChatgptAccountID string  `json:"chatgptAccountId"`
+	ChatgptPlanType  *string `json:"chatgptPlanType,omitempty"`
+}
+
+func (r ChatgptAuthTokensRefreshResponse) MarshalJSON() ([]byte, error) {
+	return json.Marshal(map[string]any{
+		"accessToken":      r.AccessToken,
+		"chatgptAccountId": r.ChatgptAccountID,
+		"chatgptPlanType":  r.ChatgptPlanType,
+	})
+}
+
+func (r *ChatgptAuthTokensRefreshResponse) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("decode ChatGPT auth-tokens refresh response into nil receiver")
+	}
+	const objectName = "ChatGPT auth-tokens refresh response"
+	payload, err := decodeRustSerdeObject(
+		data, objectName, "accessToken", "chatgptAccountId", "chatgptPlanType",
+	)
+	if err != nil {
+		return err
+	}
+	accessToken, err := decodeRequiredThreadItemValue[string](payload, objectName, "accessToken")
+	if err != nil {
+		return err
+	}
+	accountID, err := decodeRequiredThreadItemValue[string](payload, objectName, "chatgptAccountId")
+	if err != nil {
+		return err
+	}
+	planType, err := decodeOptionalNullableConfigValue[string](payload, objectName, "chatgptPlanType")
+	if err != nil {
+		return err
+	}
+	*r = ChatgptAuthTokensRefreshResponse{
+		AccessToken:      accessToken,
+		ChatgptAccountID: accountID,
+		ChatgptPlanType:  planType,
+	}
+	return nil
+}
+
+var (
+	_ json.Marshaler   = ChatgptAuthTokensRefreshReason("")
+	_ json.Unmarshaler = (*ChatgptAuthTokensRefreshReason)(nil)
+	_ json.Marshaler   = ChatgptAuthTokensRefreshParams{}
+	_ json.Unmarshaler = (*ChatgptAuthTokensRefreshParams)(nil)
+	_ json.Marshaler   = ChatgptAuthTokensRefreshResponse{}
+	_ json.Unmarshaler = (*ChatgptAuthTokensRefreshResponse)(nil)
+)

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/exec_command_approval_params_contract_test.go
+++ b/appserver/protocol/exec_command_approval_params_contract_test.go
@@ -137,8 +137,8 @@ func TestExecCommandApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ExecCommandApprovalParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(defs); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,8 +217,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,8 +203,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -260,8 +260,8 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,8 +244,8 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -162,8 +162,8 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -175,8 +175,8 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_contract_test.go
+++ b/appserver/protocol/file_change_contract_test.go
@@ -108,8 +108,8 @@ func TestFileChangeRemainsStandalone(t *testing.T) {
 			t.Fatalf("FileChange unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_output_delta_notification_contract_test.go
+++ b/appserver/protocol/file_change_output_delta_notification_contract_test.go
@@ -100,8 +100,8 @@ func TestFileChangeOutputDeltaNotificationRemainsDeprecatedAndStandalone(t *test
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("item/fileChange/outputDelta = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -381,8 +381,8 @@ func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_action_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_action_contract_test.go
@@ -226,8 +226,8 @@ func TestGuardianApprovalReviewActionRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReviewAction unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
@@ -164,8 +164,8 @@ func TestGuardianApprovalReviewCompletedNotificationRemainsStandalone(t *testing
 			t.Fatalf("completed notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_contract_test.go
@@ -139,8 +139,8 @@ func TestGuardianApprovalReviewRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReview unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
@@ -175,8 +175,8 @@ func TestGuardianApprovalReviewStartedNotificationRemainsStandalone(t *testing.T
 			t.Fatalf("started notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_enum_foundation_contract_test.go
+++ b/appserver/protocol/guardian_enum_foundation_contract_test.go
@@ -89,8 +89,8 @@ func TestGuardianEnumFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_metadata_list_contract_test.go
+++ b/appserver/protocol/hook_metadata_list_contract_test.go
@@ -352,8 +352,8 @@ func TestHookMetadataListContractsStayStandalone(t *testing.T) {
 			t.Errorf("standalone definition %s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Errorf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Errorf("definition count = %d, want 448", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 {
 		t.Errorf("wire binding count = %d, want 59", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_run_notification_contract_test.go
+++ b/appserver/protocol/hook_run_notification_contract_test.go
@@ -297,8 +297,8 @@ func TestHookRunNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("surface changed: %d methods, %d wire bindings, %d item bindings", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/hook_value_foundation_contract_test.go
+++ b/appserver/protocol/hook_value_foundation_contract_test.go
@@ -167,8 +167,8 @@ func TestHookValueFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 445 {
-		t.Fatalf("definition count = %d, want 445", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 448 {
+		t.Fatalf("definition count = %d, want 448", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/legacy_approval_response_contract_test.go
+++ b/appserver/protocol/legacy_approval_response_contract_test.go
@@ -98,8 +98,8 @@ func TestLegacyApprovalResponsesRemainStandaloneAndNominal(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_approval_context_contract_test.go
+++ b/appserver/protocol/network_approval_context_contract_test.go
@@ -84,8 +84,8 @@ func TestNetworkApprovalContextRemainsStandalone(t *testing.T) {
 			t.Fatalf("NetworkApprovalContext unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/parsed_command_contract_test.go
+++ b/appserver/protocol/parsed_command_contract_test.go
@@ -120,8 +120,8 @@ func TestParsedCommandRemainsStandalone(t *testing.T) {
 			t.Fatalf("ParsedCommand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 445 {
-		t.Fatalf("definition count = %d, want 445", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 448 {
+		t.Fatalf("definition count = %d, want 448", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 445 {
-		t.Fatalf("definition count = %d, want 445", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 448 {
+		t.Fatalf("definition count = %d, want 448", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 445 {
-		t.Fatalf("definition count = %d, want 445", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 448 {
+		t.Fatalf("definition count = %d, want 448", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 445 {
-		t.Fatalf("definition count = %d, want 445", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 448 {
+		t.Fatalf("definition count = %d, want 448", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 445 {
-		t.Fatalf("definition count = %d, want 445", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 448 {
+		t.Fatalf("definition count = %d, want 448", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/review_decision_contract_test.go
+++ b/appserver/protocol/review_decision_contract_test.go
@@ -136,8 +136,8 @@ func TestReviewDecisionRemainsStandalone(t *testing.T) {
 			t.Fatalf("ReviewDecision unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(defs); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -109,6 +109,9 @@ func wireSchemaDefinitions() Schema {
 		{Name: "CancelLoginAccountParams", Type: reflect.TypeFor[CancelLoginAccountParams]()},
 		{Name: "CancelLoginAccountResponse", Type: reflect.TypeFor[CancelLoginAccountResponse]()},
 		{Name: "CancelLoginAccountStatus", Type: reflect.TypeFor[CancelLoginAccountStatus]()},
+		{Name: "ChatgptAuthTokensRefreshParams", Type: reflect.TypeFor[ChatgptAuthTokensRefreshParams]()},
+		{Name: "ChatgptAuthTokensRefreshReason", Type: reflect.TypeFor[ChatgptAuthTokensRefreshReason]()},
+		{Name: "ChatgptAuthTokensRefreshResponse", Type: reflect.TypeFor[ChatgptAuthTokensRefreshResponse]()},
 		{Name: "ClientInfo", Type: reflect.TypeFor[ClientInfo]()},
 		{Name: "CodexErrorInfo", Type: reflect.TypeFor[CodexErrorInfo]()},
 		{Name: "CollabAgentState", Type: reflect.TypeFor[CollabAgentState]()},
@@ -573,6 +576,25 @@ func wireSchemaDefinitions() Schema {
 		string(CancelLoginAccountStatusCanceled),
 		string(CancelLoginAccountStatusNotFound),
 	)
+	schemas["ChatgptAuthTokensRefreshReason"] = stringEnumSchema(
+		string(ChatgptAuthTokensRefreshReasonUnauthorized),
+	)
+	schemas["ChatgptAuthTokensRefreshParams"] = closedThreadSessionParamSchema(Schema{
+		"reason": Schema{"$ref": "#/$defs/ChatgptAuthTokensRefreshReason"},
+		"previousAccountId": Schema{
+			"anyOf": []any{Schema{"type": "string"}, Schema{"type": "null"}},
+			"description": "Workspace/account identifier that Codex was previously using.\n\n" +
+				"Clients that manage multiple accounts/workspaces can use this as a hint to " +
+				"refresh the token for the correct workspace.\n\n" +
+				"This may be `null` when the prior auth state did not include a workspace " +
+				"identifier (`chatgpt_account_id`).",
+		},
+	}, []string{"reason"})
+	schemas["ChatgptAuthTokensRefreshResponse"] = closedThreadSessionParamSchema(Schema{
+		"accessToken":      Schema{"type": "string"},
+		"chatgptAccountId": Schema{"type": "string"},
+		"chatgptPlanType":  nullableStringSchema(),
+	}, []string{"accessToken", "chatgptAccountId"})
 	schemas["LoginAppBrand"] = stringEnumSchema(
 		string(LoginAppBrandCodex),
 		string(LoginAppBrandChatGPT),

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -543,6 +543,61 @@
       ],
       "type": "string"
     },
+    "ChatgptAuthTokensRefreshParams": {
+      "additionalProperties": false,
+      "properties": {
+        "previousAccountId": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Workspace/account identifier that Codex was previously using.\n\nClients that manage multiple accounts/workspaces can use this as a hint to refresh the token for the correct workspace.\n\nThis may be `null` when the prior auth state did not include a workspace identifier (`chatgpt_account_id`)."
+        },
+        "reason": {
+          "$ref": "#/$defs/ChatgptAuthTokensRefreshReason"
+        }
+      },
+      "required": [
+        "reason"
+      ],
+      "type": "object"
+    },
+    "ChatgptAuthTokensRefreshReason": {
+      "enum": [
+        "unauthorized"
+      ],
+      "type": "string"
+    },
+    "ChatgptAuthTokensRefreshResponse": {
+      "additionalProperties": false,
+      "properties": {
+        "accessToken": {
+          "type": "string"
+        },
+        "chatgptAccountId": {
+          "type": "string"
+        },
+        "chatgptPlanType": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "accessToken",
+        "chatgptAccountId"
+      ],
+      "type": "object"
+    },
     "ClientInfo": {
       "additionalProperties": false,
       "properties": {

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 445 {
-		t.Fatalf("definition count = %d, want 445", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 448 {
+		t.Fatalf("definition count = %d, want 448", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 445 {
-		t.Fatalf("definition count = %d, want 445", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 448 {
+		t.Fatalf("definition count = %d, want 448", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 445 {
-		t.Fatalf("definition count = %d, want 445", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 448 {
+		t.Fatalf("definition count = %d, want 448", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -39,7 +39,8 @@ func MarshalTypeScript() ([]byte, error) {
 	sort.Strings(names)
 	for _, name := range names {
 		definition := defs[name]
-		if name == "ApplyPatchApprovalParams" || name == "MigrationDetails" ||
+		if name == "ApplyPatchApprovalParams" || name == "ChatgptAuthTokensRefreshResponse" ||
+			name == "MigrationDetails" ||
 			name == "ExternalAgentConfigMigrationItem" ||
 			name == "ExternalAgentConfigImportItemTypeFailure" ||
 			name == "ExternalAgentConfigImportItemTypeSuccess" ||
@@ -62,6 +63,10 @@ func MarshalTypeScript() ([]byte, error) {
 			case "ApplyPatchApprovalParams":
 				schema["required"] = []string{
 					"conversationId", "callId", "fileChanges", "reason", "grantRoot",
+				}
+			case "ChatgptAuthTokensRefreshResponse":
+				schema["required"] = []string{
+					"accessToken", "chatgptAccountId", "chatgptPlanType",
 				}
 			case "ExecCommandApprovalParams":
 				schema["required"] = []string{

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -617,6 +617,19 @@ export type CancelLoginAccountResponse = {
 
 export type CancelLoginAccountStatus = "canceled" | "notFound";
 
+export type ChatgptAuthTokensRefreshParams = {
+  "previousAccountId"?: string | null;
+  "reason": ChatgptAuthTokensRefreshReason;
+};
+
+export type ChatgptAuthTokensRefreshReason = "unauthorized";
+
+export type ChatgptAuthTokensRefreshResponse = {
+  "accessToken": string;
+  "chatgptAccountId": string;
+  "chatgptPlanType": string | null;
+};
+
 export type ClientInfo = {
   "name": string;
   "title"?: string | null;

--- a/appserver/protocol/typescript/testdata/chatgpt_auth_tokens_refresh_contract.ts
+++ b/appserver/protocol/typescript/testdata/chatgpt_auth_tokens_refresh_contract.ts
@@ -1,0 +1,92 @@
+import type {
+  ChatgptAuthTokensRefreshParams,
+  ChatgptAuthTokensRefreshReason,
+  ChatgptAuthTokensRefreshResponse,
+  ItemPayloadByKind,
+  MethodParamsByName,
+  MethodResultsByName,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+type ExpectFalse<T extends false> = T;
+
+type Contracts = [
+  Expect<Equal<ChatgptAuthTokensRefreshReason, "unauthorized">>,
+  Expect<
+    Equal<
+      ChatgptAuthTokensRefreshParams,
+      {
+        reason: ChatgptAuthTokensRefreshReason;
+        previousAccountId?: string | null;
+      }
+    >
+  >,
+  Expect<
+    Equal<
+      ChatgptAuthTokensRefreshResponse,
+      {
+        accessToken: string;
+        chatgptAccountId: string;
+        chatgptPlanType: string | null;
+      }
+    >
+  >,
+  ExpectFalse<"account/chatgptAuthTokens/refresh" extends keyof MethodParamsByName ? true : false>,
+  ExpectFalse<"account/chatgptAuthTokens/refresh" extends keyof MethodResultsByName ? true : false>,
+  Expect<Equal<Extract<MethodParamsByName[keyof MethodParamsByName], ChatgptAuthTokensRefreshParams>, never>>,
+  Expect<Equal<Extract<MethodResultsByName[keyof MethodResultsByName], ChatgptAuthTokensRefreshResponse>, never>>,
+  Expect<Equal<Extract<ItemPayloadByKind[keyof ItemPayloadByKind], ChatgptAuthTokensRefreshParams>, never>>,
+];
+
+export const reason = "unauthorized" satisfies ChatgptAuthTokensRefreshReason;
+export const emptyParams = {
+  reason: "unauthorized",
+} satisfies ChatgptAuthTokensRefreshParams;
+export const nullParams = {
+  reason: "unauthorized",
+  previousAccountId: null,
+} satisfies ChatgptAuthTokensRefreshParams;
+export const fullParams = {
+  reason: "unauthorized",
+  previousAccountId: " workspace ",
+} satisfies ChatgptAuthTokensRefreshParams;
+export const nullResponse = {
+  accessToken: "",
+  chatgptAccountId: "",
+  chatgptPlanType: null,
+} satisfies ChatgptAuthTokensRefreshResponse;
+export const fullResponse = {
+  accessToken: " token ",
+  chatgptAccountId: " workspace ",
+  chatgptPlanType: " pro ",
+} satisfies ChatgptAuthTokensRefreshResponse;
+
+// @ts-expect-error reasons are closed and case-sensitive.
+export const rejectReason = "Unauthorized" satisfies ChatgptAuthTokensRefreshReason;
+// @ts-expect-error reason is required.
+export const rejectMissingReason = {} satisfies ChatgptAuthTokensRefreshParams;
+// @ts-expect-error reason is non-null.
+export const rejectNullReason = { reason: null } satisfies ChatgptAuthTokensRefreshParams;
+// @ts-expect-error previousAccountId is a nullable string.
+export const rejectNumericAccount = { reason: "unauthorized", previousAccountId: 1 } satisfies ChatgptAuthTokensRefreshParams;
+// @ts-expect-error canonical params are closed.
+export const rejectParamsExtension = { reason: "unauthorized", future: true } satisfies ChatgptAuthTokensRefreshParams;
+// @ts-expect-error accessToken is required.
+export const rejectMissingToken = { chatgptAccountId: "account", chatgptPlanType: null } satisfies ChatgptAuthTokensRefreshResponse;
+// @ts-expect-error chatgptAccountId is required.
+export const rejectMissingAccount = { accessToken: "token", chatgptPlanType: null } satisfies ChatgptAuthTokensRefreshResponse;
+// @ts-expect-error chatgptPlanType is canonical-required nullable.
+export const rejectMissingPlan = { accessToken: "token", chatgptAccountId: "account" } satisfies ChatgptAuthTokensRefreshResponse;
+// @ts-expect-error accessToken is non-null.
+export const rejectNullToken = { accessToken: null, chatgptAccountId: "account", chatgptPlanType: null } satisfies ChatgptAuthTokensRefreshResponse;
+// @ts-expect-error chatgptPlanType is a nullable string.
+export const rejectNumericPlan = { accessToken: "token", chatgptAccountId: "account", chatgptPlanType: 1 } satisfies ChatgptAuthTokensRefreshResponse;
+// @ts-expect-error canonical responses are closed.
+export const rejectResponseExtension = { accessToken: "token", chatgptAccountId: "account", chatgptPlanType: null, future: true } satisfies ChatgptAuthTokensRefreshResponse;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 445 {
-		t.Fatalf("definition count = %d, want 445", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 448 {
+		t.Fatalf("definition count = %d, want 448", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- export exact standalone `ChatgptAuthTokensRefreshReason`, `ChatgptAuthTokensRefreshParams`, and `ChatgptAuthTokensRefreshResponse`
- preserve serde-compatible omission and canonical nullable output while matching pinned Codex JSON Schema and TypeScript contracts
- keep `account/chatgptAuthTokens/refresh` deferred, unbound, and absent from typed method inference
- advance deterministic generation to 448 definitions without changing any of 224 methods, 59 method bindings, or 5 item bindings

## Contract
The reason is the closed `"unauthorized"` value. Params require `reason` and optionally carry nullable `previousAccountId`; responses require `accessToken`, `chatgptAccountId`, and canonical-required nullable `chatgptPlanType`. Unknown fields are discarded on serde-compatible input, known duplicates and malformed fields reject, empty and arbitrary strings are preserved, and omitted options canonicalize to null.

These are standalone wire definitions only. This change does not bind or advertise the sensitive server request; receive, log, redact, validate, select, store, refresh, exchange, or revoke credentials; infer account ownership; mutate auth state; or add runtime authority.

## Verification
- deliberate missing-type Go boundary before implementation
- focused contract tests x30, focused race, and 100% statement coverage for all seven production functions
- full protocol normal/race at 97.5% aggregate coverage
- fresh normal and race gates across exactly 59 non-Monty packages
- zero-issue lint, vet, tidy/verify, and configured pre-push both before commit and during push
- deterministic generation across two reruns; schema/TypeScript/strict-fixture SHA-256 values:
  - `22b61787c999655249283f6a2611bb079613cecb8e050628818423b58abf0b93`
  - `b7dae82b29d2a932bd713a25d099018f955545e1fd78f2f09d324af49a9ac82f`
  - `11fea3de68ca688975a814a88e75b9f35df8fe99d60118be3a2178ed6f27e546`
- normalized pinned-schema identity SHA-256 `892cab7f5ea561ff2b43112132632673d0b7128d4200cc1bfbb1d6c1b849a3dd` and compiler-level identity against the actual pinned ts-rs files
- all existing definitions and method/binding metadata unchanged; generated TypeScript restores byte-exact parent output after removing the three declarations
- full commit reversal restores exact PR #211 tree `71b134f637ed01acd0272e4facb9a386779c389e`
- reproducible feature binary SHA-256 `af7048ac30ec607e84e4de81d1706fb893481a1b2d22a5cad170ec40e8ba2db5`
- parent/feature initialize-plus-MCP transcript byte-identical at 37,898 bytes, SHA-256 `ed0009be275f657ca81a3ad89bc25d30280998018a076ceba7d956c2aee2d082`, with empty stderr
- all five existing Slang stdio, direct approval, Unix-socket, and WebSocket workflows against the feature binary
