### PR TITLE
feat(protocol): add apps config contracts

### DIFF
--- a/appserver/protocol/account_credit_nudge_values_contract_test.go
+++ b/appserver/protocol/account_credit_nudge_values_contract_test.go
@@ -119,8 +119,8 @@ func TestAccountCreditNudgeValuesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/sendAddCreditsNudgeEmail = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/account_login_completed_notification_contract_test.go
+++ b/appserver/protocol/account_login_completed_notification_contract_test.go
@@ -88,8 +88,8 @@ func TestAccountLoginCompletedNotificationRemainsStandaloneAndDeferred(t *testin
 	if !found {
 		t.Fatal("account/login/completed method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/account_token_usage_contract_test.go
+++ b/appserver/protocol/account_token_usage_contract_test.go
@@ -146,8 +146,8 @@ func TestAccountTokenUsageRecordsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/usage/read = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(defs); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_config_contract_test.go
+++ b/appserver/protocol/app_config_contract_test.go
@@ -109,8 +109,8 @@ func TestAppConfigRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppConfig unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_config_types.go
+++ b/appserver/protocol/app_config_types.go
@@ -3,7 +3,6 @@ package protocol
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 )
 
 // AppConfig is exact standalone configuration data for one app.
@@ -97,18 +96,7 @@ func (c *AppConfig) UnmarshalJSON(data []byte) error {
 }
 
 func decodeDefaultEnabledAppConfigBool(payload map[string]json.RawMessage) (bool, error) {
-	raw, ok := payload["enabled"]
-	if !ok {
-		return true, nil
-	}
-	if isJSONNull(raw) {
-		return false, errors.New("decode app config enabled: value cannot be null")
-	}
-	var enabled bool
-	if err := json.Unmarshal(raw, &enabled); err != nil {
-		return false, fmt.Errorf("decode app config enabled: %w", err)
-	}
-	return enabled, nil
+	return decodeDefaultTrueConfigBool(payload, "app config", "enabled")
 }
 
 var (

--- a/appserver/protocol/app_info_contract_test.go
+++ b/appserver/protocol/app_info_contract_test.go
@@ -131,8 +131,8 @@ func TestAppInfoRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_list_updated_notification_contract_test.go
+++ b/appserver/protocol/app_list_updated_notification_contract_test.go
@@ -105,8 +105,8 @@ func TestAppListUpdatedNotificationRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceServerNotification || method.State != MethodDeferredStub {
 		t.Fatalf("app/list/updated = %#v, %v; want deferred server notification", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_metadata_contract_test.go
+++ b/appserver/protocol/app_metadata_contract_test.go
@@ -107,8 +107,8 @@ func TestAppMetadataRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_metadata_leaf_contract_test.go
+++ b/appserver/protocol/app_metadata_leaf_contract_test.go
@@ -157,8 +157,8 @@ func TestAppMetadataLeavesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_summary_contract_test.go
+++ b/appserver/protocol/app_summary_contract_test.go
@@ -87,8 +87,8 @@ func TestAppSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppSummary unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_template_summary_contract_test.go
+++ b/appserver/protocol/app_template_summary_contract_test.go
@@ -107,8 +107,8 @@ func TestAppTemplateSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppTemplateSummary unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_template_unavailable_reason_contract_test.go
+++ b/appserver/protocol/app_template_unavailable_reason_contract_test.go
@@ -71,8 +71,8 @@ func TestAppTemplateUnavailableReasonRemainsStandalone(t *testing.T) {
 			t.Fatalf("AppTemplateUnavailableReason unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_tool_approval_contract_test.go
+++ b/appserver/protocol/app_tool_approval_contract_test.go
@@ -73,8 +73,8 @@ func TestAppToolApprovalRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppToolApproval unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_tools_config_contract_test.go
+++ b/appserver/protocol/app_tools_config_contract_test.go
@@ -140,8 +140,8 @@ func TestAppToolConfigsRemainStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/apply_patch_approval_params_contract_test.go
+++ b/appserver/protocol/apply_patch_approval_params_contract_test.go
@@ -139,8 +139,8 @@ func TestApplyPatchApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ApplyPatchApprovalParams unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(defs); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(defs); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/apps_config_contract_test.go
+++ b/appserver/protocol/apps_config_contract_test.go
@@ -1,0 +1,229 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestAppsConfigSchemasAreExact(t *testing.T) {
+	wantDefault := Schema{
+		"type": "object",
+		"properties": Schema{
+			"approvals_reviewer":          nullableSchemaRef("ApprovalsReviewer"),
+			"default_tools_approval_mode": nullableSchemaRef("AppToolApproval"),
+			"destructive_enabled":         Schema{"default": true, "type": "boolean"},
+			"enabled":                     Schema{"default": true, "type": "boolean"},
+			"open_world_enabled":          Schema{"default": true, "type": "boolean"},
+		},
+	}
+	wantApps := Schema{
+		"type": "object",
+		"properties": Schema{
+			"_default": Schema{
+				"anyOf":   []any{Schema{"$ref": "#/$defs/AppsDefaultConfig"}, Schema{"type": "null"}},
+				"default": nil,
+			},
+		},
+	}
+	definitions := JSONSchema()["$defs"].(Schema)
+	for name, want := range map[string]Schema{
+		"AppsDefaultConfig": wantDefault,
+		"AppsConfig":        wantApps,
+	} {
+		if got := definitions[name]; !reflect.DeepEqual(got, want) {
+			t.Errorf("%s = %#v, want %#v", name, got, want)
+		}
+	}
+}
+
+func TestAppsDefaultConfigAcceptsSerdeWireForms(t *testing.T) {
+	for _, tc := range []struct {
+		input string
+		want  string
+	}{
+		{
+			`{}`,
+			`{"approvals_reviewer":null,"default_tools_approval_mode":null,"destructive_enabled":true,"enabled":true,"open_world_enabled":true}`,
+		},
+		{
+			`{"enabled":false,"approvals_reviewer":"auto_review","destructive_enabled":false,"open_world_enabled":false,"default_tools_approval_mode":"prompt"}`,
+			`{"approvals_reviewer":"auto_review","default_tools_approval_mode":"prompt","destructive_enabled":false,"enabled":false,"open_world_enabled":false}`,
+		},
+		{
+			`{"future":1,"future":2,"approvals_reviewer":null,"default_tools_approval_mode":null}`,
+			`{"approvals_reviewer":null,"default_tools_approval_mode":null,"destructive_enabled":true,"enabled":true,"open_world_enabled":true}`,
+		},
+	} {
+		var value AppsDefaultConfig
+		if err := json.Unmarshal([]byte(tc.input), &value); err != nil {
+			t.Errorf("unmarshal %s: %v", tc.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(value)
+		if err != nil || string(encoded) != tc.want {
+			t.Errorf("round trip %s = %s, %v; want %s", tc.input, encoded, err, tc.want)
+		}
+	}
+}
+
+func TestAppsConfigAcceptsFlattenedMapWireForms(t *testing.T) {
+	for _, tc := range []struct {
+		input string
+		want  string
+	}{
+		{`{}`, `{"_default":null}`},
+		{`{"_default":null}`, `{"_default":null}`},
+		{
+			`{"_default":{"enabled":false},"":{"enabled":false}," ":{},"repos":{"tools":{"search":{"enabled":true}}}}`,
+			`{"_default":{"approvals_reviewer":null,"default_tools_approval_mode":null,"destructive_enabled":true,"enabled":false,"open_world_enabled":true},"":{"approvals_reviewer":null,"default_tools_approval_mode":null,"default_tools_enabled":null,"destructive_enabled":null,"enabled":false,"open_world_enabled":null,"tools":null}," ":{"approvals_reviewer":null,"default_tools_approval_mode":null,"default_tools_enabled":null,"destructive_enabled":null,"enabled":true,"open_world_enabled":null,"tools":null},"repos":{"approvals_reviewer":null,"default_tools_approval_mode":null,"default_tools_enabled":null,"destructive_enabled":null,"enabled":true,"open_world_enabled":null,"tools":{"search":{"approval_mode":null,"enabled":true}}}}`,
+		},
+		{
+			`{"app":{"enabled":false},"app":{"enabled":true,"approvals_reviewer":"user"}}`,
+			`{"_default":null,"app":{"approvals_reviewer":"user","default_tools_approval_mode":null,"default_tools_enabled":null,"destructive_enabled":null,"enabled":true,"open_world_enabled":null,"tools":null}}`,
+		},
+	} {
+		var value AppsConfig
+		if err := json.Unmarshal([]byte(tc.input), &value); err != nil {
+			t.Errorf("unmarshal %s: %v", tc.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(value)
+		if err != nil || string(encoded) != tc.want {
+			t.Errorf("round trip %s = %s, %v; want %s", tc.input, encoded, err, tc.want)
+		}
+	}
+}
+
+func TestAppsConfigsRejectMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`,
+		`{"enabled":null}`, `{"destructive_enabled":null}`, `{"open_world_enabled":null}`,
+		`{"enabled":0}`, `{"destructive_enabled":"true"}`, `{"open_world_enabled":0}`,
+		`{"approvals_reviewer":"other"}`, `{"default_tools_approval_mode":"other"}`,
+		`{"enabled":true,"enabled":false}`,
+		`{"approvals_reviewer":null,"approvals_reviewer":"user"}`, `{} {}`, `{} x`,
+	} {
+		assertJSONRejects[AppsDefaultConfig](t, input)
+	}
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`,
+		`{"_default":[]}`, `{"_default":{"enabled":null}}`,
+		`{"_default":null,"_default":null}`, `{"app":null}`, `{"app":[]}`,
+		`{"app":{"enabled":null}}`, `{"app":{"approvals_reviewer":"other"}}`,
+		`{"app":{"enabled":true,"enabled":false}}`, `{} {}`, `{} x`,
+		`{"app":{"enabled":null},"app":{"enabled":true}}`,
+	} {
+		assertJSONRejects[AppsConfig](t, input)
+	}
+}
+
+func TestAppsConfigsNilReceiversAndInvalidMarshal(t *testing.T) {
+	var defaults *AppsDefaultConfig
+	if err := defaults.UnmarshalJSON([]byte(`{}`)); err == nil {
+		t.Fatal("nil AppsDefaultConfig receiver succeeded")
+	}
+	var apps *AppsConfig
+	if err := apps.UnmarshalJSON([]byte(`{}`)); err == nil {
+		t.Fatal("nil AppsConfig receiver succeeded")
+	}
+	invalidReviewer := ApprovalsReviewer("other")
+	if _, err := json.Marshal(AppsDefaultConfig{ApprovalsReviewer: &invalidReviewer}); err == nil {
+		t.Fatal("AppsDefaultConfig with invalid reviewer marshaled")
+	}
+	invalidApproval := AppToolApproval("other")
+	if _, err := json.Marshal(AppsDefaultConfig{DefaultToolsApprovalMode: &invalidApproval}); err == nil {
+		t.Fatal("AppsDefaultConfig with invalid approval mode marshaled")
+	}
+	if _, err := json.Marshal(AppsConfig{Apps: map[string]AppConfig{
+		"app": {ApprovalsReviewer: &invalidReviewer},
+	}}); err == nil {
+		t.Fatal("AppsConfig with invalid nested app marshaled")
+	}
+	if _, err := json.Marshal(AppsConfig{Default: &AppsDefaultConfig{
+		DefaultToolsApprovalMode: &invalidApproval,
+	}}); err == nil {
+		t.Fatal("AppsConfig with invalid default marshaled")
+	}
+}
+
+func TestAppsConfigDirectDecoderErrors(t *testing.T) {
+	for _, input := range []string{
+		``, `{"`, `{"app":{}`, `{"_default":[]}`, `{} {}`, `{} x`,
+	} {
+		var value AppsConfig
+		if err := value.UnmarshalJSON([]byte(input)); err == nil {
+			t.Errorf("direct AppsConfig.UnmarshalJSON from %s succeeded", input)
+		}
+	}
+}
+
+func TestAppsConfigMarshalPreservesSerdeReservedKeyCollision(t *testing.T) {
+	encoded, err := json.Marshal(AppsConfig{Apps: map[string]AppConfig{
+		"_default": {Enabled: true},
+	}})
+	want := `{"_default":null,"_default":{"approvals_reviewer":null,"default_tools_approval_mode":null,"default_tools_enabled":null,"destructive_enabled":null,"enabled":true,"open_world_enabled":null,"tools":null}}`
+	if err != nil || string(encoded) != want {
+		t.Fatalf("reserved collision = %s, %v; want %s", encoded, err, want)
+	}
+	assertJSONRejects[AppsConfig](t, string(encoded))
+}
+
+func TestAppsConfigsRemainStandaloneAndUnbound(t *testing.T) {
+	names := []string{"AppsDefaultConfig", "AppsConfig"}
+	for _, binding := range WireTypeBindings() {
+		for _, name := range names {
+			if slices.Contains(binding.Params, name) || slices.Contains(binding.Result, name) {
+				t.Fatalf("%s unexpectedly bound to %s", name, binding.Method)
+			}
+		}
+	}
+	for _, binding := range ItemPayloadBindings() {
+		if slices.Contains(names, binding.Type) {
+			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestAppsConfigsTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	source := string(generated)
+	wants := []string{
+		"export type AppsDefaultConfig = {\n" +
+			"  \"approvals_reviewer\": ApprovalsReviewer | null;\n" +
+			"  \"default_tools_approval_mode\": AppToolApproval | null;\n" +
+			"  \"destructive_enabled\": boolean;\n" +
+			"  \"enabled\": boolean;\n" +
+			"  \"open_world_enabled\": boolean;\n" +
+			"};",
+		"export type AppsConfig = ({\n" +
+			"  \"_default\": AppsDefaultConfig | null;\n" +
+			"} & { [key in string]?: AppConfig });",
+	}
+	for _, want := range wants {
+		if !strings.Contains(source, want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}
+
+var (
+	_ json.Marshaler   = AppsDefaultConfig{}
+	_ json.Unmarshaler = (*AppsDefaultConfig)(nil)
+	_ json.Marshaler   = AppsConfig{}
+	_ json.Unmarshaler = (*AppsConfig)(nil)
+)

--- a/appserver/protocol/apps_config_types.go
+++ b/appserver/protocol/apps_config_types.go
@@ -1,0 +1,197 @@
+package protocol
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+)
+
+// AppsDefaultConfig is exact standalone default policy data for apps.
+// Default inheritance and policy evaluation remain deferred.
+type AppsDefaultConfig struct {
+	Enabled                  bool               `json:"enabled"`
+	ApprovalsReviewer        *ApprovalsReviewer `json:"approvals_reviewer,omitempty"`
+	DestructiveEnabled       bool               `json:"destructive_enabled"`
+	OpenWorldEnabled         bool               `json:"open_world_enabled"`
+	DefaultToolsApprovalMode *AppToolApproval   `json:"default_tools_approval_mode,omitempty"`
+}
+
+func (c AppsDefaultConfig) MarshalJSON() ([]byte, error) {
+	return json.Marshal(map[string]any{
+		"enabled":                     c.Enabled,
+		"approvals_reviewer":          c.ApprovalsReviewer,
+		"destructive_enabled":         c.DestructiveEnabled,
+		"open_world_enabled":          c.OpenWorldEnabled,
+		"default_tools_approval_mode": c.DefaultToolsApprovalMode,
+	})
+}
+
+func (c *AppsDefaultConfig) UnmarshalJSON(data []byte) error {
+	if c == nil {
+		return errors.New("decode apps default config into nil receiver")
+	}
+	const objectName = "apps default config"
+	payload, err := decodeRustSerdeObject(
+		data,
+		objectName,
+		"enabled",
+		"approvals_reviewer",
+		"destructive_enabled",
+		"open_world_enabled",
+		"default_tools_approval_mode",
+	)
+	if err != nil {
+		return err
+	}
+	enabled, err := decodeDefaultTrueConfigBool(payload, objectName, "enabled")
+	if err != nil {
+		return err
+	}
+	approvalsReviewer, err := decodeOptionalNullableConfigValue[ApprovalsReviewer](
+		payload, objectName, "approvals_reviewer",
+	)
+	if err != nil {
+		return err
+	}
+	destructiveEnabled, err := decodeDefaultTrueConfigBool(
+		payload, objectName, "destructive_enabled",
+	)
+	if err != nil {
+		return err
+	}
+	openWorldEnabled, err := decodeDefaultTrueConfigBool(payload, objectName, "open_world_enabled")
+	if err != nil {
+		return err
+	}
+	defaultToolsApprovalMode, err := decodeOptionalNullableConfigValue[AppToolApproval](
+		payload, objectName, "default_tools_approval_mode",
+	)
+	if err != nil {
+		return err
+	}
+	*c = AppsDefaultConfig{
+		Enabled:                  enabled,
+		ApprovalsReviewer:        approvalsReviewer,
+		DestructiveEnabled:       destructiveEnabled,
+		OpenWorldEnabled:         openWorldEnabled,
+		DefaultToolsApprovalMode: defaultToolsApprovalMode,
+	}
+	return nil
+}
+
+// AppsConfig is exact standalone default and per-app configuration data.
+type AppsConfig struct {
+	Default *AppsDefaultConfig   `json:"_default,omitempty"`
+	Apps    map[string]AppConfig `json:"-"`
+}
+
+func (c AppsConfig) MarshalJSON() ([]byte, error) {
+	defaultJSON, err := json.Marshal(c.Default)
+	if err != nil {
+		return nil, fmt.Errorf("encode apps config default: %w", err)
+	}
+	names := make([]string, 0, len(c.Apps))
+	for name := range c.Apps {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var encoded bytes.Buffer
+	encoded.WriteString(`{"_default":`)
+	encoded.Write(defaultJSON)
+	for _, name := range names {
+		nameJSON, _ := json.Marshal(name)
+		appJSON, err := json.Marshal(c.Apps[name])
+		if err != nil {
+			return nil, fmt.Errorf("encode apps config app %q: %w", name, err)
+		}
+		encoded.WriteByte(',')
+		encoded.Write(nameJSON)
+		encoded.WriteByte(':')
+		encoded.Write(appJSON)
+	}
+	encoded.WriteByte('}')
+	return encoded.Bytes(), nil
+}
+
+func (c *AppsConfig) UnmarshalJSON(data []byte) error {
+	if c == nil {
+		return errors.New("decode apps config into nil receiver")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	opening, err := decoder.Token()
+	if err != nil {
+		return fmt.Errorf("decode apps config: %w", err)
+	}
+	if opening != json.Delim('{') {
+		return errors.New("apps config must be an object")
+	}
+
+	var defaultConfig *AppsDefaultConfig
+	seenDefault := false
+	apps := make(map[string]AppConfig)
+	for decoder.More() {
+		token, err := decoder.Token()
+		if err != nil {
+			return fmt.Errorf("decode apps config key: %w", err)
+		}
+		name := token.(string)
+		if name == "_default" {
+			if seenDefault {
+				return errors.New("decode apps config: duplicate field \"_default\"")
+			}
+			seenDefault = true
+			if err := decoder.Decode(&defaultConfig); err != nil {
+				return fmt.Errorf("decode apps config default: %w", err)
+			}
+			continue
+		}
+		var app AppConfig
+		if err := decoder.Decode(&app); err != nil {
+			return fmt.Errorf("decode apps config app %q: %w", name, err)
+		}
+		// Serde's flattened HashMap lets a later duplicate replace an earlier app.
+		apps[name] = app
+	}
+	if _, err := decoder.Token(); err != nil {
+		return fmt.Errorf("decode apps config: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errors.New("apps config must contain one JSON value")
+		}
+		return fmt.Errorf("decode apps config trailing value: %w", err)
+	}
+	*c = AppsConfig{Default: defaultConfig, Apps: apps}
+	return nil
+}
+
+func decodeDefaultTrueConfigBool(
+	payload map[string]json.RawMessage,
+	objectName string,
+	field string,
+) (bool, error) {
+	raw, ok := payload[field]
+	if !ok {
+		return true, nil
+	}
+	if isJSONNull(raw) {
+		return false, fmt.Errorf("decode %s %s: value cannot be null", objectName, field)
+	}
+	var value bool
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return false, fmt.Errorf("decode %s %s: %w", objectName, field, err)
+	}
+	return value, nil
+}
+
+var (
+	_ json.Marshaler   = AppsDefaultConfig{}
+	_ json.Unmarshaler = (*AppsDefaultConfig)(nil)
+	_ json.Marshaler   = AppsConfig{}
+	_ json.Unmarshaler = (*AppsConfig)(nil)
+)

--- a/appserver/protocol/attestation_contract_test.go
+++ b/appserver/protocol/attestation_contract_test.go
@@ -133,8 +133,8 @@ func TestAttestationContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("attestation/generate = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
+++ b/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
@@ -179,8 +179,8 @@ func TestChatgptAuthTokensRefreshRemainsStandaloneAndDeferred(t *testing.T) {
 	if !found {
 		t.Fatal("refresh method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/exec_command_approval_params_contract_test.go
+++ b/appserver/protocol/exec_command_approval_params_contract_test.go
@@ -137,8 +137,8 @@ func TestExecCommandApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ExecCommandApprovalParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(defs); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,8 +217,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,8 +203,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -260,8 +260,8 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,8 +244,8 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -162,8 +162,8 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -175,8 +175,8 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_contract_test.go
+++ b/appserver/protocol/file_change_contract_test.go
@@ -108,8 +108,8 @@ func TestFileChangeRemainsStandalone(t *testing.T) {
 			t.Fatalf("FileChange unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_output_delta_notification_contract_test.go
+++ b/appserver/protocol/file_change_output_delta_notification_contract_test.go
@@ -100,8 +100,8 @@ func TestFileChangeOutputDeltaNotificationRemainsDeprecatedAndStandalone(t *test
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("item/fileChange/outputDelta = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -381,8 +381,8 @@ func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_action_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_action_contract_test.go
@@ -226,8 +226,8 @@ func TestGuardianApprovalReviewActionRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReviewAction unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
@@ -164,8 +164,8 @@ func TestGuardianApprovalReviewCompletedNotificationRemainsStandalone(t *testing
 			t.Fatalf("completed notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_contract_test.go
@@ -139,8 +139,8 @@ func TestGuardianApprovalReviewRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReview unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
@@ -175,8 +175,8 @@ func TestGuardianApprovalReviewStartedNotificationRemainsStandalone(t *testing.T
 			t.Fatalf("started notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_enum_foundation_contract_test.go
+++ b/appserver/protocol/guardian_enum_foundation_contract_test.go
@@ -89,8 +89,8 @@ func TestGuardianEnumFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_metadata_list_contract_test.go
+++ b/appserver/protocol/hook_metadata_list_contract_test.go
@@ -352,8 +352,8 @@ func TestHookMetadataListContractsStayStandalone(t *testing.T) {
 			t.Errorf("standalone definition %s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Errorf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Errorf("definition count = %d, want 468", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 {
 		t.Errorf("wire binding count = %d, want 59", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_run_notification_contract_test.go
+++ b/appserver/protocol/hook_run_notification_contract_test.go
@@ -297,8 +297,8 @@ func TestHookRunNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("surface changed: %d methods, %d wire bindings, %d item bindings", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/hook_value_foundation_contract_test.go
+++ b/appserver/protocol/hook_value_foundation_contract_test.go
@@ -167,8 +167,8 @@ func TestHookValueFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 466 {
-		t.Fatalf("definition count = %d, want 466", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 468 {
+		t.Fatalf("definition count = %d, want 468", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/legacy_approval_response_contract_test.go
+++ b/appserver/protocol/legacy_approval_response_contract_test.go
@@ -98,8 +98,8 @@ func TestLegacyApprovalResponsesRemainStandaloneAndNominal(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_approval_context_contract_test.go
+++ b/appserver/protocol/network_approval_context_contract_test.go
@@ -84,8 +84,8 @@ func TestNetworkApprovalContextRemainsStandalone(t *testing.T) {
 			t.Fatalf("NetworkApprovalContext unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/parsed_command_contract_test.go
+++ b/appserver/protocol/parsed_command_contract_test.go
@@ -120,8 +120,8 @@ func TestParsedCommandRemainsStandalone(t *testing.T) {
 			t.Fatalf("ParsedCommand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 466 {
-		t.Fatalf("definition count = %d, want 466", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 468 {
+		t.Fatalf("definition count = %d, want 468", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 466 {
-		t.Fatalf("definition count = %d, want 466", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 468 {
+		t.Fatalf("definition count = %d, want 468", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 466 {
-		t.Fatalf("definition count = %d, want 466", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 468 {
+		t.Fatalf("definition count = %d, want 468", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 466 {
-		t.Fatalf("definition count = %d, want 466", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 468 {
+		t.Fatalf("definition count = %d, want 468", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 466 {
-		t.Fatalf("definition count = %d, want 466", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 468 {
+		t.Fatalf("definition count = %d, want 468", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/review_decision_contract_test.go
+++ b/appserver/protocol/review_decision_contract_test.go
@@ -136,8 +136,8 @@ func TestReviewDecisionRemainsStandalone(t *testing.T) {
 			t.Fatalf("ReviewDecision unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(defs); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -118,6 +118,8 @@ func wireSchemaDefinitions() Schema {
 		{Name: "AppToolApproval", Type: reflect.TypeFor[AppToolApproval]()},
 		{Name: "AppToolConfig", Type: reflect.TypeFor[AppToolConfig]()},
 		{Name: "AppToolsConfig", Type: reflect.TypeFor[AppToolsConfig]()},
+		{Name: "AppsConfig", Type: reflect.TypeFor[AppsConfig]()},
+		{Name: "AppsDefaultConfig", Type: reflect.TypeFor[AppsDefaultConfig]()},
 		{Name: "ApplyPatchApprovalParams", Type: reflect.TypeFor[ApplyPatchApprovalParams]()},
 		{Name: "ApplyPatchApprovalResponse", Type: reflect.TypeFor[ApplyPatchApprovalResponse]()},
 		{Name: "AskForApproval", Type: reflect.TypeFor[AskForApproval]()},
@@ -714,6 +716,25 @@ func wireSchemaDefinitions() Schema {
 			"enabled":                     Schema{"default": true, "type": "boolean"},
 			"open_world_enabled":          Schema{"type": []any{"boolean", "null"}},
 			"tools":                       nullableSchemaRef("AppToolsConfig"),
+		},
+	}
+	schemas["AppsDefaultConfig"] = Schema{
+		"type": "object",
+		"properties": Schema{
+			"approvals_reviewer":          nullableSchemaRef("ApprovalsReviewer"),
+			"default_tools_approval_mode": nullableSchemaRef("AppToolApproval"),
+			"destructive_enabled":         Schema{"default": true, "type": "boolean"},
+			"enabled":                     Schema{"default": true, "type": "boolean"},
+			"open_world_enabled":          Schema{"default": true, "type": "boolean"},
+		},
+	}
+	schemas["AppsConfig"] = Schema{
+		"type": "object",
+		"properties": Schema{
+			"_default": Schema{
+				"anyOf":   []any{Schema{"$ref": "#/$defs/AppsDefaultConfig"}, Schema{"type": "null"}},
+				"default": nil,
+			},
 		},
 	}
 	schemas["AddCreditsNudgeCreditType"] = stringEnumSchema(

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -1111,6 +1111,59 @@
       ],
       "type": "string"
     },
+    "AppsConfig": {
+      "properties": {
+        "_default": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AppsDefaultConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "type": "object"
+    },
+    "AppsDefaultConfig": {
+      "properties": {
+        "approvals_reviewer": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ApprovalsReviewer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "default_tools_approval_mode": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AppToolApproval"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "destructive_enabled": {
+          "default": true,
+          "type": "boolean"
+        },
+        "enabled": {
+          "default": true,
+          "type": "boolean"
+        },
+        "open_world_enabled": {
+          "default": true,
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
     "AskForApproval": {
       "oneOf": [
         {

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 466 {
-		t.Fatalf("definition count = %d, want 466", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 468 {
+		t.Fatalf("definition count = %d, want 468", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 466 {
-		t.Fatalf("definition count = %d, want 466", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 468 {
+		t.Fatalf("definition count = %d, want 468", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 466 {
-		t.Fatalf("definition count = %d, want 466", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 468 {
+		t.Fatalf("definition count = %d, want 468", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -41,7 +41,7 @@ func MarshalTypeScript() ([]byte, error) {
 		definition := defs[name]
 		if name == "AccountLoginCompletedNotification" || name == "AccountTokenUsageSummary" ||
 			name == "AppBranding" || name == "AppConfig" || name == "AppInfo" || name == "AppMetadata" || name == "AppScreenshot" ||
-			name == "AppSummary" || name == "AppTemplateSummary" ||
+			name == "AppSummary" || name == "AppTemplateSummary" || name == "AppsDefaultConfig" ||
 			name == "AppToolConfig" ||
 			name == "ApplyPatchApprovalParams" ||
 			name == "ChatgptAuthTokensRefreshResponse" ||
@@ -105,6 +105,12 @@ func MarshalTypeScript() ([]byte, error) {
 				}
 			case "AppToolConfig":
 				schema["required"] = []string{"enabled", "approval_mode"}
+				schema["x-gollem-typescript-ignore-additional-properties"] = true
+			case "AppsDefaultConfig":
+				schema["required"] = []string{
+					"enabled", "approvals_reviewer", "destructive_enabled", "open_world_enabled",
+					"default_tools_approval_mode",
+				}
 				schema["x-gollem-typescript-ignore-additional-properties"] = true
 			case "ApplyPatchApprovalParams":
 				schema["required"] = []string{
@@ -220,6 +226,20 @@ func MarshalTypeScript() ([]byte, error) {
 					"required": []string{"enabled", "approval_mode"},
 					"x-gollem-typescript-ignore-additional-properties": true,
 				},
+				"x-gollem-typescript-optional-map": true,
+			}
+		}
+		if name == "AppsConfig" {
+			// ts-rs intersects the required reserved default with an optional
+			// flattened map of canonical app records. Keep this render-only
+			// structure out of the intentionally open upstream JSON Schema.
+			definition = Schema{
+				"type": "object",
+				"properties": Schema{
+					"_default": nullableSchemaRef("AppsDefaultConfig"),
+				},
+				"required":                         []string{"_default"},
+				"additionalProperties":             Schema{"$ref": "#/$defs/AppConfig"},
 				"x-gollem-typescript-optional-map": true,
 			}
 		}

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -703,6 +703,18 @@ export type ApprovalRespondResult = {
 
 export type ApprovalsReviewer = "user" | "auto_review" | "guardian_subagent";
 
+export type AppsConfig = ({
+  "_default": AppsDefaultConfig | null;
+} & { [key in string]?: AppConfig });
+
+export type AppsDefaultConfig = {
+  "approvals_reviewer": ApprovalsReviewer | null;
+  "default_tools_approval_mode": AppToolApproval | null;
+  "destructive_enabled": boolean;
+  "enabled": boolean;
+  "open_world_enabled": boolean;
+};
+
 export type AskForApproval = "untrusted" | "on-request" | {
   "granular": {
     "mcp_elicitations": boolean;

--- a/appserver/protocol/typescript/testdata/apps_config_contract.ts
+++ b/appserver/protocol/typescript/testdata/apps_config_contract.ts
@@ -1,0 +1,77 @@
+import type {
+  AppConfig,
+  AppToolApproval,
+  AppToolsConfig,
+  ApprovalsReviewer,
+  AppsConfig,
+  AppsDefaultConfig,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2) ? true : false;
+type Expect<T extends true> = T;
+
+type ExpectedDefault = {
+  approvals_reviewer: ApprovalsReviewer | null;
+  default_tools_approval_mode: AppToolApproval | null;
+  destructive_enabled: boolean;
+  enabled: boolean;
+  open_world_enabled: boolean;
+};
+type ExpectedApp = {
+  approvals_reviewer: ApprovalsReviewer | null;
+  default_tools_approval_mode: AppToolApproval | null;
+  default_tools_enabled: boolean | null;
+  destructive_enabled: boolean | null;
+  enabled: boolean;
+  open_world_enabled: boolean | null;
+  tools: AppToolsConfig | null;
+};
+type ExpectedApps = { _default: AppsDefaultConfig | null } & {
+  [key in string]?: ExpectedApp;
+};
+type Contracts = [
+  Expect<Equal<AppsDefaultConfig, ExpectedDefault>>,
+  Expect<Equal<AppConfig, ExpectedApp>>,
+  Expect<Equal<AppsConfig, ExpectedApps>>,
+];
+
+({
+  approvals_reviewer: null,
+  default_tools_approval_mode: null,
+  destructive_enabled: true,
+  enabled: true,
+  open_world_enabled: true,
+}) satisfies AppsDefaultConfig;
+
+({
+  approvals_reviewer: "guardian_subagent",
+  default_tools_approval_mode: "writes",
+  destructive_enabled: false,
+  enabled: false,
+  open_world_enabled: false,
+}) satisfies AppsDefaultConfig;
+
+declare const apps: AppsConfig;
+apps._default satisfies AppsDefaultConfig | null;
+apps["arbitrary"] satisfies AppConfig | undefined;
+
+// @ts-expect-error canonical defaults require every field.
+({ enabled: true }) satisfies AppsDefaultConfig;
+// @ts-expect-error booleans are non-null.
+({ approvals_reviewer: null, default_tools_approval_mode: null, destructive_enabled: null, enabled: true, open_world_enabled: true }) satisfies AppsDefaultConfig;
+// @ts-expect-error reviewers are closed.
+({ approvals_reviewer: "other", default_tools_approval_mode: null, destructive_enabled: true, enabled: true, open_world_enabled: true }) satisfies AppsDefaultConfig;
+// @ts-expect-error approval modes are closed.
+({ approvals_reviewer: null, default_tools_approval_mode: "other", destructive_enabled: true, enabled: true, open_world_enabled: true }) satisfies AppsDefaultConfig;
+// @ts-expect-error pinned flattened intersection requires _default.
+({}) satisfies AppsConfig;
+// @ts-expect-error pinned mapped values are strict AppConfig records.
+({ _default: null, app: { enabled: true } }) satisfies AppsConfig;
+// @ts-expect-error flattened app values cannot be null.
+({ _default: null, app: null }) satisfies AppsConfig;
+// @ts-expect-error flattened app values preserve closed reviewer values.
+({ _default: null, app: { approvals_reviewer: "other", default_tools_approval_mode: null, default_tools_enabled: null, destructive_enabled: null, enabled: true, open_world_enabled: null, tools: null } }) satisfies AppsConfig;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 466 {
-		t.Fatalf("definition count = %d, want 466", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
+		t.Fatalf("definition count = %d, want 468", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- add exact standalone `AppsDefaultConfig` and flattened `AppsConfig` codecs
- preserve default-true values, nullable canonical output, and observed serde duplicate behavior
- expose pinned schemas and compiler-equivalent TypeScript intersection with strict coverage

## Verification
- focused tests x30 and focused race
- 100% statement coverage for all five new codec/helper functions
- exact normalized schema hashes match pinned upstream
- deterministic schema/TypeScript generation
- all non-Monty Go tests and race tests
- strict TypeScript, zero-issue lint, vet, tidy/module verification
- configured pre-push hook with `hooks.skipMontyRace=true`
