### PR TITLE
feat(protocol): export process contracts

### DIFF
--- a/appserver/protocol/account_credit_nudge_values_contract_test.go
+++ b/appserver/protocol/account_credit_nudge_values_contract_test.go
@@ -119,8 +119,8 @@ func TestAccountCreditNudgeValuesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/sendAddCreditsNudgeEmail = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/account_login_completed_notification_contract_test.go
+++ b/appserver/protocol/account_login_completed_notification_contract_test.go
@@ -88,8 +88,8 @@ func TestAccountLoginCompletedNotificationRemainsStandaloneAndDeferred(t *testin
 	if !found {
 		t.Fatal("account/login/completed method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/account_token_usage_contract_test.go
+++ b/appserver/protocol/account_token_usage_contract_test.go
@@ -146,8 +146,8 @@ func TestAccountTokenUsageRecordsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/usage/read = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(defs); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_config_contract_test.go
+++ b/appserver/protocol/app_config_contract_test.go
@@ -109,8 +109,8 @@ func TestAppConfigRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppConfig unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_info_contract_test.go
+++ b/appserver/protocol/app_info_contract_test.go
@@ -131,8 +131,8 @@ func TestAppInfoRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_list_updated_notification_contract_test.go
+++ b/appserver/protocol/app_list_updated_notification_contract_test.go
@@ -105,8 +105,8 @@ func TestAppListUpdatedNotificationRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceServerNotification || method.State != MethodDeferredStub {
 		t.Fatalf("app/list/updated = %#v, %v; want deferred server notification", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_metadata_contract_test.go
+++ b/appserver/protocol/app_metadata_contract_test.go
@@ -107,8 +107,8 @@ func TestAppMetadataRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_metadata_leaf_contract_test.go
+++ b/appserver/protocol/app_metadata_leaf_contract_test.go
@@ -157,8 +157,8 @@ func TestAppMetadataLeavesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_summary_contract_test.go
+++ b/appserver/protocol/app_summary_contract_test.go
@@ -87,8 +87,8 @@ func TestAppSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppSummary unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_template_summary_contract_test.go
+++ b/appserver/protocol/app_template_summary_contract_test.go
@@ -107,8 +107,8 @@ func TestAppTemplateSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppTemplateSummary unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_template_unavailable_reason_contract_test.go
+++ b/appserver/protocol/app_template_unavailable_reason_contract_test.go
@@ -71,8 +71,8 @@ func TestAppTemplateUnavailableReasonRemainsStandalone(t *testing.T) {
 			t.Fatalf("AppTemplateUnavailableReason unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_tool_approval_contract_test.go
+++ b/appserver/protocol/app_tool_approval_contract_test.go
@@ -73,8 +73,8 @@ func TestAppToolApprovalRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppToolApproval unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_tools_config_contract_test.go
+++ b/appserver/protocol/app_tools_config_contract_test.go
@@ -140,8 +140,8 @@ func TestAppToolConfigsRemainStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/apply_patch_approval_params_contract_test.go
+++ b/appserver/protocol/apply_patch_approval_params_contract_test.go
@@ -139,8 +139,8 @@ func TestApplyPatchApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ApplyPatchApprovalParams unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(defs); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(defs); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/apps_config_contract_test.go
+++ b/appserver/protocol/apps_config_contract_test.go
@@ -185,8 +185,8 @@ func TestAppsConfigsRemainStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/apps_list_contract_test.go
+++ b/appserver/protocol/apps_list_contract_test.go
@@ -168,8 +168,8 @@ func TestAppsListContractsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/attestation_contract_test.go
+++ b/appserver/protocol/attestation_contract_test.go
@@ -133,8 +133,8 @@ func TestAttestationContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("attestation/generate = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
+++ b/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
@@ -179,8 +179,8 @@ func TestChatgptAuthTokensRefreshRemainsStandaloneAndDeferred(t *testing.T) {
 	if !found {
 		t.Fatal("refresh method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/exec_command_approval_params_contract_test.go
+++ b/appserver/protocol/exec_command_approval_params_contract_test.go
@@ -137,8 +137,8 @@ func TestExecCommandApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ExecCommandApprovalParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(defs); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,8 +217,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,8 +203,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -260,8 +260,8 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,8 +244,8 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -162,8 +162,8 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -175,8 +175,8 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_contract_test.go
+++ b/appserver/protocol/file_change_contract_test.go
@@ -108,8 +108,8 @@ func TestFileChangeRemainsStandalone(t *testing.T) {
 			t.Fatalf("FileChange unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_output_delta_notification_contract_test.go
+++ b/appserver/protocol/file_change_output_delta_notification_contract_test.go
@@ -100,8 +100,8 @@ func TestFileChangeOutputDeltaNotificationRemainsDeprecatedAndStandalone(t *test
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("item/fileChange/outputDelta = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -381,8 +381,8 @@ func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_action_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_action_contract_test.go
@@ -226,8 +226,8 @@ func TestGuardianApprovalReviewActionRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReviewAction unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
@@ -164,8 +164,8 @@ func TestGuardianApprovalReviewCompletedNotificationRemainsStandalone(t *testing
 			t.Fatalf("completed notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_contract_test.go
@@ -139,8 +139,8 @@ func TestGuardianApprovalReviewRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReview unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
@@ -175,8 +175,8 @@ func TestGuardianApprovalReviewStartedNotificationRemainsStandalone(t *testing.T
 			t.Fatalf("started notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_enum_foundation_contract_test.go
+++ b/appserver/protocol/guardian_enum_foundation_contract_test.go
@@ -89,8 +89,8 @@ func TestGuardianEnumFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_metadata_list_contract_test.go
+++ b/appserver/protocol/hook_metadata_list_contract_test.go
@@ -352,8 +352,8 @@ func TestHookMetadataListContractsStayStandalone(t *testing.T) {
 			t.Errorf("standalone definition %s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Errorf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Errorf("definition count = %d, want 474", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 {
 		t.Errorf("wire binding count = %d, want 59", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_run_notification_contract_test.go
+++ b/appserver/protocol/hook_run_notification_contract_test.go
@@ -297,8 +297,8 @@ func TestHookRunNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("surface changed: %d methods, %d wire bindings, %d item bindings", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/hook_value_foundation_contract_test.go
+++ b/appserver/protocol/hook_value_foundation_contract_test.go
@@ -167,8 +167,8 @@ func TestHookValueFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 470 {
-		t.Fatalf("definition count = %d, want 470", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 474 {
+		t.Fatalf("definition count = %d, want 474", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/legacy_approval_response_contract_test.go
+++ b/appserver/protocol/legacy_approval_response_contract_test.go
@@ -98,8 +98,8 @@ func TestLegacyApprovalResponsesRemainStandaloneAndNominal(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_approval_context_contract_test.go
+++ b/appserver/protocol/network_approval_context_contract_test.go
@@ -84,8 +84,8 @@ func TestNetworkApprovalContextRemainsStandalone(t *testing.T) {
 			t.Fatalf("NetworkApprovalContext unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/parsed_command_contract_test.go
+++ b/appserver/protocol/parsed_command_contract_test.go
@@ -120,8 +120,8 @@ func TestParsedCommandRemainsStandalone(t *testing.T) {
 			t.Fatalf("ParsedCommand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/process_contracts_contract_test.go
+++ b/appserver/protocol/process_contracts_contract_test.go
@@ -1,0 +1,354 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestProcessContractsSchemasAreExact(t *testing.T) {
+	wantTerminalSize := Schema{
+		"description": "PTY size in character cells for `process/spawn` PTY sessions.",
+		"properties": Schema{
+			"cols": Schema{
+				"description": "Terminal width in character cells.",
+				"format":      "uint16", "minimum": float64(0), "type": "integer",
+			},
+			"rows": Schema{
+				"description": "Terminal height in character cells.",
+				"format":      "uint16", "minimum": float64(0), "type": "integer",
+			},
+		},
+		"required": []string{"cols", "rows"},
+		"type":     "object",
+	}
+	wantStream := Schema{
+		"description": "Stream label for `process/outputDelta` notifications.",
+		"oneOf": []any{
+			Schema{
+				"description": "stdout stream. PTY mode multiplexes terminal output here.",
+				"enum":        []any{"stdout"}, "type": "string",
+			},
+			Schema{
+				"description": "stderr stream.",
+				"enum":        []any{"stderr"}, "type": "string",
+			},
+		},
+	}
+	wantOutputDelta := Schema{
+		"description": "Base64-encoded output chunk emitted for a streaming `process/spawn` request.",
+		"properties": Schema{
+			"capReached": Schema{
+				"description": "True on the final streamed chunk for this stream when output was truncated by `outputBytesCap`.",
+				"type":        "boolean",
+			},
+			"deltaBase64": Schema{
+				"description": "Base64-encoded output bytes.",
+				"type":        "string",
+			},
+			"processHandle": Schema{
+				"description": "Client-supplied, connection-scoped `processHandle` from `process/spawn`.",
+				"type":        "string",
+			},
+			"stream": Schema{
+				"allOf":       []any{Schema{"$ref": "#/$defs/ProcessOutputStream"}},
+				"description": "Output stream this chunk belongs to.",
+			},
+		},
+		"required": []string{"capReached", "deltaBase64", "processHandle", "stream"},
+		"type":     "object",
+	}
+	wantExited := Schema{
+		"description": "Final process exit notification for `process/spawn`.",
+		"properties": Schema{
+			"exitCode": Schema{
+				"description": "Process exit code.",
+				"format":      "int32", "type": "integer",
+			},
+			"processHandle": Schema{
+				"description": "Client-supplied, connection-scoped `processHandle` from `process/spawn`.",
+				"type":        "string",
+			},
+			"stderr": Schema{
+				"description": "Buffered stderr capture.\n\nEmpty when stderr was streamed via `process/outputDelta`.",
+				"type":        "string",
+			},
+			"stderrCapReached": Schema{
+				"description": "Whether stderr reached `outputBytesCap`.\n\nIn streaming mode, stderr is empty and cap state is also reported on the final stderr `process/outputDelta` notification.",
+				"type":        "boolean",
+			},
+			"stdout": Schema{
+				"description": "Buffered stdout capture.\n\nEmpty when stdout was streamed via `process/outputDelta`.",
+				"type":        "string",
+			},
+			"stdoutCapReached": Schema{
+				"description": "Whether stdout reached `outputBytesCap`.\n\nIn streaming mode, stdout is empty and cap state is also reported on the final stdout `process/outputDelta` notification.",
+				"type":        "boolean",
+			},
+		},
+		"required": []string{
+			"exitCode", "processHandle", "stderr", "stderrCapReached", "stdout", "stdoutCapReached",
+		},
+		"type": "object",
+	}
+
+	definitions := JSONSchema()["$defs"].(Schema)
+	for name, want := range map[string]Schema{
+		"ProcessTerminalSize":            wantTerminalSize,
+		"ProcessOutputStream":            wantStream,
+		"ProcessOutputDeltaNotification": wantOutputDelta,
+		"ProcessExitedNotification":      wantExited,
+	} {
+		if got := definitions[name]; !reflect.DeepEqual(got, want) {
+			t.Errorf("%s = %#v, want %#v", name, got, want)
+		}
+	}
+}
+
+func TestProcessTerminalSizeAcceptsSerdeWireForms(t *testing.T) {
+	for _, tc := range []struct {
+		input string
+		want  string
+	}{
+		{`{"rows":0,"cols":0}`, `{"rows":0,"cols":0}`},
+		{`{"cols":65535,"rows":65535}`, `{"rows":65535,"cols":65535}`},
+		{`{"future":true,"rows":24,"cols":80}`, `{"rows":24,"cols":80}`},
+	} {
+		var value ProcessTerminalSize
+		if err := json.Unmarshal([]byte(tc.input), &value); err != nil {
+			t.Errorf("unmarshal %s: %v", tc.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(value)
+		if err != nil || string(encoded) != tc.want {
+			t.Errorf("round trip %s = %s, %v; want %s", tc.input, encoded, err, tc.want)
+		}
+	}
+}
+
+func TestProcessTerminalSizeRejectsMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`, `{}`,
+		`{"rows":1}`, `{"cols":1}`, `{"rows":null,"cols":1}`, `{"rows":1,"cols":null}`,
+		`{"rows":-1,"cols":1}`, `{"rows":65536,"cols":1}`, `{"rows":1.5,"cols":1}`,
+		`{"rows":"1","cols":1}`, `{"rows":1,"cols":false}`,
+		`{"rows":1,"rows":2,"cols":3}`, `{"rows":1,"cols":2,"cols":3}`,
+		`{"rows":1,"cols":2} {}`, `{"rows":1,"cols":2} x`,
+	} {
+		assertJSONRejects[ProcessTerminalSize](t, input)
+	}
+}
+
+func TestProcessOutputStreamAcceptsExactValues(t *testing.T) {
+	for _, value := range []ProcessOutputStream{ProcessOutputStreamStdout, ProcessOutputStreamStderr} {
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			t.Errorf("marshal %q: %v", value, err)
+			continue
+		}
+		var decoded ProcessOutputStream
+		if err := json.Unmarshal(encoded, &decoded); err != nil || decoded != value {
+			t.Errorf("round trip %q = %q, %v", value, decoded, err)
+		}
+	}
+}
+
+func TestProcessOutputStreamRejectsInvalidValues(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `true`, `1`, `{}`, `[]`, `""`, `"STDOUT"`, `"stdout "`, `"other"`,
+		`"stdout" "stderr"`, `"stdout" x`,
+	} {
+		assertJSONRejects[ProcessOutputStream](t, input)
+	}
+	if _, err := json.Marshal(ProcessOutputStream("other")); err == nil {
+		t.Fatal("invalid ProcessOutputStream marshaled")
+	}
+}
+
+func TestProcessOutputDeltaAcceptsSerdeWireForms(t *testing.T) {
+	for _, tc := range []struct {
+		input string
+		want  string
+	}{
+		{
+			`{"processHandle":"","stream":"stdout","deltaBase64":"not base64","capReached":false}`,
+			`{"processHandle":"","stream":"stdout","deltaBase64":"not base64","capReached":false}`,
+		},
+		{
+			`{"future":1,"capReached":true,"deltaBase64":" AA== ","stream":"stderr","processHandle":" handle "}`,
+			`{"processHandle":" handle ","stream":"stderr","deltaBase64":" AA== ","capReached":true}`,
+		},
+	} {
+		var value ProcessOutputDeltaNotification
+		if err := json.Unmarshal([]byte(tc.input), &value); err != nil {
+			t.Errorf("unmarshal %s: %v", tc.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(value)
+		if err != nil || string(encoded) != tc.want {
+			t.Errorf("round trip %s = %s, %v; want %s", tc.input, encoded, err, tc.want)
+		}
+	}
+}
+
+func TestProcessOutputDeltaRejectsMalformedWireForms(t *testing.T) {
+	valid := `"processHandle":"p","stream":"stdout","deltaBase64":"","capReached":false`
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`, `{}`,
+		`{"stream":"stdout","deltaBase64":"","capReached":false}`,
+		`{"processHandle":"p","deltaBase64":"","capReached":false}`,
+		`{"processHandle":"p","stream":"stdout","capReached":false}`,
+		`{"processHandle":"p","stream":"stdout","deltaBase64":""}`,
+		`{"processHandle":null,"stream":"stdout","deltaBase64":"","capReached":false}`,
+		`{"processHandle":"p","stream":"other","deltaBase64":"","capReached":false}`,
+		`{"processHandle":"p","stream":"stdout","deltaBase64":1,"capReached":false}`,
+		`{"processHandle":"p","stream":"stdout","deltaBase64":"","capReached":null}`,
+		`{` + valid + `,"stream":"stderr"}`, `{` + valid + `,"future":1} {}`, `{` + valid + `} x`,
+	} {
+		assertJSONRejects[ProcessOutputDeltaNotification](t, input)
+	}
+	if _, err := json.Marshal(ProcessOutputDeltaNotification{Stream: ProcessOutputStream("other")}); err == nil {
+		t.Fatal("output delta with invalid stream marshaled")
+	}
+}
+
+func TestProcessExitedAcceptsSerdeWireFormsAndInt32Bounds(t *testing.T) {
+	for _, tc := range []struct {
+		input string
+		want  string
+	}{
+		{
+			`{"processHandle":"","exitCode":0,"stdout":"","stdoutCapReached":false,"stderr":"","stderrCapReached":false}`,
+			`{"processHandle":"","exitCode":0,"stdout":"","stdoutCapReached":false,"stderr":"","stderrCapReached":false}`,
+		},
+		{
+			`{"future":true,"stderrCapReached":true,"stderr":" e ","stdoutCapReached":true,"stdout":" o ","exitCode":-2147483648,"processHandle":" p "}`,
+			`{"processHandle":" p ","exitCode":-2147483648,"stdout":" o ","stdoutCapReached":true,"stderr":" e ","stderrCapReached":true}`,
+		},
+		{
+			`{"processHandle":"p","exitCode":2147483647,"stdout":"o","stdoutCapReached":false,"stderr":"e","stderrCapReached":false}`,
+			`{"processHandle":"p","exitCode":2147483647,"stdout":"o","stdoutCapReached":false,"stderr":"e","stderrCapReached":false}`,
+		},
+	} {
+		var value ProcessExitedNotification
+		if err := json.Unmarshal([]byte(tc.input), &value); err != nil {
+			t.Errorf("unmarshal %s: %v", tc.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(value)
+		if err != nil || string(encoded) != tc.want {
+			t.Errorf("round trip %s = %s, %v; want %s", tc.input, encoded, err, tc.want)
+		}
+	}
+}
+
+func TestProcessExitedRejectsMalformedWireForms(t *testing.T) {
+	valid := `"processHandle":"p","exitCode":0,"stdout":"","stdoutCapReached":false,"stderr":"","stderrCapReached":false`
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`, `{}`,
+		`{"exitCode":0,"stdout":"","stdoutCapReached":false,"stderr":"","stderrCapReached":false}`,
+		`{"processHandle":"p","stdout":"","stdoutCapReached":false,"stderr":"","stderrCapReached":false}`,
+		`{"processHandle":"p","exitCode":0,"stdoutCapReached":false,"stderr":"","stderrCapReached":false}`,
+		`{"processHandle":"p","exitCode":0,"stdout":"","stderr":"","stderrCapReached":false}`,
+		`{"processHandle":"p","exitCode":0,"stdout":"","stdoutCapReached":false,"stderrCapReached":false}`,
+		`{"processHandle":"p","exitCode":0,"stdout":"","stdoutCapReached":false,"stderr":""}`,
+		`{"processHandle":null,"exitCode":0,"stdout":"","stdoutCapReached":false,"stderr":"","stderrCapReached":false}`,
+		`{"processHandle":"p","exitCode":2147483648,"stdout":"","stdoutCapReached":false,"stderr":"","stderrCapReached":false}`,
+		`{"processHandle":"p","exitCode":-2147483649,"stdout":"","stdoutCapReached":false,"stderr":"","stderrCapReached":false}`,
+		`{"processHandle":"p","exitCode":1.5,"stdout":"","stdoutCapReached":false,"stderr":"","stderrCapReached":false}`,
+		`{"processHandle":"p","exitCode":0,"stdout":null,"stdoutCapReached":false,"stderr":"","stderrCapReached":false}`,
+		`{"processHandle":"p","exitCode":0,"stdout":"","stdoutCapReached":null,"stderr":"","stderrCapReached":false}`,
+		`{` + valid + `,"exitCode":1}`, `{` + valid + `} {}`, `{` + valid + `} x`,
+	} {
+		assertJSONRejects[ProcessExitedNotification](t, input)
+	}
+}
+
+func TestProcessContractsNilReceiversFailClosed(t *testing.T) {
+	var terminal *ProcessTerminalSize
+	if err := terminal.UnmarshalJSON([]byte(`{"rows":1,"cols":1}`)); err == nil {
+		t.Fatal("nil ProcessTerminalSize receiver succeeded")
+	}
+	var stream *ProcessOutputStream
+	if err := stream.UnmarshalJSON([]byte(`"stdout"`)); err == nil {
+		t.Fatal("nil ProcessOutputStream receiver succeeded")
+	}
+	var output *ProcessOutputDeltaNotification
+	if err := output.UnmarshalJSON([]byte(`{}`)); err == nil {
+		t.Fatal("nil ProcessOutputDeltaNotification receiver succeeded")
+	}
+	var exited *ProcessExitedNotification
+	if err := exited.UnmarshalJSON([]byte(`{}`)); err == nil {
+		t.Fatal("nil ProcessExitedNotification receiver succeeded")
+	}
+}
+
+func TestProcessContractsRemainStandaloneFromLegacyRuntime(t *testing.T) {
+	names := []string{
+		"ProcessTerminalSize", "ProcessOutputStream",
+		"ProcessOutputDeltaNotification", "ProcessExitedNotification",
+	}
+	for _, binding := range WireTypeBindings() {
+		for _, name := range names {
+			if slices.Contains(binding.Params, name) || slices.Contains(binding.Result, name) {
+				t.Fatalf("%s unexpectedly bound to %s", name, binding.Method)
+			}
+		}
+	}
+	for _, binding := range ItemPayloadBindings() {
+		if slices.Contains(names, binding.Type) {
+			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
+		}
+	}
+	for _, method := range []string{"process/outputDelta", "process/exited"} {
+		info, ok := LookupMethod(method)
+		if !ok || info.Surface != SurfaceServerNotification || info.State != MethodImplemented {
+			t.Fatalf("%s = %#v, %v; want unchanged implemented notification", method, info, ok)
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestProcessContractsTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	source := string(generated)
+	for _, want := range []string{
+		`export type ProcessOutputStream = "stdout" | "stderr";`,
+		"export type ProcessTerminalSize = {\n",
+		`  "cols": number;`, `  "rows": number;`,
+		"export type ProcessOutputDeltaNotification = {\n",
+		`  "capReached": boolean;`, `  "deltaBase64": string;`,
+		`  "processHandle": string;`, `  "stream": ProcessOutputStream;`,
+		"export type ProcessExitedNotification = {\n",
+		`  "exitCode": number;`, `  "stderr": string;`, `  "stderrCapReached": boolean;`,
+		`  "stdout": string;`, `  "stdoutCapReached": boolean;`,
+	} {
+		if !strings.Contains(source, want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}
+
+var (
+	_ json.Marshaler   = ProcessTerminalSize{}
+	_ json.Unmarshaler = (*ProcessTerminalSize)(nil)
+	_ json.Marshaler   = ProcessOutputStream("")
+	_ json.Unmarshaler = (*ProcessOutputStream)(nil)
+	_ json.Marshaler   = ProcessOutputDeltaNotification{}
+	_ json.Unmarshaler = (*ProcessOutputDeltaNotification)(nil)
+	_ json.Marshaler   = ProcessExitedNotification{}
+	_ json.Unmarshaler = (*ProcessExitedNotification)(nil)
+)

--- a/appserver/protocol/process_contracts_types.go
+++ b/appserver/protocol/process_contracts_types.go
@@ -1,0 +1,303 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// ProcessTerminalSize is the exact standalone PTY size contract used by
+// process/spawn. The process runtime remains on its existing legacy envelope.
+type ProcessTerminalSize struct {
+	Rows uint16 `json:"rows"`
+	Cols uint16 `json:"cols"`
+}
+
+func (s ProcessTerminalSize) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Rows uint16 `json:"rows"`
+		Cols uint16 `json:"cols"`
+	}{Rows: s.Rows, Cols: s.Cols})
+}
+
+func (s *ProcessTerminalSize) UnmarshalJSON(data []byte) error {
+	if s == nil {
+		return errors.New("decode process terminal size into nil receiver")
+	}
+	const objectName = "process terminal size"
+	payload, err := decodeRustSerdeObject(data, objectName, "rows", "cols")
+	if err != nil {
+		return err
+	}
+	rows, err := decodeRequiredThreadItemValue[uint16](payload, objectName, "rows")
+	if err != nil {
+		return err
+	}
+	cols, err := decodeRequiredThreadItemValue[uint16](payload, objectName, "cols")
+	if err != nil {
+		return err
+	}
+	*s = ProcessTerminalSize{Rows: rows, Cols: cols}
+	return nil
+}
+
+// ProcessOutputStream identifies the source stream for a process output chunk.
+type ProcessOutputStream string
+
+const (
+	ProcessOutputStreamStdout ProcessOutputStream = "stdout"
+	ProcessOutputStreamStderr ProcessOutputStream = "stderr"
+)
+
+func (s ProcessOutputStream) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(s, "process output stream", ProcessOutputStream.valid)
+}
+
+func (s *ProcessOutputStream) UnmarshalJSON(data []byte) error {
+	return unmarshalThreadTurnLeafEnum(data, s, "process output stream", ProcessOutputStream.valid)
+}
+
+func (s ProcessOutputStream) valid() bool {
+	return s == ProcessOutputStreamStdout || s == ProcessOutputStreamStderr
+}
+
+// ProcessOutputDeltaNotification is the standalone public streaming-output
+// payload. It is intentionally not bound to the legacy runtime notification.
+type ProcessOutputDeltaNotification struct {
+	ProcessHandle string              `json:"processHandle"`
+	Stream        ProcessOutputStream `json:"stream"`
+	DeltaBase64   string              `json:"deltaBase64"`
+	CapReached    bool                `json:"capReached"`
+}
+
+func (n ProcessOutputDeltaNotification) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		ProcessHandle string              `json:"processHandle"`
+		Stream        ProcessOutputStream `json:"stream"`
+		DeltaBase64   string              `json:"deltaBase64"`
+		CapReached    bool                `json:"capReached"`
+	}{
+		ProcessHandle: n.ProcessHandle,
+		Stream:        n.Stream,
+		DeltaBase64:   n.DeltaBase64,
+		CapReached:    n.CapReached,
+	})
+}
+
+func (n *ProcessOutputDeltaNotification) UnmarshalJSON(data []byte) error {
+	if n == nil {
+		return errors.New("decode process output delta notification into nil receiver")
+	}
+	const objectName = "process output delta notification"
+	payload, err := decodeRustSerdeObject(
+		data, objectName, "processHandle", "stream", "deltaBase64", "capReached",
+	)
+	if err != nil {
+		return err
+	}
+	processHandle, err := decodeRequiredThreadItemValue[string](payload, objectName, "processHandle")
+	if err != nil {
+		return err
+	}
+	stream, err := decodeRequiredThreadItemValue[ProcessOutputStream](payload, objectName, "stream")
+	if err != nil {
+		return err
+	}
+	deltaBase64, err := decodeRequiredThreadItemValue[string](payload, objectName, "deltaBase64")
+	if err != nil {
+		return err
+	}
+	capReached, err := decodeRequiredThreadItemValue[bool](payload, objectName, "capReached")
+	if err != nil {
+		return err
+	}
+	*n = ProcessOutputDeltaNotification{
+		ProcessHandle: processHandle,
+		Stream:        stream,
+		DeltaBase64:   deltaBase64,
+		CapReached:    capReached,
+	}
+	return nil
+}
+
+// ProcessExitedNotification is the standalone public final process payload.
+// It remains unbound until the process runtime emits this exact wire shape.
+type ProcessExitedNotification struct {
+	ProcessHandle    string `json:"processHandle"`
+	ExitCode         int32  `json:"exitCode"`
+	Stdout           string `json:"stdout"`
+	StdoutCapReached bool   `json:"stdoutCapReached"`
+	Stderr           string `json:"stderr"`
+	StderrCapReached bool   `json:"stderrCapReached"`
+}
+
+func (n ProcessExitedNotification) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		ProcessHandle    string `json:"processHandle"`
+		ExitCode         int32  `json:"exitCode"`
+		Stdout           string `json:"stdout"`
+		StdoutCapReached bool   `json:"stdoutCapReached"`
+		Stderr           string `json:"stderr"`
+		StderrCapReached bool   `json:"stderrCapReached"`
+	}{
+		ProcessHandle:    n.ProcessHandle,
+		ExitCode:         n.ExitCode,
+		Stdout:           n.Stdout,
+		StdoutCapReached: n.StdoutCapReached,
+		Stderr:           n.Stderr,
+		StderrCapReached: n.StderrCapReached,
+	})
+}
+
+func (n *ProcessExitedNotification) UnmarshalJSON(data []byte) error {
+	if n == nil {
+		return errors.New("decode process exited notification into nil receiver")
+	}
+	const objectName = "process exited notification"
+	payload, err := decodeRustSerdeObject(
+		data, objectName,
+		"processHandle", "exitCode", "stdout", "stdoutCapReached", "stderr", "stderrCapReached",
+	)
+	if err != nil {
+		return err
+	}
+	processHandle, err := decodeRequiredThreadItemValue[string](payload, objectName, "processHandle")
+	if err != nil {
+		return err
+	}
+	exitCode, err := decodeRequiredThreadItemValue[int32](payload, objectName, "exitCode")
+	if err != nil {
+		return err
+	}
+	stdout, err := decodeRequiredThreadItemValue[string](payload, objectName, "stdout")
+	if err != nil {
+		return err
+	}
+	stdoutCapReached, err := decodeRequiredThreadItemValue[bool](payload, objectName, "stdoutCapReached")
+	if err != nil {
+		return err
+	}
+	stderr, err := decodeRequiredThreadItemValue[string](payload, objectName, "stderr")
+	if err != nil {
+		return err
+	}
+	stderrCapReached, err := decodeRequiredThreadItemValue[bool](payload, objectName, "stderrCapReached")
+	if err != nil {
+		return err
+	}
+	*n = ProcessExitedNotification{
+		ProcessHandle:    processHandle,
+		ExitCode:         exitCode,
+		Stdout:           stdout,
+		StdoutCapReached: stdoutCapReached,
+		Stderr:           stderr,
+		StderrCapReached: stderrCapReached,
+	}
+	return nil
+}
+
+func processTerminalSizeSchema() Schema {
+	return Schema{
+		"description": "PTY size in character cells for `process/spawn` PTY sessions.",
+		"properties": Schema{
+			"cols": Schema{
+				"description": "Terminal width in character cells.",
+				"format":      "uint16", "minimum": float64(0), "type": "integer",
+			},
+			"rows": Schema{
+				"description": "Terminal height in character cells.",
+				"format":      "uint16", "minimum": float64(0), "type": "integer",
+			},
+		},
+		"required": []string{"cols", "rows"},
+		"type":     "object",
+	}
+}
+
+func processOutputStreamSchema() Schema {
+	return Schema{
+		"description": "Stream label for `process/outputDelta` notifications.",
+		"oneOf": []any{
+			Schema{
+				"description": "stdout stream. PTY mode multiplexes terminal output here.",
+				"enum":        []any{"stdout"}, "type": "string",
+			},
+			Schema{
+				"description": "stderr stream.",
+				"enum":        []any{"stderr"}, "type": "string",
+			},
+		},
+	}
+}
+
+func processOutputDeltaNotificationSchema() Schema {
+	return Schema{
+		"description": "Base64-encoded output chunk emitted for a streaming `process/spawn` request.",
+		"properties": Schema{
+			"capReached": Schema{
+				"description": "True on the final streamed chunk for this stream when output was truncated by `outputBytesCap`.",
+				"type":        "boolean",
+			},
+			"deltaBase64": Schema{
+				"description": "Base64-encoded output bytes.",
+				"type":        "string",
+			},
+			"processHandle": Schema{
+				"description": "Client-supplied, connection-scoped `processHandle` from `process/spawn`.",
+				"type":        "string",
+			},
+			"stream": Schema{
+				"allOf":       []any{Schema{"$ref": "#/$defs/ProcessOutputStream"}},
+				"description": "Output stream this chunk belongs to.",
+			},
+		},
+		"required": []string{"capReached", "deltaBase64", "processHandle", "stream"},
+		"type":     "object",
+	}
+}
+
+func processExitedNotificationSchema() Schema {
+	return Schema{
+		"description": "Final process exit notification for `process/spawn`.",
+		"properties": Schema{
+			"exitCode": Schema{
+				"description": "Process exit code.",
+				"format":      "int32", "type": "integer",
+			},
+			"processHandle": Schema{
+				"description": "Client-supplied, connection-scoped `processHandle` from `process/spawn`.",
+				"type":        "string",
+			},
+			"stderr": Schema{
+				"description": "Buffered stderr capture.\n\nEmpty when stderr was streamed via `process/outputDelta`.",
+				"type":        "string",
+			},
+			"stderrCapReached": Schema{
+				"description": "Whether stderr reached `outputBytesCap`.\n\nIn streaming mode, stderr is empty and cap state is also reported on the final stderr `process/outputDelta` notification.",
+				"type":        "boolean",
+			},
+			"stdout": Schema{
+				"description": "Buffered stdout capture.\n\nEmpty when stdout was streamed via `process/outputDelta`.",
+				"type":        "string",
+			},
+			"stdoutCapReached": Schema{
+				"description": "Whether stdout reached `outputBytesCap`.\n\nIn streaming mode, stdout is empty and cap state is also reported on the final stdout `process/outputDelta` notification.",
+				"type":        "boolean",
+			},
+		},
+		"required": []string{
+			"exitCode", "processHandle", "stderr", "stderrCapReached", "stdout", "stdoutCapReached",
+		},
+		"type": "object",
+	}
+}
+
+var (
+	_ json.Marshaler   = ProcessTerminalSize{}
+	_ json.Unmarshaler = (*ProcessTerminalSize)(nil)
+	_ json.Marshaler   = ProcessOutputStream("")
+	_ json.Unmarshaler = (*ProcessOutputStream)(nil)
+	_ json.Marshaler   = ProcessOutputDeltaNotification{}
+	_ json.Unmarshaler = (*ProcessOutputDeltaNotification)(nil)
+	_ json.Marshaler   = ProcessExitedNotification{}
+	_ json.Unmarshaler = (*ProcessExitedNotification)(nil)
+)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 470 {
-		t.Fatalf("definition count = %d, want 470", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 474 {
+		t.Fatalf("definition count = %d, want 474", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 470 {
-		t.Fatalf("definition count = %d, want 470", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 474 {
+		t.Fatalf("definition count = %d, want 474", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 470 {
-		t.Fatalf("definition count = %d, want 470", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 474 {
+		t.Fatalf("definition count = %d, want 474", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 470 {
-		t.Fatalf("definition count = %d, want 470", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 474 {
+		t.Fatalf("definition count = %d, want 474", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 470 {
-		t.Fatalf("definition count = %d, want 470", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 474 {
+		t.Fatalf("definition count = %d, want 474", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/review_decision_contract_test.go
+++ b/appserver/protocol/review_decision_contract_test.go
@@ -136,8 +136,8 @@ func TestReviewDecisionRemainsStandalone(t *testing.T) {
 			t.Fatalf("ReviewDecision unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(defs); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -338,6 +338,10 @@ func wireSchemaDefinitions() Schema {
 		{Name: "Personality", Type: reflect.TypeFor[Personality]()},
 		{Name: "PlanDeltaNotification", Type: reflect.TypeFor[PlanDeltaNotification]()},
 		{Name: "PluginsMigration", Type: reflect.TypeFor[PluginsMigration]()},
+		{Name: "ProcessExitedNotification", Type: reflect.TypeFor[ProcessExitedNotification]()},
+		{Name: "ProcessOutputDeltaNotification", Type: reflect.TypeFor[ProcessOutputDeltaNotification]()},
+		{Name: "ProcessOutputStream", Type: reflect.TypeFor[ProcessOutputStream]()},
+		{Name: "ProcessTerminalSize", Type: reflect.TypeFor[ProcessTerminalSize]()},
 		{Name: "SkillMigration", Type: reflect.TypeFor[SkillMigration]()},
 		{Name: "SessionMigration", Type: reflect.TypeFor[SessionMigration]()},
 		{Name: "HookMigration", Type: reflect.TypeFor[HookMigration]()},
@@ -999,6 +1003,10 @@ func wireSchemaDefinitions() Schema {
 		string(NetworkApprovalProtocolSocks5TCP), string(NetworkApprovalProtocolSocks5UDP),
 	)
 	schemas["ParsedCommand"] = parsedCommandSchema()
+	schemas["ProcessExitedNotification"] = processExitedNotificationSchema()
+	schemas["ProcessOutputDeltaNotification"] = processOutputDeltaNotificationSchema()
+	schemas["ProcessOutputStream"] = processOutputStreamSchema()
+	schemas["ProcessTerminalSize"] = processTerminalSizeSchema()
 	schemas["McpServerToolCallParams"] = mcpServerToolCallParamsSchema()
 	schemas["McpServerToolCallResponse"] = mcpServerToolCallResponseSchema()
 	schemas["ResourceContent"] = resourceContentSchema()

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -9952,6 +9952,118 @@
       ],
       "type": "object"
     },
+    "ProcessExitedNotification": {
+      "description": "Final process exit notification for `process/spawn`.",
+      "properties": {
+        "exitCode": {
+          "description": "Process exit code.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "processHandle": {
+          "description": "Client-supplied, connection-scoped `processHandle` from `process/spawn`.",
+          "type": "string"
+        },
+        "stderr": {
+          "description": "Buffered stderr capture.\n\nEmpty when stderr was streamed via `process/outputDelta`.",
+          "type": "string"
+        },
+        "stderrCapReached": {
+          "description": "Whether stderr reached `outputBytesCap`.\n\nIn streaming mode, stderr is empty and cap state is also reported on the final stderr `process/outputDelta` notification.",
+          "type": "boolean"
+        },
+        "stdout": {
+          "description": "Buffered stdout capture.\n\nEmpty when stdout was streamed via `process/outputDelta`.",
+          "type": "string"
+        },
+        "stdoutCapReached": {
+          "description": "Whether stdout reached `outputBytesCap`.\n\nIn streaming mode, stdout is empty and cap state is also reported on the final stdout `process/outputDelta` notification.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "exitCode",
+        "processHandle",
+        "stderr",
+        "stderrCapReached",
+        "stdout",
+        "stdoutCapReached"
+      ],
+      "type": "object"
+    },
+    "ProcessOutputDeltaNotification": {
+      "description": "Base64-encoded output chunk emitted for a streaming `process/spawn` request.",
+      "properties": {
+        "capReached": {
+          "description": "True on the final streamed chunk for this stream when output was truncated by `outputBytesCap`.",
+          "type": "boolean"
+        },
+        "deltaBase64": {
+          "description": "Base64-encoded output bytes.",
+          "type": "string"
+        },
+        "processHandle": {
+          "description": "Client-supplied, connection-scoped `processHandle` from `process/spawn`.",
+          "type": "string"
+        },
+        "stream": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/ProcessOutputStream"
+            }
+          ],
+          "description": "Output stream this chunk belongs to."
+        }
+      },
+      "required": [
+        "capReached",
+        "deltaBase64",
+        "processHandle",
+        "stream"
+      ],
+      "type": "object"
+    },
+    "ProcessOutputStream": {
+      "description": "Stream label for `process/outputDelta` notifications.",
+      "oneOf": [
+        {
+          "description": "stdout stream. PTY mode multiplexes terminal output here.",
+          "enum": [
+            "stdout"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "stderr stream.",
+          "enum": [
+            "stderr"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "ProcessTerminalSize": {
+      "description": "PTY size in character cells for `process/spawn` PTY sessions.",
+      "properties": {
+        "cols": {
+          "description": "Terminal width in character cells.",
+          "format": "uint16",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "rows": {
+          "description": "Terminal height in character cells.",
+          "format": "uint16",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cols",
+        "rows"
+      ],
+      "type": "object"
+    },
     "RawResponseItemCompletedNotification": {
       "additionalProperties": false,
       "properties": {

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 470 {
-		t.Fatalf("definition count = %d, want 470", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 474 {
+		t.Fatalf("definition count = %d, want 474", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 470 {
-		t.Fatalf("definition count = %d, want 470", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 474 {
+		t.Fatalf("definition count = %d, want 474", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 470 {
-		t.Fatalf("definition count = %d, want 470", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 474 {
+		t.Fatalf("definition count = %d, want 474", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -55,6 +55,8 @@ func MarshalTypeScript() ([]byte, error) {
 			name == "HookRunSummary" || name == "HookStartedNotification" ||
 			name == "HookCompletedNotification" || name == "HookMetadata" ||
 			name == "GuardianApprovalReview" || name == "ParsedCommand" ||
+			name == "ProcessExitedNotification" || name == "ProcessOutputDeltaNotification" ||
+			name == "ProcessTerminalSize" ||
 			name == "ItemGuardianApprovalReviewCompletedNotification" ||
 			name == "ItemGuardianApprovalReviewStartedNotification" {
 			// Rust accepts omitted serde default/Option fields while generated
@@ -182,6 +184,8 @@ func MarshalTypeScript() ([]byte, error) {
 					copy["required"] = required
 					variants[index] = copy
 				}
+			case "ProcessExitedNotification", "ProcessOutputDeltaNotification", "ProcessTerminalSize":
+				schema["x-gollem-typescript-ignore-additional-properties"] = true
 			case "ItemGuardianApprovalReviewCompletedNotification":
 				schema["required"] = []string{
 					"threadId", "turnId", "startedAtMs", "completedAtMs", "reviewId",
@@ -261,6 +265,13 @@ func MarshalTypeScript() ([]byte, error) {
 		if name == "AppsListResponse" {
 			definition = typeScriptDefinitionWithPropertySchemas(definition, Schema{
 				"nextCursor": nullableStringSchema(),
+			})
+		}
+		if name == "ProcessOutputDeltaNotification" {
+			// The exact schema wraps the stream reference in allOf to attach its
+			// description. Render that property as the referenced Rust type.
+			definition = typeScriptDefinitionWithPropertySchemas(definition, Schema{
+				"stream": Schema{"$ref": "#/$defs/ProcessOutputStream"},
 			})
 		}
 		if name == "AppInfo" {

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -2565,6 +2565,29 @@ export type PluginsMigration = {
   "pluginNames": Array<string>;
 };
 
+export type ProcessExitedNotification = {
+  "exitCode": number;
+  "processHandle": string;
+  "stderr": string;
+  "stderrCapReached": boolean;
+  "stdout": string;
+  "stdoutCapReached": boolean;
+};
+
+export type ProcessOutputDeltaNotification = {
+  "capReached": boolean;
+  "deltaBase64": string;
+  "processHandle": string;
+  "stream": ProcessOutputStream;
+};
+
+export type ProcessOutputStream = "stdout" | "stderr";
+
+export type ProcessTerminalSize = {
+  "cols": number;
+  "rows": number;
+};
+
 export type RawResponseItemCompletedNotification = {
   "item": ResponseItem;
   "threadId": string;

--- a/appserver/protocol/typescript/testdata/process_contracts_contract.ts
+++ b/appserver/protocol/typescript/testdata/process_contracts_contract.ts
@@ -1,0 +1,59 @@
+import type {
+  ProcessExitedNotification,
+  ProcessOutputDeltaNotification,
+  ProcessOutputStream,
+  ProcessTerminalSize,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2) ? true : false;
+type Expect<T extends true> = T;
+
+type Contracts = [
+  Expect<Equal<ProcessOutputStream, "stdout" | "stderr">>,
+  Expect<Equal<ProcessTerminalSize, { rows: number; cols: number }>>,
+  Expect<Equal<ProcessOutputDeltaNotification, {
+    processHandle: string;
+    stream: ProcessOutputStream;
+    deltaBase64: string;
+    capReached: boolean;
+  }>>,
+  Expect<Equal<ProcessExitedNotification, {
+    processHandle: string;
+    exitCode: number;
+    stdout: string;
+    stdoutCapReached: boolean;
+    stderr: string;
+    stderrCapReached: boolean;
+  }>>,
+];
+
+"stdout" satisfies ProcessOutputStream;
+"stderr" satisfies ProcessOutputStream;
+({ rows: 0, cols: 65535 }) satisfies ProcessTerminalSize;
+({ processHandle: "", stream: "stdout", deltaBase64: "not base64", capReached: false }) satisfies ProcessOutputDeltaNotification;
+({ processHandle: "p", exitCode: -1, stdout: "", stdoutCapReached: true, stderr: "e", stderrCapReached: false }) satisfies ProcessExitedNotification;
+
+// @ts-expect-error stream labels are exact.
+"other" satisfies ProcessOutputStream;
+// @ts-expect-error terminal rows are required.
+({ cols: 80 }) satisfies ProcessTerminalSize;
+// @ts-expect-error terminal dimensions are numeric.
+({ rows: "24", cols: 80 }) satisfies ProcessTerminalSize;
+// @ts-expect-error terminal size is closed.
+({ rows: 24, cols: 80, future: true }) satisfies ProcessTerminalSize;
+// @ts-expect-error output delta requires capReached.
+({ processHandle: "p", stream: "stdout", deltaBase64: "" }) satisfies ProcessOutputDeltaNotification;
+// @ts-expect-error output delta stream is exact.
+({ processHandle: "p", stream: "other", deltaBase64: "", capReached: false }) satisfies ProcessOutputDeltaNotification;
+// @ts-expect-error output delta is closed.
+({ processHandle: "p", stream: "stdout", deltaBase64: "", capReached: false, future: true }) satisfies ProcessOutputDeltaNotification;
+// @ts-expect-error exited requires stderrCapReached.
+({ processHandle: "p", exitCode: 0, stdout: "", stdoutCapReached: false, stderr: "" }) satisfies ProcessExitedNotification;
+// @ts-expect-error exited cap markers are boolean.
+({ processHandle: "p", exitCode: 0, stdout: "", stdoutCapReached: 0, stderr: "", stderrCapReached: false }) satisfies ProcessExitedNotification;
+// @ts-expect-error exited is closed.
+({ processHandle: "p", exitCode: 0, stdout: "", stdoutCapReached: false, stderr: "", stderrCapReached: false, future: true }) satisfies ProcessExitedNotification;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 470 {
-		t.Fatalf("definition count = %d, want 470", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
+		t.Fatalf("definition count = %d, want 474", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- export exact standalone process terminal, stream, output-delta, and exit contracts
- preserve the incompatible legacy process runtime notifications and all method/item bindings
- regenerate schema and TypeScript at 474 definitions

## Verification
- focused process tests x30 and race x30 with 100% coverage for every new function
- all 59 non-Monty packages in normal and race modes
- strict TypeScript, golangci-lint, go vet, go mod tidy/verify, deterministic generation
- exact generated-artifact reversal and byte-identical parent/feature app-server transcript

Local Monty tests were skipped per repository workflow; hosted CI remains unchanged.