### PR TITLE
appserver/protocol: add account token usage records

### DIFF
--- a/appserver/protocol/account_login_completed_notification_contract_test.go
+++ b/appserver/protocol/account_login_completed_notification_contract_test.go
@@ -88,8 +88,8 @@ func TestAccountLoginCompletedNotificationRemainsStandaloneAndDeferred(t *testin
 	if !found {
 		t.Fatal("account/login/completed method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/account_token_usage_contract_test.go
+++ b/appserver/protocol/account_token_usage_contract_test.go
@@ -1,0 +1,186 @@
+package protocol
+
+import (
+	"encoding/json"
+	"math"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestAccountTokenUsageSchemasAreExact(t *testing.T) {
+	int64Schema := Schema{"type": "integer", "format": "int64"}
+	nullableInt64Schema := Schema{"type": []any{"integer", "null"}, "format": "int64"}
+	wants := map[string]Schema{
+		"AccountTokenUsageDailyBucket": closedThreadSessionParamSchema(Schema{
+			"startDate": Schema{"type": "string"},
+			"tokens":    int64Schema,
+		}, []string{"startDate", "tokens"}),
+		"AccountTokenUsageSummary": closedThreadSessionParamSchema(Schema{
+			"lifetimeTokens":        nullableInt64Schema,
+			"peakDailyTokens":       nullableInt64Schema,
+			"longestRunningTurnSec": nullableInt64Schema,
+			"currentStreakDays":     nullableInt64Schema,
+			"longestStreakDays":     nullableInt64Schema,
+		}, nil),
+	}
+	defs := JSONSchema()["$defs"].(Schema)
+	for name, want := range wants {
+		if got := defs[name]; !reflect.DeepEqual(got, want) {
+			t.Errorf("%s = %#v, want %#v", name, got, want)
+		}
+	}
+}
+
+func TestAccountTokenUsageRecordsAcceptSerdeWireForms(t *testing.T) {
+	for _, tc := range []struct {
+		input string
+		want  AccountTokenUsageDailyBucket
+		json  string
+	}{
+		{`{"startDate":"","tokens":0}`, AccountTokenUsageDailyBucket{}, `{"startDate":"","tokens":0}`},
+		{`{"future":true,"startDate":" 2026-07-16 ","tokens":-9223372036854775808}`, AccountTokenUsageDailyBucket{StartDate: " 2026-07-16 ", Tokens: math.MinInt64}, `{"startDate":" 2026-07-16 ","tokens":-9223372036854775808}`},
+		{`{"startDate":"arbitrary","tokens":9223372036854775807}`, AccountTokenUsageDailyBucket{StartDate: "arbitrary", Tokens: math.MaxInt64}, `{"startDate":"arbitrary","tokens":9223372036854775807}`},
+	} {
+		var bucket AccountTokenUsageDailyBucket
+		if err := json.Unmarshal([]byte(tc.input), &bucket); err != nil {
+			t.Errorf("unmarshal bucket %s: %v", tc.input, err)
+			continue
+		}
+		if !reflect.DeepEqual(bucket, tc.want) {
+			t.Errorf("bucket %s = %#v, want %#v", tc.input, bucket, tc.want)
+		}
+		encoded, err := json.Marshal(bucket)
+		if err != nil || string(encoded) != tc.json {
+			t.Errorf("marshal bucket %#v = %s, %v; want %s", bucket, encoded, err, tc.json)
+		}
+	}
+
+	minimum := int64(math.MinInt64)
+	maximum := int64(math.MaxInt64)
+	for _, tc := range []struct {
+		input string
+		want  AccountTokenUsageSummary
+		json  string
+	}{
+		{`{}`, AccountTokenUsageSummary{}, `{"lifetimeTokens":null,"peakDailyTokens":null,"longestRunningTurnSec":null,"currentStreakDays":null,"longestStreakDays":null}`},
+		{`{"lifetimeTokens":null,"peakDailyTokens":null,"longestRunningTurnSec":null,"currentStreakDays":null,"longestStreakDays":null}`, AccountTokenUsageSummary{}, `{"lifetimeTokens":null,"peakDailyTokens":null,"longestRunningTurnSec":null,"currentStreakDays":null,"longestStreakDays":null}`},
+		{
+			`{"future":true,"lifetimeTokens":-9223372036854775808,"peakDailyTokens":9223372036854775807,"longestRunningTurnSec":0,"currentStreakDays":-1,"longestStreakDays":1}`,
+			AccountTokenUsageSummary{LifetimeTokens: &minimum, PeakDailyTokens: &maximum, LongestRunningTurnSec: int64Pointer(0), CurrentStreakDays: int64Pointer(-1), LongestStreakDays: int64Pointer(1)},
+			`{"lifetimeTokens":-9223372036854775808,"peakDailyTokens":9223372036854775807,"longestRunningTurnSec":0,"currentStreakDays":-1,"longestStreakDays":1}`,
+		},
+	} {
+		var summary AccountTokenUsageSummary
+		if err := json.Unmarshal([]byte(tc.input), &summary); err != nil {
+			t.Errorf("unmarshal summary %s: %v", tc.input, err)
+			continue
+		}
+		if !reflect.DeepEqual(summary, tc.want) {
+			t.Errorf("summary %s = %#v, want %#v", tc.input, summary, tc.want)
+		}
+		encoded, err := json.Marshal(summary)
+		if err != nil || string(encoded) != tc.json {
+			t.Errorf("marshal summary %#v = %s, %v; want %s", summary, encoded, err, tc.json)
+		}
+	}
+}
+
+func TestAccountTokenUsageRecordsRejectMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`, `{}`,
+		`{"tokens":0}`, `{"startDate":null,"tokens":0}`, `{"startDate":1,"tokens":0}`,
+		`{"startDate":"date"}`, `{"startDate":"date","tokens":null}`,
+		`{"startDate":"date","tokens":"0"}`, `{"startDate":"date","tokens":true}`,
+		`{"startDate":"date","tokens":0.5}`, `{"startDate":"date","tokens":1e3}`,
+		`{"startDate":"date","tokens":9223372036854775808}`,
+		`{"startDate":"date","tokens":-9223372036854775809}`,
+		`{"startDate":"a","startDate":"b","tokens":0}`,
+		`{"startDate":"date","tokens":0,"tokens":1}`,
+		`{"startDate":"date","tokens":0} {}`, `{"startDate":"date","tokens":0} x`,
+	} {
+		assertJSONRejects[AccountTokenUsageDailyBucket](t, input)
+	}
+
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`,
+		`{"lifetimeTokens":"0"}`, `{"peakDailyTokens":true}`,
+		`{"longestRunningTurnSec":0.5}`, `{"currentStreakDays":1e3}`,
+		`{"longestStreakDays":9223372036854775808}`,
+		`{"lifetimeTokens":-9223372036854775809}`,
+		`{"lifetimeTokens":null,"lifetimeTokens":0}`,
+		`{"peakDailyTokens":0,"peakDailyTokens":null}`,
+		`{"currentStreakDays":0} {}`, `{"currentStreakDays":0} x`,
+	} {
+		assertJSONRejects[AccountTokenUsageSummary](t, input)
+	}
+}
+
+func TestAccountTokenUsageNilReceiversFailClosed(t *testing.T) {
+	var bucket *AccountTokenUsageDailyBucket
+	if err := bucket.UnmarshalJSON([]byte(`{"startDate":"date","tokens":0}`)); err == nil {
+		t.Fatal("nil daily bucket receiver succeeded")
+	}
+	var summary *AccountTokenUsageSummary
+	if err := summary.UnmarshalJSON([]byte(`{}`)); err == nil {
+		t.Fatal("nil summary receiver succeeded")
+	}
+}
+
+func TestAccountTokenUsageRecordsRemainStandaloneAndDeferred(t *testing.T) {
+	names := []string{"AccountTokenUsageDailyBucket", "AccountTokenUsageSummary"}
+	for _, binding := range WireTypeBindings() {
+		for _, name := range names {
+			if slices.Contains(binding.Params, name) || slices.Contains(binding.Result, name) {
+				t.Fatalf("%s unexpectedly bound to %s", name, binding.Method)
+			}
+		}
+	}
+	for _, binding := range ItemPayloadBindings() {
+		if slices.Contains(names, binding.Type) {
+			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
+		}
+	}
+	method, ok := LookupMethod("account/usage/read")
+	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
+		t.Fatalf("account/usage/read = %#v, %v; want deferred client request", method, ok)
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestAccountTokenUsageTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	for _, want := range []string{
+		"export type AccountTokenUsageDailyBucket = {\n" +
+			"  \"startDate\": string;\n" +
+			"  \"tokens\": bigint;\n" +
+			"};",
+		"export type AccountTokenUsageSummary = {\n" +
+			"  \"currentStreakDays\": bigint | null;\n" +
+			"  \"lifetimeTokens\": bigint | null;\n" +
+			"  \"longestRunningTurnSec\": bigint | null;\n" +
+			"  \"longestStreakDays\": bigint | null;\n" +
+			"  \"peakDailyTokens\": bigint | null;\n" +
+			"};",
+	} {
+		if !strings.Contains(string(generated), want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+	plainInt64, err := typeScriptType(Schema{"type": "integer", "format": "int64"}, 0)
+	if err != nil || plainInt64 != "number" {
+		t.Fatalf("plain int64 TypeScript = %q, %v; want number", plainInt64, err)
+	}
+}

--- a/appserver/protocol/account_token_usage_types.go
+++ b/appserver/protocol/account_token_usage_types.go
@@ -1,0 +1,113 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// AccountTokenUsageDailyBucket is exact standalone public account-usage data.
+// Gollem does not fetch, aggregate, or persist account token usage.
+type AccountTokenUsageDailyBucket struct {
+	StartDate string `json:"startDate"`
+	Tokens    int64  `json:"tokens"`
+}
+
+func (b AccountTokenUsageDailyBucket) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		StartDate string `json:"startDate"`
+		Tokens    int64  `json:"tokens"`
+	}{StartDate: b.StartDate, Tokens: b.Tokens})
+}
+
+func (b *AccountTokenUsageDailyBucket) UnmarshalJSON(data []byte) error {
+	if b == nil {
+		return errors.New("decode account token usage daily bucket into nil receiver")
+	}
+	const objectName = "account token usage daily bucket"
+	payload, err := decodeRustSerdeObject(data, objectName, "startDate", "tokens")
+	if err != nil {
+		return err
+	}
+	startDate, err := decodeRequiredThreadItemValue[string](payload, objectName, "startDate")
+	if err != nil {
+		return err
+	}
+	tokens, err := decodeRequiredThreadItemValue[int64](payload, objectName, "tokens")
+	if err != nil {
+		return err
+	}
+	*b = AccountTokenUsageDailyBucket{StartDate: startDate, Tokens: tokens}
+	return nil
+}
+
+// AccountTokenUsageSummary is exact standalone public account-usage summary
+// data. Nullable values are canonicalized explicitly without aggregation.
+type AccountTokenUsageSummary struct {
+	LifetimeTokens        *int64 `json:"lifetimeTokens,omitempty"`
+	PeakDailyTokens       *int64 `json:"peakDailyTokens,omitempty"`
+	LongestRunningTurnSec *int64 `json:"longestRunningTurnSec,omitempty"`
+	CurrentStreakDays     *int64 `json:"currentStreakDays,omitempty"`
+	LongestStreakDays     *int64 `json:"longestStreakDays,omitempty"`
+}
+
+func (s AccountTokenUsageSummary) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		LifetimeTokens        *int64 `json:"lifetimeTokens"`
+		PeakDailyTokens       *int64 `json:"peakDailyTokens"`
+		LongestRunningTurnSec *int64 `json:"longestRunningTurnSec"`
+		CurrentStreakDays     *int64 `json:"currentStreakDays"`
+		LongestStreakDays     *int64 `json:"longestStreakDays"`
+	}{
+		LifetimeTokens: s.LifetimeTokens, PeakDailyTokens: s.PeakDailyTokens,
+		LongestRunningTurnSec: s.LongestRunningTurnSec,
+		CurrentStreakDays:     s.CurrentStreakDays, LongestStreakDays: s.LongestStreakDays,
+	})
+}
+
+func (s *AccountTokenUsageSummary) UnmarshalJSON(data []byte) error {
+	if s == nil {
+		return errors.New("decode account token usage summary into nil receiver")
+	}
+	const objectName = "account token usage summary"
+	payload, err := decodeRustSerdeObject(
+		data, objectName,
+		"lifetimeTokens", "peakDailyTokens", "longestRunningTurnSec",
+		"currentStreakDays", "longestStreakDays",
+	)
+	if err != nil {
+		return err
+	}
+	lifetimeTokens, err := decodeOptionalNullableConfigValue[int64](payload, objectName, "lifetimeTokens")
+	if err != nil {
+		return err
+	}
+	peakDailyTokens, err := decodeOptionalNullableConfigValue[int64](payload, objectName, "peakDailyTokens")
+	if err != nil {
+		return err
+	}
+	longestRunningTurnSec, err := decodeOptionalNullableConfigValue[int64](payload, objectName, "longestRunningTurnSec")
+	if err != nil {
+		return err
+	}
+	currentStreakDays, err := decodeOptionalNullableConfigValue[int64](payload, objectName, "currentStreakDays")
+	if err != nil {
+		return err
+	}
+	longestStreakDays, err := decodeOptionalNullableConfigValue[int64](payload, objectName, "longestStreakDays")
+	if err != nil {
+		return err
+	}
+	*s = AccountTokenUsageSummary{
+		LifetimeTokens: lifetimeTokens, PeakDailyTokens: peakDailyTokens,
+		LongestRunningTurnSec: longestRunningTurnSec,
+		CurrentStreakDays:     currentStreakDays, LongestStreakDays: longestStreakDays,
+	}
+	return nil
+}
+
+var (
+	_ json.Marshaler   = AccountTokenUsageDailyBucket{}
+	_ json.Unmarshaler = (*AccountTokenUsageDailyBucket)(nil)
+	_ json.Marshaler   = AccountTokenUsageSummary{}
+	_ json.Unmarshaler = (*AccountTokenUsageSummary)(nil)
+)

--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(defs); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/apply_patch_approval_params_contract_test.go
+++ b/appserver/protocol/apply_patch_approval_params_contract_test.go
@@ -139,8 +139,8 @@ func TestApplyPatchApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ApplyPatchApprovalParams unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(defs); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(defs); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/attestation_contract_test.go
+++ b/appserver/protocol/attestation_contract_test.go
@@ -133,8 +133,8 @@ func TestAttestationContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("attestation/generate = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
+++ b/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
@@ -179,8 +179,8 @@ func TestChatgptAuthTokensRefreshRemainsStandaloneAndDeferred(t *testing.T) {
 	if !found {
 		t.Fatal("refresh method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/exec_command_approval_params_contract_test.go
+++ b/appserver/protocol/exec_command_approval_params_contract_test.go
@@ -137,8 +137,8 @@ func TestExecCommandApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ExecCommandApprovalParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(defs); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,8 +217,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,8 +203,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -260,8 +260,8 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,8 +244,8 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -162,8 +162,8 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -175,8 +175,8 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_contract_test.go
+++ b/appserver/protocol/file_change_contract_test.go
@@ -108,8 +108,8 @@ func TestFileChangeRemainsStandalone(t *testing.T) {
 			t.Fatalf("FileChange unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_output_delta_notification_contract_test.go
+++ b/appserver/protocol/file_change_output_delta_notification_contract_test.go
@@ -100,8 +100,8 @@ func TestFileChangeOutputDeltaNotificationRemainsDeprecatedAndStandalone(t *test
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("item/fileChange/outputDelta = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -381,8 +381,8 @@ func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_action_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_action_contract_test.go
@@ -226,8 +226,8 @@ func TestGuardianApprovalReviewActionRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReviewAction unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
@@ -164,8 +164,8 @@ func TestGuardianApprovalReviewCompletedNotificationRemainsStandalone(t *testing
 			t.Fatalf("completed notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_contract_test.go
@@ -139,8 +139,8 @@ func TestGuardianApprovalReviewRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReview unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
@@ -175,8 +175,8 @@ func TestGuardianApprovalReviewStartedNotificationRemainsStandalone(t *testing.T
 			t.Fatalf("started notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_enum_foundation_contract_test.go
+++ b/appserver/protocol/guardian_enum_foundation_contract_test.go
@@ -89,8 +89,8 @@ func TestGuardianEnumFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_metadata_list_contract_test.go
+++ b/appserver/protocol/hook_metadata_list_contract_test.go
@@ -352,8 +352,8 @@ func TestHookMetadataListContractsStayStandalone(t *testing.T) {
 			t.Errorf("standalone definition %s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Errorf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Errorf("definition count = %d, want 451", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 {
 		t.Errorf("wire binding count = %d, want 59", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_run_notification_contract_test.go
+++ b/appserver/protocol/hook_run_notification_contract_test.go
@@ -297,8 +297,8 @@ func TestHookRunNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("surface changed: %d methods, %d wire bindings, %d item bindings", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/hook_value_foundation_contract_test.go
+++ b/appserver/protocol/hook_value_foundation_contract_test.go
@@ -167,8 +167,8 @@ func TestHookValueFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 449 {
-		t.Fatalf("definition count = %d, want 449", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 451 {
+		t.Fatalf("definition count = %d, want 451", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/legacy_approval_response_contract_test.go
+++ b/appserver/protocol/legacy_approval_response_contract_test.go
@@ -98,8 +98,8 @@ func TestLegacyApprovalResponsesRemainStandaloneAndNominal(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_approval_context_contract_test.go
+++ b/appserver/protocol/network_approval_context_contract_test.go
@@ -84,8 +84,8 @@ func TestNetworkApprovalContextRemainsStandalone(t *testing.T) {
 			t.Fatalf("NetworkApprovalContext unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/parsed_command_contract_test.go
+++ b/appserver/protocol/parsed_command_contract_test.go
@@ -120,8 +120,8 @@ func TestParsedCommandRemainsStandalone(t *testing.T) {
 			t.Fatalf("ParsedCommand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 449 {
-		t.Fatalf("definition count = %d, want 449", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 451 {
+		t.Fatalf("definition count = %d, want 451", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 449 {
-		t.Fatalf("definition count = %d, want 449", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 451 {
+		t.Fatalf("definition count = %d, want 451", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 449 {
-		t.Fatalf("definition count = %d, want 449", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 451 {
+		t.Fatalf("definition count = %d, want 451", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 449 {
-		t.Fatalf("definition count = %d, want 449", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 451 {
+		t.Fatalf("definition count = %d, want 451", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 449 {
-		t.Fatalf("definition count = %d, want 449", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 451 {
+		t.Fatalf("definition count = %d, want 451", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/review_decision_contract_test.go
+++ b/appserver/protocol/review_decision_contract_test.go
@@ -136,8 +136,8 @@ func TestReviewDecisionRemainsStandalone(t *testing.T) {
 			t.Fatalf("ReviewDecision unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(defs); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -92,6 +92,8 @@ func wireSchemaDefinitions() Schema {
 		{Name: "AdditionalNetworkPermissions", Type: reflect.TypeFor[AdditionalNetworkPermissions]()},
 		{Name: "AdditionalPermissionProfile", Type: reflect.TypeFor[AdditionalPermissionProfile]()},
 		{Name: "AccountLoginCompletedNotification", Type: reflect.TypeFor[AccountLoginCompletedNotification]()},
+		{Name: "AccountTokenUsageDailyBucket", Type: reflect.TypeFor[AccountTokenUsageDailyBucket]()},
+		{Name: "AccountTokenUsageSummary", Type: reflect.TypeFor[AccountTokenUsageSummary]()},
 		{Name: "AmazonBedrockCredentialSource", Type: reflect.TypeFor[AmazonBedrockCredentialSource]()},
 		{Name: "AnalyticsConfig", Type: reflect.TypeFor[AnalyticsConfig]()},
 		{Name: "AttestationGenerateParams", Type: reflect.TypeFor[AttestationGenerateParams]()},
@@ -561,6 +563,17 @@ func wireSchemaDefinitions() Schema {
 		"success": Schema{"type": "boolean"},
 		"error":   nullableStringSchema(),
 	}, []string{"success"})
+	schemas["AccountTokenUsageDailyBucket"] = closedThreadSessionParamSchema(Schema{
+		"startDate": Schema{"type": "string"},
+		"tokens":    Schema{"type": "integer", "format": "int64"},
+	}, []string{"startDate", "tokens"})
+	schemas["AccountTokenUsageSummary"] = closedThreadSessionParamSchema(Schema{
+		"lifetimeTokens":        Schema{"type": []any{"integer", "null"}, "format": "int64"},
+		"peakDailyTokens":       Schema{"type": []any{"integer", "null"}, "format": "int64"},
+		"longestRunningTurnSec": Schema{"type": []any{"integer", "null"}, "format": "int64"},
+		"currentStreakDays":     Schema{"type": []any{"integer", "null"}, "format": "int64"},
+		"longestStreakDays":     Schema{"type": []any{"integer", "null"}, "format": "int64"},
+	}, nil)
 	schemas["AgentPath"] = Schema{"type": "string"}
 	schemas["AmazonBedrockCredentialSource"] = stringEnumSchema(
 		string(AmazonBedrockCredentialSourceCodexManaged),

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -36,6 +36,64 @@
       ],
       "type": "object"
     },
+    "AccountTokenUsageDailyBucket": {
+      "additionalProperties": false,
+      "properties": {
+        "startDate": {
+          "type": "string"
+        },
+        "tokens": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "startDate",
+        "tokens"
+      ],
+      "type": "object"
+    },
+    "AccountTokenUsageSummary": {
+      "additionalProperties": false,
+      "properties": {
+        "currentStreakDays": {
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "lifetimeTokens": {
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "longestRunningTurnSec": {
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "longestStreakDays": {
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "peakDailyTokens": {
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
     "ActivePermissionProfile": {
       "additionalProperties": false,
       "properties": {

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 449 {
-		t.Fatalf("definition count = %d, want 449", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 451 {
+		t.Fatalf("definition count = %d, want 451", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 449 {
-		t.Fatalf("definition count = %d, want 449", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 451 {
+		t.Fatalf("definition count = %d, want 451", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 449 {
-		t.Fatalf("definition count = %d, want 449", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 451 {
+		t.Fatalf("definition count = %d, want 451", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -39,7 +39,8 @@ func MarshalTypeScript() ([]byte, error) {
 	sort.Strings(names)
 	for _, name := range names {
 		definition := defs[name]
-		if name == "AccountLoginCompletedNotification" || name == "ApplyPatchApprovalParams" ||
+		if name == "AccountLoginCompletedNotification" || name == "AccountTokenUsageSummary" ||
+			name == "ApplyPatchApprovalParams" ||
 			name == "ChatgptAuthTokensRefreshResponse" ||
 			name == "MigrationDetails" ||
 			name == "ExternalAgentConfigMigrationItem" ||
@@ -63,6 +64,11 @@ func MarshalTypeScript() ([]byte, error) {
 			switch name {
 			case "AccountLoginCompletedNotification":
 				schema["required"] = []string{"loginId", "success", "error"}
+			case "AccountTokenUsageSummary":
+				schema["required"] = []string{
+					"lifetimeTokens", "peakDailyTokens", "longestRunningTurnSec",
+					"currentStreakDays", "longestStreakDays",
+				}
 			case "ApplyPatchApprovalParams":
 				schema["required"] = []string{
 					"conversationId", "callId", "fileChanges", "reason", "grantRoot",
@@ -154,6 +160,19 @@ func MarshalTypeScript() ([]byte, error) {
 			// ts-rs maps this Rust i64 to bigint. Apply the hint only to a
 			// render copy so the public JSON Schema remains exact.
 			definition = typeScriptDefinitionWithBigIntProperties(definition, "completedAtMs")
+		}
+		if name == "AccountTokenUsageDailyBucket" {
+			// ts-rs maps this Rust i64 to bigint. Keep the render hint out of
+			// the exact public JSON Schema.
+			definition = typeScriptDefinitionWithBigIntProperties(definition, "tokens")
+		}
+		if name == "AccountTokenUsageSummary" {
+			// ts-rs maps every optional Rust i64 to required nullable bigint.
+			// Keep the render hints out of the exact public JSON Schema.
+			definition = typeScriptDefinitionWithBigIntProperties(
+				definition, "lifetimeTokens", "peakDailyTokens", "longestRunningTurnSec",
+				"currentStreakDays", "longestStreakDays",
+			)
 		}
 		if name == "HookRunSummary" {
 			// ts-rs maps each Rust i64 field to bigint, including nullable i64

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -500,6 +500,19 @@ export type AccountLoginCompletedNotification = {
   "success": boolean;
 };
 
+export type AccountTokenUsageDailyBucket = {
+  "startDate": string;
+  "tokens": bigint;
+};
+
+export type AccountTokenUsageSummary = {
+  "currentStreakDays": bigint | null;
+  "lifetimeTokens": bigint | null;
+  "longestRunningTurnSec": bigint | null;
+  "longestStreakDays": bigint | null;
+  "peakDailyTokens": bigint | null;
+};
+
 export type ActivePermissionProfile = {
   "extends": string | null;
   "id": string;

--- a/appserver/protocol/typescript/testdata/account_token_usage_contract.ts
+++ b/appserver/protocol/typescript/testdata/account_token_usage_contract.ts
@@ -1,0 +1,90 @@
+import type {
+  AccountTokenUsageDailyBucket,
+  AccountTokenUsageSummary,
+  ItemPayloadByKind,
+  MethodParamsByName,
+  MethodResultsByName,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+type ExpectFalse<T extends false> = T;
+
+type ExactDailyBucket = {
+  startDate: string;
+  tokens: bigint;
+};
+type ExactSummary = {
+  lifetimeTokens: bigint | null;
+  peakDailyTokens: bigint | null;
+  longestRunningTurnSec: bigint | null;
+  currentStreakDays: bigint | null;
+  longestStreakDays: bigint | null;
+};
+
+type Contracts = [
+  Expect<Equal<AccountTokenUsageDailyBucket, ExactDailyBucket>>,
+  Expect<Equal<AccountTokenUsageSummary, ExactSummary>>,
+  ExpectFalse<"account/usage/read" extends keyof MethodParamsByName ? true : false>,
+  ExpectFalse<"account/usage/read" extends keyof MethodResultsByName ? true : false>,
+  Expect<Equal<Extract<MethodParamsByName[keyof MethodParamsByName], AccountTokenUsageDailyBucket | AccountTokenUsageSummary>, never>>,
+  Expect<Equal<Extract<MethodResultsByName[keyof MethodResultsByName], AccountTokenUsageDailyBucket | AccountTokenUsageSummary>, never>>,
+  Expect<Equal<Extract<ItemPayloadByKind[keyof ItemPayloadByKind], AccountTokenUsageDailyBucket | AccountTokenUsageSummary>, never>>,
+];
+
+export const minimumBucket = {
+  startDate: "",
+  tokens: -9223372036854775808n,
+} satisfies AccountTokenUsageDailyBucket;
+export const maximumBucket = {
+  startDate: " arbitrary ",
+  tokens: 9223372036854775807n,
+} satisfies AccountTokenUsageDailyBucket;
+export const nullSummary = {
+  lifetimeTokens: null,
+  peakDailyTokens: null,
+  longestRunningTurnSec: null,
+  currentStreakDays: null,
+  longestStreakDays: null,
+} satisfies AccountTokenUsageSummary;
+export const populatedSummary = {
+  lifetimeTokens: -9223372036854775808n,
+  peakDailyTokens: 9223372036854775807n,
+  longestRunningTurnSec: 0n,
+  currentStreakDays: -1n,
+  longestStreakDays: 1n,
+} satisfies AccountTokenUsageSummary;
+
+// @ts-expect-error startDate is required.
+export const rejectBucketMissingDate = { tokens: 0n } satisfies AccountTokenUsageDailyBucket;
+// @ts-expect-error tokens is required.
+export const rejectBucketMissingTokens = { startDate: "date" } satisfies AccountTokenUsageDailyBucket;
+// @ts-expect-error startDate is non-null.
+export const rejectBucketNullDate = { startDate: null, tokens: 0n } satisfies AccountTokenUsageDailyBucket;
+// @ts-expect-error tokens is bigint in exact ts-rs output.
+export const rejectBucketNumberTokens = { startDate: "date", tokens: 0 } satisfies AccountTokenUsageDailyBucket;
+// @ts-expect-error canonical buckets are closed.
+export const rejectBucketExtension = { startDate: "date", tokens: 0n, future: true } satisfies AccountTokenUsageDailyBucket;
+
+// @ts-expect-error lifetimeTokens is canonical-required nullable.
+export const rejectSummaryMissingLifetime = { peakDailyTokens: null, longestRunningTurnSec: null, currentStreakDays: null, longestStreakDays: null } satisfies AccountTokenUsageSummary;
+// @ts-expect-error peakDailyTokens is canonical-required nullable.
+export const rejectSummaryMissingPeak = { lifetimeTokens: null, longestRunningTurnSec: null, currentStreakDays: null, longestStreakDays: null } satisfies AccountTokenUsageSummary;
+// @ts-expect-error longestRunningTurnSec is canonical-required nullable.
+export const rejectSummaryMissingLongestTurn = { lifetimeTokens: null, peakDailyTokens: null, currentStreakDays: null, longestStreakDays: null } satisfies AccountTokenUsageSummary;
+// @ts-expect-error currentStreakDays is canonical-required nullable.
+export const rejectSummaryMissingCurrentStreak = { lifetimeTokens: null, peakDailyTokens: null, longestRunningTurnSec: null, longestStreakDays: null } satisfies AccountTokenUsageSummary;
+// @ts-expect-error longestStreakDays is canonical-required nullable.
+export const rejectSummaryMissingLongestStreak = { lifetimeTokens: null, peakDailyTokens: null, longestRunningTurnSec: null, currentStreakDays: null } satisfies AccountTokenUsageSummary;
+// @ts-expect-error summary integers are bigint, not number.
+export const rejectSummaryNumber = { ...nullSummary, lifetimeTokens: 0 } satisfies AccountTokenUsageSummary;
+// @ts-expect-error summary values are bigint or null.
+export const rejectSummaryString = { ...nullSummary, peakDailyTokens: "0" } satisfies AccountTokenUsageSummary;
+// @ts-expect-error canonical summaries are closed.
+export const rejectSummaryExtension = { ...nullSummary, future: true } satisfies AccountTokenUsageSummary;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 449 {
-		t.Fatalf("definition count = %d, want 449", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 451 {
+		t.Fatalf("definition count = %d, want 451", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- export exact standalone AccountTokenUsageDailyBucket and AccountTokenUsageSummary contracts
- preserve serde omission-to-null input while requiring canonical nullable summary fields
- match pinned ts-rs bigint output through render-only hints scoped to the seven signed-int64 fields
- keep account/usage/read deferred and leave methods, bindings, account runtime, and telemetry behavior unchanged

## Verification
- focused tests x30, focused race, and 100% production-function coverage
- full protocol race coverage: 97.5%
- exactly 59 non-Monty packages: normal and race
- golangci-lint, vet, tidy/verify, deterministic generation
- configured pre-push before commit and during push
- exact normalized pinned schemas and compiler-level pinned ts-rs identity
- exact generated-artifact and full-commit structural reversal
- reproducible parent/feature binaries and byte-identical runtime transcripts
- all five Slang stdio/Unix-socket/WebSocket workflows