### PR TITLE
Export app metadata leaf records

### DIFF
--- a/appserver/protocol/account_credit_nudge_values_contract_test.go
+++ b/appserver/protocol/account_credit_nudge_values_contract_test.go
@@ -119,8 +119,8 @@ func TestAccountCreditNudgeValuesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/sendAddCreditsNudgeEmail = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/account_login_completed_notification_contract_test.go
+++ b/appserver/protocol/account_login_completed_notification_contract_test.go
@@ -88,8 +88,8 @@ func TestAccountLoginCompletedNotificationRemainsStandaloneAndDeferred(t *testin
 	if !found {
 		t.Fatal("account/login/completed method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/account_token_usage_contract_test.go
+++ b/appserver/protocol/account_token_usage_contract_test.go
@@ -146,8 +146,8 @@ func TestAccountTokenUsageRecordsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/usage/read = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(defs); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_metadata_leaf_contract_test.go
+++ b/appserver/protocol/app_metadata_leaf_contract_test.go
@@ -1,0 +1,185 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestAppMetadataLeafSchemasAreExact(t *testing.T) {
+	wants := map[string]Schema{
+		"AppBranding": closedThreadSessionParamSchema(Schema{
+			"category":          nullableStringSchema(),
+			"developer":         nullableStringSchema(),
+			"website":           nullableStringSchema(),
+			"privacyPolicy":     nullableStringSchema(),
+			"termsOfService":    nullableStringSchema(),
+			"isDiscoverableApp": Schema{"type": "boolean"},
+		}, []string{"isDiscoverableApp"}),
+		"AppReview": closedThreadSessionParamSchema(Schema{
+			"status": Schema{"type": "string"},
+		}, []string{"status"}),
+		"AppScreenshot": closedThreadSessionParamSchema(Schema{
+			"url":        nullableStringSchema(),
+			"fileId":     nullableStringSchema(),
+			"userPrompt": Schema{"type": "string"},
+		}, []string{"userPrompt"}),
+	}
+	defs := JSONSchema()["$defs"].(Schema)
+	for name, want := range wants {
+		if got := defs[name]; !reflect.DeepEqual(got, want) {
+			t.Errorf("%s = %#v, want %#v", name, got, want)
+		}
+	}
+}
+
+func TestAppMetadataLeavesAcceptSerdeWireForms(t *testing.T) {
+	for _, tc := range []struct {
+		input string
+		want  string
+	}{
+		{`{"isDiscoverableApp":false}`, `{"category":null,"developer":null,"isDiscoverableApp":false,"privacyPolicy":null,"termsOfService":null,"website":null}`},
+		{`{"category":null,"developer":null,"website":null,"privacyPolicy":null,"termsOfService":null,"isDiscoverableApp":true}`, `{"category":null,"developer":null,"isDiscoverableApp":true,"privacyPolicy":null,"termsOfService":null,"website":null}`},
+		{`{"future":true,"category":" category ","developer":"","website":"not a url","privacyPolicy":" privacy ","termsOfService":" terms ","isDiscoverableApp":true}`, `{"category":" category ","developer":"","isDiscoverableApp":true,"privacyPolicy":" privacy ","termsOfService":" terms ","website":"not a url"}`},
+	} {
+		var value AppBranding
+		if err := json.Unmarshal([]byte(tc.input), &value); err != nil {
+			t.Errorf("unmarshal AppBranding %s: %v", tc.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(value)
+		if err != nil || string(encoded) != tc.want {
+			t.Errorf("AppBranding round trip %s = %s, %v; want %s", tc.input, encoded, err, tc.want)
+		}
+	}
+
+	for _, input := range []string{`{"status":""}`, `{"future":true,"status":" arbitrary review state "}`} {
+		var value AppReview
+		if err := json.Unmarshal([]byte(input), &value); err != nil {
+			t.Errorf("unmarshal AppReview %s: %v", input, err)
+			continue
+		}
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			t.Errorf("marshal AppReview %s: %v", input, err)
+		}
+		var canonical map[string]string
+		if err := json.Unmarshal(encoded, &canonical); err != nil || canonical["status"] != value.Status {
+			t.Errorf("AppReview round trip %s = %s, %v", input, encoded, err)
+		}
+	}
+
+	for _, tc := range []struct {
+		input string
+		want  string
+	}{
+		{`{"userPrompt":""}`, `{"fileId":null,"url":null,"userPrompt":""}`},
+		{`{"url":null,"fileId":null,"userPrompt":" prompt "}`, `{"fileId":null,"url":null,"userPrompt":" prompt "}`},
+		{`{"future":true,"url":"not a url","fileId":" file ","userPrompt":" arbitrary "}`, `{"fileId":" file ","url":"not a url","userPrompt":" arbitrary "}`},
+	} {
+		var value AppScreenshot
+		if err := json.Unmarshal([]byte(tc.input), &value); err != nil {
+			t.Errorf("unmarshal AppScreenshot %s: %v", tc.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(value)
+		if err != nil || string(encoded) != tc.want {
+			t.Errorf("AppScreenshot round trip %s = %s, %v; want %s", tc.input, encoded, err, tc.want)
+		}
+	}
+}
+
+func TestAppMetadataLeavesRejectMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`, `{}`,
+		`{"isDiscoverableApp":null}`, `{"isDiscoverableApp":"true"}`,
+		`{"category":1,"isDiscoverableApp":true}`,
+		`{"developer":false,"isDiscoverableApp":true}`,
+		`{"website":{},"isDiscoverableApp":true}`,
+		`{"privacyPolicy":[],"isDiscoverableApp":true}`,
+		`{"termsOfService":1,"isDiscoverableApp":true}`,
+		`{"isDiscoverableApp":true,"isDiscoverableApp":false}`,
+		`{"isDiscoverableApp":true} {}`, `{"isDiscoverableApp":true} x`,
+	} {
+		assertJSONRejects[AppBranding](t, input)
+	}
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`, `{}`,
+		`{"status":null}`, `{"status":1}`, `{"status":false}`,
+		`{"status":"ok","status":"other"}`, `{"status":"ok"} {}`, `{"status":"ok"} x`,
+	} {
+		assertJSONRejects[AppReview](t, input)
+	}
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`, `{}`,
+		`{"userPrompt":null}`, `{"userPrompt":1}`,
+		`{"url":1,"userPrompt":"x"}`, `{"fileId":false,"userPrompt":"x"}`,
+		`{"userPrompt":"x","userPrompt":"y"}`,
+		`{"url":null,"url":"x","userPrompt":"y"}`,
+		`{"userPrompt":"x"} {}`, `{"userPrompt":"x"} x`,
+	} {
+		assertJSONRejects[AppScreenshot](t, input)
+	}
+}
+
+func TestAppMetadataLeavesNilReceiversFailClosed(t *testing.T) {
+	var branding *AppBranding
+	if err := branding.UnmarshalJSON([]byte(`{"isDiscoverableApp":true}`)); err == nil {
+		t.Fatal("nil AppBranding receiver succeeded")
+	}
+	var review *AppReview
+	if err := review.UnmarshalJSON([]byte(`{"status":"ok"}`)); err == nil {
+		t.Fatal("nil AppReview receiver succeeded")
+	}
+	var screenshot *AppScreenshot
+	if err := screenshot.UnmarshalJSON([]byte(`{"userPrompt":"x"}`)); err == nil {
+		t.Fatal("nil AppScreenshot receiver succeeded")
+	}
+}
+
+func TestAppMetadataLeavesRemainStandaloneAndDeferred(t *testing.T) {
+	names := []string{"AppBranding", "AppReview", "AppScreenshot"}
+	for _, binding := range WireTypeBindings() {
+		for _, name := range names {
+			if slices.Contains(binding.Params, name) || slices.Contains(binding.Result, name) {
+				t.Fatalf("%s unexpectedly bound to %s", name, binding.Method)
+			}
+		}
+	}
+	for _, binding := range ItemPayloadBindings() {
+		if slices.Contains(names, binding.Type) {
+			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
+		}
+	}
+	method, ok := LookupMethod("app/list")
+	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
+		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestAppMetadataLeavesTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	for _, want := range []string{
+		"export type AppBranding = {\n  \"category\": string | null;\n  \"developer\": string | null;\n  \"isDiscoverableApp\": boolean;\n  \"privacyPolicy\": string | null;\n  \"termsOfService\": string | null;\n  \"website\": string | null;\n};",
+		"export type AppReview = {\n  \"status\": string;\n};",
+		"export type AppScreenshot = {\n  \"fileId\": string | null;\n  \"url\": string | null;\n  \"userPrompt\": string;\n};",
+	} {
+		if !strings.Contains(string(generated), want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}

--- a/appserver/protocol/app_metadata_leaf_types.go
+++ b/appserver/protocol/app_metadata_leaf_types.go
@@ -1,0 +1,150 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// AppBranding is exact standalone public branding data for experimental apps.
+// App discovery and runtime behavior remain deferred and unbound.
+type AppBranding struct {
+	Category          *string `json:"category,omitempty"`
+	Developer         *string `json:"developer,omitempty"`
+	Website           *string `json:"website,omitempty"`
+	PrivacyPolicy     *string `json:"privacyPolicy,omitempty"`
+	TermsOfService    *string `json:"termsOfService,omitempty"`
+	IsDiscoverableApp bool    `json:"isDiscoverableApp"`
+}
+
+func (b AppBranding) MarshalJSON() ([]byte, error) {
+	return json.Marshal(map[string]any{
+		"category":          b.Category,
+		"developer":         b.Developer,
+		"website":           b.Website,
+		"privacyPolicy":     b.PrivacyPolicy,
+		"termsOfService":    b.TermsOfService,
+		"isDiscoverableApp": b.IsDiscoverableApp,
+	})
+}
+
+func (b *AppBranding) UnmarshalJSON(data []byte) error {
+	if b == nil {
+		return errors.New("decode app branding into nil receiver")
+	}
+	const objectName = "app branding"
+	payload, err := decodeRustSerdeObject(
+		data, objectName,
+		"category", "developer", "website", "privacyPolicy", "termsOfService", "isDiscoverableApp",
+	)
+	if err != nil {
+		return err
+	}
+	category, err := decodeOptionalNullableConfigValue[string](payload, objectName, "category")
+	if err != nil {
+		return err
+	}
+	developer, err := decodeOptionalNullableConfigValue[string](payload, objectName, "developer")
+	if err != nil {
+		return err
+	}
+	website, err := decodeOptionalNullableConfigValue[string](payload, objectName, "website")
+	if err != nil {
+		return err
+	}
+	privacyPolicy, err := decodeOptionalNullableConfigValue[string](payload, objectName, "privacyPolicy")
+	if err != nil {
+		return err
+	}
+	termsOfService, err := decodeOptionalNullableConfigValue[string](payload, objectName, "termsOfService")
+	if err != nil {
+		return err
+	}
+	isDiscoverableApp, err := decodeRequiredThreadItemValue[bool](payload, objectName, "isDiscoverableApp")
+	if err != nil {
+		return err
+	}
+	*b = AppBranding{
+		Category: category, Developer: developer, Website: website,
+		PrivacyPolicy: privacyPolicy, TermsOfService: termsOfService,
+		IsDiscoverableApp: isDiscoverableApp,
+	}
+	return nil
+}
+
+// AppReview is an exact opaque app-review status value.
+type AppReview struct {
+	Status string `json:"status"`
+}
+
+func (r AppReview) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Status string `json:"status"`
+	}{Status: r.Status})
+}
+
+func (r *AppReview) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("decode app review into nil receiver")
+	}
+	const objectName = "app review"
+	payload, err := decodeRustSerdeObject(data, objectName, "status")
+	if err != nil {
+		return err
+	}
+	status, err := decodeRequiredThreadItemValue[string](payload, objectName, "status")
+	if err != nil {
+		return err
+	}
+	*r = AppReview{Status: status}
+	return nil
+}
+
+// AppScreenshot is exact standalone public screenshot metadata. Gollem does
+// not fetch or interpret the URL, file identifier, or user prompt.
+type AppScreenshot struct {
+	URL        *string `json:"url,omitempty"`
+	FileID     *string `json:"fileId,omitempty"`
+	UserPrompt string  `json:"userPrompt"`
+}
+
+func (s AppScreenshot) MarshalJSON() ([]byte, error) {
+	return json.Marshal(map[string]any{
+		"url":        s.URL,
+		"fileId":     s.FileID,
+		"userPrompt": s.UserPrompt,
+	})
+}
+
+func (s *AppScreenshot) UnmarshalJSON(data []byte) error {
+	if s == nil {
+		return errors.New("decode app screenshot into nil receiver")
+	}
+	const objectName = "app screenshot"
+	payload, err := decodeRustSerdeObject(data, objectName, "url", "fileId", "userPrompt")
+	if err != nil {
+		return err
+	}
+	url, err := decodeOptionalNullableConfigValue[string](payload, objectName, "url")
+	if err != nil {
+		return err
+	}
+	fileID, err := decodeOptionalNullableConfigValue[string](payload, objectName, "fileId")
+	if err != nil {
+		return err
+	}
+	userPrompt, err := decodeRequiredThreadItemValue[string](payload, objectName, "userPrompt")
+	if err != nil {
+		return err
+	}
+	*s = AppScreenshot{URL: url, FileID: fileID, UserPrompt: userPrompt}
+	return nil
+}
+
+var (
+	_ json.Marshaler   = AppBranding{}
+	_ json.Unmarshaler = (*AppBranding)(nil)
+	_ json.Marshaler   = AppReview{}
+	_ json.Unmarshaler = (*AppReview)(nil)
+	_ json.Marshaler   = AppScreenshot{}
+	_ json.Unmarshaler = (*AppScreenshot)(nil)
+)

--- a/appserver/protocol/apply_patch_approval_params_contract_test.go
+++ b/appserver/protocol/apply_patch_approval_params_contract_test.go
@@ -139,8 +139,8 @@ func TestApplyPatchApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ApplyPatchApprovalParams unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(defs); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(defs); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/attestation_contract_test.go
+++ b/appserver/protocol/attestation_contract_test.go
@@ -133,8 +133,8 @@ func TestAttestationContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("attestation/generate = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
+++ b/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
@@ -179,8 +179,8 @@ func TestChatgptAuthTokensRefreshRemainsStandaloneAndDeferred(t *testing.T) {
 	if !found {
 		t.Fatal("refresh method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/exec_command_approval_params_contract_test.go
+++ b/appserver/protocol/exec_command_approval_params_contract_test.go
@@ -137,8 +137,8 @@ func TestExecCommandApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ExecCommandApprovalParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(defs); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,8 +217,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,8 +203,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -260,8 +260,8 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,8 +244,8 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -162,8 +162,8 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -175,8 +175,8 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_contract_test.go
+++ b/appserver/protocol/file_change_contract_test.go
@@ -108,8 +108,8 @@ func TestFileChangeRemainsStandalone(t *testing.T) {
 			t.Fatalf("FileChange unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_output_delta_notification_contract_test.go
+++ b/appserver/protocol/file_change_output_delta_notification_contract_test.go
@@ -100,8 +100,8 @@ func TestFileChangeOutputDeltaNotificationRemainsDeprecatedAndStandalone(t *test
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("item/fileChange/outputDelta = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -381,8 +381,8 @@ func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_action_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_action_contract_test.go
@@ -226,8 +226,8 @@ func TestGuardianApprovalReviewActionRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReviewAction unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
@@ -164,8 +164,8 @@ func TestGuardianApprovalReviewCompletedNotificationRemainsStandalone(t *testing
 			t.Fatalf("completed notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_contract_test.go
@@ -139,8 +139,8 @@ func TestGuardianApprovalReviewRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReview unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
@@ -175,8 +175,8 @@ func TestGuardianApprovalReviewStartedNotificationRemainsStandalone(t *testing.T
 			t.Fatalf("started notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_enum_foundation_contract_test.go
+++ b/appserver/protocol/guardian_enum_foundation_contract_test.go
@@ -89,8 +89,8 @@ func TestGuardianEnumFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_metadata_list_contract_test.go
+++ b/appserver/protocol/hook_metadata_list_contract_test.go
@@ -352,8 +352,8 @@ func TestHookMetadataListContractsStayStandalone(t *testing.T) {
 			t.Errorf("standalone definition %s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Errorf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Errorf("definition count = %d, want 456", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 {
 		t.Errorf("wire binding count = %d, want 59", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_run_notification_contract_test.go
+++ b/appserver/protocol/hook_run_notification_contract_test.go
@@ -297,8 +297,8 @@ func TestHookRunNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("surface changed: %d methods, %d wire bindings, %d item bindings", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/hook_value_foundation_contract_test.go
+++ b/appserver/protocol/hook_value_foundation_contract_test.go
@@ -167,8 +167,8 @@ func TestHookValueFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 453 {
-		t.Fatalf("definition count = %d, want 453", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 456 {
+		t.Fatalf("definition count = %d, want 456", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/legacy_approval_response_contract_test.go
+++ b/appserver/protocol/legacy_approval_response_contract_test.go
@@ -98,8 +98,8 @@ func TestLegacyApprovalResponsesRemainStandaloneAndNominal(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_approval_context_contract_test.go
+++ b/appserver/protocol/network_approval_context_contract_test.go
@@ -84,8 +84,8 @@ func TestNetworkApprovalContextRemainsStandalone(t *testing.T) {
 			t.Fatalf("NetworkApprovalContext unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/parsed_command_contract_test.go
+++ b/appserver/protocol/parsed_command_contract_test.go
@@ -120,8 +120,8 @@ func TestParsedCommandRemainsStandalone(t *testing.T) {
 			t.Fatalf("ParsedCommand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 453 {
-		t.Fatalf("definition count = %d, want 453", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 456 {
+		t.Fatalf("definition count = %d, want 456", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 453 {
-		t.Fatalf("definition count = %d, want 453", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 456 {
+		t.Fatalf("definition count = %d, want 456", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 453 {
-		t.Fatalf("definition count = %d, want 453", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 456 {
+		t.Fatalf("definition count = %d, want 456", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 453 {
-		t.Fatalf("definition count = %d, want 453", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 456 {
+		t.Fatalf("definition count = %d, want 456", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 453 {
-		t.Fatalf("definition count = %d, want 453", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 456 {
+		t.Fatalf("definition count = %d, want 456", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/review_decision_contract_test.go
+++ b/appserver/protocol/review_decision_contract_test.go
@@ -136,8 +136,8 @@ func TestReviewDecisionRemainsStandalone(t *testing.T) {
 			t.Fatalf("ReviewDecision unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(defs); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -105,6 +105,9 @@ func wireSchemaDefinitions() Schema {
 		{Name: "ApprovalRespondParams", Type: reflect.TypeFor[ApprovalRespondParams]()},
 		{Name: "ApprovalRespondResult", Type: reflect.TypeFor[ApprovalRespondResult]()},
 		{Name: "ApprovalsReviewer", Type: reflect.TypeFor[ApprovalsReviewer]()},
+		{Name: "AppBranding", Type: reflect.TypeFor[AppBranding]()},
+		{Name: "AppReview", Type: reflect.TypeFor[AppReview]()},
+		{Name: "AppScreenshot", Type: reflect.TypeFor[AppScreenshot]()},
 		{Name: "ApplyPatchApprovalParams", Type: reflect.TypeFor[ApplyPatchApprovalParams]()},
 		{Name: "ApplyPatchApprovalResponse", Type: reflect.TypeFor[ApplyPatchApprovalResponse]()},
 		{Name: "AskForApproval", Type: reflect.TypeFor[AskForApproval]()},
@@ -576,6 +579,22 @@ func wireSchemaDefinitions() Schema {
 		"currentStreakDays":     Schema{"type": []any{"integer", "null"}, "format": "int64"},
 		"longestStreakDays":     Schema{"type": []any{"integer", "null"}, "format": "int64"},
 	}, nil)
+	schemas["AppBranding"] = closedThreadSessionParamSchema(Schema{
+		"category":          nullableStringSchema(),
+		"developer":         nullableStringSchema(),
+		"website":           nullableStringSchema(),
+		"privacyPolicy":     nullableStringSchema(),
+		"termsOfService":    nullableStringSchema(),
+		"isDiscoverableApp": Schema{"type": "boolean"},
+	}, []string{"isDiscoverableApp"})
+	schemas["AppReview"] = closedThreadSessionParamSchema(Schema{
+		"status": Schema{"type": "string"},
+	}, []string{"status"})
+	schemas["AppScreenshot"] = closedThreadSessionParamSchema(Schema{
+		"url":        nullableStringSchema(),
+		"fileId":     nullableStringSchema(),
+		"userPrompt": Schema{"type": "string"},
+	}, []string{"userPrompt"})
 	schemas["AddCreditsNudgeCreditType"] = stringEnumSchema(
 		string(AddCreditsNudgeCreditTypeCredits),
 		string(AddCreditsNudgeCreditTypeUsageLimit),

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -350,6 +350,112 @@
       "type": "object",
       "x-gollem-typescript-optional-map": true
     },
+    "AppBranding": {
+      "additionalProperties": false,
+      "properties": {
+        "category": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "developer": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "isDiscoverableApp": {
+          "type": "boolean"
+        },
+        "privacyPolicy": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "termsOfService": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "website": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "isDiscoverableApp"
+      ],
+      "type": "object"
+    },
+    "AppReview": {
+      "additionalProperties": false,
+      "properties": {
+        "status": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "status"
+      ],
+      "type": "object"
+    },
+    "AppScreenshot": {
+      "additionalProperties": false,
+      "properties": {
+        "fileId": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "userPrompt": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "userPrompt"
+      ],
+      "type": "object"
+    },
     "ApplyPatchApprovalParams": {
       "additionalProperties": false,
       "properties": {

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 453 {
-		t.Fatalf("definition count = %d, want 453", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 456 {
+		t.Fatalf("definition count = %d, want 456", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 453 {
-		t.Fatalf("definition count = %d, want 453", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 456 {
+		t.Fatalf("definition count = %d, want 456", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 453 {
-		t.Fatalf("definition count = %d, want 453", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 456 {
+		t.Fatalf("definition count = %d, want 456", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -40,6 +40,7 @@ func MarshalTypeScript() ([]byte, error) {
 	for _, name := range names {
 		definition := defs[name]
 		if name == "AccountLoginCompletedNotification" || name == "AccountTokenUsageSummary" ||
+			name == "AppBranding" || name == "AppScreenshot" ||
 			name == "ApplyPatchApprovalParams" ||
 			name == "ChatgptAuthTokensRefreshResponse" ||
 			name == "MigrationDetails" ||
@@ -69,6 +70,12 @@ func MarshalTypeScript() ([]byte, error) {
 					"lifetimeTokens", "peakDailyTokens", "longestRunningTurnSec",
 					"currentStreakDays", "longestStreakDays",
 				}
+			case "AppBranding":
+				schema["required"] = []string{
+					"category", "developer", "website", "privacyPolicy", "termsOfService", "isDiscoverableApp",
+				}
+			case "AppScreenshot":
+				schema["required"] = []string{"url", "fileId", "userPrompt"}
 			case "ApplyPatchApprovalParams":
 				schema["required"] = []string{
 					"conversationId", "callId", "fileChanges", "reason", "grantRoot",

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -568,6 +568,25 @@ export type AnalyticsConfig = ({
   "enabled": boolean | null;
 } & { [key in string]?: JsonValue });
 
+export type AppBranding = {
+  "category": string | null;
+  "developer": string | null;
+  "isDiscoverableApp": boolean;
+  "privacyPolicy": string | null;
+  "termsOfService": string | null;
+  "website": string | null;
+};
+
+export type AppReview = {
+  "status": string;
+};
+
+export type AppScreenshot = {
+  "fileId": string | null;
+  "url": string | null;
+  "userPrompt": string;
+};
+
 export type ApplyPatchApprovalParams = {
   "callId": string;
   "conversationId": ThreadId;

--- a/appserver/protocol/typescript/testdata/app_metadata_leaf_contract.ts
+++ b/appserver/protocol/typescript/testdata/app_metadata_leaf_contract.ts
@@ -1,0 +1,74 @@
+import type {
+  AppBranding,
+  AppReview,
+  AppScreenshot,
+  MethodParamsByName,
+  MethodResultsByName,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+type ExpectFalse<T extends false> = T;
+
+type ExactBranding = {
+  category: string | null;
+  developer: string | null;
+  isDiscoverableApp: boolean;
+  privacyPolicy: string | null;
+  termsOfService: string | null;
+  website: string | null;
+};
+type ExactReview = { status: string };
+type ExactScreenshot = {
+  fileId: string | null;
+  url: string | null;
+  userPrompt: string;
+};
+
+type Contracts = [
+  Expect<Equal<AppBranding, ExactBranding>>,
+  Expect<Equal<AppReview, ExactReview>>,
+  Expect<Equal<AppScreenshot, ExactScreenshot>>,
+  ExpectFalse<"app/list" extends keyof MethodParamsByName ? true : false>,
+  ExpectFalse<"app/list" extends keyof MethodResultsByName ? true : false>,
+];
+
+({ category: null, developer: null, isDiscoverableApp: false, privacyPolicy: null, termsOfService: null, website: null }) satisfies AppBranding;
+({ category: "", developer: " arbitrary ", isDiscoverableApp: true, privacyPolicy: "", termsOfService: "", website: "not a url" }) satisfies AppBranding;
+({ status: "" }) satisfies AppReview;
+({ status: " arbitrary " }) satisfies AppReview;
+({ fileId: null, url: null, userPrompt: "" }) satisfies AppScreenshot;
+({ fileId: " file ", url: "not a url", userPrompt: " arbitrary " }) satisfies AppScreenshot;
+
+// @ts-expect-error canonical branding requires every nullable field.
+({ isDiscoverableApp: true }) satisfies AppBranding;
+// @ts-expect-error discoverability is boolean.
+({ category: null, developer: null, isDiscoverableApp: "true", privacyPolicy: null, termsOfService: null, website: null }) satisfies AppBranding;
+// @ts-expect-error nullable branding values are strings or null.
+({ category: 1, developer: null, isDiscoverableApp: true, privacyPolicy: null, termsOfService: null, website: null }) satisfies AppBranding;
+// @ts-expect-error canonical branding is closed.
+({ category: null, developer: null, isDiscoverableApp: true, privacyPolicy: null, termsOfService: null, website: null, future: true }) satisfies AppBranding;
+
+// @ts-expect-error review status is required.
+({}) satisfies AppReview;
+// @ts-expect-error review status is a string.
+({ status: null }) satisfies AppReview;
+// @ts-expect-error canonical reviews are closed.
+({ status: "ok", future: true }) satisfies AppReview;
+
+// @ts-expect-error canonical screenshots require nullable fields.
+({ userPrompt: "x" }) satisfies AppScreenshot;
+// @ts-expect-error userPrompt is required.
+({ fileId: null, url: null }) satisfies AppScreenshot;
+// @ts-expect-error screenshot URLs are strings or null.
+({ fileId: null, url: 1, userPrompt: "x" }) satisfies AppScreenshot;
+// @ts-expect-error screenshot file ids are strings or null.
+({ fileId: false, url: null, userPrompt: "x" }) satisfies AppScreenshot;
+// @ts-expect-error canonical screenshots are closed.
+({ fileId: null, url: null, userPrompt: "x", future: true }) satisfies AppScreenshot;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 453 {
-		t.Fatalf("definition count = %d, want 453", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
+		t.Fatalf("definition count = %d, want 456", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- export exact standalone `AppBranding`, `AppReview`, and `AppScreenshot` wire records
- preserve serde-compatible omitted nullable inputs while emitting canonical explicit nulls
- generate exact closed JSON Schema and canonical TypeScript without binding deferred app methods

## Verification
- focused tests x30, focused race, and 100% coverage for all six new codec functions
- full protocol tests and strict TypeScript compilation
- all 59 non-Monty packages in normal and race modes
- golangci-lint, go vet, go mod tidy/verify, deterministic generation, configured pre-push
- exact normalized pinned Codex schema parity and exact structural reversal to PR #215
- all five Slang real-process workflows and byte-identical parent/feature initialize-plus-MCP transcript

Local Monty normal/race/coverage tests remain skipped per project direction; hosted CI is unchanged.