### PR TITLE
appserver/protocol: add app-list update record

### DIFF
--- a/appserver/protocol/account_credit_nudge_values_contract_test.go
+++ b/appserver/protocol/account_credit_nudge_values_contract_test.go
@@ -119,8 +119,8 @@ func TestAccountCreditNudgeValuesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/sendAddCreditsNudgeEmail = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/account_login_completed_notification_contract_test.go
+++ b/appserver/protocol/account_login_completed_notification_contract_test.go
@@ -88,8 +88,8 @@ func TestAccountLoginCompletedNotificationRemainsStandaloneAndDeferred(t *testin
 	if !found {
 		t.Fatal("account/login/completed method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/account_token_usage_contract_test.go
+++ b/appserver/protocol/account_token_usage_contract_test.go
@@ -146,8 +146,8 @@ func TestAccountTokenUsageRecordsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/usage/read = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(defs); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_info_contract_test.go
+++ b/appserver/protocol/app_info_contract_test.go
@@ -131,8 +131,8 @@ func TestAppInfoRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_list_updated_notification_contract_test.go
+++ b/appserver/protocol/app_list_updated_notification_contract_test.go
@@ -1,0 +1,130 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestAppListUpdatedNotificationSchemaIsExact(t *testing.T) {
+	want := closedThreadSessionParamSchema(Schema{
+		"data": Schema{"type": "array", "items": Schema{"$ref": "#/$defs/AppInfo"}},
+	}, []string{"data"})
+	want["description"] = "EXPERIMENTAL - notification emitted when the app list changes."
+	got := JSONSchema()["$defs"].(Schema)["AppListUpdatedNotification"]
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("AppListUpdatedNotification = %#v, want %#v", got, want)
+	}
+}
+
+func TestAppListUpdatedNotificationAcceptsSerdeWireForms(t *testing.T) {
+	const minimalInfo = `{"id":"id","name":"name"}`
+	const canonicalInfo = `{"appMetadata":null,"branding":null,"description":null,"distributionChannel":null,"iconAssets":null,"iconDarkAssets":null,"id":"id","installUrl":null,"isAccessible":false,"isEnabled":true,"labels":null,"logoUrl":null,"logoUrlDark":null,"name":"name","pluginDisplayNames":[]}`
+	for _, tc := range []struct {
+		input string
+		want  string
+	}{
+		{`{"data":[]}`, `{"data":[]}`},
+		{`{"future":true,"data":[` + minimalInfo + `]}`, `{"data":[` + canonicalInfo + `]}`},
+		{`{"data":[` + minimalInfo + `,` + minimalInfo + `]}`, `{"data":[` + canonicalInfo + `,` + canonicalInfo + `]}`},
+	} {
+		var value AppListUpdatedNotification
+		if err := json.Unmarshal([]byte(tc.input), &value); err != nil {
+			t.Errorf("unmarshal %s: %v", tc.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(value)
+		if err != nil || string(encoded) != tc.want {
+			t.Errorf("round trip %s = %s, %v; want %s", tc.input, encoded, err, tc.want)
+		}
+	}
+}
+
+func TestAppListUpdatedNotificationPreservesNestedOrderAndOpaqueValues(t *testing.T) {
+	input := `{"data":[` +
+		`{"id":" second ","name":"","pluginDisplayNames":[" x "," x "]},` +
+		`{"id":"first","name":" name ","labels":{"":""," key ":" value "}}]}`
+	var value AppListUpdatedNotification
+	if err := json.Unmarshal([]byte(input), &value); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got := []string{value.Data[0].ID, value.Data[1].ID}; !slices.Equal(got, []string{" second ", "first"}) {
+		t.Fatalf("ids = %q", got)
+	}
+	if !slices.Equal(value.Data[0].PluginDisplayNames, []string{" x ", " x "}) {
+		t.Fatalf("plugin display names = %q", value.Data[0].PluginDisplayNames)
+	}
+	if value.Data[1].Labels == nil || (*value.Data[1].Labels)[" key "] != " value " {
+		t.Fatalf("labels = %#v", value.Data[1].Labels)
+	}
+}
+
+func TestAppListUpdatedNotificationRejectsMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`, `{}`,
+		`{"future":true}`, `{"data":null}`, `{"data":{}}`, `{"data":"apps"}`,
+		`{"data":[null]}`, `{"data":[1]}`, `{"data":[{}]}`,
+		`{"data":[{"id":"id"}]}`, `{"data":[{"name":"name"}]}`,
+		`{"data":[{"id":null,"name":"name"}]}`,
+		`{"data":[{"id":"id","name":"name","isEnabled":null}]}`,
+		`{"data":[{"id":"id","name":"name","pluginDisplayNames":[null]}]}`,
+		`{"data":[],"data":[]}`, `{"data":[]} {}`, `{"data":[]} x`,
+	} {
+		assertJSONRejects[AppListUpdatedNotification](t, input)
+	}
+}
+
+func TestAppListUpdatedNotificationNilReceiverFailsClosed(t *testing.T) {
+	var notification *AppListUpdatedNotification
+	if err := notification.UnmarshalJSON([]byte(`{"data":[]}`)); err == nil {
+		t.Fatal("nil AppListUpdatedNotification receiver succeeded")
+	}
+}
+
+func TestAppListUpdatedNotificationMarshalRejectsNilData(t *testing.T) {
+	if _, err := json.Marshal(AppListUpdatedNotification{}); err == nil {
+		t.Fatal("nil notification data marshaled")
+	}
+}
+
+func TestAppListUpdatedNotificationRemainsStandaloneAndDeferred(t *testing.T) {
+	for _, binding := range WireTypeBindings() {
+		if slices.Contains(binding.Params, "AppListUpdatedNotification") ||
+			slices.Contains(binding.Result, "AppListUpdatedNotification") {
+			t.Fatalf("AppListUpdatedNotification unexpectedly bound to %s", binding.Method)
+		}
+	}
+	for _, binding := range ItemPayloadBindings() {
+		if binding.Type == "AppListUpdatedNotification" {
+			t.Fatalf("AppListUpdatedNotification unexpectedly bound to item %s", binding.Kind)
+		}
+	}
+	method, ok := LookupMethod("app/list/updated")
+	if !ok || method.Surface != SurfaceServerNotification || method.State != MethodDeferredStub {
+		t.Fatalf("app/list/updated = %#v, %v; want deferred server notification", method, ok)
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestAppListUpdatedNotificationTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	want := "export type AppListUpdatedNotification = {\n" +
+		"  \"data\": Array<AppInfo>;\n" +
+		"};"
+	if !strings.Contains(string(generated), want) {
+		t.Fatalf("generated TypeScript missing %q", want)
+	}
+}

--- a/appserver/protocol/app_list_updated_notification_types.go
+++ b/appserver/protocol/app_list_updated_notification_types.go
@@ -1,0 +1,42 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// AppListUpdatedNotification is an exact standalone app-list snapshot value.
+// Production, delivery, and app discovery remain deferred.
+type AppListUpdatedNotification struct {
+	Data []AppInfo `json:"data" jsonschema:"nonnullable=true"`
+}
+
+func (n AppListUpdatedNotification) MarshalJSON() ([]byte, error) {
+	if n.Data == nil {
+		return nil, errors.New("app-list updated notification data cannot be null")
+	}
+	type wire AppListUpdatedNotification
+	return json.Marshal(wire(n))
+}
+
+func (n *AppListUpdatedNotification) UnmarshalJSON(data []byte) error {
+	if n == nil {
+		return errors.New("decode app-list updated notification into nil receiver")
+	}
+	const objectName = "app-list updated notification"
+	payload, err := decodeRustSerdeObject(data, objectName, "data")
+	if err != nil {
+		return err
+	}
+	apps, err := decodeRequiredThreadItemArray[AppInfo](payload, objectName, "data")
+	if err != nil {
+		return err
+	}
+	*n = AppListUpdatedNotification{Data: apps}
+	return nil
+}
+
+var (
+	_ json.Marshaler   = AppListUpdatedNotification{}
+	_ json.Unmarshaler = (*AppListUpdatedNotification)(nil)
+)

--- a/appserver/protocol/app_metadata_contract_test.go
+++ b/appserver/protocol/app_metadata_contract_test.go
@@ -107,8 +107,8 @@ func TestAppMetadataRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_metadata_leaf_contract_test.go
+++ b/appserver/protocol/app_metadata_leaf_contract_test.go
@@ -157,8 +157,8 @@ func TestAppMetadataLeavesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/apply_patch_approval_params_contract_test.go
+++ b/appserver/protocol/apply_patch_approval_params_contract_test.go
@@ -139,8 +139,8 @@ func TestApplyPatchApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ApplyPatchApprovalParams unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(defs); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(defs); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/attestation_contract_test.go
+++ b/appserver/protocol/attestation_contract_test.go
@@ -133,8 +133,8 @@ func TestAttestationContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("attestation/generate = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
+++ b/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
@@ -179,8 +179,8 @@ func TestChatgptAuthTokensRefreshRemainsStandaloneAndDeferred(t *testing.T) {
 	if !found {
 		t.Fatal("refresh method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/exec_command_approval_params_contract_test.go
+++ b/appserver/protocol/exec_command_approval_params_contract_test.go
@@ -137,8 +137,8 @@ func TestExecCommandApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ExecCommandApprovalParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(defs); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,8 +217,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,8 +203,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -260,8 +260,8 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,8 +244,8 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -162,8 +162,8 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -175,8 +175,8 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_contract_test.go
+++ b/appserver/protocol/file_change_contract_test.go
@@ -108,8 +108,8 @@ func TestFileChangeRemainsStandalone(t *testing.T) {
 			t.Fatalf("FileChange unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_output_delta_notification_contract_test.go
+++ b/appserver/protocol/file_change_output_delta_notification_contract_test.go
@@ -100,8 +100,8 @@ func TestFileChangeOutputDeltaNotificationRemainsDeprecatedAndStandalone(t *test
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("item/fileChange/outputDelta = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -381,8 +381,8 @@ func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_action_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_action_contract_test.go
@@ -226,8 +226,8 @@ func TestGuardianApprovalReviewActionRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReviewAction unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
@@ -164,8 +164,8 @@ func TestGuardianApprovalReviewCompletedNotificationRemainsStandalone(t *testing
 			t.Fatalf("completed notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_contract_test.go
@@ -139,8 +139,8 @@ func TestGuardianApprovalReviewRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReview unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
@@ -175,8 +175,8 @@ func TestGuardianApprovalReviewStartedNotificationRemainsStandalone(t *testing.T
 			t.Fatalf("started notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_enum_foundation_contract_test.go
+++ b/appserver/protocol/guardian_enum_foundation_contract_test.go
@@ -89,8 +89,8 @@ func TestGuardianEnumFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_metadata_list_contract_test.go
+++ b/appserver/protocol/hook_metadata_list_contract_test.go
@@ -352,8 +352,8 @@ func TestHookMetadataListContractsStayStandalone(t *testing.T) {
 			t.Errorf("standalone definition %s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Errorf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Errorf("definition count = %d, want 459", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 {
 		t.Errorf("wire binding count = %d, want 59", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_run_notification_contract_test.go
+++ b/appserver/protocol/hook_run_notification_contract_test.go
@@ -297,8 +297,8 @@ func TestHookRunNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("surface changed: %d methods, %d wire bindings, %d item bindings", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/hook_value_foundation_contract_test.go
+++ b/appserver/protocol/hook_value_foundation_contract_test.go
@@ -167,8 +167,8 @@ func TestHookValueFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 458 {
-		t.Fatalf("definition count = %d, want 458", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 459 {
+		t.Fatalf("definition count = %d, want 459", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/legacy_approval_response_contract_test.go
+++ b/appserver/protocol/legacy_approval_response_contract_test.go
@@ -98,8 +98,8 @@ func TestLegacyApprovalResponsesRemainStandaloneAndNominal(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_approval_context_contract_test.go
+++ b/appserver/protocol/network_approval_context_contract_test.go
@@ -84,8 +84,8 @@ func TestNetworkApprovalContextRemainsStandalone(t *testing.T) {
 			t.Fatalf("NetworkApprovalContext unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/parsed_command_contract_test.go
+++ b/appserver/protocol/parsed_command_contract_test.go
@@ -120,8 +120,8 @@ func TestParsedCommandRemainsStandalone(t *testing.T) {
 			t.Fatalf("ParsedCommand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 458 {
-		t.Fatalf("definition count = %d, want 458", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 459 {
+		t.Fatalf("definition count = %d, want 459", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 458 {
-		t.Fatalf("definition count = %d, want 458", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 459 {
+		t.Fatalf("definition count = %d, want 459", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 458 {
-		t.Fatalf("definition count = %d, want 458", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 459 {
+		t.Fatalf("definition count = %d, want 459", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 458 {
-		t.Fatalf("definition count = %d, want 458", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 459 {
+		t.Fatalf("definition count = %d, want 459", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 458 {
-		t.Fatalf("definition count = %d, want 458", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 459 {
+		t.Fatalf("definition count = %d, want 459", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/review_decision_contract_test.go
+++ b/appserver/protocol/review_decision_contract_test.go
@@ -136,8 +136,8 @@ func TestReviewDecisionRemainsStandalone(t *testing.T) {
 			t.Fatalf("ReviewDecision unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(defs); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -107,6 +107,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "ApprovalsReviewer", Type: reflect.TypeFor[ApprovalsReviewer]()},
 		{Name: "AppBranding", Type: reflect.TypeFor[AppBranding]()},
 		{Name: "AppInfo", Type: reflect.TypeFor[AppInfo]()},
+		{Name: "AppListUpdatedNotification", Type: reflect.TypeFor[AppListUpdatedNotification]()},
 		{Name: "AppMetadata", Type: reflect.TypeFor[AppMetadata]()},
 		{Name: "AppReview", Type: reflect.TypeFor[AppReview]()},
 		{Name: "AppScreenshot", Type: reflect.TypeFor[AppScreenshot]()},
@@ -618,6 +619,11 @@ func wireSchemaDefinitions() Schema {
 		},
 	}, []string{"id", "name"})
 	schemas["AppInfo"].(Schema)["description"] = "EXPERIMENTAL - app metadata returned by app-list APIs."
+	schemas["AppListUpdatedNotification"] = closedThreadSessionParamSchema(Schema{
+		"data": Schema{"type": "array", "items": Schema{"$ref": "#/$defs/AppInfo"}},
+	}, []string{"data"})
+	schemas["AppListUpdatedNotification"].(Schema)["description"] =
+		"EXPERIMENTAL - notification emitted when the app list changes."
 	schemas["AppMetadata"] = closedThreadSessionParamSchema(Schema{
 		"review": Schema{"anyOf": []any{
 			Schema{"$ref": "#/$defs/AppReview"}, Schema{"type": "null"},

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -554,6 +554,22 @@
       ],
       "type": "object"
     },
+    "AppListUpdatedNotification": {
+      "additionalProperties": false,
+      "description": "EXPERIMENTAL - notification emitted when the app list changes.",
+      "properties": {
+        "data": {
+          "items": {
+            "$ref": "#/$defs/AppInfo"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "data"
+      ],
+      "type": "object"
+    },
     "AppMetadata": {
       "additionalProperties": false,
       "properties": {

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 458 {
-		t.Fatalf("definition count = %d, want 458", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 459 {
+		t.Fatalf("definition count = %d, want 459", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 458 {
-		t.Fatalf("definition count = %d, want 458", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 459 {
+		t.Fatalf("definition count = %d, want 459", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 458 {
-		t.Fatalf("definition count = %d, want 458", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 459 {
+		t.Fatalf("definition count = %d, want 459", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -595,6 +595,10 @@ export type AppInfo = {
   "pluginDisplayNames": Array<string>;
 };
 
+export type AppListUpdatedNotification = {
+  "data": Array<AppInfo>;
+};
+
 export type AppMetadata = {
   "categories": Array<string> | null;
   "developer": string | null;

--- a/appserver/protocol/typescript/testdata/app_list_updated_notification_contract.ts
+++ b/appserver/protocol/typescript/testdata/app_list_updated_notification_contract.ts
@@ -1,0 +1,81 @@
+import type {
+  AppInfo,
+  AppListUpdatedNotification,
+  MethodParamsByName,
+  MethodResultsByName,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+type ExpectFalse<T extends false> = T;
+
+type Contracts = [
+  Expect<Equal<AppListUpdatedNotification, { data: Array<AppInfo> }>>,
+  ExpectFalse<"app/list/updated" extends keyof MethodParamsByName ? true : false>,
+  ExpectFalse<"app/list/updated" extends keyof MethodResultsByName ? true : false>,
+];
+
+({ data: [] }) satisfies AppListUpdatedNotification;
+
+({
+  data: [{
+    id: " id ",
+    name: "",
+    description: " description ",
+    logoUrl: "not a url",
+    logoUrlDark: "",
+    iconAssets: { "": "", " icon ": " value " },
+    iconDarkAssets: {},
+    distributionChannel: " arbitrary ",
+    branding: {
+      category: " category ",
+      developer: "",
+      website: "site",
+      privacyPolicy: "privacy",
+      termsOfService: "terms",
+      isDiscoverableApp: true,
+    },
+    appMetadata: {
+      review: { status: " review " },
+      categories: ["", " category ", " category "],
+      subCategories: [],
+      seoDescription: " seo ",
+      screenshots: [],
+      developer: "dev",
+      version: "v",
+      versionId: "vid",
+      versionNotes: "notes",
+      firstPartyType: "first",
+      firstPartyRequiresInstall: false,
+      showInComposerWhenUnlinked: true,
+    },
+    labels: { "": "", " label ": " value " },
+    installUrl: " install ",
+    isAccessible: true,
+    isEnabled: false,
+    pluginDisplayNames: ["", " plugin ", " plugin "],
+  }],
+}) satisfies AppListUpdatedNotification;
+
+// @ts-expect-error data is required.
+({}) satisfies AppListUpdatedNotification;
+// @ts-expect-error data is a non-null array.
+({ data: null }) satisfies AppListUpdatedNotification;
+// @ts-expect-error data is an array.
+({ data: {} }) satisfies AppListUpdatedNotification;
+// @ts-expect-error array items are AppInfo values.
+({ data: [null] }) satisfies AppListUpdatedNotification;
+// @ts-expect-error array items are AppInfo values.
+({ data: [1] }) satisfies AppListUpdatedNotification;
+// @ts-expect-error nested canonical AppInfo requires every field.
+({ data: [{ id: "id", name: "name" }] }) satisfies AppListUpdatedNotification;
+// @ts-expect-error nested pluginDisplayNames contains only strings.
+({ data: [{ id: "id", name: "name", description: null, logoUrl: null, logoUrlDark: null, iconAssets: null, iconDarkAssets: null, distributionChannel: null, branding: null, appMetadata: null, labels: null, installUrl: null, isAccessible: false, isEnabled: true, pluginDisplayNames: [null] }] }) satisfies AppListUpdatedNotification;
+// @ts-expect-error the canonical notification is closed.
+({ data: [], future: true }) satisfies AppListUpdatedNotification;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 458 {
-		t.Fatalf("definition count = %d, want 458", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 459 {
+		t.Fatalf("definition count = %d, want 459", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary

- export exact standalone `AppListUpdatedNotification` over the existing exact `AppInfo` record
- preserve required non-null data arrays, nested serde behavior, ordering, duplicates, and closed canonical schema/TypeScript
- keep `app/list/updated` deferred, unbound, producerless, and absent from generated params/results inference

## Validation

- focused tests x30, focused race, and 100% coverage for both production functions
- full protocol suite and strict TypeScript 5.9.2
- all 59 non-Monty packages in normal and race modes
- golangci-lint, vet, tidy, deterministic generation, and configured pre-push
- all five Slang real-process workflows
- exact pinned schema/ts-rs identity and full-tree reversal to PR #218

Local Monty normal/race/coverage is skipped per project direction; hosted CI remains unchanged.