### PR TITLE
feat(protocol): export app list contracts

### DIFF
--- a/appserver/protocol/account_credit_nudge_values_contract_test.go
+++ b/appserver/protocol/account_credit_nudge_values_contract_test.go
@@ -119,8 +119,8 @@ func TestAccountCreditNudgeValuesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/sendAddCreditsNudgeEmail = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/account_login_completed_notification_contract_test.go
+++ b/appserver/protocol/account_login_completed_notification_contract_test.go
@@ -88,8 +88,8 @@ func TestAccountLoginCompletedNotificationRemainsStandaloneAndDeferred(t *testin
 	if !found {
 		t.Fatal("account/login/completed method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/account_token_usage_contract_test.go
+++ b/appserver/protocol/account_token_usage_contract_test.go
@@ -146,8 +146,8 @@ func TestAccountTokenUsageRecordsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/usage/read = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(defs); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_config_contract_test.go
+++ b/appserver/protocol/app_config_contract_test.go
@@ -109,8 +109,8 @@ func TestAppConfigRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppConfig unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_info_contract_test.go
+++ b/appserver/protocol/app_info_contract_test.go
@@ -131,8 +131,8 @@ func TestAppInfoRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_list_updated_notification_contract_test.go
+++ b/appserver/protocol/app_list_updated_notification_contract_test.go
@@ -105,8 +105,8 @@ func TestAppListUpdatedNotificationRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceServerNotification || method.State != MethodDeferredStub {
 		t.Fatalf("app/list/updated = %#v, %v; want deferred server notification", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_metadata_contract_test.go
+++ b/appserver/protocol/app_metadata_contract_test.go
@@ -107,8 +107,8 @@ func TestAppMetadataRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_metadata_leaf_contract_test.go
+++ b/appserver/protocol/app_metadata_leaf_contract_test.go
@@ -157,8 +157,8 @@ func TestAppMetadataLeavesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_summary_contract_test.go
+++ b/appserver/protocol/app_summary_contract_test.go
@@ -87,8 +87,8 @@ func TestAppSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppSummary unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_template_summary_contract_test.go
+++ b/appserver/protocol/app_template_summary_contract_test.go
@@ -107,8 +107,8 @@ func TestAppTemplateSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppTemplateSummary unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_template_unavailable_reason_contract_test.go
+++ b/appserver/protocol/app_template_unavailable_reason_contract_test.go
@@ -71,8 +71,8 @@ func TestAppTemplateUnavailableReasonRemainsStandalone(t *testing.T) {
 			t.Fatalf("AppTemplateUnavailableReason unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_tool_approval_contract_test.go
+++ b/appserver/protocol/app_tool_approval_contract_test.go
@@ -73,8 +73,8 @@ func TestAppToolApprovalRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppToolApproval unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_tools_config_contract_test.go
+++ b/appserver/protocol/app_tools_config_contract_test.go
@@ -140,8 +140,8 @@ func TestAppToolConfigsRemainStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/apply_patch_approval_params_contract_test.go
+++ b/appserver/protocol/apply_patch_approval_params_contract_test.go
@@ -139,8 +139,8 @@ func TestApplyPatchApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ApplyPatchApprovalParams unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(defs); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(defs); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/apps_config_contract_test.go
+++ b/appserver/protocol/apps_config_contract_test.go
@@ -185,8 +185,8 @@ func TestAppsConfigsRemainStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/apps_list_contract_test.go
+++ b/appserver/protocol/apps_list_contract_test.go
@@ -1,0 +1,209 @@
+package protocol
+
+import (
+	"encoding/json"
+	"math"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+const (
+	appsListMinimalInfoWire   = `{"id":"id","name":"name"}`
+	appsListCanonicalInfoWire = `{"appMetadata":null,"branding":null,"description":null,"distributionChannel":null,` +
+		`"iconAssets":null,"iconDarkAssets":null,"id":"id","installUrl":null,"isAccessible":false,` +
+		`"isEnabled":true,"labels":null,"logoUrl":null,"logoUrlDark":null,"name":"name","pluginDisplayNames":[]}`
+)
+
+func TestAppsListSchemasAreExact(t *testing.T) {
+	wantParams := Schema{
+		"type":        "object",
+		"description": "EXPERIMENTAL - list available apps/connectors.",
+		"properties": Schema{
+			"cursor": Schema{
+				"description": "Opaque pagination cursor returned by a previous call.",
+				"type":        []any{"string", "null"},
+			},
+			"forceRefetch": Schema{
+				"description": "When true, bypass app caches and fetch the latest data from sources.",
+				"type":        "boolean",
+			},
+			"limit": Schema{
+				"description": "Optional page size; defaults to a reasonable server-side value.",
+				"format":      "uint32", "minimum": float64(0), "type": []any{"integer", "null"},
+			},
+			"threadId": Schema{
+				"description": "Optional thread id used to evaluate app feature gating from that thread's config.",
+				"type":        []any{"string", "null"},
+			},
+		},
+	}
+	wantResponse := Schema{
+		"type":        "object",
+		"description": "EXPERIMENTAL - app list response.",
+		"properties": Schema{
+			"data": Schema{"type": "array", "items": Schema{"$ref": "#/$defs/AppInfo"}},
+			"nextCursor": Schema{
+				"description": "Opaque cursor to pass to the next call to continue after the last item. If None, there are no more items to return.",
+				"type":        []any{"string", "null"},
+			},
+		},
+		"required": []string{"data"},
+	}
+	definitions := JSONSchema()["$defs"].(Schema)
+	for name, want := range map[string]Schema{
+		"AppsListParams":   wantParams,
+		"AppsListResponse": wantResponse,
+	} {
+		if got := definitions[name]; !reflect.DeepEqual(got, want) {
+			t.Errorf("%s = %#v, want %#v", name, got, want)
+		}
+	}
+}
+
+func TestAppsListParamsAcceptsSerdeWireForms(t *testing.T) {
+	for _, tc := range []struct {
+		input string
+		want  string
+	}{
+		{`{}`, `{"cursor":null,"limit":null,"threadId":null}`},
+		{`{"cursor":null,"limit":null,"threadId":null}`, `{"cursor":null,"limit":null,"threadId":null}`},
+		{`{"cursor":"","limit":0,"threadId":" ","forceRefetch":false}`, `{"cursor":"","limit":0,"threadId":" "}`},
+		{`{"cursor":" next ","limit":4294967295,"threadId":"thread","forceRefetch":true}`, `{"cursor":" next ","limit":4294967295,"threadId":"thread","forceRefetch":true}`},
+		{`{"future":1,"future":2,"forceRefetch":true}`, `{"cursor":null,"limit":null,"threadId":null,"forceRefetch":true}`},
+	} {
+		var value AppsListParams
+		if err := json.Unmarshal([]byte(tc.input), &value); err != nil {
+			t.Errorf("unmarshal %s: %v", tc.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(value)
+		if err != nil || string(encoded) != tc.want {
+			t.Errorf("round trip %s = %s, %v; want %s", tc.input, encoded, err, tc.want)
+		}
+	}
+	limit := uint32(math.MaxUint32)
+	if encoded, err := json.Marshal(AppsListParams{Limit: &limit}); err != nil ||
+		string(encoded) != `{"cursor":null,"limit":4294967295,"threadId":null}` {
+		t.Fatalf("max limit = %s, %v", encoded, err)
+	}
+}
+
+func TestAppsListParamsRejectsMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`,
+		`{"cursor":1}`, `{"limit":-1}`, `{"limit":1.5}`, `{"limit":4294967296}`,
+		`{"limit":"1"}`, `{"threadId":false}`, `{"forceRefetch":null}`,
+		`{"forceRefetch":0}`, `{"cursor":null,"cursor":"next"}`,
+		`{"forceRefetch":false,"forceRefetch":true}`, `{} {}`, `{} x`,
+	} {
+		assertJSONRejects[AppsListParams](t, input)
+	}
+}
+
+func TestAppsListResponseAcceptsSerdeWireForms(t *testing.T) {
+	for _, tc := range []struct {
+		input string
+		want  string
+	}{
+		{`{"data":[]}`, `{"data":[],"nextCursor":null}`},
+		{`{"future":true,"data":[],"nextCursor":null}`, `{"data":[],"nextCursor":null}`},
+		{`{"data":[` + appsListMinimalInfoWire + `],"nextCursor":""}`, `{"data":[` + appsListCanonicalInfoWire + `],"nextCursor":""}`},
+		{`{"data":[` + appsListMinimalInfoWire + `,` + appsListMinimalInfoWire + `],"nextCursor":" next "}`, `{"data":[` + appsListCanonicalInfoWire + `,` + appsListCanonicalInfoWire + `],"nextCursor":" next "}`},
+	} {
+		var value AppsListResponse
+		if err := json.Unmarshal([]byte(tc.input), &value); err != nil {
+			t.Errorf("unmarshal %s: %v", tc.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(value)
+		if err != nil || string(encoded) != tc.want {
+			t.Errorf("round trip %s = %s, %v; want %s", tc.input, encoded, err, tc.want)
+		}
+	}
+}
+
+func TestAppsListResponseRejectsMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`, `{}`,
+		`{"data":null}`, `{"data":{}}`, `{"data":[null]}`, `{"data":[{}]}`,
+		`{"data":[{"id":"id"}]}`, `{"data":[{"name":"name"}]}`,
+		`{"data":[],"nextCursor":1}`, `{"data":[],"data":[]}`,
+		`{"data":[],"nextCursor":null,"nextCursor":"next"}`, `{"data":[]} {}`, `{"data":[]} x`,
+	} {
+		assertJSONRejects[AppsListResponse](t, input)
+	}
+}
+
+func TestAppsListNilReceiversAndInvalidMarshal(t *testing.T) {
+	var params *AppsListParams
+	if err := params.UnmarshalJSON([]byte(`{}`)); err == nil {
+		t.Fatal("nil AppsListParams receiver succeeded")
+	}
+	var response *AppsListResponse
+	if err := response.UnmarshalJSON([]byte(`{"data":[]}`)); err == nil {
+		t.Fatal("nil AppsListResponse receiver succeeded")
+	}
+	if _, err := json.Marshal(AppsListResponse{}); err == nil {
+		t.Fatal("nil response data marshaled")
+	}
+}
+
+func TestAppsListContractsRemainStandaloneAndDeferred(t *testing.T) {
+	names := []string{"AppsListParams", "AppsListResponse"}
+	for _, binding := range WireTypeBindings() {
+		for _, name := range names {
+			if slices.Contains(binding.Params, name) || slices.Contains(binding.Result, name) {
+				t.Fatalf("%s unexpectedly bound to %s", name, binding.Method)
+			}
+		}
+	}
+	for _, binding := range ItemPayloadBindings() {
+		if slices.Contains(names, binding.Type) {
+			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
+		}
+	}
+	method, ok := LookupMethod("app/list")
+	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
+		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestAppsListTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	source := string(generated)
+	for _, want := range []string{
+		"export type AppsListParams = {\n",
+		`  "cursor"?: string | null;`,
+		`  "forceRefetch"?: boolean;`,
+		`  "limit"?: number | null;`,
+		`  "threadId"?: string | null;`,
+		"export type AppsListResponse = {\n",
+		`  "data": Array<AppInfo>;`,
+		`  "nextCursor": string | null;`,
+	} {
+		if !strings.Contains(source, want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}
+
+var (
+	_ json.Marshaler   = AppsListParams{}
+	_ json.Unmarshaler = (*AppsListParams)(nil)
+	_ json.Marshaler   = AppsListResponse{}
+	_ json.Unmarshaler = (*AppsListResponse)(nil)
+)

--- a/appserver/protocol/apps_list_types.go
+++ b/appserver/protocol/apps_list_types.go
@@ -1,0 +1,103 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// AppsListParams is the exact public app-catalog page selector. It remains
+// separate from the deferred app/list method until a live adapter is defined.
+type AppsListParams struct {
+	Cursor       *string `json:"cursor,omitempty"`
+	ForceRefetch bool    `json:"forceRefetch,omitempty"`
+	Limit        *uint32 `json:"limit,omitempty"`
+	ThreadID     *string `json:"threadId,omitempty"`
+}
+
+func (p AppsListParams) MarshalJSON() ([]byte, error) {
+	type wire struct {
+		Cursor       *string `json:"cursor"`
+		Limit        *uint32 `json:"limit"`
+		ThreadID     *string `json:"threadId"`
+		ForceRefetch bool    `json:"forceRefetch,omitempty"`
+	}
+	return json.Marshal(wire{
+		Cursor: p.Cursor, Limit: p.Limit, ThreadID: p.ThreadID, ForceRefetch: p.ForceRefetch,
+	})
+}
+
+func (p *AppsListParams) UnmarshalJSON(data []byte) error {
+	if p == nil {
+		return errors.New("decode apps-list params into nil receiver")
+	}
+	const objectName = "apps-list params"
+	payload, err := decodeRustSerdeObject(
+		data, objectName, "cursor", "forceRefetch", "limit", "threadId",
+	)
+	if err != nil {
+		return err
+	}
+	cursor, err := decodeOptionalNullableConfigValue[string](payload, objectName, "cursor")
+	if err != nil {
+		return err
+	}
+	forceRefetch, err := decodeOptionalConfigBool(payload, objectName, "forceRefetch")
+	if err != nil {
+		return err
+	}
+	limit, err := decodeOptionalNullableConfigValue[uint32](payload, objectName, "limit")
+	if err != nil {
+		return err
+	}
+	threadID, err := decodeOptionalNullableConfigValue[string](payload, objectName, "threadId")
+	if err != nil {
+		return err
+	}
+	*p = AppsListParams{
+		Cursor: cursor, ForceRefetch: forceRefetch, Limit: limit, ThreadID: threadID,
+	}
+	return nil
+}
+
+// AppsListResponse is the exact public page of strict AppInfo values. It stays
+// outside the deferred app/list method binding until that method is implemented.
+type AppsListResponse struct {
+	Data       []AppInfo `json:"data" jsonschema:"nonnullable=true"`
+	NextCursor *string   `json:"nextCursor"`
+}
+
+func (r AppsListResponse) MarshalJSON() ([]byte, error) {
+	if r.Data == nil {
+		return nil, errors.New("apps-list response data cannot be null")
+	}
+	type wire AppsListResponse
+	return json.Marshal(wire(r))
+}
+
+func (r *AppsListResponse) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("decode apps-list response into nil receiver")
+	}
+	const objectName = "apps-list response"
+	payload, err := decodeRustSerdeObject(data, objectName, "data", "nextCursor")
+	if err != nil {
+		return err
+	}
+	apps, err := decodeRequiredThreadItemArray[AppInfo](payload, objectName, "data")
+	if err != nil {
+		return err
+	}
+	nextCursor, err := decodeOptionalNullableConfigValue[string](payload, objectName, "nextCursor")
+	if err != nil {
+		return err
+	}
+	*r = AppsListResponse{Data: apps, NextCursor: nextCursor}
+	return nil
+}
+
+var (
+	_ json.Marshaler   = AppsListParams{}
+	_ json.Unmarshaler = (*AppsListParams)(nil)
+	_ json.Marshaler   = AppsListResponse{}
+	_ json.Unmarshaler = (*AppsListResponse)(nil)
+)

--- a/appserver/protocol/attestation_contract_test.go
+++ b/appserver/protocol/attestation_contract_test.go
@@ -133,8 +133,8 @@ func TestAttestationContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("attestation/generate = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
+++ b/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
@@ -179,8 +179,8 @@ func TestChatgptAuthTokensRefreshRemainsStandaloneAndDeferred(t *testing.T) {
 	if !found {
 		t.Fatal("refresh method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/exec_command_approval_params_contract_test.go
+++ b/appserver/protocol/exec_command_approval_params_contract_test.go
@@ -137,8 +137,8 @@ func TestExecCommandApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ExecCommandApprovalParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(defs); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,8 +217,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,8 +203,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -260,8 +260,8 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,8 +244,8 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -162,8 +162,8 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -175,8 +175,8 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_contract_test.go
+++ b/appserver/protocol/file_change_contract_test.go
@@ -108,8 +108,8 @@ func TestFileChangeRemainsStandalone(t *testing.T) {
 			t.Fatalf("FileChange unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_output_delta_notification_contract_test.go
+++ b/appserver/protocol/file_change_output_delta_notification_contract_test.go
@@ -100,8 +100,8 @@ func TestFileChangeOutputDeltaNotificationRemainsDeprecatedAndStandalone(t *test
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("item/fileChange/outputDelta = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -381,8 +381,8 @@ func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_action_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_action_contract_test.go
@@ -226,8 +226,8 @@ func TestGuardianApprovalReviewActionRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReviewAction unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
@@ -164,8 +164,8 @@ func TestGuardianApprovalReviewCompletedNotificationRemainsStandalone(t *testing
 			t.Fatalf("completed notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_contract_test.go
@@ -139,8 +139,8 @@ func TestGuardianApprovalReviewRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReview unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
@@ -175,8 +175,8 @@ func TestGuardianApprovalReviewStartedNotificationRemainsStandalone(t *testing.T
 			t.Fatalf("started notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_enum_foundation_contract_test.go
+++ b/appserver/protocol/guardian_enum_foundation_contract_test.go
@@ -89,8 +89,8 @@ func TestGuardianEnumFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_metadata_list_contract_test.go
+++ b/appserver/protocol/hook_metadata_list_contract_test.go
@@ -352,8 +352,8 @@ func TestHookMetadataListContractsStayStandalone(t *testing.T) {
 			t.Errorf("standalone definition %s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Errorf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Errorf("definition count = %d, want 470", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 {
 		t.Errorf("wire binding count = %d, want 59", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_run_notification_contract_test.go
+++ b/appserver/protocol/hook_run_notification_contract_test.go
@@ -297,8 +297,8 @@ func TestHookRunNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("surface changed: %d methods, %d wire bindings, %d item bindings", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/hook_value_foundation_contract_test.go
+++ b/appserver/protocol/hook_value_foundation_contract_test.go
@@ -167,8 +167,8 @@ func TestHookValueFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 468 {
-		t.Fatalf("definition count = %d, want 468", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 470 {
+		t.Fatalf("definition count = %d, want 470", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/legacy_approval_response_contract_test.go
+++ b/appserver/protocol/legacy_approval_response_contract_test.go
@@ -98,8 +98,8 @@ func TestLegacyApprovalResponsesRemainStandaloneAndNominal(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_approval_context_contract_test.go
+++ b/appserver/protocol/network_approval_context_contract_test.go
@@ -84,8 +84,8 @@ func TestNetworkApprovalContextRemainsStandalone(t *testing.T) {
 			t.Fatalf("NetworkApprovalContext unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/parsed_command_contract_test.go
+++ b/appserver/protocol/parsed_command_contract_test.go
@@ -120,8 +120,8 @@ func TestParsedCommandRemainsStandalone(t *testing.T) {
 			t.Fatalf("ParsedCommand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 468 {
-		t.Fatalf("definition count = %d, want 468", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 470 {
+		t.Fatalf("definition count = %d, want 470", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 468 {
-		t.Fatalf("definition count = %d, want 468", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 470 {
+		t.Fatalf("definition count = %d, want 470", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 468 {
-		t.Fatalf("definition count = %d, want 468", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 470 {
+		t.Fatalf("definition count = %d, want 470", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 468 {
-		t.Fatalf("definition count = %d, want 468", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 470 {
+		t.Fatalf("definition count = %d, want 470", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 468 {
-		t.Fatalf("definition count = %d, want 468", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 470 {
+		t.Fatalf("definition count = %d, want 470", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/review_decision_contract_test.go
+++ b/appserver/protocol/review_decision_contract_test.go
@@ -136,8 +136,8 @@ func TestReviewDecisionRemainsStandalone(t *testing.T) {
 			t.Fatalf("ReviewDecision unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(defs); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -120,6 +120,8 @@ func wireSchemaDefinitions() Schema {
 		{Name: "AppToolsConfig", Type: reflect.TypeFor[AppToolsConfig]()},
 		{Name: "AppsConfig", Type: reflect.TypeFor[AppsConfig]()},
 		{Name: "AppsDefaultConfig", Type: reflect.TypeFor[AppsDefaultConfig]()},
+		{Name: "AppsListParams", Type: reflect.TypeFor[AppsListParams]()},
+		{Name: "AppsListResponse", Type: reflect.TypeFor[AppsListResponse]()},
 		{Name: "ApplyPatchApprovalParams", Type: reflect.TypeFor[ApplyPatchApprovalParams]()},
 		{Name: "ApplyPatchApprovalResponse", Type: reflect.TypeFor[ApplyPatchApprovalResponse]()},
 		{Name: "AskForApproval", Type: reflect.TypeFor[AskForApproval]()},
@@ -736,6 +738,40 @@ func wireSchemaDefinitions() Schema {
 				"default": nil,
 			},
 		},
+	}
+	schemas["AppsListParams"] = Schema{
+		"type":        "object",
+		"description": "EXPERIMENTAL - list available apps/connectors.",
+		"properties": Schema{
+			"cursor": Schema{
+				"description": "Opaque pagination cursor returned by a previous call.",
+				"type":        []any{"string", "null"},
+			},
+			"forceRefetch": Schema{
+				"description": "When true, bypass app caches and fetch the latest data from sources.",
+				"type":        "boolean",
+			},
+			"limit": Schema{
+				"description": "Optional page size; defaults to a reasonable server-side value.",
+				"format":      "uint32", "minimum": float64(0), "type": []any{"integer", "null"},
+			},
+			"threadId": Schema{
+				"description": "Optional thread id used to evaluate app feature gating from that thread's config.",
+				"type":        []any{"string", "null"},
+			},
+		},
+	}
+	schemas["AppsListResponse"] = Schema{
+		"type":        "object",
+		"description": "EXPERIMENTAL - app list response.",
+		"properties": Schema{
+			"data": Schema{"type": "array", "items": Schema{"$ref": "#/$defs/AppInfo"}},
+			"nextCursor": Schema{
+				"description": "Opaque cursor to pass to the next call to continue after the last item. If None, there are no more items to return.",
+				"type":        []any{"string", "null"},
+			},
+		},
+		"required": []string{"data"},
 	}
 	schemas["AddCreditsNudgeCreditType"] = stringEnumSchema(
 		string(AddCreditsNudgeCreditTypeCredits),

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -1164,6 +1164,61 @@
       },
       "type": "object"
     },
+    "AppsListParams": {
+      "description": "EXPERIMENTAL - list available apps/connectors.",
+      "properties": {
+        "cursor": {
+          "description": "Opaque pagination cursor returned by a previous call.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "forceRefetch": {
+          "description": "When true, bypass app caches and fetch the latest data from sources.",
+          "type": "boolean"
+        },
+        "limit": {
+          "description": "Optional page size; defaults to a reasonable server-side value.",
+          "format": "uint32",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "threadId": {
+          "description": "Optional thread id used to evaluate app feature gating from that thread's config.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "AppsListResponse": {
+      "description": "EXPERIMENTAL - app list response.",
+      "properties": {
+        "data": {
+          "items": {
+            "$ref": "#/$defs/AppInfo"
+          },
+          "type": "array"
+        },
+        "nextCursor": {
+          "description": "Opaque cursor to pass to the next call to continue after the last item. If None, there are no more items to return.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "data"
+      ],
+      "type": "object"
+    },
     "AskForApproval": {
       "oneOf": [
         {

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 468 {
-		t.Fatalf("definition count = %d, want 468", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 470 {
+		t.Fatalf("definition count = %d, want 470", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 468 {
-		t.Fatalf("definition count = %d, want 468", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 470 {
+		t.Fatalf("definition count = %d, want 470", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 468 {
-		t.Fatalf("definition count = %d, want 468", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 470 {
+		t.Fatalf("definition count = %d, want 470", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -42,6 +42,7 @@ func MarshalTypeScript() ([]byte, error) {
 		if name == "AccountLoginCompletedNotification" || name == "AccountTokenUsageSummary" ||
 			name == "AppBranding" || name == "AppConfig" || name == "AppInfo" || name == "AppMetadata" || name == "AppScreenshot" ||
 			name == "AppSummary" || name == "AppTemplateSummary" || name == "AppsDefaultConfig" ||
+			name == "AppsListParams" || name == "AppsListResponse" ||
 			name == "AppToolConfig" ||
 			name == "ApplyPatchApprovalParams" ||
 			name == "ChatgptAuthTokensRefreshResponse" ||
@@ -111,6 +112,11 @@ func MarshalTypeScript() ([]byte, error) {
 					"enabled", "approvals_reviewer", "destructive_enabled", "open_world_enabled",
 					"default_tools_approval_mode",
 				}
+				schema["x-gollem-typescript-ignore-additional-properties"] = true
+			case "AppsListParams":
+				schema["x-gollem-typescript-ignore-additional-properties"] = true
+			case "AppsListResponse":
+				schema["required"] = []string{"data", "nextCursor"}
 				schema["x-gollem-typescript-ignore-additional-properties"] = true
 			case "ApplyPatchApprovalParams":
 				schema["required"] = []string{
@@ -242,6 +248,20 @@ func MarshalTypeScript() ([]byte, error) {
 				"additionalProperties":             Schema{"$ref": "#/$defs/AppConfig"},
 				"x-gollem-typescript-optional-map": true,
 			}
+		}
+		if name == "AppsListParams" {
+			// The pinned schema uses JSON Schema type arrays for nullable fields;
+			// normalize only the render copy into unions understood by this renderer.
+			definition = typeScriptDefinitionWithPropertySchemas(definition, Schema{
+				"cursor":   nullableStringSchema(),
+				"limit":    nullableIntegerSchema(),
+				"threadId": nullableStringSchema(),
+			})
+		}
+		if name == "AppsListResponse" {
+			definition = typeScriptDefinitionWithPropertySchemas(definition, Schema{
+				"nextCursor": nullableStringSchema(),
+			})
 		}
 		if name == "AppInfo" {
 			// ts-rs models HashMap values with optional mapped keys. Apply the

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -715,6 +715,18 @@ export type AppsDefaultConfig = {
   "open_world_enabled": boolean;
 };
 
+export type AppsListParams = {
+  "cursor"?: string | null;
+  "forceRefetch"?: boolean;
+  "limit"?: number | null;
+  "threadId"?: string | null;
+};
+
+export type AppsListResponse = {
+  "data": Array<AppInfo>;
+  "nextCursor": string | null;
+};
+
 export type AskForApproval = "untrusted" | "on-request" | {
   "granular": {
     "mcp_elicitations": boolean;

--- a/appserver/protocol/typescript/testdata/apps_list_contract.ts
+++ b/appserver/protocol/typescript/testdata/apps_list_contract.ts
@@ -1,0 +1,51 @@
+import type {
+  AppInfo,
+  AppsListParams,
+  AppsListResponse,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2) ? true : false;
+type Expect<T extends true> = T;
+
+type Contracts = [
+  Expect<Equal<AppsListParams, {
+    cursor?: string | null;
+    forceRefetch?: boolean;
+    limit?: number | null;
+    threadId?: string | null;
+  }>>,
+  Expect<Equal<AppsListResponse, {
+    data: Array<AppInfo>;
+    nextCursor: string | null;
+  }>>,
+];
+
+({}) satisfies AppsListParams;
+({ cursor: null, forceRefetch: false, limit: null, threadId: null }) satisfies AppsListParams;
+({ cursor: "", forceRefetch: true, limit: 0, threadId: " " }) satisfies AppsListParams;
+({ data: [], nextCursor: null }) satisfies AppsListResponse;
+
+// @ts-expect-error cursor is nullable string only.
+({ cursor: 1 }) satisfies AppsListParams;
+// @ts-expect-error forceRefetch is optional but non-null.
+({ forceRefetch: null }) satisfies AppsListParams;
+// @ts-expect-error limit is nullable number only.
+({ limit: "1" }) satisfies AppsListParams;
+// @ts-expect-error threadId is nullable string only.
+({ threadId: false }) satisfies AppsListParams;
+// @ts-expect-error canonical compiler record is closed.
+({ future: true }) satisfies AppsListParams;
+// @ts-expect-error response requires data.
+({ nextCursor: null }) satisfies AppsListResponse;
+// @ts-expect-error response requires nextCursor in canonical TypeScript.
+({ data: [] }) satisfies AppsListResponse;
+// @ts-expect-error response data elements are strict AppInfo.
+({ data: [{}], nextCursor: null }) satisfies AppsListResponse;
+// @ts-expect-error response cursor is nullable string only.
+({ data: [], nextCursor: 1 }) satisfies AppsListResponse;
+// @ts-expect-error canonical response is closed.
+({ data: [], nextCursor: null, future: true }) satisfies AppsListResponse;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 468 {
-		t.Fatalf("definition count = %d, want 468", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
+		t.Fatalf("definition count = %d, want 470", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- export exact standalone `AppsListParams` and `AppsListResponse` contracts
- preserve pinned serde defaults, nullable canonicalization, uint32 bounds, unknown-field handling, and duplicate-known rejection
- generate exact JSON Schema and closed canonical TypeScript while keeping deferred `app/list` unbound

## Verification
- focused tests x30, race, and 100% coverage for all four new codec functions
- full protocol tests and strict TypeScript compile
- all 59 non-Monty packages in normal and race modes
- golangci-lint, go vet, go mod tidy/verify, deterministic generation, configured pre-push
- parent/feature transport transcripts byte-identical; empty stderr
- committed no-VCS binary matches reviewed feature binary (`610e93361fb2ee86e3a776f100dcf3354bce336a56eeba60056a07fdc749c2bd`)

Local Monty normal/race/coverage was skipped per project direction; hosted CI remains unchanged.