### PR TITLE
feat(protocol): add app config contract

### DIFF
--- a/appserver/protocol/account_credit_nudge_values_contract_test.go
+++ b/appserver/protocol/account_credit_nudge_values_contract_test.go
@@ -119,8 +119,8 @@ func TestAccountCreditNudgeValuesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/sendAddCreditsNudgeEmail = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/account_login_completed_notification_contract_test.go
+++ b/appserver/protocol/account_login_completed_notification_contract_test.go
@@ -88,8 +88,8 @@ func TestAccountLoginCompletedNotificationRemainsStandaloneAndDeferred(t *testin
 	if !found {
 		t.Fatal("account/login/completed method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/account_token_usage_contract_test.go
+++ b/appserver/protocol/account_token_usage_contract_test.go
@@ -146,8 +146,8 @@ func TestAccountTokenUsageRecordsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/usage/read = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(defs); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_config_contract_test.go
+++ b/appserver/protocol/app_config_contract_test.go
@@ -1,0 +1,145 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestAppConfigSchemaIsExact(t *testing.T) {
+	want := Schema{
+		"type": "object",
+		"properties": Schema{
+			"approvals_reviewer":          nullableSchemaRef("ApprovalsReviewer"),
+			"default_tools_approval_mode": nullableSchemaRef("AppToolApproval"),
+			"default_tools_enabled":       Schema{"type": []any{"boolean", "null"}},
+			"destructive_enabled":         Schema{"type": []any{"boolean", "null"}},
+			"enabled":                     Schema{"default": true, "type": "boolean"},
+			"open_world_enabled":          Schema{"type": []any{"boolean", "null"}},
+			"tools":                       nullableSchemaRef("AppToolsConfig"),
+		},
+	}
+	got := JSONSchema()["$defs"].(Schema)["AppConfig"]
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("AppConfig = %#v, want %#v", got, want)
+	}
+}
+
+func TestAppConfigAcceptsSerdeWireForms(t *testing.T) {
+	for _, tc := range []struct {
+		input string
+		want  string
+	}{
+		{
+			`{}`,
+			`{"approvals_reviewer":null,"default_tools_approval_mode":null,"default_tools_enabled":null,"destructive_enabled":null,"enabled":true,"open_world_enabled":null,"tools":null}`,
+		},
+		{
+			`{"enabled":false,"approvals_reviewer":"guardian_subagent","destructive_enabled":true,"open_world_enabled":false,"default_tools_approval_mode":"writes","default_tools_enabled":true,"tools":{"repos/list":{"enabled":false,"approval_mode":"prompt"}}}`,
+			`{"approvals_reviewer":"guardian_subagent","default_tools_approval_mode":"writes","default_tools_enabled":true,"destructive_enabled":true,"enabled":false,"open_world_enabled":false,"tools":{"repos/list":{"approval_mode":"prompt","enabled":false}}}`,
+		},
+		{
+			`{"future":1,"future":2,"enabled":true,"approvals_reviewer":null,"destructive_enabled":null,"open_world_enabled":null,"default_tools_approval_mode":null,"default_tools_enabled":null,"tools":null}`,
+			`{"approvals_reviewer":null,"default_tools_approval_mode":null,"default_tools_enabled":null,"destructive_enabled":null,"enabled":true,"open_world_enabled":null,"tools":null}`,
+		},
+		{
+			`{"tools":{"":{"future":true}," ":{"enabled":true},"duplicate":{"enabled":false},"duplicate":{"approval_mode":"approve"}}}`,
+			`{"approvals_reviewer":null,"default_tools_approval_mode":null,"default_tools_enabled":null,"destructive_enabled":null,"enabled":true,"open_world_enabled":null,"tools":{"":{"approval_mode":null,"enabled":null}," ":{"approval_mode":null,"enabled":true},"duplicate":{"approval_mode":"approve","enabled":null}}}`,
+		},
+	} {
+		var value AppConfig
+		if err := json.Unmarshal([]byte(tc.input), &value); err != nil {
+			t.Errorf("unmarshal %s: %v", tc.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(value)
+		if err != nil || string(encoded) != tc.want {
+			t.Errorf("round trip %s = %s, %v; want %s", tc.input, encoded, err, tc.want)
+		}
+	}
+}
+
+func TestAppConfigRejectsMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`,
+		`{"enabled":null}`, `{"enabled":0}`, `{"enabled":"true"}`,
+		`{"approvals_reviewer":"other"}`, `{"approvals_reviewer":true}`,
+		`{"destructive_enabled":0}`, `{"open_world_enabled":"false"}`,
+		`{"default_tools_approval_mode":"other"}`, `{"default_tools_approval_mode":true}`,
+		`{"default_tools_enabled":0}`, `{"tools":[]}`, `{"tools":{"tool":null}}`,
+		`{"tools":{"tool":{"enabled":0}}}`, `{"tools":{"tool":{"approval_mode":"other"}}}`,
+		`{"enabled":true,"enabled":false}`,
+		`{"approvals_reviewer":null,"approvals_reviewer":"user"}`,
+		`{"tools":null,"tools":{}}`, `{} {}`, `{} x`,
+	} {
+		assertJSONRejects[AppConfig](t, input)
+	}
+}
+
+func TestAppConfigNilReceiverAndInvalidMarshalFailClosed(t *testing.T) {
+	var config *AppConfig
+	if err := config.UnmarshalJSON([]byte(`{}`)); err == nil {
+		t.Fatal("nil AppConfig receiver succeeded")
+	}
+	invalidReviewer := ApprovalsReviewer("other")
+	if _, err := json.Marshal(AppConfig{Enabled: true, ApprovalsReviewer: &invalidReviewer}); err == nil {
+		t.Fatal("AppConfig with invalid reviewer marshaled")
+	}
+	invalidApproval := AppToolApproval("other")
+	if _, err := json.Marshal(AppConfig{Enabled: true, DefaultToolsApprovalMode: &invalidApproval}); err == nil {
+		t.Fatal("AppConfig with invalid approval mode marshaled")
+	}
+	if _, err := json.Marshal(AppConfig{Enabled: true, Tools: &AppToolsConfig{Tools: map[string]AppToolConfig{
+		"tool": {ApprovalMode: &invalidApproval},
+	}}}); err == nil {
+		t.Fatal("AppConfig with invalid nested tool config marshaled")
+	}
+}
+
+func TestAppConfigRemainsStandaloneAndUnbound(t *testing.T) {
+	for _, binding := range WireTypeBindings() {
+		if slices.Contains(binding.Params, "AppConfig") || slices.Contains(binding.Result, "AppConfig") {
+			t.Fatalf("AppConfig unexpectedly bound to %s", binding.Method)
+		}
+	}
+	for _, binding := range ItemPayloadBindings() {
+		if binding.Type == "AppConfig" {
+			t.Fatalf("AppConfig unexpectedly bound to item %s", binding.Kind)
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestAppConfigTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	want := "export type AppConfig = {\n" +
+		"  \"approvals_reviewer\": ApprovalsReviewer | null;\n" +
+		"  \"default_tools_approval_mode\": AppToolApproval | null;\n" +
+		"  \"default_tools_enabled\": boolean | null;\n" +
+		"  \"destructive_enabled\": boolean | null;\n" +
+		"  \"enabled\": boolean;\n" +
+		"  \"open_world_enabled\": boolean | null;\n" +
+		"  \"tools\": AppToolsConfig | null;\n" +
+		"};"
+	if !strings.Contains(string(generated), want) {
+		t.Fatalf("generated TypeScript missing %q", want)
+	}
+}
+
+var (
+	_ json.Marshaler   = AppConfig{}
+	_ json.Unmarshaler = (*AppConfig)(nil)
+)

--- a/appserver/protocol/app_config_types.go
+++ b/appserver/protocol/app_config_types.go
@@ -1,0 +1,117 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// AppConfig is exact standalone configuration data for one app.
+// Policy interpretation, persistence, and app-tool execution remain deferred.
+type AppConfig struct {
+	Enabled                  bool               `json:"enabled"`
+	ApprovalsReviewer        *ApprovalsReviewer `json:"approvals_reviewer,omitempty"`
+	DestructiveEnabled       *bool              `json:"destructive_enabled,omitempty"`
+	OpenWorldEnabled         *bool              `json:"open_world_enabled,omitempty"`
+	DefaultToolsApprovalMode *AppToolApproval   `json:"default_tools_approval_mode,omitempty"`
+	DefaultToolsEnabled      *bool              `json:"default_tools_enabled,omitempty"`
+	Tools                    *AppToolsConfig    `json:"tools,omitempty"`
+}
+
+func (c AppConfig) MarshalJSON() ([]byte, error) {
+	return json.Marshal(map[string]any{
+		"enabled":                     c.Enabled,
+		"approvals_reviewer":          c.ApprovalsReviewer,
+		"destructive_enabled":         c.DestructiveEnabled,
+		"open_world_enabled":          c.OpenWorldEnabled,
+		"default_tools_approval_mode": c.DefaultToolsApprovalMode,
+		"default_tools_enabled":       c.DefaultToolsEnabled,
+		"tools":                       c.Tools,
+	})
+}
+
+func (c *AppConfig) UnmarshalJSON(data []byte) error {
+	if c == nil {
+		return errors.New("decode app config into nil receiver")
+	}
+	const objectName = "app config"
+	payload, err := decodeRustSerdeObject(
+		data,
+		objectName,
+		"enabled",
+		"approvals_reviewer",
+		"destructive_enabled",
+		"open_world_enabled",
+		"default_tools_approval_mode",
+		"default_tools_enabled",
+		"tools",
+	)
+	if err != nil {
+		return err
+	}
+	enabled, err := decodeDefaultEnabledAppConfigBool(payload)
+	if err != nil {
+		return err
+	}
+	approvalsReviewer, err := decodeOptionalNullableConfigValue[ApprovalsReviewer](
+		payload, objectName, "approvals_reviewer",
+	)
+	if err != nil {
+		return err
+	}
+	destructiveEnabled, err := decodeOptionalNullableConfigValue[bool](
+		payload, objectName, "destructive_enabled",
+	)
+	if err != nil {
+		return err
+	}
+	openWorldEnabled, err := decodeOptionalNullableConfigValue[bool](
+		payload, objectName, "open_world_enabled",
+	)
+	if err != nil {
+		return err
+	}
+	defaultToolsApprovalMode, err := decodeOptionalNullableConfigValue[AppToolApproval](
+		payload, objectName, "default_tools_approval_mode",
+	)
+	if err != nil {
+		return err
+	}
+	defaultToolsEnabled, err := decodeOptionalNullableConfigValue[bool](
+		payload, objectName, "default_tools_enabled",
+	)
+	if err != nil {
+		return err
+	}
+	tools, err := decodeOptionalNullableConfigValue[AppToolsConfig](payload, objectName, "tools")
+	if err != nil {
+		return err
+	}
+	*c = AppConfig{
+		Enabled: enabled, ApprovalsReviewer: approvalsReviewer,
+		DestructiveEnabled: destructiveEnabled, OpenWorldEnabled: openWorldEnabled,
+		DefaultToolsApprovalMode: defaultToolsApprovalMode,
+		DefaultToolsEnabled:      defaultToolsEnabled, Tools: tools,
+	}
+	return nil
+}
+
+func decodeDefaultEnabledAppConfigBool(payload map[string]json.RawMessage) (bool, error) {
+	raw, ok := payload["enabled"]
+	if !ok {
+		return true, nil
+	}
+	if isJSONNull(raw) {
+		return false, errors.New("decode app config enabled: value cannot be null")
+	}
+	var enabled bool
+	if err := json.Unmarshal(raw, &enabled); err != nil {
+		return false, fmt.Errorf("decode app config enabled: %w", err)
+	}
+	return enabled, nil
+}
+
+var (
+	_ json.Marshaler   = AppConfig{}
+	_ json.Unmarshaler = (*AppConfig)(nil)
+)

--- a/appserver/protocol/app_info_contract_test.go
+++ b/appserver/protocol/app_info_contract_test.go
@@ -131,8 +131,8 @@ func TestAppInfoRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_list_updated_notification_contract_test.go
+++ b/appserver/protocol/app_list_updated_notification_contract_test.go
@@ -105,8 +105,8 @@ func TestAppListUpdatedNotificationRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceServerNotification || method.State != MethodDeferredStub {
 		t.Fatalf("app/list/updated = %#v, %v; want deferred server notification", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_metadata_contract_test.go
+++ b/appserver/protocol/app_metadata_contract_test.go
@@ -107,8 +107,8 @@ func TestAppMetadataRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_metadata_leaf_contract_test.go
+++ b/appserver/protocol/app_metadata_leaf_contract_test.go
@@ -157,8 +157,8 @@ func TestAppMetadataLeavesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_summary_contract_test.go
+++ b/appserver/protocol/app_summary_contract_test.go
@@ -87,8 +87,8 @@ func TestAppSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppSummary unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_template_summary_contract_test.go
+++ b/appserver/protocol/app_template_summary_contract_test.go
@@ -107,8 +107,8 @@ func TestAppTemplateSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppTemplateSummary unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_template_unavailable_reason_contract_test.go
+++ b/appserver/protocol/app_template_unavailable_reason_contract_test.go
@@ -71,8 +71,8 @@ func TestAppTemplateUnavailableReasonRemainsStandalone(t *testing.T) {
 			t.Fatalf("AppTemplateUnavailableReason unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_tool_approval_contract_test.go
+++ b/appserver/protocol/app_tool_approval_contract_test.go
@@ -73,8 +73,8 @@ func TestAppToolApprovalRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppToolApproval unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_tools_config_contract_test.go
+++ b/appserver/protocol/app_tools_config_contract_test.go
@@ -140,8 +140,8 @@ func TestAppToolConfigsRemainStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/apply_patch_approval_params_contract_test.go
+++ b/appserver/protocol/apply_patch_approval_params_contract_test.go
@@ -139,8 +139,8 @@ func TestApplyPatchApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ApplyPatchApprovalParams unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(defs); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(defs); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/attestation_contract_test.go
+++ b/appserver/protocol/attestation_contract_test.go
@@ -133,8 +133,8 @@ func TestAttestationContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("attestation/generate = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
+++ b/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
@@ -179,8 +179,8 @@ func TestChatgptAuthTokensRefreshRemainsStandaloneAndDeferred(t *testing.T) {
 	if !found {
 		t.Fatal("refresh method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/exec_command_approval_params_contract_test.go
+++ b/appserver/protocol/exec_command_approval_params_contract_test.go
@@ -137,8 +137,8 @@ func TestExecCommandApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ExecCommandApprovalParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(defs); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,8 +217,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,8 +203,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -260,8 +260,8 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,8 +244,8 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -162,8 +162,8 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -175,8 +175,8 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_contract_test.go
+++ b/appserver/protocol/file_change_contract_test.go
@@ -108,8 +108,8 @@ func TestFileChangeRemainsStandalone(t *testing.T) {
 			t.Fatalf("FileChange unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_output_delta_notification_contract_test.go
+++ b/appserver/protocol/file_change_output_delta_notification_contract_test.go
@@ -100,8 +100,8 @@ func TestFileChangeOutputDeltaNotificationRemainsDeprecatedAndStandalone(t *test
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("item/fileChange/outputDelta = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -381,8 +381,8 @@ func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_action_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_action_contract_test.go
@@ -226,8 +226,8 @@ func TestGuardianApprovalReviewActionRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReviewAction unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
@@ -164,8 +164,8 @@ func TestGuardianApprovalReviewCompletedNotificationRemainsStandalone(t *testing
 			t.Fatalf("completed notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_contract_test.go
@@ -139,8 +139,8 @@ func TestGuardianApprovalReviewRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReview unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
@@ -175,8 +175,8 @@ func TestGuardianApprovalReviewStartedNotificationRemainsStandalone(t *testing.T
 			t.Fatalf("started notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_enum_foundation_contract_test.go
+++ b/appserver/protocol/guardian_enum_foundation_contract_test.go
@@ -89,8 +89,8 @@ func TestGuardianEnumFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_metadata_list_contract_test.go
+++ b/appserver/protocol/hook_metadata_list_contract_test.go
@@ -352,8 +352,8 @@ func TestHookMetadataListContractsStayStandalone(t *testing.T) {
 			t.Errorf("standalone definition %s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Errorf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Errorf("definition count = %d, want 466", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 {
 		t.Errorf("wire binding count = %d, want 59", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_run_notification_contract_test.go
+++ b/appserver/protocol/hook_run_notification_contract_test.go
@@ -297,8 +297,8 @@ func TestHookRunNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("surface changed: %d methods, %d wire bindings, %d item bindings", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/hook_value_foundation_contract_test.go
+++ b/appserver/protocol/hook_value_foundation_contract_test.go
@@ -167,8 +167,8 @@ func TestHookValueFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 465 {
-		t.Fatalf("definition count = %d, want 465", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 466 {
+		t.Fatalf("definition count = %d, want 466", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/legacy_approval_response_contract_test.go
+++ b/appserver/protocol/legacy_approval_response_contract_test.go
@@ -98,8 +98,8 @@ func TestLegacyApprovalResponsesRemainStandaloneAndNominal(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_approval_context_contract_test.go
+++ b/appserver/protocol/network_approval_context_contract_test.go
@@ -84,8 +84,8 @@ func TestNetworkApprovalContextRemainsStandalone(t *testing.T) {
 			t.Fatalf("NetworkApprovalContext unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/parsed_command_contract_test.go
+++ b/appserver/protocol/parsed_command_contract_test.go
@@ -120,8 +120,8 @@ func TestParsedCommandRemainsStandalone(t *testing.T) {
 			t.Fatalf("ParsedCommand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 465 {
-		t.Fatalf("definition count = %d, want 465", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 466 {
+		t.Fatalf("definition count = %d, want 466", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 465 {
-		t.Fatalf("definition count = %d, want 465", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 466 {
+		t.Fatalf("definition count = %d, want 466", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 465 {
-		t.Fatalf("definition count = %d, want 465", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 466 {
+		t.Fatalf("definition count = %d, want 466", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 465 {
-		t.Fatalf("definition count = %d, want 465", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 466 {
+		t.Fatalf("definition count = %d, want 466", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 465 {
-		t.Fatalf("definition count = %d, want 465", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 466 {
+		t.Fatalf("definition count = %d, want 466", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/review_decision_contract_test.go
+++ b/appserver/protocol/review_decision_contract_test.go
@@ -136,8 +136,8 @@ func TestReviewDecisionRemainsStandalone(t *testing.T) {
 			t.Fatalf("ReviewDecision unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(defs); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -106,6 +106,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "ApprovalRespondResult", Type: reflect.TypeFor[ApprovalRespondResult]()},
 		{Name: "ApprovalsReviewer", Type: reflect.TypeFor[ApprovalsReviewer]()},
 		{Name: "AppBranding", Type: reflect.TypeFor[AppBranding]()},
+		{Name: "AppConfig", Type: reflect.TypeFor[AppConfig]()},
 		{Name: "AppInfo", Type: reflect.TypeFor[AppInfo]()},
 		{Name: "AppListUpdatedNotification", Type: reflect.TypeFor[AppListUpdatedNotification]()},
 		{Name: "AppMetadata", Type: reflect.TypeFor[AppMetadata]()},
@@ -703,6 +704,18 @@ func wireSchemaDefinitions() Schema {
 		},
 	}
 	schemas["AppToolsConfig"] = Schema{"type": "object"}
+	schemas["AppConfig"] = Schema{
+		"type": "object",
+		"properties": Schema{
+			"approvals_reviewer":          nullableSchemaRef("ApprovalsReviewer"),
+			"default_tools_approval_mode": nullableSchemaRef("AppToolApproval"),
+			"default_tools_enabled":       Schema{"type": []any{"boolean", "null"}},
+			"destructive_enabled":         Schema{"type": []any{"boolean", "null"}},
+			"enabled":                     Schema{"default": true, "type": "boolean"},
+			"open_world_enabled":          Schema{"type": []any{"boolean", "null"}},
+			"tools":                       nullableSchemaRef("AppToolsConfig"),
+		},
+	}
 	schemas["AddCreditsNudgeCreditType"] = stringEnumSchema(
 		string(AddCreditsNudgeCreditTypeCredits),
 		string(AddCreditsNudgeCreditTypeUsageLimit),

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -412,6 +412,63 @@
       ],
       "type": "object"
     },
+    "AppConfig": {
+      "properties": {
+        "approvals_reviewer": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ApprovalsReviewer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "default_tools_approval_mode": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AppToolApproval"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "default_tools_enabled": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "destructive_enabled": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "enabled": {
+          "default": true,
+          "type": "boolean"
+        },
+        "open_world_enabled": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "tools": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AppToolsConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
     "AppInfo": {
       "additionalProperties": false,
       "description": "EXPERIMENTAL - app metadata returned by app-list APIs.",

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 465 {
-		t.Fatalf("definition count = %d, want 465", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 466 {
+		t.Fatalf("definition count = %d, want 466", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 465 {
-		t.Fatalf("definition count = %d, want 465", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 466 {
+		t.Fatalf("definition count = %d, want 466", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 465 {
-		t.Fatalf("definition count = %d, want 465", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 466 {
+		t.Fatalf("definition count = %d, want 466", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -40,7 +40,7 @@ func MarshalTypeScript() ([]byte, error) {
 	for _, name := range names {
 		definition := defs[name]
 		if name == "AccountLoginCompletedNotification" || name == "AccountTokenUsageSummary" ||
-			name == "AppBranding" || name == "AppInfo" || name == "AppMetadata" || name == "AppScreenshot" ||
+			name == "AppBranding" || name == "AppConfig" || name == "AppInfo" || name == "AppMetadata" || name == "AppScreenshot" ||
 			name == "AppSummary" || name == "AppTemplateSummary" ||
 			name == "AppToolConfig" ||
 			name == "ApplyPatchApprovalParams" ||
@@ -76,6 +76,12 @@ func MarshalTypeScript() ([]byte, error) {
 				schema["required"] = []string{
 					"category", "developer", "website", "privacyPolicy", "termsOfService", "isDiscoverableApp",
 				}
+			case "AppConfig":
+				schema["required"] = []string{
+					"enabled", "approvals_reviewer", "destructive_enabled", "open_world_enabled",
+					"default_tools_approval_mode", "default_tools_enabled", "tools",
+				}
+				schema["x-gollem-typescript-ignore-additional-properties"] = true
 			case "AppInfo":
 				schema["required"] = []string{
 					"id", "name", "description", "logoUrl", "logoUrlDark", "iconAssets",
@@ -190,6 +196,13 @@ func MarshalTypeScript() ([]byte, error) {
 		if name == "AppToolConfig" {
 			definition = typeScriptDefinitionWithPropertySchemas(definition, Schema{
 				"enabled": nullableBooleanSchema(),
+			})
+		}
+		if name == "AppConfig" {
+			definition = typeScriptDefinitionWithPropertySchemas(definition, Schema{
+				"default_tools_enabled": nullableBooleanSchema(),
+				"destructive_enabled":   nullableBooleanSchema(),
+				"open_world_enabled":    nullableBooleanSchema(),
 			})
 		}
 		if name == "AppToolsConfig" {

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -577,6 +577,16 @@ export type AppBranding = {
   "website": string | null;
 };
 
+export type AppConfig = {
+  "approvals_reviewer": ApprovalsReviewer | null;
+  "default_tools_approval_mode": AppToolApproval | null;
+  "default_tools_enabled": boolean | null;
+  "destructive_enabled": boolean | null;
+  "enabled": boolean;
+  "open_world_enabled": boolean | null;
+  "tools": AppToolsConfig | null;
+};
+
 export type AppInfo = {
   "appMetadata": AppMetadata | null;
   "branding": AppBranding | null;

--- a/appserver/protocol/typescript/testdata/app_config_contract.ts
+++ b/appserver/protocol/typescript/testdata/app_config_contract.ts
@@ -1,0 +1,63 @@
+import type {
+  AppConfig,
+  AppToolApproval,
+  AppToolsConfig,
+  ApprovalsReviewer,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2) ? true : false;
+type Expect<T extends true> = T;
+
+type Contract = Expect<Equal<AppConfig, {
+  approvals_reviewer: ApprovalsReviewer | null;
+  default_tools_approval_mode: AppToolApproval | null;
+  default_tools_enabled: boolean | null;
+  destructive_enabled: boolean | null;
+  enabled: boolean;
+  open_world_enabled: boolean | null;
+  tools: AppToolsConfig | null;
+}>>;
+
+({
+  approvals_reviewer: null,
+  default_tools_approval_mode: null,
+  default_tools_enabled: null,
+  destructive_enabled: null,
+  enabled: true,
+  open_world_enabled: null,
+  tools: null,
+}) satisfies AppConfig;
+
+({
+  approvals_reviewer: "guardian_subagent",
+  default_tools_approval_mode: "writes",
+  default_tools_enabled: true,
+  destructive_enabled: true,
+  enabled: false,
+  open_world_enabled: false,
+  tools: {
+    "": { approval_mode: null, enabled: null },
+    "repos/list": { approval_mode: "prompt", enabled: false },
+  },
+}) satisfies AppConfig;
+
+// @ts-expect-error canonical AppConfig requires every field.
+({ enabled: true }) satisfies AppConfig;
+// @ts-expect-error enabled is required and non-null.
+({ approvals_reviewer: null, default_tools_approval_mode: null, default_tools_enabled: null, destructive_enabled: null, open_world_enabled: null, tools: null }) satisfies AppConfig;
+// @ts-expect-error enabled is non-null.
+({ approvals_reviewer: null, default_tools_approval_mode: null, default_tools_enabled: null, destructive_enabled: null, enabled: null, open_world_enabled: null, tools: null }) satisfies AppConfig;
+// @ts-expect-error reviewers are closed.
+({ approvals_reviewer: "other", default_tools_approval_mode: null, default_tools_enabled: null, destructive_enabled: null, enabled: true, open_world_enabled: null, tools: null }) satisfies AppConfig;
+// @ts-expect-error approval modes are closed.
+({ approvals_reviewer: null, default_tools_approval_mode: "other", default_tools_enabled: null, destructive_enabled: null, enabled: true, open_world_enabled: null, tools: null }) satisfies AppConfig;
+// @ts-expect-error default_tools_enabled is boolean or null.
+({ approvals_reviewer: null, default_tools_approval_mode: null, default_tools_enabled: 1, destructive_enabled: null, enabled: true, open_world_enabled: null, tools: null }) satisfies AppConfig;
+// @ts-expect-error nested tool values are exact.
+({ approvals_reviewer: null, default_tools_approval_mode: null, default_tools_enabled: null, destructive_enabled: null, enabled: true, open_world_enabled: null, tools: { tool: { enabled: true } } }) satisfies AppConfig;
+// @ts-expect-error canonical AppConfig is closed.
+({ approvals_reviewer: null, default_tools_approval_mode: null, default_tools_enabled: null, destructive_enabled: null, enabled: true, open_world_enabled: null, tools: null, future: true }) satisfies AppConfig;
+
+void (true satisfies Contract);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 465 {
-		t.Fatalf("definition count = %d, want 465", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
+		t.Fatalf("definition count = %d, want 466", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- add exact standalone `AppConfig` JSON/serde contract
- expose the pinned schema and TypeScript shape
- add strict Go and TypeScript contract coverage

## Verification
- `go test ./appserver/protocol -run "^TestAppConfig" -count=30`
- `go test -race ./appserver/protocol -run "^TestAppConfig" -count=1`
- focused statement coverage: all new functions 100%
- all non-Monty Go tests and race tests
- `tsc --project appserver/protocol/typescript/tsconfig.json`
- `golangci-lint run ./...`
- `go vet ./...`
- `go mod tidy && go mod verify`
- repository pre-push hook (Monty race skipped via `hooks.skipMontyRace=true`)
