### PR TITLE
appserver/protocol: add app info record

### DIFF
--- a/appserver/protocol/account_credit_nudge_values_contract_test.go
+++ b/appserver/protocol/account_credit_nudge_values_contract_test.go
@@ -119,8 +119,8 @@ func TestAccountCreditNudgeValuesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/sendAddCreditsNudgeEmail = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/account_login_completed_notification_contract_test.go
+++ b/appserver/protocol/account_login_completed_notification_contract_test.go
@@ -88,8 +88,8 @@ func TestAccountLoginCompletedNotificationRemainsStandaloneAndDeferred(t *testin
 	if !found {
 		t.Fatal("account/login/completed method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/account_token_usage_contract_test.go
+++ b/appserver/protocol/account_token_usage_contract_test.go
@@ -146,8 +146,8 @@ func TestAccountTokenUsageRecordsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/usage/read = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(defs); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_info_contract_test.go
+++ b/appserver/protocol/app_info_contract_test.go
@@ -1,0 +1,170 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestAppInfoSchemaIsExact(t *testing.T) {
+	want := closedThreadSessionParamSchema(Schema{
+		"id":                  Schema{"type": "string"},
+		"name":                Schema{"type": "string"},
+		"description":         nullableStringSchema(),
+		"logoUrl":             nullableStringSchema(),
+		"logoUrlDark":         nullableStringSchema(),
+		"iconAssets":          nullableAppInfoStringMapSchema(),
+		"iconDarkAssets":      nullableAppInfoStringMapSchema(),
+		"distributionChannel": nullableStringSchema(),
+		"branding":            nullableAppMetadataRefSchema("AppBranding"),
+		"appMetadata":         nullableAppMetadataRefSchema("AppMetadata"),
+		"labels":              nullableAppInfoStringMapSchema(),
+		"installUrl":          nullableStringSchema(),
+		"isAccessible":        Schema{"type": "boolean", "default": false},
+		"isEnabled": Schema{
+			"type": "boolean", "default": true,
+			"description": "Whether this app is enabled in config.toml. Example: ```toml [apps.bad_app] enabled = false ```",
+		},
+		"pluginDisplayNames": Schema{
+			"type": "array", "items": Schema{"type": "string"}, "default": []any{},
+		},
+	}, []string{"id", "name"})
+	want["description"] = "EXPERIMENTAL - app metadata returned by app-list APIs."
+	got := JSONSchema()["$defs"].(Schema)["AppInfo"]
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("AppInfo = %#v, want %#v", got, want)
+	}
+}
+
+func TestAppInfoAcceptsSerdeWireForms(t *testing.T) {
+	const defaults = `{"appMetadata":null,"branding":null,"description":null,"distributionChannel":null,"iconAssets":null,"iconDarkAssets":null,"id":"id","installUrl":null,"isAccessible":false,"isEnabled":true,"labels":null,"logoUrl":null,"logoUrlDark":null,"name":"name","pluginDisplayNames":[]}`
+	for _, tc := range []struct {
+		input string
+		want  string
+	}{
+		{`{"id":"id","name":"name"}`, defaults},
+		{
+			`{"future":{"ignored":true},"id":" id ","name":"","description":" description ","logoUrl":"not a url","logoUrlDark":"","iconAssets":{"":""," icon ":" value "},"iconDarkAssets":{},"distributionChannel":" arbitrary ","branding":{"category":" category ","developer":"","website":"site","privacyPolicy":"privacy","termsOfService":"terms","isDiscoverableApp":true},"appMetadata":{"review":{"status":" review "},"categories":["", " category ", " category "],"subCategories":[],"seoDescription":" seo ","screenshots":[],"developer":"dev","version":"v","versionId":"vid","versionNotes":"notes","firstPartyType":"first","firstPartyRequiresInstall":false,"showInComposerWhenUnlinked":true},"labels":{"":""," label ":" value "},"installUrl":" install ","isAccessible":true,"isEnabled":false,"pluginDisplayNames":["", " plugin ", " plugin "]}`,
+			`{"appMetadata":{"categories":[""," category "," category "],"developer":"dev","firstPartyRequiresInstall":false,"firstPartyType":"first","review":{"status":" review "},"screenshots":[],"seoDescription":" seo ","showInComposerWhenUnlinked":true,"subCategories":[],"version":"v","versionId":"vid","versionNotes":"notes"},"branding":{"category":" category ","developer":"","isDiscoverableApp":true,"privacyPolicy":"privacy","termsOfService":"terms","website":"site"},"description":" description ","distributionChannel":" arbitrary ","iconAssets":{"":""," icon ":" value "},"iconDarkAssets":{},"id":" id ","installUrl":" install ","isAccessible":true,"isEnabled":false,"labels":{"":""," label ":" value "},"logoUrl":"not a url","logoUrlDark":"","name":"","pluginDisplayNames":[""," plugin "," plugin "]}`,
+		},
+	} {
+		var value AppInfo
+		if err := json.Unmarshal([]byte(tc.input), &value); err != nil {
+			t.Errorf("unmarshal %s: %v", tc.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(value)
+		if err != nil || string(encoded) != tc.want {
+			t.Errorf("round trip %s = %s, %v; want %s", tc.input, encoded, err, tc.want)
+		}
+	}
+}
+
+func TestAppInfoRejectsMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`, `{}`,
+		`{"name":"name"}`, `{"id":"id"}`, `{"id":null,"name":"name"}`,
+		`{"id":"id","name":null}`, `{"id":1,"name":"name"}`,
+		`{"id":"id","name":false}`, `{"id":"id","name":"name","description":1}`,
+		`{"id":"id","name":"name","logoUrl":[]}`,
+		`{"id":"id","name":"name","logoUrlDark":{}}`,
+		`{"id":"id","name":"name","iconAssets":[]}`,
+		`{"id":"id","name":"name","iconAssets":{"key":null}}`,
+		`{"id":"id","name":"name","iconAssets":{"key":1}}`,
+		`{"id":"id","name":"name","iconDarkAssets":{"key":false}}`,
+		`{"id":"id","name":"name","distributionChannel":1}`,
+		`{"id":"id","name":"name","branding":{}}`,
+		`{"id":"id","name":"name","branding":{"isDiscoverableApp":null}}`,
+		`{"id":"id","name":"name","appMetadata":[]}`,
+		`{"id":"id","name":"name","appMetadata":{"categories":[null]}}`,
+		`{"id":"id","name":"name","labels":{"key":null}}`,
+		`{"id":"id","name":"name","installUrl":false}`,
+		`{"id":"id","name":"name","isAccessible":null}`,
+		`{"id":"id","name":"name","isAccessible":"true"}`,
+		`{"id":"id","name":"name","isEnabled":null}`,
+		`{"id":"id","name":"name","isEnabled":0}`,
+		`{"id":"id","name":"name","pluginDisplayNames":null}`,
+		`{"id":"id","name":"name","pluginDisplayNames":{}}`,
+		`{"id":"id","name":"name","pluginDisplayNames":[null]}`,
+		`{"id":"id","name":"name","pluginDisplayNames":[1]}`,
+		`{"id":"id","id":"other","name":"name"}`,
+		`{"id":"id","name":"name","name":"other"}`,
+		`{"id":"id","name":"name","labels":null,"labels":{}}`,
+		`{"id":"id","name":"name"} {}`, `{"id":"id","name":"name"} x`,
+	} {
+		assertJSONRejects[AppInfo](t, input)
+	}
+}
+
+func TestAppInfoNilReceiverFailsClosed(t *testing.T) {
+	var info *AppInfo
+	if err := info.UnmarshalJSON([]byte(`{"id":"id","name":"name"}`)); err == nil {
+		t.Fatal("nil AppInfo receiver succeeded")
+	}
+}
+
+func TestAppInfoMarshalCanonicalizesNilPluginDisplayNames(t *testing.T) {
+	encoded, err := json.Marshal(AppInfo{ID: "id", Name: "name", IsEnabled: true})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	const want = `{"appMetadata":null,"branding":null,"description":null,"distributionChannel":null,"iconAssets":null,"iconDarkAssets":null,"id":"id","installUrl":null,"isAccessible":false,"isEnabled":true,"labels":null,"logoUrl":null,"logoUrlDark":null,"name":"name","pluginDisplayNames":[]}`
+	if string(encoded) != want {
+		t.Fatalf("marshal = %s, want %s", encoded, want)
+	}
+}
+
+func TestAppInfoRemainsStandaloneAndDeferred(t *testing.T) {
+	for _, binding := range WireTypeBindings() {
+		if slices.Contains(binding.Params, "AppInfo") || slices.Contains(binding.Result, "AppInfo") {
+			t.Fatalf("AppInfo unexpectedly bound to %s", binding.Method)
+		}
+	}
+	for _, binding := range ItemPayloadBindings() {
+		if binding.Type == "AppInfo" {
+			t.Fatalf("AppInfo unexpectedly bound to item %s", binding.Kind)
+		}
+	}
+	method, ok := LookupMethod("app/list")
+	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
+		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestAppInfoTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	want := "export type AppInfo = {\n" +
+		"  \"appMetadata\": AppMetadata | null;\n" +
+		"  \"branding\": AppBranding | null;\n" +
+		"  \"description\": string | null;\n" +
+		"  \"distributionChannel\": string | null;\n" +
+		"  \"iconAssets\": { [key in string]?: string } | null;\n" +
+		"  \"iconDarkAssets\": { [key in string]?: string } | null;\n" +
+		"  \"id\": string;\n" +
+		"  \"installUrl\": string | null;\n" +
+		"  \"isAccessible\": boolean;\n" +
+		"  \"isEnabled\": boolean;\n" +
+		"  \"labels\": { [key in string]?: string } | null;\n" +
+		"  \"logoUrl\": string | null;\n" +
+		"  \"logoUrlDark\": string | null;\n" +
+		"  \"name\": string;\n" +
+		"  \"pluginDisplayNames\": Array<string>;\n" +
+		"};"
+	if !strings.Contains(string(generated), want) {
+		t.Fatalf("generated TypeScript missing %q", want)
+	}
+}

--- a/appserver/protocol/app_info_types.go
+++ b/appserver/protocol/app_info_types.go
@@ -1,0 +1,218 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// AppInfo is exact standalone metadata for an experimental app.
+// App discovery, policy interpretation, and runtime behavior remain deferred.
+type AppInfo struct {
+	ID                  string             `json:"id"`
+	Name                string             `json:"name"`
+	Description         *string            `json:"description,omitempty"`
+	LogoURL             *string            `json:"logoUrl,omitempty"`
+	LogoURLDark         *string            `json:"logoUrlDark,omitempty"`
+	IconAssets          *map[string]string `json:"iconAssets,omitempty"`
+	IconDarkAssets      *map[string]string `json:"iconDarkAssets,omitempty"`
+	DistributionChannel *string            `json:"distributionChannel,omitempty"`
+	Branding            *AppBranding       `json:"branding,omitempty"`
+	AppMetadata         *AppMetadata       `json:"appMetadata,omitempty"`
+	Labels              *map[string]string `json:"labels,omitempty"`
+	InstallURL          *string            `json:"installUrl,omitempty"`
+	IsAccessible        bool               `json:"isAccessible"`
+	IsEnabled           bool               `json:"isEnabled"`
+	PluginDisplayNames  []string           `json:"pluginDisplayNames"`
+}
+
+func (i AppInfo) MarshalJSON() ([]byte, error) {
+	pluginDisplayNames := i.PluginDisplayNames
+	if pluginDisplayNames == nil {
+		pluginDisplayNames = []string{}
+	}
+	return json.Marshal(map[string]any{
+		"id":                  i.ID,
+		"name":                i.Name,
+		"description":         i.Description,
+		"logoUrl":             i.LogoURL,
+		"logoUrlDark":         i.LogoURLDark,
+		"iconAssets":          i.IconAssets,
+		"iconDarkAssets":      i.IconDarkAssets,
+		"distributionChannel": i.DistributionChannel,
+		"branding":            i.Branding,
+		"appMetadata":         i.AppMetadata,
+		"labels":              i.Labels,
+		"installUrl":          i.InstallURL,
+		"isAccessible":        i.IsAccessible,
+		"isEnabled":           i.IsEnabled,
+		"pluginDisplayNames":  pluginDisplayNames,
+	})
+}
+
+func (i *AppInfo) UnmarshalJSON(data []byte) error {
+	if i == nil {
+		return errors.New("decode app info into nil receiver")
+	}
+	const objectName = "app info"
+	payload, err := decodeRustSerdeObject(
+		data, objectName,
+		"id", "name", "description", "logoUrl", "logoUrlDark", "iconAssets",
+		"iconDarkAssets", "distributionChannel", "branding", "appMetadata", "labels",
+		"installUrl", "isAccessible", "isEnabled", "pluginDisplayNames",
+	)
+	if err != nil {
+		return err
+	}
+	id, err := decodeRequiredThreadItemValue[string](payload, objectName, "id")
+	if err != nil {
+		return err
+	}
+	name, err := decodeRequiredThreadItemValue[string](payload, objectName, "name")
+	if err != nil {
+		return err
+	}
+	description, err := decodeOptionalNullableConfigValue[string](payload, objectName, "description")
+	if err != nil {
+		return err
+	}
+	logoURL, err := decodeOptionalNullableConfigValue[string](payload, objectName, "logoUrl")
+	if err != nil {
+		return err
+	}
+	logoURLDark, err := decodeOptionalNullableConfigValue[string](payload, objectName, "logoUrlDark")
+	if err != nil {
+		return err
+	}
+	iconAssets, err := decodeOptionalNullableAppInfoStringMap(payload, objectName, "iconAssets")
+	if err != nil {
+		return err
+	}
+	iconDarkAssets, err := decodeOptionalNullableAppInfoStringMap(payload, objectName, "iconDarkAssets")
+	if err != nil {
+		return err
+	}
+	distributionChannel, err := decodeOptionalNullableConfigValue[string](
+		payload, objectName, "distributionChannel",
+	)
+	if err != nil {
+		return err
+	}
+	branding, err := decodeOptionalNullableConfigValue[AppBranding](payload, objectName, "branding")
+	if err != nil {
+		return err
+	}
+	appMetadata, err := decodeOptionalNullableConfigValue[AppMetadata](payload, objectName, "appMetadata")
+	if err != nil {
+		return err
+	}
+	labels, err := decodeOptionalNullableAppInfoStringMap(payload, objectName, "labels")
+	if err != nil {
+		return err
+	}
+	installURL, err := decodeOptionalNullableConfigValue[string](payload, objectName, "installUrl")
+	if err != nil {
+		return err
+	}
+	isAccessible, err := decodeOptionalConfigBool(payload, objectName, "isAccessible")
+	if err != nil {
+		return err
+	}
+	isEnabled, err := decodeDefaultEnabledAppInfoBool(payload, objectName, "isEnabled")
+	if err != nil {
+		return err
+	}
+	pluginDisplayNames, err := decodeDefaultedAppInfoStringArray(
+		payload, objectName, "pluginDisplayNames",
+	)
+	if err != nil {
+		return err
+	}
+	*i = AppInfo{
+		ID: id, Name: name, Description: description, LogoURL: logoURL, LogoURLDark: logoURLDark,
+		IconAssets: iconAssets, IconDarkAssets: iconDarkAssets,
+		DistributionChannel: distributionChannel, Branding: branding, AppMetadata: appMetadata,
+		Labels: labels, InstallURL: installURL, IsAccessible: isAccessible, IsEnabled: isEnabled,
+		PluginDisplayNames: pluginDisplayNames,
+	}
+	return nil
+}
+
+func decodeOptionalNullableAppInfoStringMap(
+	payload map[string]json.RawMessage,
+	objectName string,
+	fieldName string,
+) (*map[string]string, error) {
+	raw, ok := payload[fieldName]
+	if !ok || isJSONNull(raw) {
+		return nil, nil
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return nil, fmt.Errorf("decode %s %s: %w", objectName, fieldName, err)
+	}
+	values := make(map[string]string, len(fields))
+	for key, value := range fields {
+		if isJSONNull(value) {
+			return nil, fmt.Errorf("decode %s %s[%q]: value cannot be null", objectName, fieldName, key)
+		}
+		var decoded string
+		if err := json.Unmarshal(value, &decoded); err != nil {
+			return nil, fmt.Errorf("decode %s %s[%q]: %w", objectName, fieldName, key, err)
+		}
+		values[key] = decoded
+	}
+	return &values, nil
+}
+
+func decodeDefaultEnabledAppInfoBool(
+	payload map[string]json.RawMessage,
+	objectName string,
+	fieldName string,
+) (bool, error) {
+	raw, ok := payload[fieldName]
+	if !ok {
+		return true, nil
+	}
+	if isJSONNull(raw) {
+		return false, fmt.Errorf("decode %s %s: value cannot be null", objectName, fieldName)
+	}
+	var value bool
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return false, fmt.Errorf("decode %s %s: %w", objectName, fieldName, err)
+	}
+	return value, nil
+}
+
+func decodeDefaultedAppInfoStringArray(
+	payload map[string]json.RawMessage,
+	objectName string,
+	fieldName string,
+) ([]string, error) {
+	raw, ok := payload[fieldName]
+	if !ok {
+		return []string{}, nil
+	}
+	if isJSONNull(raw) {
+		return nil, fmt.Errorf("decode %s %s: value cannot be null", objectName, fieldName)
+	}
+	var elements []json.RawMessage
+	if err := json.Unmarshal(raw, &elements); err != nil {
+		return nil, fmt.Errorf("decode %s %s: %w", objectName, fieldName, err)
+	}
+	values := make([]string, len(elements))
+	for index, element := range elements {
+		if isJSONNull(element) {
+			return nil, fmt.Errorf("decode %s %s[%d]: value cannot be null", objectName, fieldName, index)
+		}
+		if err := json.Unmarshal(element, &values[index]); err != nil {
+			return nil, fmt.Errorf("decode %s %s[%d]: %w", objectName, fieldName, index, err)
+		}
+	}
+	return values, nil
+}
+
+var (
+	_ json.Marshaler   = AppInfo{}
+	_ json.Unmarshaler = (*AppInfo)(nil)
+)

--- a/appserver/protocol/app_metadata_contract_test.go
+++ b/appserver/protocol/app_metadata_contract_test.go
@@ -107,8 +107,8 @@ func TestAppMetadataRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_metadata_leaf_contract_test.go
+++ b/appserver/protocol/app_metadata_leaf_contract_test.go
@@ -157,8 +157,8 @@ func TestAppMetadataLeavesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/apply_patch_approval_params_contract_test.go
+++ b/appserver/protocol/apply_patch_approval_params_contract_test.go
@@ -139,8 +139,8 @@ func TestApplyPatchApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ApplyPatchApprovalParams unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(defs); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(defs); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/attestation_contract_test.go
+++ b/appserver/protocol/attestation_contract_test.go
@@ -133,8 +133,8 @@ func TestAttestationContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("attestation/generate = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
+++ b/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
@@ -179,8 +179,8 @@ func TestChatgptAuthTokensRefreshRemainsStandaloneAndDeferred(t *testing.T) {
 	if !found {
 		t.Fatal("refresh method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/exec_command_approval_params_contract_test.go
+++ b/appserver/protocol/exec_command_approval_params_contract_test.go
@@ -137,8 +137,8 @@ func TestExecCommandApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ExecCommandApprovalParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(defs); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,8 +217,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,8 +203,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -260,8 +260,8 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,8 +244,8 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -162,8 +162,8 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -175,8 +175,8 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_contract_test.go
+++ b/appserver/protocol/file_change_contract_test.go
@@ -108,8 +108,8 @@ func TestFileChangeRemainsStandalone(t *testing.T) {
 			t.Fatalf("FileChange unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_output_delta_notification_contract_test.go
+++ b/appserver/protocol/file_change_output_delta_notification_contract_test.go
@@ -100,8 +100,8 @@ func TestFileChangeOutputDeltaNotificationRemainsDeprecatedAndStandalone(t *test
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("item/fileChange/outputDelta = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -381,8 +381,8 @@ func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_action_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_action_contract_test.go
@@ -226,8 +226,8 @@ func TestGuardianApprovalReviewActionRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReviewAction unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
@@ -164,8 +164,8 @@ func TestGuardianApprovalReviewCompletedNotificationRemainsStandalone(t *testing
 			t.Fatalf("completed notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_contract_test.go
@@ -139,8 +139,8 @@ func TestGuardianApprovalReviewRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReview unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
@@ -175,8 +175,8 @@ func TestGuardianApprovalReviewStartedNotificationRemainsStandalone(t *testing.T
 			t.Fatalf("started notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_enum_foundation_contract_test.go
+++ b/appserver/protocol/guardian_enum_foundation_contract_test.go
@@ -89,8 +89,8 @@ func TestGuardianEnumFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_metadata_list_contract_test.go
+++ b/appserver/protocol/hook_metadata_list_contract_test.go
@@ -352,8 +352,8 @@ func TestHookMetadataListContractsStayStandalone(t *testing.T) {
 			t.Errorf("standalone definition %s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Errorf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Errorf("definition count = %d, want 458", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 {
 		t.Errorf("wire binding count = %d, want 59", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_run_notification_contract_test.go
+++ b/appserver/protocol/hook_run_notification_contract_test.go
@@ -297,8 +297,8 @@ func TestHookRunNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("surface changed: %d methods, %d wire bindings, %d item bindings", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/hook_value_foundation_contract_test.go
+++ b/appserver/protocol/hook_value_foundation_contract_test.go
@@ -167,8 +167,8 @@ func TestHookValueFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 457 {
-		t.Fatalf("definition count = %d, want 457", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 458 {
+		t.Fatalf("definition count = %d, want 458", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/legacy_approval_response_contract_test.go
+++ b/appserver/protocol/legacy_approval_response_contract_test.go
@@ -98,8 +98,8 @@ func TestLegacyApprovalResponsesRemainStandaloneAndNominal(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_approval_context_contract_test.go
+++ b/appserver/protocol/network_approval_context_contract_test.go
@@ -84,8 +84,8 @@ func TestNetworkApprovalContextRemainsStandalone(t *testing.T) {
 			t.Fatalf("NetworkApprovalContext unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/parsed_command_contract_test.go
+++ b/appserver/protocol/parsed_command_contract_test.go
@@ -120,8 +120,8 @@ func TestParsedCommandRemainsStandalone(t *testing.T) {
 			t.Fatalf("ParsedCommand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 457 {
-		t.Fatalf("definition count = %d, want 457", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 458 {
+		t.Fatalf("definition count = %d, want 458", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 457 {
-		t.Fatalf("definition count = %d, want 457", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 458 {
+		t.Fatalf("definition count = %d, want 458", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 457 {
-		t.Fatalf("definition count = %d, want 457", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 458 {
+		t.Fatalf("definition count = %d, want 458", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 457 {
-		t.Fatalf("definition count = %d, want 457", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 458 {
+		t.Fatalf("definition count = %d, want 458", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 457 {
-		t.Fatalf("definition count = %d, want 457", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 458 {
+		t.Fatalf("definition count = %d, want 458", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/review_decision_contract_test.go
+++ b/appserver/protocol/review_decision_contract_test.go
@@ -136,8 +136,8 @@ func TestReviewDecisionRemainsStandalone(t *testing.T) {
 			t.Fatalf("ReviewDecision unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(defs); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -106,6 +106,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "ApprovalRespondResult", Type: reflect.TypeFor[ApprovalRespondResult]()},
 		{Name: "ApprovalsReviewer", Type: reflect.TypeFor[ApprovalsReviewer]()},
 		{Name: "AppBranding", Type: reflect.TypeFor[AppBranding]()},
+		{Name: "AppInfo", Type: reflect.TypeFor[AppInfo]()},
 		{Name: "AppMetadata", Type: reflect.TypeFor[AppMetadata]()},
 		{Name: "AppReview", Type: reflect.TypeFor[AppReview]()},
 		{Name: "AppScreenshot", Type: reflect.TypeFor[AppScreenshot]()},
@@ -588,6 +589,35 @@ func wireSchemaDefinitions() Schema {
 		"termsOfService":    nullableStringSchema(),
 		"isDiscoverableApp": Schema{"type": "boolean"},
 	}, []string{"isDiscoverableApp"})
+	schemas["AppInfo"] = closedThreadSessionParamSchema(Schema{
+		"id":                  Schema{"type": "string"},
+		"name":                Schema{"type": "string"},
+		"description":         nullableStringSchema(),
+		"logoUrl":             nullableStringSchema(),
+		"logoUrlDark":         nullableStringSchema(),
+		"iconAssets":          nullableAppInfoStringMapSchema(),
+		"iconDarkAssets":      nullableAppInfoStringMapSchema(),
+		"distributionChannel": nullableStringSchema(),
+		"branding": Schema{"anyOf": []any{
+			Schema{"$ref": "#/$defs/AppBranding"}, Schema{"type": "null"},
+		}},
+		"appMetadata": Schema{"anyOf": []any{
+			Schema{"$ref": "#/$defs/AppMetadata"}, Schema{"type": "null"},
+		}},
+		"labels":     nullableAppInfoStringMapSchema(),
+		"installUrl": nullableStringSchema(),
+		"isAccessible": Schema{
+			"type": "boolean", "default": false,
+		},
+		"isEnabled": Schema{
+			"type": "boolean", "default": true,
+			"description": "Whether this app is enabled in config.toml. Example: ```toml [apps.bad_app] enabled = false ```",
+		},
+		"pluginDisplayNames": Schema{
+			"type": "array", "items": Schema{"type": "string"}, "default": []any{},
+		},
+	}, []string{"id", "name"})
+	schemas["AppInfo"].(Schema)["description"] = "EXPERIMENTAL - app metadata returned by app-list APIs."
 	schemas["AppMetadata"] = closedThreadSessionParamSchema(Schema{
 		"review": Schema{"anyOf": []any{
 			Schema{"$ref": "#/$defs/AppReview"}, Schema{"type": "null"},
@@ -2850,6 +2880,13 @@ func patchChangeKindVariantSchema(kind, requiredMovePath string) Schema {
 
 func nullableStringSchema() Schema {
 	return Schema{"anyOf": []any{Schema{"type": "string"}, Schema{"type": "null"}}}
+}
+
+func nullableAppInfoStringMapSchema() Schema {
+	return Schema{"anyOf": []any{
+		Schema{"type": "object", "additionalProperties": Schema{"type": "string"}},
+		Schema{"type": "null"},
+	}}
 }
 
 func schemaWithRequiredIDAlternative(base Schema) Schema {

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -412,6 +412,148 @@
       ],
       "type": "object"
     },
+    "AppInfo": {
+      "additionalProperties": false,
+      "description": "EXPERIMENTAL - app metadata returned by app-list APIs.",
+      "properties": {
+        "appMetadata": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AppMetadata"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "branding": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AppBranding"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "distributionChannel": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "iconAssets": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "iconDarkAssets": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "id": {
+          "type": "string"
+        },
+        "installUrl": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "isAccessible": {
+          "default": false,
+          "type": "boolean"
+        },
+        "isEnabled": {
+          "default": true,
+          "description": "Whether this app is enabled in config.toml. Example: ```toml [apps.bad_app] enabled = false ```",
+          "type": "boolean"
+        },
+        "labels": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "logoUrl": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "logoUrlDark": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "pluginDisplayNames": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "id",
+        "name"
+      ],
+      "type": "object"
+    },
     "AppMetadata": {
       "additionalProperties": false,
       "properties": {

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 457 {
-		t.Fatalf("definition count = %d, want 457", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 458 {
+		t.Fatalf("definition count = %d, want 458", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 457 {
-		t.Fatalf("definition count = %d, want 457", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 458 {
+		t.Fatalf("definition count = %d, want 458", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 457 {
-		t.Fatalf("definition count = %d, want 457", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 458 {
+		t.Fatalf("definition count = %d, want 458", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -40,7 +40,7 @@ func MarshalTypeScript() ([]byte, error) {
 	for _, name := range names {
 		definition := defs[name]
 		if name == "AccountLoginCompletedNotification" || name == "AccountTokenUsageSummary" ||
-			name == "AppBranding" || name == "AppMetadata" || name == "AppScreenshot" ||
+			name == "AppBranding" || name == "AppInfo" || name == "AppMetadata" || name == "AppScreenshot" ||
 			name == "ApplyPatchApprovalParams" ||
 			name == "ChatgptAuthTokensRefreshResponse" ||
 			name == "MigrationDetails" ||
@@ -73,6 +73,12 @@ func MarshalTypeScript() ([]byte, error) {
 			case "AppBranding":
 				schema["required"] = []string{
 					"category", "developer", "website", "privacyPolicy", "termsOfService", "isDiscoverableApp",
+				}
+			case "AppInfo":
+				schema["required"] = []string{
+					"id", "name", "description", "logoUrl", "logoUrlDark", "iconAssets",
+					"iconDarkAssets", "distributionChannel", "branding", "appMetadata", "labels",
+					"installUrl", "isAccessible", "isEnabled", "pluginDisplayNames",
 				}
 			case "AppMetadata":
 				schema["required"] = []string{
@@ -167,6 +173,21 @@ func MarshalTypeScript() ([]byte, error) {
 					"additionalProperties":             Schema{"$ref": "#/$defs/FileChange"},
 					"x-gollem-typescript-optional-map": true,
 				},
+			})
+		}
+		if name == "AppInfo" {
+			// ts-rs models HashMap values with optional mapped keys. Apply the
+			// hint only to TypeScript rendering, not the exact public schema.
+			nullableStringMap := Schema{"anyOf": []any{
+				Schema{
+					"type": "object", "additionalProperties": Schema{"type": "string"},
+					"x-gollem-typescript-optional-map": true,
+				},
+				Schema{"type": "null"},
+			}}
+			definition = typeScriptDefinitionWithPropertySchemas(definition, Schema{
+				"iconAssets": nullableStringMap, "iconDarkAssets": nullableStringMap,
+				"labels": nullableStringMap,
 			})
 		}
 		if name == "ExternalAgentConfigImportHistory" {

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -577,6 +577,24 @@ export type AppBranding = {
   "website": string | null;
 };
 
+export type AppInfo = {
+  "appMetadata": AppMetadata | null;
+  "branding": AppBranding | null;
+  "description": string | null;
+  "distributionChannel": string | null;
+  "iconAssets": { [key in string]?: string } | null;
+  "iconDarkAssets": { [key in string]?: string } | null;
+  "id": string;
+  "installUrl": string | null;
+  "isAccessible": boolean;
+  "isEnabled": boolean;
+  "labels": { [key in string]?: string } | null;
+  "logoUrl": string | null;
+  "logoUrlDark": string | null;
+  "name": string;
+  "pluginDisplayNames": Array<string>;
+};
+
 export type AppMetadata = {
   "categories": Array<string> | null;
   "developer": string | null;

--- a/appserver/protocol/typescript/testdata/app_info_contract.ts
+++ b/appserver/protocol/typescript/testdata/app_info_contract.ts
@@ -1,0 +1,124 @@
+import type {
+  AppBranding,
+  AppInfo,
+  AppMetadata,
+  MethodParamsByName,
+  MethodResultsByName,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+type ExpectFalse<T extends false> = T;
+
+type ExactInfo = {
+  id: string;
+  name: string;
+  description: string | null;
+  logoUrl: string | null;
+  logoUrlDark: string | null;
+  iconAssets: { [key in string]?: string } | null;
+  iconDarkAssets: { [key in string]?: string } | null;
+  distributionChannel: string | null;
+  branding: AppBranding | null;
+  appMetadata: AppMetadata | null;
+  labels: { [key in string]?: string } | null;
+  installUrl: string | null;
+  isAccessible: boolean;
+  isEnabled: boolean;
+  pluginDisplayNames: Array<string>;
+};
+
+type Contracts = [
+  Expect<Equal<AppInfo, ExactInfo>>,
+  ExpectFalse<"app/list" extends keyof MethodParamsByName ? true : false>,
+  ExpectFalse<"app/list" extends keyof MethodResultsByName ? true : false>,
+];
+
+({
+  id: "id",
+  name: "name",
+  description: null,
+  logoUrl: null,
+  logoUrlDark: null,
+  iconAssets: null,
+  iconDarkAssets: null,
+  distributionChannel: null,
+  branding: null,
+  appMetadata: null,
+  labels: null,
+  installUrl: null,
+  isAccessible: false,
+  isEnabled: true,
+  pluginDisplayNames: [],
+}) satisfies AppInfo;
+
+({
+  id: " id ",
+  name: "",
+  description: " description ",
+  logoUrl: "not a url",
+  logoUrlDark: "",
+  iconAssets: { "": "", " icon ": " value " },
+  iconDarkAssets: {},
+  distributionChannel: " arbitrary ",
+  branding: {
+    category: " category ",
+    developer: "",
+    website: "site",
+    privacyPolicy: "privacy",
+    termsOfService: "terms",
+    isDiscoverableApp: true,
+  },
+  appMetadata: {
+    review: { status: " review " },
+    categories: ["", " category ", " category "],
+    subCategories: [],
+    seoDescription: " seo ",
+    screenshots: [],
+    developer: "dev",
+    version: "v",
+    versionId: "vid",
+    versionNotes: "notes",
+    firstPartyType: "first",
+    firstPartyRequiresInstall: false,
+    showInComposerWhenUnlinked: true,
+  },
+  labels: { "": "", " label ": " value " },
+  installUrl: " install ",
+  isAccessible: true,
+  isEnabled: false,
+  pluginDisplayNames: ["", " plugin ", " plugin "],
+}) satisfies AppInfo;
+
+// @ts-expect-error canonical AppInfo requires every field.
+({ id: "id", name: "name" }) satisfies AppInfo;
+// @ts-expect-error id is required.
+({ name: "name", description: null, logoUrl: null, logoUrlDark: null, iconAssets: null, iconDarkAssets: null, distributionChannel: null, branding: null, appMetadata: null, labels: null, installUrl: null, isAccessible: false, isEnabled: true, pluginDisplayNames: [] }) satisfies AppInfo;
+// @ts-expect-error name is a string.
+({ id: "id", name: null, description: null, logoUrl: null, logoUrlDark: null, iconAssets: null, iconDarkAssets: null, distributionChannel: null, branding: null, appMetadata: null, labels: null, installUrl: null, isAccessible: false, isEnabled: true, pluginDisplayNames: [] }) satisfies AppInfo;
+// @ts-expect-error description is a string or null.
+({ id: "id", name: "name", description: 1, logoUrl: null, logoUrlDark: null, iconAssets: null, iconDarkAssets: null, distributionChannel: null, branding: null, appMetadata: null, labels: null, installUrl: null, isAccessible: false, isEnabled: true, pluginDisplayNames: [] }) satisfies AppInfo;
+// @ts-expect-error iconAssets values are strings.
+({ id: "id", name: "name", description: null, logoUrl: null, logoUrlDark: null, iconAssets: { key: null }, iconDarkAssets: null, distributionChannel: null, branding: null, appMetadata: null, labels: null, installUrl: null, isAccessible: false, isEnabled: true, pluginDisplayNames: [] }) satisfies AppInfo;
+// @ts-expect-error iconDarkAssets is a string map or null.
+({ id: "id", name: "name", description: null, logoUrl: null, logoUrlDark: null, iconAssets: null, iconDarkAssets: [], distributionChannel: null, branding: null, appMetadata: null, labels: null, installUrl: null, isAccessible: false, isEnabled: true, pluginDisplayNames: [] }) satisfies AppInfo;
+// @ts-expect-error branding requires the canonical AppBranding fields.
+({ id: "id", name: "name", description: null, logoUrl: null, logoUrlDark: null, iconAssets: null, iconDarkAssets: null, distributionChannel: null, branding: {}, appMetadata: null, labels: null, installUrl: null, isAccessible: false, isEnabled: true, pluginDisplayNames: [] }) satisfies AppInfo;
+// @ts-expect-error appMetadata requires the canonical AppMetadata fields.
+({ id: "id", name: "name", description: null, logoUrl: null, logoUrlDark: null, iconAssets: null, iconDarkAssets: null, distributionChannel: null, branding: null, appMetadata: {}, labels: null, installUrl: null, isAccessible: false, isEnabled: true, pluginDisplayNames: [] }) satisfies AppInfo;
+// @ts-expect-error labels values are strings.
+({ id: "id", name: "name", description: null, logoUrl: null, logoUrlDark: null, iconAssets: null, iconDarkAssets: null, distributionChannel: null, branding: null, appMetadata: null, labels: { key: false }, installUrl: null, isAccessible: false, isEnabled: true, pluginDisplayNames: [] }) satisfies AppInfo;
+// @ts-expect-error isAccessible is boolean.
+({ id: "id", name: "name", description: null, logoUrl: null, logoUrlDark: null, iconAssets: null, iconDarkAssets: null, distributionChannel: null, branding: null, appMetadata: null, labels: null, installUrl: null, isAccessible: null, isEnabled: true, pluginDisplayNames: [] }) satisfies AppInfo;
+// @ts-expect-error isEnabled is boolean.
+({ id: "id", name: "name", description: null, logoUrl: null, logoUrlDark: null, iconAssets: null, iconDarkAssets: null, distributionChannel: null, branding: null, appMetadata: null, labels: null, installUrl: null, isAccessible: false, isEnabled: "true", pluginDisplayNames: [] }) satisfies AppInfo;
+// @ts-expect-error pluginDisplayNames is a string array.
+({ id: "id", name: "name", description: null, logoUrl: null, logoUrlDark: null, iconAssets: null, iconDarkAssets: null, distributionChannel: null, branding: null, appMetadata: null, labels: null, installUrl: null, isAccessible: false, isEnabled: true, pluginDisplayNames: [null] }) satisfies AppInfo;
+// @ts-expect-error canonical AppInfo is closed.
+({ id: "id", name: "name", description: null, logoUrl: null, logoUrlDark: null, iconAssets: null, iconDarkAssets: null, distributionChannel: null, branding: null, appMetadata: null, labels: null, installUrl: null, isAccessible: false, isEnabled: true, pluginDisplayNames: [], future: true }) satisfies AppInfo;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 457 {
-		t.Fatalf("definition count = %d, want 457", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
+		t.Fatalf("definition count = %d, want 458", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary

- export the exact standalone `AppInfo` protocol record from the pinned public Codex schema
- preserve serde omission/default behavior while emitting the canonical 15-field TypeScript shape
- keep `app/list` deferred and unbound with no app runtime authority

## Validation

- focused contract tests x30, focused race, and 100% statement coverage for all five new production functions
- full protocol suite and strict TypeScript 7.0.2 fixture
- all 59 non-Monty packages in normal and race modes
- golangci-lint, vet, tidy/verify, deterministic generation, and configured pre-push
- all five Slang real-process stdio/Unix-socket/WebSocket workflows
- exact parent/feature initialize plus MCP transcript comparison