### PR TITLE
appserver/protocol: add app metadata record

### DIFF
--- a/appserver/protocol/account_credit_nudge_values_contract_test.go
+++ b/appserver/protocol/account_credit_nudge_values_contract_test.go
@@ -119,8 +119,8 @@ func TestAccountCreditNudgeValuesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/sendAddCreditsNudgeEmail = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/account_login_completed_notification_contract_test.go
+++ b/appserver/protocol/account_login_completed_notification_contract_test.go
@@ -88,8 +88,8 @@ func TestAccountLoginCompletedNotificationRemainsStandaloneAndDeferred(t *testin
 	if !found {
 		t.Fatal("account/login/completed method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/account_token_usage_contract_test.go
+++ b/appserver/protocol/account_token_usage_contract_test.go
@@ -146,8 +146,8 @@ func TestAccountTokenUsageRecordsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/usage/read = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(defs); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_metadata_contract_test.go
+++ b/appserver/protocol/app_metadata_contract_test.go
@@ -1,0 +1,150 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestAppMetadataSchemaIsExact(t *testing.T) {
+	want := closedThreadSessionParamSchema(Schema{
+		"review": nullableAppMetadataRefSchema("AppReview"),
+		"categories": Schema{"anyOf": []any{
+			Schema{"type": "array", "items": Schema{"type": "string"}}, Schema{"type": "null"},
+		}},
+		"subCategories": Schema{"anyOf": []any{
+			Schema{"type": "array", "items": Schema{"type": "string"}}, Schema{"type": "null"},
+		}},
+		"seoDescription": nullableStringSchema(),
+		"screenshots": Schema{"anyOf": []any{
+			Schema{"type": "array", "items": Schema{"$ref": "#/$defs/AppScreenshot"}},
+			Schema{"type": "null"},
+		}},
+		"developer":      nullableStringSchema(),
+		"version":        nullableStringSchema(),
+		"versionId":      nullableStringSchema(),
+		"versionNotes":   nullableStringSchema(),
+		"firstPartyType": nullableStringSchema(),
+		"firstPartyRequiresInstall": Schema{"anyOf": []any{
+			Schema{"type": "boolean"}, Schema{"type": "null"},
+		}},
+		"showInComposerWhenUnlinked": Schema{"anyOf": []any{
+			Schema{"type": "boolean"}, Schema{"type": "null"},
+		}},
+	}, nil)
+	got := JSONSchema()["$defs"].(Schema)["AppMetadata"]
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("AppMetadata = %#v, want %#v", got, want)
+	}
+}
+
+func TestAppMetadataAcceptsSerdeWireForms(t *testing.T) {
+	const nullCanonical = `{"categories":null,"developer":null,"firstPartyRequiresInstall":null,"firstPartyType":null,"review":null,"screenshots":null,"seoDescription":null,"showInComposerWhenUnlinked":null,"subCategories":null,"version":null,"versionId":null,"versionNotes":null}`
+	for _, tc := range []struct {
+		input string
+		want  string
+	}{
+		{`{}`, nullCanonical},
+		{`{"review":null,"categories":null,"subCategories":null,"seoDescription":null,"screenshots":null,"developer":null,"version":null,"versionId":null,"versionNotes":null,"firstPartyType":null,"firstPartyRequiresInstall":null,"showInComposerWhenUnlinked":null}`, nullCanonical},
+		{
+			`{"future":{"ignored":true},"review":{"future":1,"status":" arbitrary review "},"categories":["", " category ", " category "],"subCategories":[],"seoDescription":" seo ","screenshots":[{"future":true,"url":"not a url","fileId":" file ","userPrompt":" prompt "},{"userPrompt":""}],"developer":"","version":" v ","versionId":"id","versionNotes":" notes ","firstPartyType":" arbitrary ","firstPartyRequiresInstall":false,"showInComposerWhenUnlinked":true}`,
+			`{"categories":[""," category "," category "],"developer":"","firstPartyRequiresInstall":false,"firstPartyType":" arbitrary ","review":{"status":" arbitrary review "},"screenshots":[{"fileId":" file ","url":"not a url","userPrompt":" prompt "},{"fileId":null,"url":null,"userPrompt":""}],"seoDescription":" seo ","showInComposerWhenUnlinked":true,"subCategories":[],"version":" v ","versionId":"id","versionNotes":" notes "}`,
+		},
+	} {
+		var value AppMetadata
+		if err := json.Unmarshal([]byte(tc.input), &value); err != nil {
+			t.Errorf("unmarshal %s: %v", tc.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(value)
+		if err != nil || string(encoded) != tc.want {
+			t.Errorf("round trip %s = %s, %v; want %s", tc.input, encoded, err, tc.want)
+		}
+	}
+}
+
+func TestAppMetadataRejectsMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`,
+		`{"review":"approved"}`, `{"review":{}}`, `{"review":{"status":null}}`,
+		`{"categories":"category"}`, `{"categories":[null]}`, `{"categories":[1]}`,
+		`{"subCategories":{}}`, `{"subCategories":[false]}`,
+		`{"seoDescription":1}`, `{"screenshots":{}}`, `{"screenshots":[null]}`,
+		`{"screenshots":[{}]}`, `{"screenshots":[{"userPrompt":1}]}`,
+		`{"developer":false}`, `{"version":[]}`, `{"versionId":1}`,
+		`{"versionNotes":{}}`, `{"firstPartyType":true}`,
+		`{"firstPartyRequiresInstall":"false"}`, `{"showInComposerWhenUnlinked":0}`,
+		`{"categories":null,"categories":[]}`,
+		`{"review":null,"review":{"status":"ok"}}`,
+		`{"screenshots":null,"screenshots":[]}`,
+		`{} {}`, `{} x`,
+	} {
+		assertJSONRejects[AppMetadata](t, input)
+	}
+}
+
+func TestAppMetadataNilReceiverFailsClosed(t *testing.T) {
+	var metadata *AppMetadata
+	if err := metadata.UnmarshalJSON([]byte(`{}`)); err == nil {
+		t.Fatal("nil AppMetadata receiver succeeded")
+	}
+}
+
+func TestAppMetadataRemainsStandaloneAndDeferred(t *testing.T) {
+	for _, binding := range WireTypeBindings() {
+		if slices.Contains(binding.Params, "AppMetadata") || slices.Contains(binding.Result, "AppMetadata") {
+			t.Fatalf("AppMetadata unexpectedly bound to %s", binding.Method)
+		}
+	}
+	for _, binding := range ItemPayloadBindings() {
+		if binding.Type == "AppMetadata" {
+			t.Fatalf("AppMetadata unexpectedly bound to item %s", binding.Kind)
+		}
+	}
+	method, ok := LookupMethod("app/list")
+	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
+		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestAppMetadataTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	want := "export type AppMetadata = {\n" +
+		"  \"categories\": Array<string> | null;\n" +
+		"  \"developer\": string | null;\n" +
+		"  \"firstPartyRequiresInstall\": boolean | null;\n" +
+		"  \"firstPartyType\": string | null;\n" +
+		"  \"review\": AppReview | null;\n" +
+		"  \"screenshots\": Array<AppScreenshot> | null;\n" +
+		"  \"seoDescription\": string | null;\n" +
+		"  \"showInComposerWhenUnlinked\": boolean | null;\n" +
+		"  \"subCategories\": Array<string> | null;\n" +
+		"  \"version\": string | null;\n" +
+		"  \"versionId\": string | null;\n" +
+		"  \"versionNotes\": string | null;\n" +
+		"};"
+	if !strings.Contains(string(generated), want) {
+		t.Fatalf("generated TypeScript missing %q", want)
+	}
+}
+
+func nullableAppMetadataRefSchema(name string) Schema {
+	return Schema{"anyOf": []any{
+		Schema{"$ref": "#/$defs/" + name},
+		Schema{"type": "null"},
+	}}
+}

--- a/appserver/protocol/app_metadata_leaf_contract_test.go
+++ b/appserver/protocol/app_metadata_leaf_contract_test.go
@@ -157,8 +157,8 @@ func TestAppMetadataLeavesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_metadata_types.go
+++ b/appserver/protocol/app_metadata_types.go
@@ -1,0 +1,147 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// AppMetadata is exact standalone descriptive metadata for experimental apps.
+// App discovery, policy interpretation, and runtime behavior remain deferred.
+type AppMetadata struct {
+	Review                     *AppReview       `json:"review,omitempty"`
+	Categories                 *[]string        `json:"categories,omitempty"`
+	SubCategories              *[]string        `json:"subCategories,omitempty"`
+	SEODescription             *string          `json:"seoDescription,omitempty"`
+	Screenshots                *[]AppScreenshot `json:"screenshots,omitempty"`
+	Developer                  *string          `json:"developer,omitempty"`
+	Version                    *string          `json:"version,omitempty"`
+	VersionID                  *string          `json:"versionId,omitempty"`
+	VersionNotes               *string          `json:"versionNotes,omitempty"`
+	FirstPartyType             *string          `json:"firstPartyType,omitempty"`
+	FirstPartyRequiresInstall  *bool            `json:"firstPartyRequiresInstall,omitempty"`
+	ShowInComposerWhenUnlinked *bool            `json:"showInComposerWhenUnlinked,omitempty"`
+}
+
+func (m AppMetadata) MarshalJSON() ([]byte, error) {
+	return json.Marshal(map[string]any{
+		"review":                     m.Review,
+		"categories":                 m.Categories,
+		"subCategories":              m.SubCategories,
+		"seoDescription":             m.SEODescription,
+		"screenshots":                m.Screenshots,
+		"developer":                  m.Developer,
+		"version":                    m.Version,
+		"versionId":                  m.VersionID,
+		"versionNotes":               m.VersionNotes,
+		"firstPartyType":             m.FirstPartyType,
+		"firstPartyRequiresInstall":  m.FirstPartyRequiresInstall,
+		"showInComposerWhenUnlinked": m.ShowInComposerWhenUnlinked,
+	})
+}
+
+func (m *AppMetadata) UnmarshalJSON(data []byte) error {
+	if m == nil {
+		return errors.New("decode app metadata into nil receiver")
+	}
+	const objectName = "app metadata"
+	payload, err := decodeRustSerdeObject(
+		data, objectName,
+		"review", "categories", "subCategories", "seoDescription", "screenshots",
+		"developer", "version", "versionId", "versionNotes", "firstPartyType",
+		"firstPartyRequiresInstall", "showInComposerWhenUnlinked",
+	)
+	if err != nil {
+		return err
+	}
+	review, err := decodeOptionalNullableConfigValue[AppReview](payload, objectName, "review")
+	if err != nil {
+		return err
+	}
+	categories, err := decodeOptionalNullableAppMetadataArray[string](payload, objectName, "categories")
+	if err != nil {
+		return err
+	}
+	subCategories, err := decodeOptionalNullableAppMetadataArray[string](payload, objectName, "subCategories")
+	if err != nil {
+		return err
+	}
+	seoDescription, err := decodeOptionalNullableConfigValue[string](payload, objectName, "seoDescription")
+	if err != nil {
+		return err
+	}
+	screenshots, err := decodeOptionalNullableAppMetadataArray[AppScreenshot](payload, objectName, "screenshots")
+	if err != nil {
+		return err
+	}
+	developer, err := decodeOptionalNullableConfigValue[string](payload, objectName, "developer")
+	if err != nil {
+		return err
+	}
+	version, err := decodeOptionalNullableConfigValue[string](payload, objectName, "version")
+	if err != nil {
+		return err
+	}
+	versionID, err := decodeOptionalNullableConfigValue[string](payload, objectName, "versionId")
+	if err != nil {
+		return err
+	}
+	versionNotes, err := decodeOptionalNullableConfigValue[string](payload, objectName, "versionNotes")
+	if err != nil {
+		return err
+	}
+	firstPartyType, err := decodeOptionalNullableConfigValue[string](payload, objectName, "firstPartyType")
+	if err != nil {
+		return err
+	}
+	firstPartyRequiresInstall, err := decodeOptionalNullableConfigValue[bool](
+		payload, objectName, "firstPartyRequiresInstall",
+	)
+	if err != nil {
+		return err
+	}
+	showInComposerWhenUnlinked, err := decodeOptionalNullableConfigValue[bool](
+		payload, objectName, "showInComposerWhenUnlinked",
+	)
+	if err != nil {
+		return err
+	}
+	*m = AppMetadata{
+		Review: review, Categories: categories, SubCategories: subCategories,
+		SEODescription: seoDescription, Screenshots: screenshots, Developer: developer,
+		Version: version, VersionID: versionID, VersionNotes: versionNotes,
+		FirstPartyType: firstPartyType, FirstPartyRequiresInstall: firstPartyRequiresInstall,
+		ShowInComposerWhenUnlinked: showInComposerWhenUnlinked,
+	}
+	return nil
+}
+
+func decodeOptionalNullableAppMetadataArray[T any](
+	payload map[string]json.RawMessage,
+	objectName string,
+	fieldName string,
+) (*[]T, error) {
+	raw, ok := payload[fieldName]
+	if !ok || isJSONNull(raw) {
+		return nil, nil
+	}
+	var elements []json.RawMessage
+	if err := json.Unmarshal(raw, &elements); err != nil {
+		return nil, fmt.Errorf("decode %s %s: %w", objectName, fieldName, err)
+	}
+	values := make([]T, len(elements))
+	for index, element := range elements {
+		if isJSONNull(element) {
+			return nil, fmt.Errorf("decode %s %s[%d]: value cannot be null", objectName, fieldName, index)
+		}
+		if err := json.Unmarshal(element, &values[index]); err != nil {
+			return nil, fmt.Errorf("decode %s %s[%d]: %w", objectName, fieldName, index, err)
+		}
+	}
+	return &values, nil
+}
+
+var (
+	_ json.Marshaler   = AppMetadata{}
+	_ json.Unmarshaler = (*AppMetadata)(nil)
+)

--- a/appserver/protocol/apply_patch_approval_params_contract_test.go
+++ b/appserver/protocol/apply_patch_approval_params_contract_test.go
@@ -139,8 +139,8 @@ func TestApplyPatchApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ApplyPatchApprovalParams unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(defs); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(defs); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/attestation_contract_test.go
+++ b/appserver/protocol/attestation_contract_test.go
@@ -133,8 +133,8 @@ func TestAttestationContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("attestation/generate = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
+++ b/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
@@ -179,8 +179,8 @@ func TestChatgptAuthTokensRefreshRemainsStandaloneAndDeferred(t *testing.T) {
 	if !found {
 		t.Fatal("refresh method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/exec_command_approval_params_contract_test.go
+++ b/appserver/protocol/exec_command_approval_params_contract_test.go
@@ -137,8 +137,8 @@ func TestExecCommandApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ExecCommandApprovalParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(defs); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,8 +217,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,8 +203,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -260,8 +260,8 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,8 +244,8 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -162,8 +162,8 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -175,8 +175,8 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_contract_test.go
+++ b/appserver/protocol/file_change_contract_test.go
@@ -108,8 +108,8 @@ func TestFileChangeRemainsStandalone(t *testing.T) {
 			t.Fatalf("FileChange unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_output_delta_notification_contract_test.go
+++ b/appserver/protocol/file_change_output_delta_notification_contract_test.go
@@ -100,8 +100,8 @@ func TestFileChangeOutputDeltaNotificationRemainsDeprecatedAndStandalone(t *test
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("item/fileChange/outputDelta = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -381,8 +381,8 @@ func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_action_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_action_contract_test.go
@@ -226,8 +226,8 @@ func TestGuardianApprovalReviewActionRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReviewAction unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
@@ -164,8 +164,8 @@ func TestGuardianApprovalReviewCompletedNotificationRemainsStandalone(t *testing
 			t.Fatalf("completed notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_contract_test.go
@@ -139,8 +139,8 @@ func TestGuardianApprovalReviewRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReview unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
@@ -175,8 +175,8 @@ func TestGuardianApprovalReviewStartedNotificationRemainsStandalone(t *testing.T
 			t.Fatalf("started notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_enum_foundation_contract_test.go
+++ b/appserver/protocol/guardian_enum_foundation_contract_test.go
@@ -89,8 +89,8 @@ func TestGuardianEnumFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_metadata_list_contract_test.go
+++ b/appserver/protocol/hook_metadata_list_contract_test.go
@@ -352,8 +352,8 @@ func TestHookMetadataListContractsStayStandalone(t *testing.T) {
 			t.Errorf("standalone definition %s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Errorf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Errorf("definition count = %d, want 457", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 {
 		t.Errorf("wire binding count = %d, want 59", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_run_notification_contract_test.go
+++ b/appserver/protocol/hook_run_notification_contract_test.go
@@ -297,8 +297,8 @@ func TestHookRunNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("surface changed: %d methods, %d wire bindings, %d item bindings", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/hook_value_foundation_contract_test.go
+++ b/appserver/protocol/hook_value_foundation_contract_test.go
@@ -167,8 +167,8 @@ func TestHookValueFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 456 {
-		t.Fatalf("definition count = %d, want 456", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 457 {
+		t.Fatalf("definition count = %d, want 457", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/legacy_approval_response_contract_test.go
+++ b/appserver/protocol/legacy_approval_response_contract_test.go
@@ -98,8 +98,8 @@ func TestLegacyApprovalResponsesRemainStandaloneAndNominal(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_approval_context_contract_test.go
+++ b/appserver/protocol/network_approval_context_contract_test.go
@@ -84,8 +84,8 @@ func TestNetworkApprovalContextRemainsStandalone(t *testing.T) {
 			t.Fatalf("NetworkApprovalContext unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/parsed_command_contract_test.go
+++ b/appserver/protocol/parsed_command_contract_test.go
@@ -120,8 +120,8 @@ func TestParsedCommandRemainsStandalone(t *testing.T) {
 			t.Fatalf("ParsedCommand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 456 {
-		t.Fatalf("definition count = %d, want 456", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 457 {
+		t.Fatalf("definition count = %d, want 457", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 456 {
-		t.Fatalf("definition count = %d, want 456", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 457 {
+		t.Fatalf("definition count = %d, want 457", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 456 {
-		t.Fatalf("definition count = %d, want 456", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 457 {
+		t.Fatalf("definition count = %d, want 457", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 456 {
-		t.Fatalf("definition count = %d, want 456", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 457 {
+		t.Fatalf("definition count = %d, want 457", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 456 {
-		t.Fatalf("definition count = %d, want 456", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 457 {
+		t.Fatalf("definition count = %d, want 457", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/review_decision_contract_test.go
+++ b/appserver/protocol/review_decision_contract_test.go
@@ -136,8 +136,8 @@ func TestReviewDecisionRemainsStandalone(t *testing.T) {
 			t.Fatalf("ReviewDecision unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(defs); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -106,6 +106,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "ApprovalRespondResult", Type: reflect.TypeFor[ApprovalRespondResult]()},
 		{Name: "ApprovalsReviewer", Type: reflect.TypeFor[ApprovalsReviewer]()},
 		{Name: "AppBranding", Type: reflect.TypeFor[AppBranding]()},
+		{Name: "AppMetadata", Type: reflect.TypeFor[AppMetadata]()},
 		{Name: "AppReview", Type: reflect.TypeFor[AppReview]()},
 		{Name: "AppScreenshot", Type: reflect.TypeFor[AppScreenshot]()},
 		{Name: "ApplyPatchApprovalParams", Type: reflect.TypeFor[ApplyPatchApprovalParams]()},
@@ -587,6 +588,33 @@ func wireSchemaDefinitions() Schema {
 		"termsOfService":    nullableStringSchema(),
 		"isDiscoverableApp": Schema{"type": "boolean"},
 	}, []string{"isDiscoverableApp"})
+	schemas["AppMetadata"] = closedThreadSessionParamSchema(Schema{
+		"review": Schema{"anyOf": []any{
+			Schema{"$ref": "#/$defs/AppReview"}, Schema{"type": "null"},
+		}},
+		"categories": Schema{"anyOf": []any{
+			Schema{"type": "array", "items": Schema{"type": "string"}}, Schema{"type": "null"},
+		}},
+		"subCategories": Schema{"anyOf": []any{
+			Schema{"type": "array", "items": Schema{"type": "string"}}, Schema{"type": "null"},
+		}},
+		"seoDescription": nullableStringSchema(),
+		"screenshots": Schema{"anyOf": []any{
+			Schema{"type": "array", "items": Schema{"$ref": "#/$defs/AppScreenshot"}},
+			Schema{"type": "null"},
+		}},
+		"developer":      nullableStringSchema(),
+		"version":        nullableStringSchema(),
+		"versionId":      nullableStringSchema(),
+		"versionNotes":   nullableStringSchema(),
+		"firstPartyType": nullableStringSchema(),
+		"firstPartyRequiresInstall": Schema{"anyOf": []any{
+			Schema{"type": "boolean"}, Schema{"type": "null"},
+		}},
+		"showInComposerWhenUnlinked": Schema{"anyOf": []any{
+			Schema{"type": "boolean"}, Schema{"type": "null"},
+		}},
+	}, nil)
 	schemas["AppReview"] = closedThreadSessionParamSchema(Schema{
 		"status": Schema{"type": "string"},
 	}, []string{"status"})

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -412,6 +412,141 @@
       ],
       "type": "object"
     },
+    "AppMetadata": {
+      "additionalProperties": false,
+      "properties": {
+        "categories": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "developer": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "firstPartyRequiresInstall": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "firstPartyType": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "review": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AppReview"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "screenshots": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/AppScreenshot"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "seoDescription": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "showInComposerWhenUnlinked": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "subCategories": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "version": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "versionId": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "versionNotes": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
     "AppReview": {
       "additionalProperties": false,
       "properties": {

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 456 {
-		t.Fatalf("definition count = %d, want 456", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 457 {
+		t.Fatalf("definition count = %d, want 457", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 456 {
-		t.Fatalf("definition count = %d, want 456", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 457 {
+		t.Fatalf("definition count = %d, want 457", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 456 {
-		t.Fatalf("definition count = %d, want 456", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 457 {
+		t.Fatalf("definition count = %d, want 457", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -40,7 +40,7 @@ func MarshalTypeScript() ([]byte, error) {
 	for _, name := range names {
 		definition := defs[name]
 		if name == "AccountLoginCompletedNotification" || name == "AccountTokenUsageSummary" ||
-			name == "AppBranding" || name == "AppScreenshot" ||
+			name == "AppBranding" || name == "AppMetadata" || name == "AppScreenshot" ||
 			name == "ApplyPatchApprovalParams" ||
 			name == "ChatgptAuthTokensRefreshResponse" ||
 			name == "MigrationDetails" ||
@@ -73,6 +73,12 @@ func MarshalTypeScript() ([]byte, error) {
 			case "AppBranding":
 				schema["required"] = []string{
 					"category", "developer", "website", "privacyPolicy", "termsOfService", "isDiscoverableApp",
+				}
+			case "AppMetadata":
+				schema["required"] = []string{
+					"review", "categories", "subCategories", "seoDescription", "screenshots", "developer",
+					"version", "versionId", "versionNotes", "firstPartyType",
+					"firstPartyRequiresInstall", "showInComposerWhenUnlinked",
 				}
 			case "AppScreenshot":
 				schema["required"] = []string{"url", "fileId", "userPrompt"}

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -577,6 +577,21 @@ export type AppBranding = {
   "website": string | null;
 };
 
+export type AppMetadata = {
+  "categories": Array<string> | null;
+  "developer": string | null;
+  "firstPartyRequiresInstall": boolean | null;
+  "firstPartyType": string | null;
+  "review": AppReview | null;
+  "screenshots": Array<AppScreenshot> | null;
+  "seoDescription": string | null;
+  "showInComposerWhenUnlinked": boolean | null;
+  "subCategories": Array<string> | null;
+  "version": string | null;
+  "versionId": string | null;
+  "versionNotes": string | null;
+};
+
 export type AppReview = {
   "status": string;
 };

--- a/appserver/protocol/typescript/testdata/app_metadata_contract.ts
+++ b/appserver/protocol/typescript/testdata/app_metadata_contract.ts
@@ -1,0 +1,102 @@
+import type {
+  AppMetadata,
+  AppReview,
+  AppScreenshot,
+  MethodParamsByName,
+  MethodResultsByName,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+type ExpectFalse<T extends false> = T;
+
+type ExactMetadata = {
+  review: AppReview | null;
+  categories: Array<string> | null;
+  subCategories: Array<string> | null;
+  seoDescription: string | null;
+  screenshots: Array<AppScreenshot> | null;
+  developer: string | null;
+  version: string | null;
+  versionId: string | null;
+  versionNotes: string | null;
+  firstPartyType: string | null;
+  firstPartyRequiresInstall: boolean | null;
+  showInComposerWhenUnlinked: boolean | null;
+};
+
+type Contracts = [
+  Expect<Equal<AppMetadata, ExactMetadata>>,
+  ExpectFalse<"app/list" extends keyof MethodParamsByName ? true : false>,
+  ExpectFalse<"app/list" extends keyof MethodResultsByName ? true : false>,
+];
+
+({
+  review: null,
+  categories: null,
+  subCategories: null,
+  seoDescription: null,
+  screenshots: null,
+  developer: null,
+  version: null,
+  versionId: null,
+  versionNotes: null,
+  firstPartyType: null,
+  firstPartyRequiresInstall: null,
+  showInComposerWhenUnlinked: null,
+}) satisfies AppMetadata;
+
+({
+  review: { status: " arbitrary review " },
+  categories: ["", " category ", " category "],
+  subCategories: [],
+  seoDescription: " seo ",
+  screenshots: [
+    { fileId: " file ", url: "not a url", userPrompt: " prompt " },
+    { fileId: null, url: null, userPrompt: "" },
+  ],
+  developer: "",
+  version: " v ",
+  versionId: "id",
+  versionNotes: " notes ",
+  firstPartyType: " arbitrary ",
+  firstPartyRequiresInstall: false,
+  showInComposerWhenUnlinked: true,
+}) satisfies AppMetadata;
+
+// @ts-expect-error canonical metadata requires all nullable fields.
+({}) satisfies AppMetadata;
+// @ts-expect-error review is an AppReview or null.
+({ review: "approved", categories: null, subCategories: null, seoDescription: null, screenshots: null, developer: null, version: null, versionId: null, versionNotes: null, firstPartyType: null, firstPartyRequiresInstall: null, showInComposerWhenUnlinked: null }) satisfies AppMetadata;
+// @ts-expect-error review status is required.
+({ review: {}, categories: null, subCategories: null, seoDescription: null, screenshots: null, developer: null, version: null, versionId: null, versionNotes: null, firstPartyType: null, firstPartyRequiresInstall: null, showInComposerWhenUnlinked: null }) satisfies AppMetadata;
+// @ts-expect-error categories is a string array or null.
+({ review: null, categories: "category", subCategories: null, seoDescription: null, screenshots: null, developer: null, version: null, versionId: null, versionNotes: null, firstPartyType: null, firstPartyRequiresInstall: null, showInComposerWhenUnlinked: null }) satisfies AppMetadata;
+// @ts-expect-error category elements are strings.
+({ review: null, categories: [null], subCategories: null, seoDescription: null, screenshots: null, developer: null, version: null, versionId: null, versionNotes: null, firstPartyType: null, firstPartyRequiresInstall: null, showInComposerWhenUnlinked: null }) satisfies AppMetadata;
+// @ts-expect-error subCategories is a string array or null.
+({ review: null, categories: null, subCategories: [false], seoDescription: null, screenshots: null, developer: null, version: null, versionId: null, versionNotes: null, firstPartyType: null, firstPartyRequiresInstall: null, showInComposerWhenUnlinked: null }) satisfies AppMetadata;
+// @ts-expect-error seoDescription is a string or null.
+({ review: null, categories: null, subCategories: null, seoDescription: 1, screenshots: null, developer: null, version: null, versionId: null, versionNotes: null, firstPartyType: null, firstPartyRequiresInstall: null, showInComposerWhenUnlinked: null }) satisfies AppMetadata;
+// @ts-expect-error screenshots is an AppScreenshot array or null.
+({ review: null, categories: null, subCategories: null, seoDescription: null, screenshots: {}, developer: null, version: null, versionId: null, versionNotes: null, firstPartyType: null, firstPartyRequiresInstall: null, showInComposerWhenUnlinked: null }) satisfies AppMetadata;
+// @ts-expect-error screenshot elements cannot be null.
+({ review: null, categories: null, subCategories: null, seoDescription: null, screenshots: [null], developer: null, version: null, versionId: null, versionNotes: null, firstPartyType: null, firstPartyRequiresInstall: null, showInComposerWhenUnlinked: null }) satisfies AppMetadata;
+// @ts-expect-error nested screenshots require canonical nullable fields.
+({ review: null, categories: null, subCategories: null, seoDescription: null, screenshots: [{ userPrompt: "x" }], developer: null, version: null, versionId: null, versionNotes: null, firstPartyType: null, firstPartyRequiresInstall: null, showInComposerWhenUnlinked: null }) satisfies AppMetadata;
+// @ts-expect-error developer is a string or null.
+({ review: null, categories: null, subCategories: null, seoDescription: null, screenshots: null, developer: false, version: null, versionId: null, versionNotes: null, firstPartyType: null, firstPartyRequiresInstall: null, showInComposerWhenUnlinked: null }) satisfies AppMetadata;
+// @ts-expect-error version is a string or null.
+({ review: null, categories: null, subCategories: null, seoDescription: null, screenshots: null, developer: null, version: 1, versionId: null, versionNotes: null, firstPartyType: null, firstPartyRequiresInstall: null, showInComposerWhenUnlinked: null }) satisfies AppMetadata;
+// @ts-expect-error firstPartyRequiresInstall is boolean or null.
+({ review: null, categories: null, subCategories: null, seoDescription: null, screenshots: null, developer: null, version: null, versionId: null, versionNotes: null, firstPartyType: null, firstPartyRequiresInstall: "false", showInComposerWhenUnlinked: null }) satisfies AppMetadata;
+// @ts-expect-error showInComposerWhenUnlinked is boolean or null.
+({ review: null, categories: null, subCategories: null, seoDescription: null, screenshots: null, developer: null, version: null, versionId: null, versionNotes: null, firstPartyType: null, firstPartyRequiresInstall: null, showInComposerWhenUnlinked: 0 }) satisfies AppMetadata;
+// @ts-expect-error canonical metadata is closed.
+({ review: null, categories: null, subCategories: null, seoDescription: null, screenshots: null, developer: null, version: null, versionId: null, versionNotes: null, firstPartyType: null, firstPartyRequiresInstall: null, showInComposerWhenUnlinked: null, future: true }) satisfies AppMetadata;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 456 {
-		t.Fatalf("definition count = %d, want 456", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
+		t.Fatalf("definition count = %d, want 457", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- export exact standalone AppMetadata with strict Rust-compatible JSON decoding
- generate its closed schema and pinned TypeScript shape without binding app/list
- cover omission/null canonicalization, nested arrays, malformed inputs, and deferred registries

## Verification
- focused tests x30, focused race, and 100%% coverage for all production functions
- full protocol normal/race and all non-Monty packages normal/race
- strict TypeScript 7.0.2, deterministic generation, lint, vet, tidy/verify, and configured pre-push
- five real-process Slang stdio/Unix-socket/WebSocket workflows
- exact normalized pinned schema and exact reverse to PR #216 tree