### PR TITLE
feat(protocol): export account rate-limit contracts

### DIFF
--- a/appserver/protocol/account_credit_nudge_values_contract_test.go
+++ b/appserver/protocol/account_credit_nudge_values_contract_test.go
@@ -119,8 +119,8 @@ func TestAccountCreditNudgeValuesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/sendAddCreditsNudgeEmail = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/account_login_completed_notification_contract_test.go
+++ b/appserver/protocol/account_login_completed_notification_contract_test.go
@@ -88,8 +88,8 @@ func TestAccountLoginCompletedNotificationRemainsStandaloneAndDeferred(t *testin
 	if !found {
 		t.Fatal("account/login/completed method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/account_rate_limits_contract_test.go
+++ b/appserver/protocol/account_rate_limits_contract_test.go
@@ -1,0 +1,567 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestAccountRateLimitSchemasAreExact(t *testing.T) {
+	nullableString := Schema{"type": []any{"string", "null"}}
+	nullableInt64 := Schema{"type": []any{"integer", "null"}, "format": "int64"}
+	nullableRef := func(name string) Schema {
+		return Schema{"anyOf": []any{Schema{"$ref": "#/$defs/" + name}, Schema{"type": "null"}}}
+	}
+	object := func(properties Schema, required ...string) Schema {
+		out := Schema{"type": "object", "properties": properties}
+		if len(required) != 0 {
+			out["required"] = required
+		}
+		return out
+	}
+
+	wants := map[string]Schema{
+		"PlanType": stringEnumSchema(
+			"free", "go", "plus", "pro", "prolite", "team",
+			"self_serve_business_usage_based", "business",
+			"enterprise_cbp_usage_based", "enterprise", "edu", "unknown",
+		),
+		"RateLimitReachedType": stringEnumSchema(
+			"rate_limit_reached", "workspace_owner_credits_depleted",
+			"workspace_member_credits_depleted", "workspace_owner_usage_limit_reached",
+			"workspace_member_usage_limit_reached",
+		),
+		"RateLimitResetType": stringEnumSchema("codexRateLimits", "unknown"),
+		"RateLimitResetCreditStatus": stringEnumSchema(
+			"available", "redeeming", "redeemed", "unknown",
+		),
+		"ConsumeAccountRateLimitResetCreditOutcome": Schema{"oneOf": []any{
+			Schema{"description": "A reset credit was consumed and the eligible rate-limit windows were reset.", "enum": []any{"reset"}, "type": "string"},
+			Schema{"description": "No current rate-limit window is eligible for a reset.", "enum": []any{"nothingToReset"}, "type": "string"},
+			Schema{"description": "The account has no earned reset credits available.", "enum": []any{"noCredit"}, "type": "string"},
+			Schema{"description": "The same idempotency key already completed a reset successfully.", "enum": []any{"alreadyRedeemed"}, "type": "string"},
+		}},
+		"RateLimitWindow": object(Schema{
+			"usedPercent":        Schema{"type": "integer", "format": "int32"},
+			"windowDurationMins": nullableInt64,
+			"resetsAt":           nullableInt64,
+		}, "usedPercent"),
+		"CreditsSnapshot": object(Schema{
+			"hasCredits": Schema{"type": "boolean"},
+			"unlimited":  Schema{"type": "boolean"},
+			"balance":    nullableString,
+		}, "hasCredits", "unlimited"),
+		"SpendControlLimitSnapshot": object(Schema{
+			"limit":            Schema{"type": "string"},
+			"used":             Schema{"type": "string"},
+			"remainingPercent": Schema{"type": "integer", "format": "int32"},
+			"resetsAt":         Schema{"type": "integer", "format": "int64"},
+		}, "limit", "remainingPercent", "resetsAt", "used"),
+		"RateLimitSnapshot": object(Schema{
+			"limitId":              nullableString,
+			"limitName":            nullableString,
+			"primary":              nullableRef("RateLimitWindow"),
+			"secondary":            nullableRef("RateLimitWindow"),
+			"credits":              nullableRef("CreditsSnapshot"),
+			"individualLimit":      nullableRef("SpendControlLimitSnapshot"),
+			"planType":             nullableRef("PlanType"),
+			"rateLimitReachedType": nullableRef("RateLimitReachedType"),
+		}),
+		"RateLimitResetCredit": object(Schema{
+			"id":          Schema{"description": "Opaque backend identifier for this reset credit.", "type": "string"},
+			"resetType":   Schema{"$ref": "#/$defs/RateLimitResetType"},
+			"status":      Schema{"$ref": "#/$defs/RateLimitResetCreditStatus"},
+			"grantedAt":   Schema{"description": "Unix timestamp in seconds when the credit was granted.", "format": "int64", "type": "integer"},
+			"expiresAt":   Schema{"description": "Unix timestamp in seconds when the credit expires, or `null` if it does not expire.", "format": "int64", "type": []any{"integer", "null"}},
+			"title":       Schema{"description": "Backend-provided display title for this credit, or `null` when unavailable.", "type": []any{"string", "null"}},
+			"description": Schema{"description": "Backend-provided display description for this credit, or `null` when unavailable.", "type": []any{"string", "null"}},
+		}, "grantedAt", "id", "resetType", "status"),
+		"RateLimitResetCreditsSummary": object(Schema{
+			"availableCount": Schema{"format": "int64", "type": "integer"},
+			"credits": Schema{
+				"description": "Detail rows for available reset credits, when the backend provides them.\n\n`null` means only `availableCount` is known, while an empty array means details were fetched and no available credits were returned. The backend may cap this list, so its length can be less than `availableCount`.",
+				"items":       Schema{"$ref": "#/$defs/RateLimitResetCredit"}, "type": []any{"array", "null"},
+			},
+		}, "availableCount"),
+		"GetAccountRateLimitsResponse": object(Schema{
+			"rateLimits": Schema{
+				"allOf":       []any{Schema{"$ref": "#/$defs/RateLimitSnapshot"}},
+				"description": "Backward-compatible single-bucket view; mirrors the historical payload.",
+			},
+			"rateLimitsByLimitId": Schema{
+				"additionalProperties": Schema{"$ref": "#/$defs/RateLimitSnapshot"},
+				"description":          "Multi-bucket view keyed by metered `limit_id` (for example, `codex`).",
+				"type":                 []any{"object", "null"},
+			},
+			"rateLimitResetCredits": nullableRef("RateLimitResetCreditsSummary"),
+		}, "rateLimits"),
+		"ConsumeAccountRateLimitResetCreditParams": object(Schema{
+			"idempotencyKey": Schema{"description": "Identifies one logical reset attempt. A UUID is recommended; reuse the same value when retrying that attempt.", "type": "string"},
+			"creditId":       Schema{"description": "Opaque reset-credit identifier to redeem. When omitted, the backend selects the next available credit.", "type": []any{"string", "null"}},
+		}, "idempotencyKey"),
+		"ConsumeAccountRateLimitResetCreditResponse": object(Schema{
+			"outcome": Schema{"$ref": "#/$defs/ConsumeAccountRateLimitResetCreditOutcome"},
+		}, "outcome"),
+		"AccountRateLimitsUpdatedNotification": Schema{
+			"description": "Sparse rolling rate-limit update.\n\nClients should merge available values into the most recent `account/rateLimits/read` response or refetch that snapshot. Nullable account metadata may be unavailable in a rolling update and does not clear a previously observed value.",
+			"properties":  Schema{"rateLimits": Schema{"$ref": "#/$defs/RateLimitSnapshot"}},
+			"required":    []string{"rateLimits"}, "type": "object",
+		},
+	}
+
+	defs := JSONSchema()["$defs"].(Schema)
+	for name, want := range wants {
+		if got := defs[name]; !reflect.DeepEqual(got, want) {
+			t.Errorf("%s = %#v, want %#v", name, got, want)
+		}
+	}
+}
+
+func TestAccountRateLimitEnumsPreserveExactAndFallbackSemantics(t *testing.T) {
+	closed := map[string]any{
+		`"rate_limit_reached"`:                   RateLimitReachedTypeRateLimitReached,
+		`"workspace_owner_credits_depleted"`:     RateLimitReachedTypeWorkspaceOwnerCreditsDepleted,
+		`"workspace_member_credits_depleted"`:    RateLimitReachedTypeWorkspaceMemberCreditsDepleted,
+		`"workspace_owner_usage_limit_reached"`:  RateLimitReachedTypeWorkspaceOwnerUsageLimitReached,
+		`"workspace_member_usage_limit_reached"`: RateLimitReachedTypeWorkspaceMemberUsageLimitReached,
+		`"reset"`:                                ConsumeAccountRateLimitResetCreditOutcomeReset,
+		`"nothingToReset"`:                       ConsumeAccountRateLimitResetCreditOutcomeNothingToReset,
+		`"noCredit"`:                             ConsumeAccountRateLimitResetCreditOutcomeNoCredit,
+		`"alreadyRedeemed"`:                      ConsumeAccountRateLimitResetCreditOutcomeAlreadyRedeemed,
+	}
+	for input, want := range closed {
+		var got any
+		switch want.(type) {
+		case RateLimitReachedType:
+			var value RateLimitReachedType
+			if err := json.Unmarshal([]byte(input), &value); err != nil {
+				t.Fatalf("unmarshal %s: %v", input, err)
+			}
+			got = value
+		case ConsumeAccountRateLimitResetCreditOutcome:
+			var value ConsumeAccountRateLimitResetCreditOutcome
+			if err := json.Unmarshal([]byte(input), &value); err != nil {
+				t.Fatalf("unmarshal %s: %v", input, err)
+			}
+			got = value
+		}
+		if got != want {
+			t.Errorf("unmarshal %s = %#v, want %#v", input, got, want)
+		}
+	}
+
+	for _, input := range []string{`""`, `"other"`, `"unknown"`, `"RateLimitReached"`, `null`, `1`, `true`, `{}`, `[]`, `"rate_limit_reached" {}`, `"rate_limit_reached" x`} {
+		assertJSONRejects[RateLimitReachedType](t, input)
+	}
+	for _, input := range []string{`""`, `"other"`, `"unknown"`, `"nothing_to_reset"`, `null`, `1`, `true`, `{}`, `[]`, `"reset" {}`, `"reset" x`} {
+		assertJSONRejects[ConsumeAccountRateLimitResetCreditOutcome](t, input)
+	}
+
+	for _, tc := range []struct {
+		input  string
+		plan   PlanType
+		reset  RateLimitResetType
+		status RateLimitResetCreditStatus
+	}{
+		{input: `"free"`, plan: PlanTypeFree},
+		{input: `"self_serve_business_usage_based"`, plan: PlanTypeSelfServeBusinessUsageBased},
+		{input: `"enterprise_cbp_usage_based"`, plan: PlanTypeEnterpriseCBPUsageBased},
+		{input: `"edu"`, plan: PlanTypeEdu},
+		{input: `"codexRateLimits"`, reset: RateLimitResetTypeCodexRateLimits},
+		{input: `"available"`, status: RateLimitResetCreditStatusAvailable},
+		{input: `"redeeming"`, status: RateLimitResetCreditStatusRedeeming},
+		{input: `"redeemed"`, status: RateLimitResetCreditStatusRedeemed},
+	} {
+		switch {
+		case tc.plan != "":
+			var value PlanType
+			if err := json.Unmarshal([]byte(tc.input), &value); err != nil || value != tc.plan {
+				t.Errorf("plan %s = %q, %v; want %q", tc.input, value, err, tc.plan)
+			}
+		case tc.reset != "":
+			var value RateLimitResetType
+			if err := json.Unmarshal([]byte(tc.input), &value); err != nil || value != tc.reset {
+				t.Errorf("reset %s = %q, %v; want %q", tc.input, value, err, tc.reset)
+			}
+		case tc.status != "":
+			var value RateLimitResetCreditStatus
+			if err := json.Unmarshal([]byte(tc.input), &value); err != nil || value != tc.status {
+				t.Errorf("status %s = %q, %v; want %q", tc.input, value, err, tc.status)
+			}
+		}
+	}
+
+	for _, input := range []string{`"unknown"`, `"future-plan"`, `""`, `" FREE "`} {
+		var value PlanType
+		if err := json.Unmarshal([]byte(input), &value); err != nil || value != PlanTypeUnknown {
+			t.Errorf("fallback plan %s = %q, %v", input, value, err)
+		}
+		encoded, err := json.Marshal(value)
+		if err != nil || string(encoded) != `"unknown"` {
+			t.Errorf("fallback plan marshal = %s, %v", encoded, err)
+		}
+	}
+	for _, input := range []string{`"unknown"`, `"future-reset"`, `""`} {
+		var value RateLimitResetType
+		if err := json.Unmarshal([]byte(input), &value); err != nil || value != RateLimitResetTypeUnknown {
+			t.Errorf("fallback reset %s = %q, %v", input, value, err)
+		}
+	}
+	for _, input := range []string{`"unknown"`, `"future-status"`, `""`} {
+		var value RateLimitResetCreditStatus
+		if err := json.Unmarshal([]byte(input), &value); err != nil || value != RateLimitResetCreditStatusUnknown {
+			t.Errorf("fallback status %s = %q, %v", input, value, err)
+		}
+	}
+	for _, input := range []string{``, `null`, `1`, `true`, `{}`, `[]`, `"free" {}`, `"free" x`} {
+		assertJSONRejects[PlanType](t, input)
+		assertJSONRejects[RateLimitResetType](t, input)
+		assertJSONRejects[RateLimitResetCreditStatus](t, input)
+	}
+}
+
+func TestAccountRateLimitLeafRecordsAcceptSerdeFormsAndBounds(t *testing.T) {
+	for _, tc := range []struct{ input, want string }{
+		{`{"usedPercent":-2147483648}`, `{"usedPercent":-2147483648,"windowDurationMins":null,"resetsAt":null}`},
+		{`{"future":true,"resetsAt":9223372036854775807,"windowDurationMins":-9223372036854775808,"usedPercent":2147483647}`, `{"usedPercent":2147483647,"windowDurationMins":-9223372036854775808,"resetsAt":9223372036854775807}`},
+	} {
+		assertAccountRateLimitRoundTrip[RateLimitWindow](t, tc.input, tc.want)
+	}
+	for _, tc := range []struct{ input, want string }{
+		{`{"hasCredits":false,"unlimited":false}`, `{"hasCredits":false,"unlimited":false,"balance":null}`},
+		{`{"future":1,"balance":" arbitrary ","unlimited":true,"hasCredits":true}`, `{"hasCredits":true,"unlimited":true,"balance":" arbitrary "}`},
+	} {
+		assertAccountRateLimitRoundTrip[CreditsSnapshot](t, tc.input, tc.want)
+	}
+	for _, tc := range []struct{ input, want string }{
+		{`{"limit":"","used":"","remainingPercent":-2147483648,"resetsAt":-9223372036854775808}`, `{"limit":"","used":"","remainingPercent":-2147483648,"resetsAt":-9223372036854775808}`},
+		{`{"future":true,"resetsAt":9223372036854775807,"remainingPercent":2147483647,"used":" used ","limit":" limit "}`, `{"limit":" limit ","used":" used ","remainingPercent":2147483647,"resetsAt":9223372036854775807}`},
+	} {
+		assertAccountRateLimitRoundTrip[SpendControlLimitSnapshot](t, tc.input, tc.want)
+	}
+}
+
+func TestAccountRateLimitLeafRecordsRejectMalformedForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`, `{}`,
+		`{"windowDurationMins":1}`, `{"usedPercent":null}`, `{"usedPercent":"1"}`,
+		`{"usedPercent":1.5}`, `{"usedPercent":1e3}`, `{"usedPercent":2147483648}`,
+		`{"usedPercent":-2147483649}`, `{"usedPercent":1,"windowDurationMins":1.5}`,
+		`{"usedPercent":1,"resetsAt":9223372036854775808}`,
+		`{"usedPercent":1,"usedPercent":2}`, `{"usedPercent":1} {}`, `{"usedPercent":1} x`,
+	} {
+		assertJSONRejects[RateLimitWindow](t, input)
+	}
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`, `{}`,
+		`{"hasCredits":true}`, `{"unlimited":false}`, `{"hasCredits":null,"unlimited":false}`,
+		`{"hasCredits":true,"unlimited":0}`, `{"hasCredits":true,"unlimited":false,"balance":1}`,
+		`{"hasCredits":true,"hasCredits":false,"unlimited":false}`,
+		`{"hasCredits":true,"unlimited":false} {}`, `{"hasCredits":true,"unlimited":false} x`,
+	} {
+		assertJSONRejects[CreditsSnapshot](t, input)
+	}
+	valid := `"limit":"l","used":"u","remainingPercent":0,"resetsAt":0`
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`, `{}`,
+		`{"used":"u","remainingPercent":0,"resetsAt":0}`,
+		`{"limit":"l","remainingPercent":0,"resetsAt":0}`,
+		`{"limit":"l","used":"u","resetsAt":0}`,
+		`{"limit":"l","used":"u","remainingPercent":0}`,
+		`{"limit":null,"used":"u","remainingPercent":0,"resetsAt":0}`,
+		`{"limit":"l","used":"u","remainingPercent":2147483648,"resetsAt":0}`,
+		`{"limit":"l","used":"u","remainingPercent":0,"resetsAt":9223372036854775808}`,
+		`{` + valid + `,"limit":"x"}`, `{` + valid + `} {}`, `{` + valid + `} x`,
+	} {
+		assertJSONRejects[SpendControlLimitSnapshot](t, input)
+	}
+}
+
+func TestRateLimitSnapshotCanonicalizesSparseNestedData(t *testing.T) {
+	allNull := `{"limitId":null,"limitName":null,"primary":null,"secondary":null,"credits":null,"individualLimit":null,"planType":null,"rateLimitReachedType":null}`
+	assertAccountRateLimitRoundTrip[RateLimitSnapshot](t, `{}`, allNull)
+	assertAccountRateLimitRoundTrip[RateLimitSnapshot](t, allNull, allNull)
+	assertAccountRateLimitRoundTrip[RateLimitSnapshot](t,
+		`{"future":true,"rateLimitReachedType":"workspace_member_usage_limit_reached","planType":"future-plan","individualLimit":{"limit":"10","used":"2","remainingPercent":80,"resetsAt":9},"credits":{"hasCredits":true,"unlimited":false,"balance":"8"},"secondary":{"usedPercent":2,"windowDurationMins":3,"resetsAt":4},"primary":{"usedPercent":1},"limitName":" name ","limitId":" id "}`,
+		`{"limitId":" id ","limitName":" name ","primary":{"usedPercent":1,"windowDurationMins":null,"resetsAt":null},"secondary":{"usedPercent":2,"windowDurationMins":3,"resetsAt":4},"credits":{"hasCredits":true,"unlimited":false,"balance":"8"},"individualLimit":{"limit":"10","used":"2","remainingPercent":80,"resetsAt":9},"planType":"unknown","rateLimitReachedType":"workspace_member_usage_limit_reached"}`,
+	)
+}
+
+func TestRateLimitSnapshotRejectsMalformedNestedData(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`,
+		`{"limitId":1}`, `{"limitName":true}`, `{"primary":{}}`,
+		`{"secondary":{"usedPercent":2147483648}}`, `{"credits":{"hasCredits":true}}`,
+		`{"individualLimit":{"limit":"l","used":"u","remainingPercent":0}}`,
+		`{"planType":1}`, `{"rateLimitReachedType":"other"}`,
+		`{"limitId":"a","limitId":"b"}`, `{} {}`, `{} x`,
+	} {
+		assertJSONRejects[RateLimitSnapshot](t, input)
+	}
+}
+
+func TestRateLimitResetCreditRecordsPreserveOrderDuplicatesAndBounds(t *testing.T) {
+	credit := `{"id":" c ","resetType":"codexRateLimits","status":"available","grantedAt":-9223372036854775808}`
+	wantCredit := `{"id":" c ","resetType":"codexRateLimits","status":"available","grantedAt":-9223372036854775808,"expiresAt":null,"title":null,"description":null}`
+	assertAccountRateLimitRoundTrip[RateLimitResetCredit](t, credit, wantCredit)
+	assertAccountRateLimitRoundTrip[RateLimitResetCredit](t,
+		`{"future":true,"description":" d ","title":" t ","expiresAt":9223372036854775807,"grantedAt":9223372036854775807,"status":"future-status","resetType":"future-reset","id":""}`,
+		`{"id":"","resetType":"unknown","status":"unknown","grantedAt":9223372036854775807,"expiresAt":9223372036854775807,"title":" t ","description":" d "}`,
+	)
+	assertAccountRateLimitRoundTrip[RateLimitResetCreditsSummary](t,
+		`{"availableCount":-9223372036854775808}`,
+		`{"availableCount":-9223372036854775808,"credits":null}`,
+	)
+	assertAccountRateLimitRoundTrip[RateLimitResetCreditsSummary](t,
+		`{"future":true,"credits":[],"availableCount":9223372036854775807}`,
+		`{"availableCount":9223372036854775807,"credits":[]}`,
+	)
+	assertAccountRateLimitRoundTrip[RateLimitResetCreditsSummary](t,
+		`{"availableCount":2,"credits":[`+credit+`,`+credit+`]}`,
+		`{"availableCount":2,"credits":[`+wantCredit+`,`+wantCredit+`]}`,
+	)
+}
+
+func TestRateLimitResetCreditRecordsRejectMalformedForms(t *testing.T) {
+	valid := `"id":"c","resetType":"codexRateLimits","status":"available","grantedAt":0`
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`, `{}`,
+		`{"resetType":"codexRateLimits","status":"available","grantedAt":0}`,
+		`{"id":"c","status":"available","grantedAt":0}`,
+		`{"id":"c","resetType":"codexRateLimits","grantedAt":0}`,
+		`{"id":"c","resetType":"codexRateLimits","status":"available"}`,
+		`{"id":null,"resetType":"codexRateLimits","status":"available","grantedAt":0}`,
+		`{"id":"c","resetType":1,"status":"available","grantedAt":0}`,
+		`{"id":"c","resetType":"codexRateLimits","status":null,"grantedAt":0}`,
+		`{"id":"c","resetType":"codexRateLimits","status":"available","grantedAt":1.5}`,
+		`{"id":"c","resetType":"codexRateLimits","status":"available","grantedAt":9223372036854775808}`,
+		`{` + valid + `,"expiresAt":"1"}`, `{` + valid + `,"title":1}`, `{` + valid + `,"description":true}`,
+		`{` + valid + `,"id":"x"}`, `{` + valid + `} {}`, `{` + valid + `} x`,
+	} {
+		assertJSONRejects[RateLimitResetCredit](t, input)
+	}
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`, `{}`,
+		`{"availableCount":null}`, `{"availableCount":"1"}`, `{"availableCount":1.5}`,
+		`{"availableCount":9223372036854775808}`, `{"availableCount":0,"credits":{}}`,
+		`{"availableCount":0,"credits":[{}]}`, `{"availableCount":0,"availableCount":1}`,
+		`{"availableCount":0} {}`, `{"availableCount":0} x`,
+	} {
+		assertJSONRejects[RateLimitResetCreditsSummary](t, input)
+	}
+}
+
+func TestAccountRateLimitEnvelopeRecordsCanonicalizeAndMapLastWins(t *testing.T) {
+	nullSnapshot := `{"limitId":null,"limitName":null,"primary":null,"secondary":null,"credits":null,"individualLimit":null,"planType":null,"rateLimitReachedType":null}`
+	assertAccountRateLimitRoundTrip[GetAccountRateLimitsResponse](t,
+		`{"rateLimits":{}}`,
+		`{"rateLimits":`+nullSnapshot+`,"rateLimitsByLimitId":null,"rateLimitResetCredits":null}`,
+	)
+	assertAccountRateLimitRoundTrip[GetAccountRateLimitsResponse](t,
+		`{"future":true,"rateLimitResetCredits":{"availableCount":0,"credits":[]},"rateLimitsByLimitId":{"":{"limitId":"first"},"dup":{"limitId":"first"},"dup":{"limitId":"last"}},"rateLimits":{"limitId":"root"}}`,
+		`{"rateLimits":{"limitId":"root","limitName":null,"primary":null,"secondary":null,"credits":null,"individualLimit":null,"planType":null,"rateLimitReachedType":null},"rateLimitsByLimitId":{"":{"limitId":"first","limitName":null,"primary":null,"secondary":null,"credits":null,"individualLimit":null,"planType":null,"rateLimitReachedType":null},"dup":{"limitId":"last","limitName":null,"primary":null,"secondary":null,"credits":null,"individualLimit":null,"planType":null,"rateLimitReachedType":null}},"rateLimitResetCredits":{"availableCount":0,"credits":[]}}`,
+	)
+	assertAccountRateLimitRoundTrip[ConsumeAccountRateLimitResetCreditParams](t,
+		`{"idempotencyKey":""}`, `{"idempotencyKey":"","creditId":null}`,
+	)
+	assertAccountRateLimitRoundTrip[ConsumeAccountRateLimitResetCreditParams](t,
+		`{"future":1,"creditId":" credit ","idempotencyKey":" key "}`,
+		`{"idempotencyKey":" key ","creditId":" credit "}`,
+	)
+	assertAccountRateLimitRoundTrip[ConsumeAccountRateLimitResetCreditResponse](t,
+		`{"future":true,"outcome":"alreadyRedeemed"}`, `{"outcome":"alreadyRedeemed"}`,
+	)
+	assertAccountRateLimitRoundTrip[AccountRateLimitsUpdatedNotification](t,
+		`{"future":true,"rateLimits":{}}`, `{"rateLimits":`+nullSnapshot+`}`,
+	)
+}
+
+func TestAccountRateLimitEnvelopeRecordsRejectMalformedForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`, `{}`,
+		`{"rateLimits":null}`, `{"rateLimits":[]}`, `{"rateLimits":{"primary":{}}}`,
+		`{"rateLimits":{},"rateLimitsByLimitId":[]}`,
+		`{"rateLimits":{},"rateLimitsByLimitId":{"x":null}}`,
+		`{"rateLimits":{},"rateLimitResetCredits":{}}`,
+		`{"rateLimits":{},"rateLimits":{}}`, `{"rateLimits":{}} {}`, `{"rateLimits":{}} x`,
+	} {
+		assertJSONRejects[GetAccountRateLimitsResponse](t, input)
+	}
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`, `{}`,
+		`{"idempotencyKey":null}`, `{"idempotencyKey":1}`, `{"idempotencyKey":"k","creditId":1}`,
+		`{"idempotencyKey":"k","idempotencyKey":"x"}`, `{"idempotencyKey":"k"} {}`, `{"idempotencyKey":"k"} x`,
+	} {
+		assertJSONRejects[ConsumeAccountRateLimitResetCreditParams](t, input)
+	}
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`, `{}`,
+		`{"outcome":null}`, `{"outcome":"other"}`, `{"outcome":"reset","outcome":"noCredit"}`,
+		`{"outcome":"reset"} {}`, `{"outcome":"reset"} x`,
+	} {
+		assertJSONRejects[ConsumeAccountRateLimitResetCreditResponse](t, input)
+	}
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`, `{}`,
+		`{"rateLimits":null}`, `{"rateLimits":{"planType":1}}`,
+		`{"rateLimits":{},"rateLimits":{}}`, `{"rateLimits":{}} {}`, `{"rateLimits":{}} x`,
+	} {
+		assertJSONRejects[AccountRateLimitsUpdatedNotification](t, input)
+	}
+}
+
+func TestAccountRateLimitContractsNilReceiversAndInvalidMarshalFailClosed(t *testing.T) {
+	for name, unmarshal := range map[string]func() error{
+		"PlanType":                   func() error { var v *PlanType; return v.UnmarshalJSON([]byte(`"free"`)) },
+		"RateLimitReachedType":       func() error { var v *RateLimitReachedType; return v.UnmarshalJSON([]byte(`"rate_limit_reached"`)) },
+		"RateLimitResetType":         func() error { var v *RateLimitResetType; return v.UnmarshalJSON([]byte(`"codexRateLimits"`)) },
+		"RateLimitResetCreditStatus": func() error { var v *RateLimitResetCreditStatus; return v.UnmarshalJSON([]byte(`"available"`)) },
+		"ConsumeOutcome": func() error {
+			var v *ConsumeAccountRateLimitResetCreditOutcome
+			return v.UnmarshalJSON([]byte(`"reset"`))
+		},
+		"RateLimitWindow": func() error { var v *RateLimitWindow; return v.UnmarshalJSON([]byte(`{"usedPercent":0}`)) },
+		"CreditsSnapshot": func() error {
+			var v *CreditsSnapshot
+			return v.UnmarshalJSON([]byte(`{"hasCredits":false,"unlimited":false}`))
+		},
+		"SpendControlLimitSnapshot":    func() error { var v *SpendControlLimitSnapshot; return v.UnmarshalJSON([]byte(`{}`)) },
+		"RateLimitSnapshot":            func() error { var v *RateLimitSnapshot; return v.UnmarshalJSON([]byte(`{}`)) },
+		"RateLimitResetCredit":         func() error { var v *RateLimitResetCredit; return v.UnmarshalJSON([]byte(`{}`)) },
+		"RateLimitResetCreditsSummary": func() error { var v *RateLimitResetCreditsSummary; return v.UnmarshalJSON([]byte(`{}`)) },
+		"GetAccountRateLimitsResponse": func() error { var v *GetAccountRateLimitsResponse; return v.UnmarshalJSON([]byte(`{}`)) },
+		"ConsumeParams":                func() error { var v *ConsumeAccountRateLimitResetCreditParams; return v.UnmarshalJSON([]byte(`{}`)) },
+		"ConsumeResponse":              func() error { var v *ConsumeAccountRateLimitResetCreditResponse; return v.UnmarshalJSON([]byte(`{}`)) },
+		"UpdatedNotification":          func() error { var v *AccountRateLimitsUpdatedNotification; return v.UnmarshalJSON([]byte(`{}`)) },
+	} {
+		if err := unmarshal(); err == nil {
+			t.Errorf("nil %s receiver succeeded", name)
+		}
+	}
+	for name, marshal := range map[string]func() error{
+		"PlanType":                   func() error { _, err := json.Marshal(PlanType("invalid")); return err },
+		"RateLimitReachedType":       func() error { _, err := json.Marshal(RateLimitReachedType("invalid")); return err },
+		"RateLimitResetType":         func() error { _, err := json.Marshal(RateLimitResetType("invalid")); return err },
+		"RateLimitResetCreditStatus": func() error { _, err := json.Marshal(RateLimitResetCreditStatus("invalid")); return err },
+		"ConsumeOutcome":             func() error { _, err := json.Marshal(ConsumeAccountRateLimitResetCreditOutcome("invalid")); return err },
+	} {
+		if err := marshal(); err == nil {
+			t.Errorf("invalid %s marshaled", name)
+		}
+	}
+}
+
+func TestAccountRateLimitContractsRemainStandaloneAndDeferred(t *testing.T) {
+	names := []string{
+		"PlanType", "RateLimitReachedType", "RateLimitResetType", "RateLimitResetCreditStatus",
+		"ConsumeAccountRateLimitResetCreditOutcome", "RateLimitWindow", "CreditsSnapshot",
+		"SpendControlLimitSnapshot", "RateLimitSnapshot", "RateLimitResetCredit",
+		"RateLimitResetCreditsSummary", "GetAccountRateLimitsResponse",
+		"ConsumeAccountRateLimitResetCreditParams", "ConsumeAccountRateLimitResetCreditResponse",
+		"AccountRateLimitsUpdatedNotification",
+	}
+	for _, binding := range WireTypeBindings() {
+		for _, name := range names {
+			if slices.Contains(binding.Params, name) || slices.Contains(binding.Result, name) {
+				t.Fatalf("%s unexpectedly bound to %s", name, binding.Method)
+			}
+		}
+	}
+	for _, binding := range ItemPayloadBindings() {
+		if slices.Contains(names, binding.Type) {
+			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
+		}
+	}
+	for methodName, surface := range map[string]Surface{
+		"account/rateLimits/read":              SurfaceClientRequest,
+		"account/rateLimitResetCredit/consume": SurfaceClientRequest,
+		"account/rateLimits/updated":           SurfaceServerNotification,
+	} {
+		method, ok := LookupMethod(methodName)
+		if !ok || method.Surface != surface || method.State != MethodDeferredStub {
+			t.Errorf("%s = %#v, %v; want deferred %s", methodName, method, ok, surface)
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestAccountRateLimitTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	wants := []string{
+		`export type PlanType = "free" | "go" | "plus" | "pro" | "prolite" | "team" | "self_serve_business_usage_based" | "business" | "enterprise_cbp_usage_based" | "enterprise" | "edu" | "unknown";`,
+		`export type RateLimitReachedType = "rate_limit_reached" | "workspace_owner_credits_depleted" | "workspace_member_credits_depleted" | "workspace_owner_usage_limit_reached" | "workspace_member_usage_limit_reached";`,
+		`export type RateLimitResetType = "codexRateLimits" | "unknown";`,
+		`export type RateLimitResetCreditStatus = "available" | "redeeming" | "redeemed" | "unknown";`,
+		`export type ConsumeAccountRateLimitResetCreditOutcome = "reset" | "nothingToReset" | "noCredit" | "alreadyRedeemed";`,
+		"export type RateLimitWindow = {\n  \"resetsAt\": number | null;\n  \"usedPercent\": number;\n  \"windowDurationMins\": number | null;\n};",
+		"export type CreditsSnapshot = {\n  \"balance\": string | null;\n  \"hasCredits\": boolean;\n  \"unlimited\": boolean;\n};",
+		"export type SpendControlLimitSnapshot = {\n  \"limit\": string;\n  \"remainingPercent\": number;\n  \"resetsAt\": number;\n  \"used\": string;\n};",
+		"export type RateLimitSnapshot = {\n  \"credits\": CreditsSnapshot | null;\n  \"individualLimit\": SpendControlLimitSnapshot | null;\n  \"limitId\": string | null;\n  \"limitName\": string | null;\n  \"planType\": PlanType | null;\n  \"primary\": RateLimitWindow | null;\n  \"rateLimitReachedType\": RateLimitReachedType | null;\n  \"secondary\": RateLimitWindow | null;\n};",
+		"export type RateLimitResetCreditsSummary = {\n  \"availableCount\": bigint;\n  \"credits\": Array<RateLimitResetCredit> | null;\n};",
+		"export type GetAccountRateLimitsResponse = {\n  \"rateLimitResetCredits\": RateLimitResetCreditsSummary | null;\n  \"rateLimits\": RateLimitSnapshot;\n  \"rateLimitsByLimitId\": { [key in string]?: RateLimitSnapshot } | null;\n};",
+		"export type ConsumeAccountRateLimitResetCreditParams = {\n  \"creditId\"?: string | null;\n  \"idempotencyKey\": string;\n};",
+		"export type ConsumeAccountRateLimitResetCreditResponse = {\n  \"outcome\": ConsumeAccountRateLimitResetCreditOutcome;\n};",
+		"export type AccountRateLimitsUpdatedNotification = {\n  \"rateLimits\": RateLimitSnapshot;\n};",
+	}
+	for _, want := range wants {
+		if !strings.Contains(string(generated), want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+	for _, name := range []string{
+		"RateLimitWindow", "CreditsSnapshot", "SpendControlLimitSnapshot", "RateLimitSnapshot",
+		"RateLimitResetCredit", "RateLimitResetCreditsSummary", "GetAccountRateLimitsResponse",
+		"ConsumeAccountRateLimitResetCreditResponse", "AccountRateLimitsUpdatedNotification",
+	} {
+		declaration := accountRateLimitTypeScriptDeclaration(t, generated, name)
+		if strings.Contains(declaration, "Record<string, unknown>") {
+			t.Errorf("%s TypeScript remains structurally open: %s", name, declaration)
+		}
+	}
+	credit := accountRateLimitTypeScriptDeclaration(t, generated, "RateLimitResetCredit")
+	for _, field := range []string{`"grantedAt": number;`, `"expiresAt": number | null;`} {
+		if !strings.Contains(credit, field) {
+			t.Errorf("RateLimitResetCredit missing %q", field)
+		}
+	}
+}
+
+func assertAccountRateLimitRoundTrip[T any](t *testing.T, input, want string) {
+	t.Helper()
+	var value T
+	if err := json.Unmarshal([]byte(input), &value); err != nil {
+		t.Fatalf("unmarshal %T %s: %v", value, input, err)
+	}
+	encoded, err := json.Marshal(value)
+	if err != nil || string(encoded) != want {
+		t.Fatalf("round trip %T %s = %s, %v; want %s", value, input, encoded, err, want)
+	}
+}
+
+func accountRateLimitTypeScriptDeclaration(t *testing.T, generated []byte, name string) string {
+	t.Helper()
+	prefix := "export type " + name + " = "
+	start := strings.Index(string(generated), prefix)
+	if start < 0 {
+		t.Fatalf("generated TypeScript missing declaration %s", name)
+	}
+	rest := string(generated[start:])
+	end := strings.Index(rest, ";\n\n")
+	if end < 0 {
+		t.Fatalf("generated TypeScript declaration %s has no terminator", name)
+	}
+	return rest[:end+1]
+}

--- a/appserver/protocol/account_rate_limits_types.go
+++ b/appserver/protocol/account_rate_limits_types.go
@@ -1,0 +1,774 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// PlanType is the public account plan classification. Unknown upstream strings
+// collapse to the serde fallback literal instead of retaining provider data.
+type PlanType string
+
+const (
+	PlanTypeFree                        PlanType = "free"
+	PlanTypeGo                          PlanType = "go"
+	PlanTypePlus                        PlanType = "plus"
+	PlanTypePro                         PlanType = "pro"
+	PlanTypeProLite                     PlanType = "prolite"
+	PlanTypeTeam                        PlanType = "team"
+	PlanTypeSelfServeBusinessUsageBased PlanType = "self_serve_business_usage_based"
+	PlanTypeBusiness                    PlanType = "business"
+	PlanTypeEnterpriseCBPUsageBased     PlanType = "enterprise_cbp_usage_based"
+	PlanTypeEnterprise                  PlanType = "enterprise"
+	PlanTypeEdu                         PlanType = "edu"
+	PlanTypeUnknown                     PlanType = "unknown"
+)
+
+func (p PlanType) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(p, "plan type", PlanType.valid)
+}
+
+func (p *PlanType) UnmarshalJSON(data []byte) error {
+	return unmarshalRateLimitFallbackEnum(data, p, "plan type", PlanType.valid, PlanTypeUnknown)
+}
+
+func (p PlanType) valid() bool {
+	switch p {
+	case PlanTypeFree, PlanTypeGo, PlanTypePlus, PlanTypePro, PlanTypeProLite,
+		PlanTypeTeam, PlanTypeSelfServeBusinessUsageBased, PlanTypeBusiness,
+		PlanTypeEnterpriseCBPUsageBased, PlanTypeEnterprise, PlanTypeEdu, PlanTypeUnknown:
+		return true
+	default:
+		return false
+	}
+}
+
+// RateLimitReachedType is the exact closed reason a public rate limit was hit.
+type RateLimitReachedType string
+
+const (
+	RateLimitReachedTypeRateLimitReached                 RateLimitReachedType = "rate_limit_reached"
+	RateLimitReachedTypeWorkspaceOwnerCreditsDepleted    RateLimitReachedType = "workspace_owner_credits_depleted"
+	RateLimitReachedTypeWorkspaceMemberCreditsDepleted   RateLimitReachedType = "workspace_member_credits_depleted"
+	RateLimitReachedTypeWorkspaceOwnerUsageLimitReached  RateLimitReachedType = "workspace_owner_usage_limit_reached"
+	RateLimitReachedTypeWorkspaceMemberUsageLimitReached RateLimitReachedType = "workspace_member_usage_limit_reached"
+)
+
+func (r RateLimitReachedType) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(r, "rate-limit reached type", RateLimitReachedType.valid)
+}
+
+func (r *RateLimitReachedType) UnmarshalJSON(data []byte) error {
+	return unmarshalThreadTurnLeafEnum(data, r, "rate-limit reached type", RateLimitReachedType.valid)
+}
+
+func (r RateLimitReachedType) valid() bool {
+	switch r {
+	case RateLimitReachedTypeRateLimitReached,
+		RateLimitReachedTypeWorkspaceOwnerCreditsDepleted,
+		RateLimitReachedTypeWorkspaceMemberCreditsDepleted,
+		RateLimitReachedTypeWorkspaceOwnerUsageLimitReached,
+		RateLimitReachedTypeWorkspaceMemberUsageLimitReached:
+		return true
+	default:
+		return false
+	}
+}
+
+// RateLimitResetType identifies the backend meter reset by a credit.
+type RateLimitResetType string
+
+const (
+	RateLimitResetTypeCodexRateLimits RateLimitResetType = "codexRateLimits"
+	RateLimitResetTypeUnknown         RateLimitResetType = "unknown"
+)
+
+func (r RateLimitResetType) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(r, "rate-limit reset type", RateLimitResetType.valid)
+}
+
+func (r *RateLimitResetType) UnmarshalJSON(data []byte) error {
+	return unmarshalRateLimitFallbackEnum(
+		data, r, "rate-limit reset type", RateLimitResetType.valid, RateLimitResetTypeUnknown,
+	)
+}
+
+func (r RateLimitResetType) valid() bool {
+	return r == RateLimitResetTypeCodexRateLimits || r == RateLimitResetTypeUnknown
+}
+
+// RateLimitResetCreditStatus is the public reset-credit lifecycle state.
+type RateLimitResetCreditStatus string
+
+const (
+	RateLimitResetCreditStatusAvailable RateLimitResetCreditStatus = "available"
+	RateLimitResetCreditStatusRedeeming RateLimitResetCreditStatus = "redeeming"
+	RateLimitResetCreditStatusRedeemed  RateLimitResetCreditStatus = "redeemed"
+	RateLimitResetCreditStatusUnknown   RateLimitResetCreditStatus = "unknown"
+)
+
+func (s RateLimitResetCreditStatus) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(s, "rate-limit reset credit status", RateLimitResetCreditStatus.valid)
+}
+
+func (s *RateLimitResetCreditStatus) UnmarshalJSON(data []byte) error {
+	return unmarshalRateLimitFallbackEnum(
+		data, s, "rate-limit reset credit status",
+		RateLimitResetCreditStatus.valid, RateLimitResetCreditStatusUnknown,
+	)
+}
+
+func (s RateLimitResetCreditStatus) valid() bool {
+	switch s {
+	case RateLimitResetCreditStatusAvailable, RateLimitResetCreditStatusRedeeming,
+		RateLimitResetCreditStatusRedeemed, RateLimitResetCreditStatusUnknown:
+		return true
+	default:
+		return false
+	}
+}
+
+// ConsumeAccountRateLimitResetCreditOutcome is the exact closed redemption result.
+type ConsumeAccountRateLimitResetCreditOutcome string
+
+const (
+	ConsumeAccountRateLimitResetCreditOutcomeReset           ConsumeAccountRateLimitResetCreditOutcome = "reset"
+	ConsumeAccountRateLimitResetCreditOutcomeNothingToReset  ConsumeAccountRateLimitResetCreditOutcome = "nothingToReset"
+	ConsumeAccountRateLimitResetCreditOutcomeNoCredit        ConsumeAccountRateLimitResetCreditOutcome = "noCredit"
+	ConsumeAccountRateLimitResetCreditOutcomeAlreadyRedeemed ConsumeAccountRateLimitResetCreditOutcome = "alreadyRedeemed"
+)
+
+func (o ConsumeAccountRateLimitResetCreditOutcome) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(
+		o, "consume account rate-limit reset credit outcome",
+		ConsumeAccountRateLimitResetCreditOutcome.valid,
+	)
+}
+
+func (o *ConsumeAccountRateLimitResetCreditOutcome) UnmarshalJSON(data []byte) error {
+	return unmarshalThreadTurnLeafEnum(
+		data, o, "consume account rate-limit reset credit outcome",
+		ConsumeAccountRateLimitResetCreditOutcome.valid,
+	)
+}
+
+func (o ConsumeAccountRateLimitResetCreditOutcome) valid() bool {
+	switch o {
+	case ConsumeAccountRateLimitResetCreditOutcomeReset,
+		ConsumeAccountRateLimitResetCreditOutcomeNothingToReset,
+		ConsumeAccountRateLimitResetCreditOutcomeNoCredit,
+		ConsumeAccountRateLimitResetCreditOutcomeAlreadyRedeemed:
+		return true
+	default:
+		return false
+	}
+}
+
+func unmarshalRateLimitFallbackEnum[T ~string](
+	data []byte,
+	destination *T,
+	name string,
+	valid func(T) bool,
+	unknown T,
+) error {
+	if destination == nil {
+		return fmt.Errorf("decode %s into nil receiver", name)
+	}
+	if isJSONNull(data) {
+		return fmt.Errorf("decode %s: value cannot be null", name)
+	}
+	var literal string
+	if err := json.Unmarshal(data, &literal); err != nil {
+		return fmt.Errorf("decode %s: %w", name, err)
+	}
+	value := T(literal)
+	if !valid(value) {
+		value = unknown
+	}
+	*destination = value
+	return nil
+}
+
+// RateLimitWindow is one exact public usage window.
+type RateLimitWindow struct {
+	UsedPercent        int32  `json:"usedPercent"`
+	WindowDurationMins *int64 `json:"windowDurationMins,omitempty"`
+	ResetsAt           *int64 `json:"resetsAt,omitempty"`
+}
+
+func (w RateLimitWindow) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		UsedPercent        int32  `json:"usedPercent"`
+		WindowDurationMins *int64 `json:"windowDurationMins"`
+		ResetsAt           *int64 `json:"resetsAt"`
+	}{w.UsedPercent, w.WindowDurationMins, w.ResetsAt})
+}
+
+func (w *RateLimitWindow) UnmarshalJSON(data []byte) error {
+	if w == nil {
+		return errors.New("decode rate-limit window into nil receiver")
+	}
+	const objectName = "rate-limit window"
+	payload, err := decodeRustSerdeObject(data, objectName, "usedPercent", "windowDurationMins", "resetsAt")
+	if err != nil {
+		return err
+	}
+	usedPercent, err := decodeRequiredThreadItemValue[int32](payload, objectName, "usedPercent")
+	if err != nil {
+		return err
+	}
+	windowDurationMins, err := decodeOptionalNullableConfigValue[int64](payload, objectName, "windowDurationMins")
+	if err != nil {
+		return err
+	}
+	resetsAt, err := decodeOptionalNullableConfigValue[int64](payload, objectName, "resetsAt")
+	if err != nil {
+		return err
+	}
+	*w = RateLimitWindow{UsedPercent: usedPercent, WindowDurationMins: windowDurationMins, ResetsAt: resetsAt}
+	return nil
+}
+
+// CreditsSnapshot is exact public account-credit availability data.
+type CreditsSnapshot struct {
+	HasCredits bool    `json:"hasCredits"`
+	Unlimited  bool    `json:"unlimited"`
+	Balance    *string `json:"balance,omitempty"`
+}
+
+func (s CreditsSnapshot) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		HasCredits bool    `json:"hasCredits"`
+		Unlimited  bool    `json:"unlimited"`
+		Balance    *string `json:"balance"`
+	}{s.HasCredits, s.Unlimited, s.Balance})
+}
+
+func (s *CreditsSnapshot) UnmarshalJSON(data []byte) error {
+	if s == nil {
+		return errors.New("decode credits snapshot into nil receiver")
+	}
+	const objectName = "credits snapshot"
+	payload, err := decodeRustSerdeObject(data, objectName, "hasCredits", "unlimited", "balance")
+	if err != nil {
+		return err
+	}
+	hasCredits, err := decodeRequiredThreadItemValue[bool](payload, objectName, "hasCredits")
+	if err != nil {
+		return err
+	}
+	unlimited, err := decodeRequiredThreadItemValue[bool](payload, objectName, "unlimited")
+	if err != nil {
+		return err
+	}
+	balance, err := decodeOptionalNullableConfigValue[string](payload, objectName, "balance")
+	if err != nil {
+		return err
+	}
+	*s = CreditsSnapshot{HasCredits: hasCredits, Unlimited: unlimited, Balance: balance}
+	return nil
+}
+
+// SpendControlLimitSnapshot is exact public individual spend-control data.
+type SpendControlLimitSnapshot struct {
+	Limit            string `json:"limit"`
+	Used             string `json:"used"`
+	RemainingPercent int32  `json:"remainingPercent"`
+	ResetsAt         int64  `json:"resetsAt"`
+}
+
+func (s SpendControlLimitSnapshot) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Limit            string `json:"limit"`
+		Used             string `json:"used"`
+		RemainingPercent int32  `json:"remainingPercent"`
+		ResetsAt         int64  `json:"resetsAt"`
+	}{s.Limit, s.Used, s.RemainingPercent, s.ResetsAt})
+}
+
+func (s *SpendControlLimitSnapshot) UnmarshalJSON(data []byte) error {
+	if s == nil {
+		return errors.New("decode spend-control limit snapshot into nil receiver")
+	}
+	const objectName = "spend-control limit snapshot"
+	payload, err := decodeRustSerdeObject(data, objectName, "limit", "used", "remainingPercent", "resetsAt")
+	if err != nil {
+		return err
+	}
+	limit, err := decodeRequiredThreadItemValue[string](payload, objectName, "limit")
+	if err != nil {
+		return err
+	}
+	used, err := decodeRequiredThreadItemValue[string](payload, objectName, "used")
+	if err != nil {
+		return err
+	}
+	remainingPercent, err := decodeRequiredThreadItemValue[int32](payload, objectName, "remainingPercent")
+	if err != nil {
+		return err
+	}
+	resetsAt, err := decodeRequiredThreadItemValue[int64](payload, objectName, "resetsAt")
+	if err != nil {
+		return err
+	}
+	*s = SpendControlLimitSnapshot{Limit: limit, Used: used, RemainingPercent: remainingPercent, ResetsAt: resetsAt}
+	return nil
+}
+
+// RateLimitSnapshot is a sparse standalone public rate-limit snapshot.
+type RateLimitSnapshot struct {
+	LimitID              *string                    `json:"limitId,omitempty"`
+	LimitName            *string                    `json:"limitName,omitempty"`
+	Primary              *RateLimitWindow           `json:"primary,omitempty"`
+	Secondary            *RateLimitWindow           `json:"secondary,omitempty"`
+	Credits              *CreditsSnapshot           `json:"credits,omitempty"`
+	IndividualLimit      *SpendControlLimitSnapshot `json:"individualLimit,omitempty"`
+	PlanType             *PlanType                  `json:"planType,omitempty"`
+	RateLimitReachedType *RateLimitReachedType      `json:"rateLimitReachedType,omitempty"`
+}
+
+func (s RateLimitSnapshot) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		LimitID              *string                    `json:"limitId"`
+		LimitName            *string                    `json:"limitName"`
+		Primary              *RateLimitWindow           `json:"primary"`
+		Secondary            *RateLimitWindow           `json:"secondary"`
+		Credits              *CreditsSnapshot           `json:"credits"`
+		IndividualLimit      *SpendControlLimitSnapshot `json:"individualLimit"`
+		PlanType             *PlanType                  `json:"planType"`
+		RateLimitReachedType *RateLimitReachedType      `json:"rateLimitReachedType"`
+	}{s.LimitID, s.LimitName, s.Primary, s.Secondary, s.Credits, s.IndividualLimit, s.PlanType, s.RateLimitReachedType})
+}
+
+func (s *RateLimitSnapshot) UnmarshalJSON(data []byte) error {
+	if s == nil {
+		return errors.New("decode rate-limit snapshot into nil receiver")
+	}
+	const objectName = "rate-limit snapshot"
+	payload, err := decodeRustSerdeObject(
+		data, objectName, "limitId", "limitName", "primary", "secondary", "credits",
+		"individualLimit", "planType", "rateLimitReachedType",
+	)
+	if err != nil {
+		return err
+	}
+	limitID, err := decodeOptionalNullableConfigValue[string](payload, objectName, "limitId")
+	if err != nil {
+		return err
+	}
+	limitName, err := decodeOptionalNullableConfigValue[string](payload, objectName, "limitName")
+	if err != nil {
+		return err
+	}
+	primary, err := decodeOptionalNullableConfigValue[RateLimitWindow](payload, objectName, "primary")
+	if err != nil {
+		return err
+	}
+	secondary, err := decodeOptionalNullableConfigValue[RateLimitWindow](payload, objectName, "secondary")
+	if err != nil {
+		return err
+	}
+	credits, err := decodeOptionalNullableConfigValue[CreditsSnapshot](payload, objectName, "credits")
+	if err != nil {
+		return err
+	}
+	individualLimit, err := decodeOptionalNullableConfigValue[SpendControlLimitSnapshot](payload, objectName, "individualLimit")
+	if err != nil {
+		return err
+	}
+	planType, err := decodeOptionalNullableConfigValue[PlanType](payload, objectName, "planType")
+	if err != nil {
+		return err
+	}
+	rateLimitReachedType, err := decodeOptionalNullableConfigValue[RateLimitReachedType](payload, objectName, "rateLimitReachedType")
+	if err != nil {
+		return err
+	}
+	*s = RateLimitSnapshot{
+		LimitID: limitID, LimitName: limitName, Primary: primary, Secondary: secondary,
+		Credits: credits, IndividualLimit: individualLimit, PlanType: planType,
+		RateLimitReachedType: rateLimitReachedType,
+	}
+	return nil
+}
+
+// RateLimitResetCredit is exact standalone reset-credit metadata.
+type RateLimitResetCredit struct {
+	ID          string                     `json:"id"`
+	ResetType   RateLimitResetType         `json:"resetType"`
+	Status      RateLimitResetCreditStatus `json:"status"`
+	GrantedAt   int64                      `json:"grantedAt"`
+	ExpiresAt   *int64                     `json:"expiresAt,omitempty"`
+	Title       *string                    `json:"title,omitempty"`
+	Description *string                    `json:"description,omitempty"`
+}
+
+func (c RateLimitResetCredit) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		ID          string                     `json:"id"`
+		ResetType   RateLimitResetType         `json:"resetType"`
+		Status      RateLimitResetCreditStatus `json:"status"`
+		GrantedAt   int64                      `json:"grantedAt"`
+		ExpiresAt   *int64                     `json:"expiresAt"`
+		Title       *string                    `json:"title"`
+		Description *string                    `json:"description"`
+	}{c.ID, c.ResetType, c.Status, c.GrantedAt, c.ExpiresAt, c.Title, c.Description})
+}
+
+func (c *RateLimitResetCredit) UnmarshalJSON(data []byte) error {
+	if c == nil {
+		return errors.New("decode rate-limit reset credit into nil receiver")
+	}
+	const objectName = "rate-limit reset credit"
+	payload, err := decodeRustSerdeObject(
+		data, objectName, "id", "resetType", "status", "grantedAt", "expiresAt", "title", "description",
+	)
+	if err != nil {
+		return err
+	}
+	id, err := decodeRequiredThreadItemValue[string](payload, objectName, "id")
+	if err != nil {
+		return err
+	}
+	resetType, err := decodeRequiredThreadItemValue[RateLimitResetType](payload, objectName, "resetType")
+	if err != nil {
+		return err
+	}
+	status, err := decodeRequiredThreadItemValue[RateLimitResetCreditStatus](payload, objectName, "status")
+	if err != nil {
+		return err
+	}
+	grantedAt, err := decodeRequiredThreadItemValue[int64](payload, objectName, "grantedAt")
+	if err != nil {
+		return err
+	}
+	expiresAt, err := decodeOptionalNullableConfigValue[int64](payload, objectName, "expiresAt")
+	if err != nil {
+		return err
+	}
+	title, err := decodeOptionalNullableConfigValue[string](payload, objectName, "title")
+	if err != nil {
+		return err
+	}
+	description, err := decodeOptionalNullableConfigValue[string](payload, objectName, "description")
+	if err != nil {
+		return err
+	}
+	*c = RateLimitResetCredit{
+		ID: id, ResetType: resetType, Status: status, GrantedAt: grantedAt,
+		ExpiresAt: expiresAt, Title: title, Description: description,
+	}
+	return nil
+}
+
+// RateLimitResetCreditsSummary is standalone reset-credit availability data.
+type RateLimitResetCreditsSummary struct {
+	AvailableCount int64                  `json:"availableCount"`
+	Credits        []RateLimitResetCredit `json:"credits,omitempty"`
+}
+
+func (s RateLimitResetCreditsSummary) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		AvailableCount int64                  `json:"availableCount"`
+		Credits        []RateLimitResetCredit `json:"credits"`
+	}{s.AvailableCount, s.Credits})
+}
+
+func (s *RateLimitResetCreditsSummary) UnmarshalJSON(data []byte) error {
+	if s == nil {
+		return errors.New("decode rate-limit reset credits summary into nil receiver")
+	}
+	const objectName = "rate-limit reset credits summary"
+	payload, err := decodeRustSerdeObject(data, objectName, "availableCount", "credits")
+	if err != nil {
+		return err
+	}
+	availableCount, err := decodeRequiredThreadItemValue[int64](payload, objectName, "availableCount")
+	if err != nil {
+		return err
+	}
+	credits, err := decodeOptionalNullableRateLimitValue[[]RateLimitResetCredit](payload, objectName, "credits")
+	if err != nil {
+		return err
+	}
+	*s = RateLimitResetCreditsSummary{AvailableCount: availableCount, Credits: credits}
+	return nil
+}
+
+// GetAccountRateLimitsResponse is exact standalone rate-limit read data.
+type GetAccountRateLimitsResponse struct {
+	RateLimits            RateLimitSnapshot             `json:"rateLimits"`
+	RateLimitsByLimitID   map[string]RateLimitSnapshot  `json:"rateLimitsByLimitId,omitempty"`
+	RateLimitResetCredits *RateLimitResetCreditsSummary `json:"rateLimitResetCredits,omitempty"`
+}
+
+func (r GetAccountRateLimitsResponse) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		RateLimits            RateLimitSnapshot             `json:"rateLimits"`
+		RateLimitsByLimitID   map[string]RateLimitSnapshot  `json:"rateLimitsByLimitId"`
+		RateLimitResetCredits *RateLimitResetCreditsSummary `json:"rateLimitResetCredits"`
+	}{r.RateLimits, r.RateLimitsByLimitID, r.RateLimitResetCredits})
+}
+
+func (r *GetAccountRateLimitsResponse) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("decode get account rate limits response into nil receiver")
+	}
+	const objectName = "get account rate limits response"
+	payload, err := decodeRustSerdeObject(
+		data, objectName, "rateLimits", "rateLimitsByLimitId", "rateLimitResetCredits",
+	)
+	if err != nil {
+		return err
+	}
+	rateLimits, err := decodeRequiredThreadItemValue[RateLimitSnapshot](payload, objectName, "rateLimits")
+	if err != nil {
+		return err
+	}
+	rateLimitsByLimitID, err := decodeOptionalNullableRateLimitValue[map[string]RateLimitSnapshot](
+		payload, objectName, "rateLimitsByLimitId",
+	)
+	if err != nil {
+		return err
+	}
+	rateLimitResetCredits, err := decodeOptionalNullableConfigValue[RateLimitResetCreditsSummary](
+		payload, objectName, "rateLimitResetCredits",
+	)
+	if err != nil {
+		return err
+	}
+	*r = GetAccountRateLimitsResponse{
+		RateLimits: rateLimits, RateLimitsByLimitID: rateLimitsByLimitID,
+		RateLimitResetCredits: rateLimitResetCredits,
+	}
+	return nil
+}
+
+// ConsumeAccountRateLimitResetCreditParams is a standalone redemption request.
+// It does not perform or persist redemption.
+type ConsumeAccountRateLimitResetCreditParams struct {
+	IdempotencyKey string  `json:"idempotencyKey"`
+	CreditID       *string `json:"creditId,omitempty"`
+}
+
+func (p ConsumeAccountRateLimitResetCreditParams) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		IdempotencyKey string  `json:"idempotencyKey"`
+		CreditID       *string `json:"creditId"`
+	}{p.IdempotencyKey, p.CreditID})
+}
+
+func (p *ConsumeAccountRateLimitResetCreditParams) UnmarshalJSON(data []byte) error {
+	if p == nil {
+		return errors.New("decode consume account rate-limit reset credit params into nil receiver")
+	}
+	const objectName = "consume account rate-limit reset credit params"
+	payload, err := decodeRustSerdeObject(data, objectName, "idempotencyKey", "creditId")
+	if err != nil {
+		return err
+	}
+	idempotencyKey, err := decodeRequiredThreadItemValue[string](payload, objectName, "idempotencyKey")
+	if err != nil {
+		return err
+	}
+	creditID, err := decodeOptionalNullableConfigValue[string](payload, objectName, "creditId")
+	if err != nil {
+		return err
+	}
+	*p = ConsumeAccountRateLimitResetCreditParams{IdempotencyKey: idempotencyKey, CreditID: creditID}
+	return nil
+}
+
+// ConsumeAccountRateLimitResetCreditResponse is the standalone redemption outcome.
+type ConsumeAccountRateLimitResetCreditResponse struct {
+	Outcome ConsumeAccountRateLimitResetCreditOutcome `json:"outcome"`
+}
+
+func (r ConsumeAccountRateLimitResetCreditResponse) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Outcome ConsumeAccountRateLimitResetCreditOutcome `json:"outcome"`
+	}{r.Outcome})
+}
+
+func (r *ConsumeAccountRateLimitResetCreditResponse) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("decode consume account rate-limit reset credit response into nil receiver")
+	}
+	const objectName = "consume account rate-limit reset credit response"
+	payload, err := decodeRustSerdeObject(data, objectName, "outcome")
+	if err != nil {
+		return err
+	}
+	outcome, err := decodeRequiredThreadItemValue[ConsumeAccountRateLimitResetCreditOutcome](payload, objectName, "outcome")
+	if err != nil {
+		return err
+	}
+	*r = ConsumeAccountRateLimitResetCreditResponse{Outcome: outcome}
+	return nil
+}
+
+// AccountRateLimitsUpdatedNotification is exact standalone rolling-update data.
+type AccountRateLimitsUpdatedNotification struct {
+	RateLimits RateLimitSnapshot `json:"rateLimits"`
+}
+
+func (n AccountRateLimitsUpdatedNotification) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		RateLimits RateLimitSnapshot `json:"rateLimits"`
+	}{n.RateLimits})
+}
+
+func (n *AccountRateLimitsUpdatedNotification) UnmarshalJSON(data []byte) error {
+	if n == nil {
+		return errors.New("decode account rate limits updated notification into nil receiver")
+	}
+	const objectName = "account rate limits updated notification"
+	payload, err := decodeRustSerdeObject(data, objectName, "rateLimits")
+	if err != nil {
+		return err
+	}
+	rateLimits, err := decodeRequiredThreadItemValue[RateLimitSnapshot](payload, objectName, "rateLimits")
+	if err != nil {
+		return err
+	}
+	*n = AccountRateLimitsUpdatedNotification{RateLimits: rateLimits}
+	return nil
+}
+
+func decodeOptionalNullableRateLimitValue[T any](
+	payload map[string]json.RawMessage,
+	objectName string,
+	fieldName string,
+) (T, error) {
+	var zero T
+	raw, ok := payload[fieldName]
+	if !ok || isJSONNull(raw) {
+		return zero, nil
+	}
+	var value T
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return zero, fmt.Errorf("decode %s %s: %w", objectName, fieldName, err)
+	}
+	return value, nil
+}
+
+func accountRateLimitSchemas() map[string]Schema {
+	nullableString := Schema{"type": []any{"string", "null"}}
+	nullableInt64 := Schema{"type": []any{"integer", "null"}, "format": "int64"}
+	nullableRef := func(name string) Schema {
+		return Schema{"anyOf": []any{Schema{"$ref": "#/$defs/" + name}, Schema{"type": "null"}}}
+	}
+	object := func(properties Schema, required ...string) Schema {
+		out := Schema{"type": "object", "properties": properties}
+		if len(required) != 0 {
+			out["required"] = required
+		}
+		return out
+	}
+	return map[string]Schema{
+		"PlanType": stringEnumSchema(
+			"free", "go", "plus", "pro", "prolite", "team",
+			"self_serve_business_usage_based", "business",
+			"enterprise_cbp_usage_based", "enterprise", "edu", "unknown",
+		),
+		"RateLimitReachedType": stringEnumSchema(
+			"rate_limit_reached", "workspace_owner_credits_depleted",
+			"workspace_member_credits_depleted", "workspace_owner_usage_limit_reached",
+			"workspace_member_usage_limit_reached",
+		),
+		"RateLimitResetType":         stringEnumSchema("codexRateLimits", "unknown"),
+		"RateLimitResetCreditStatus": stringEnumSchema("available", "redeeming", "redeemed", "unknown"),
+		"ConsumeAccountRateLimitResetCreditOutcome": Schema{"oneOf": []any{
+			Schema{"description": "A reset credit was consumed and the eligible rate-limit windows were reset.", "enum": []any{"reset"}, "type": "string"},
+			Schema{"description": "No current rate-limit window is eligible for a reset.", "enum": []any{"nothingToReset"}, "type": "string"},
+			Schema{"description": "The account has no earned reset credits available.", "enum": []any{"noCredit"}, "type": "string"},
+			Schema{"description": "The same idempotency key already completed a reset successfully.", "enum": []any{"alreadyRedeemed"}, "type": "string"},
+		}},
+		"RateLimitWindow": object(Schema{
+			"resetsAt": nullableInt64, "usedPercent": Schema{"format": "int32", "type": "integer"},
+			"windowDurationMins": nullableInt64,
+		}, "usedPercent"),
+		"CreditsSnapshot": object(Schema{
+			"balance": nullableString, "hasCredits": Schema{"type": "boolean"}, "unlimited": Schema{"type": "boolean"},
+		}, "hasCredits", "unlimited"),
+		"SpendControlLimitSnapshot": object(Schema{
+			"limit": Schema{"type": "string"}, "remainingPercent": Schema{"format": "int32", "type": "integer"},
+			"resetsAt": Schema{"format": "int64", "type": "integer"}, "used": Schema{"type": "string"},
+		}, "limit", "remainingPercent", "resetsAt", "used"),
+		"RateLimitSnapshot": object(Schema{
+			"credits": nullableRef("CreditsSnapshot"), "individualLimit": nullableRef("SpendControlLimitSnapshot"),
+			"limitId": nullableString, "limitName": nullableString, "planType": nullableRef("PlanType"),
+			"primary": nullableRef("RateLimitWindow"), "rateLimitReachedType": nullableRef("RateLimitReachedType"),
+			"secondary": nullableRef("RateLimitWindow"),
+		}),
+		"RateLimitResetCredit": object(Schema{
+			"description": Schema{"description": "Backend-provided display description for this credit, or `null` when unavailable.", "type": []any{"string", "null"}},
+			"expiresAt":   Schema{"description": "Unix timestamp in seconds when the credit expires, or `null` if it does not expire.", "format": "int64", "type": []any{"integer", "null"}},
+			"grantedAt":   Schema{"description": "Unix timestamp in seconds when the credit was granted.", "format": "int64", "type": "integer"},
+			"id":          Schema{"description": "Opaque backend identifier for this reset credit.", "type": "string"},
+			"resetType":   Schema{"$ref": "#/$defs/RateLimitResetType"}, "status": Schema{"$ref": "#/$defs/RateLimitResetCreditStatus"},
+			"title": Schema{"description": "Backend-provided display title for this credit, or `null` when unavailable.", "type": []any{"string", "null"}},
+		}, "grantedAt", "id", "resetType", "status"),
+		"RateLimitResetCreditsSummary": object(Schema{
+			"availableCount": Schema{"format": "int64", "type": "integer"},
+			"credits": Schema{
+				"description": "Detail rows for available reset credits, when the backend provides them.\n\n`null` means only `availableCount` is known, while an empty array means details were fetched and no available credits were returned. The backend may cap this list, so its length can be less than `availableCount`.",
+				"items":       Schema{"$ref": "#/$defs/RateLimitResetCredit"}, "type": []any{"array", "null"},
+			},
+		}, "availableCount"),
+		"GetAccountRateLimitsResponse": object(Schema{
+			"rateLimitResetCredits": nullableRef("RateLimitResetCreditsSummary"),
+			"rateLimits":            Schema{"allOf": []any{Schema{"$ref": "#/$defs/RateLimitSnapshot"}}, "description": "Backward-compatible single-bucket view; mirrors the historical payload."},
+			"rateLimitsByLimitId": Schema{
+				"additionalProperties": Schema{"$ref": "#/$defs/RateLimitSnapshot"},
+				"description":          "Multi-bucket view keyed by metered `limit_id` (for example, `codex`).", "type": []any{"object", "null"},
+			},
+		}, "rateLimits"),
+		"ConsumeAccountRateLimitResetCreditParams": object(Schema{
+			"creditId":       Schema{"description": "Opaque reset-credit identifier to redeem. When omitted, the backend selects the next available credit.", "type": []any{"string", "null"}},
+			"idempotencyKey": Schema{"description": "Identifies one logical reset attempt. A UUID is recommended; reuse the same value when retrying that attempt.", "type": "string"},
+		}, "idempotencyKey"),
+		"ConsumeAccountRateLimitResetCreditResponse": object(Schema{
+			"outcome": Schema{"$ref": "#/$defs/ConsumeAccountRateLimitResetCreditOutcome"},
+		}, "outcome"),
+		"AccountRateLimitsUpdatedNotification": Schema{
+			"description": "Sparse rolling rate-limit update.\n\nClients should merge available values into the most recent `account/rateLimits/read` response or refetch that snapshot. Nullable account metadata may be unavailable in a rolling update and does not clear a previously observed value.",
+			"properties":  Schema{"rateLimits": Schema{"$ref": "#/$defs/RateLimitSnapshot"}},
+			"required":    []string{"rateLimits"}, "type": "object",
+		},
+	}
+}
+
+var (
+	_ json.Marshaler   = PlanType("")
+	_ json.Unmarshaler = (*PlanType)(nil)
+	_ json.Marshaler   = RateLimitReachedType("")
+	_ json.Unmarshaler = (*RateLimitReachedType)(nil)
+	_ json.Marshaler   = RateLimitResetType("")
+	_ json.Unmarshaler = (*RateLimitResetType)(nil)
+	_ json.Marshaler   = RateLimitResetCreditStatus("")
+	_ json.Unmarshaler = (*RateLimitResetCreditStatus)(nil)
+	_ json.Marshaler   = ConsumeAccountRateLimitResetCreditOutcome("")
+	_ json.Unmarshaler = (*ConsumeAccountRateLimitResetCreditOutcome)(nil)
+	_ json.Marshaler   = RateLimitWindow{}
+	_ json.Unmarshaler = (*RateLimitWindow)(nil)
+	_ json.Marshaler   = CreditsSnapshot{}
+	_ json.Unmarshaler = (*CreditsSnapshot)(nil)
+	_ json.Marshaler   = SpendControlLimitSnapshot{}
+	_ json.Unmarshaler = (*SpendControlLimitSnapshot)(nil)
+	_ json.Marshaler   = RateLimitSnapshot{}
+	_ json.Unmarshaler = (*RateLimitSnapshot)(nil)
+	_ json.Marshaler   = RateLimitResetCredit{}
+	_ json.Unmarshaler = (*RateLimitResetCredit)(nil)
+	_ json.Marshaler   = RateLimitResetCreditsSummary{}
+	_ json.Unmarshaler = (*RateLimitResetCreditsSummary)(nil)
+	_ json.Marshaler   = GetAccountRateLimitsResponse{}
+	_ json.Unmarshaler = (*GetAccountRateLimitsResponse)(nil)
+	_ json.Marshaler   = ConsumeAccountRateLimitResetCreditParams{}
+	_ json.Unmarshaler = (*ConsumeAccountRateLimitResetCreditParams)(nil)
+	_ json.Marshaler   = ConsumeAccountRateLimitResetCreditResponse{}
+	_ json.Unmarshaler = (*ConsumeAccountRateLimitResetCreditResponse)(nil)
+	_ json.Marshaler   = AccountRateLimitsUpdatedNotification{}
+	_ json.Unmarshaler = (*AccountRateLimitsUpdatedNotification)(nil)
+)

--- a/appserver/protocol/account_token_usage_contract_test.go
+++ b/appserver/protocol/account_token_usage_contract_test.go
@@ -146,8 +146,8 @@ func TestAccountTokenUsageRecordsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/usage/read = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(defs); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_config_contract_test.go
+++ b/appserver/protocol/app_config_contract_test.go
@@ -109,8 +109,8 @@ func TestAppConfigRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppConfig unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_info_contract_test.go
+++ b/appserver/protocol/app_info_contract_test.go
@@ -131,8 +131,8 @@ func TestAppInfoRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_list_updated_notification_contract_test.go
+++ b/appserver/protocol/app_list_updated_notification_contract_test.go
@@ -105,8 +105,8 @@ func TestAppListUpdatedNotificationRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceServerNotification || method.State != MethodDeferredStub {
 		t.Fatalf("app/list/updated = %#v, %v; want deferred server notification", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_metadata_contract_test.go
+++ b/appserver/protocol/app_metadata_contract_test.go
@@ -107,8 +107,8 @@ func TestAppMetadataRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_metadata_leaf_contract_test.go
+++ b/appserver/protocol/app_metadata_leaf_contract_test.go
@@ -157,8 +157,8 @@ func TestAppMetadataLeavesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_summary_contract_test.go
+++ b/appserver/protocol/app_summary_contract_test.go
@@ -87,8 +87,8 @@ func TestAppSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppSummary unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_template_summary_contract_test.go
+++ b/appserver/protocol/app_template_summary_contract_test.go
@@ -107,8 +107,8 @@ func TestAppTemplateSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppTemplateSummary unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_template_unavailable_reason_contract_test.go
+++ b/appserver/protocol/app_template_unavailable_reason_contract_test.go
@@ -71,8 +71,8 @@ func TestAppTemplateUnavailableReasonRemainsStandalone(t *testing.T) {
 			t.Fatalf("AppTemplateUnavailableReason unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_tool_approval_contract_test.go
+++ b/appserver/protocol/app_tool_approval_contract_test.go
@@ -73,8 +73,8 @@ func TestAppToolApprovalRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppToolApproval unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_tools_config_contract_test.go
+++ b/appserver/protocol/app_tools_config_contract_test.go
@@ -140,8 +140,8 @@ func TestAppToolConfigsRemainStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/apply_patch_approval_params_contract_test.go
+++ b/appserver/protocol/apply_patch_approval_params_contract_test.go
@@ -139,8 +139,8 @@ func TestApplyPatchApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ApplyPatchApprovalParams unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(defs); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(defs); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/apps_config_contract_test.go
+++ b/appserver/protocol/apps_config_contract_test.go
@@ -185,8 +185,8 @@ func TestAppsConfigsRemainStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/apps_list_contract_test.go
+++ b/appserver/protocol/apps_list_contract_test.go
@@ -168,8 +168,8 @@ func TestAppsListContractsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/attestation_contract_test.go
+++ b/appserver/protocol/attestation_contract_test.go
@@ -133,8 +133,8 @@ func TestAttestationContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("attestation/generate = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
+++ b/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
@@ -179,8 +179,8 @@ func TestChatgptAuthTokensRefreshRemainsStandaloneAndDeferred(t *testing.T) {
 	if !found {
 		t.Fatal("refresh method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/exec_command_approval_params_contract_test.go
+++ b/appserver/protocol/exec_command_approval_params_contract_test.go
@@ -137,8 +137,8 @@ func TestExecCommandApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ExecCommandApprovalParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(defs); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,8 +217,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,8 +203,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -260,8 +260,8 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,8 +244,8 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -162,8 +162,8 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -175,8 +175,8 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_contract_test.go
+++ b/appserver/protocol/file_change_contract_test.go
@@ -108,8 +108,8 @@ func TestFileChangeRemainsStandalone(t *testing.T) {
 			t.Fatalf("FileChange unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_output_delta_notification_contract_test.go
+++ b/appserver/protocol/file_change_output_delta_notification_contract_test.go
@@ -100,8 +100,8 @@ func TestFileChangeOutputDeltaNotificationRemainsDeprecatedAndStandalone(t *test
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("item/fileChange/outputDelta = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -381,8 +381,8 @@ func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_action_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_action_contract_test.go
@@ -226,8 +226,8 @@ func TestGuardianApprovalReviewActionRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReviewAction unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
@@ -164,8 +164,8 @@ func TestGuardianApprovalReviewCompletedNotificationRemainsStandalone(t *testing
 			t.Fatalf("completed notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_contract_test.go
@@ -139,8 +139,8 @@ func TestGuardianApprovalReviewRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReview unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
@@ -175,8 +175,8 @@ func TestGuardianApprovalReviewStartedNotificationRemainsStandalone(t *testing.T
 			t.Fatalf("started notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_enum_foundation_contract_test.go
+++ b/appserver/protocol/guardian_enum_foundation_contract_test.go
@@ -89,8 +89,8 @@ func TestGuardianEnumFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_metadata_list_contract_test.go
+++ b/appserver/protocol/hook_metadata_list_contract_test.go
@@ -352,8 +352,8 @@ func TestHookMetadataListContractsStayStandalone(t *testing.T) {
 			t.Errorf("standalone definition %s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Errorf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Errorf("definition count = %d, want 489", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 {
 		t.Errorf("wire binding count = %d, want 59", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_run_notification_contract_test.go
+++ b/appserver/protocol/hook_run_notification_contract_test.go
@@ -297,8 +297,8 @@ func TestHookRunNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("surface changed: %d methods, %d wire bindings, %d item bindings", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/hook_value_foundation_contract_test.go
+++ b/appserver/protocol/hook_value_foundation_contract_test.go
@@ -167,8 +167,8 @@ func TestHookValueFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 474 {
-		t.Fatalf("definition count = %d, want 474", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 489 {
+		t.Fatalf("definition count = %d, want 489", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/legacy_approval_response_contract_test.go
+++ b/appserver/protocol/legacy_approval_response_contract_test.go
@@ -98,8 +98,8 @@ func TestLegacyApprovalResponsesRemainStandaloneAndNominal(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_approval_context_contract_test.go
+++ b/appserver/protocol/network_approval_context_contract_test.go
@@ -84,8 +84,8 @@ func TestNetworkApprovalContextRemainsStandalone(t *testing.T) {
 			t.Fatalf("NetworkApprovalContext unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/parsed_command_contract_test.go
+++ b/appserver/protocol/parsed_command_contract_test.go
@@ -120,8 +120,8 @@ func TestParsedCommandRemainsStandalone(t *testing.T) {
 			t.Fatalf("ParsedCommand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/process_contracts_contract_test.go
+++ b/appserver/protocol/process_contracts_contract_test.go
@@ -308,8 +308,8 @@ func TestProcessContractsRemainStandaloneFromLegacyRuntime(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want unchanged implemented notification", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 474 {
-		t.Fatalf("definition count = %d, want 474", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 489 {
+		t.Fatalf("definition count = %d, want 489", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 474 {
-		t.Fatalf("definition count = %d, want 474", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 489 {
+		t.Fatalf("definition count = %d, want 489", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 474 {
-		t.Fatalf("definition count = %d, want 474", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 489 {
+		t.Fatalf("definition count = %d, want 489", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 474 {
-		t.Fatalf("definition count = %d, want 474", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 489 {
+		t.Fatalf("definition count = %d, want 489", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 474 {
-		t.Fatalf("definition count = %d, want 474", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 489 {
+		t.Fatalf("definition count = %d, want 489", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/review_decision_contract_test.go
+++ b/appserver/protocol/review_decision_contract_test.go
@@ -136,8 +136,8 @@ func TestReviewDecisionRemainsStandalone(t *testing.T) {
 			t.Fatalf("ReviewDecision unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(defs); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -92,6 +92,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "AdditionalNetworkPermissions", Type: reflect.TypeFor[AdditionalNetworkPermissions]()},
 		{Name: "AdditionalPermissionProfile", Type: reflect.TypeFor[AdditionalPermissionProfile]()},
 		{Name: "AccountLoginCompletedNotification", Type: reflect.TypeFor[AccountLoginCompletedNotification]()},
+		{Name: "AccountRateLimitsUpdatedNotification", Type: reflect.TypeFor[AccountRateLimitsUpdatedNotification]()},
 		{Name: "AccountTokenUsageDailyBucket", Type: reflect.TypeFor[AccountTokenUsageDailyBucket]()},
 		{Name: "AccountTokenUsageSummary", Type: reflect.TypeFor[AccountTokenUsageSummary]()},
 		{Name: "AddCreditsNudgeCreditType", Type: reflect.TypeFor[AddCreditsNudgeCreditType]()},
@@ -176,7 +177,11 @@ func wireSchemaDefinitions() Schema {
 		{Name: "ConfiguredHookHandler", Type: reflect.TypeFor[ConfiguredHookHandler]()},
 		{Name: "ConfiguredHookMatcherGroup", Type: reflect.TypeFor[ConfiguredHookMatcherGroup]()},
 		{Name: "ContentItem", Type: reflect.TypeFor[ContentItem]()},
+		{Name: "ConsumeAccountRateLimitResetCreditOutcome", Type: reflect.TypeFor[ConsumeAccountRateLimitResetCreditOutcome]()},
+		{Name: "ConsumeAccountRateLimitResetCreditParams", Type: reflect.TypeFor[ConsumeAccountRateLimitResetCreditParams]()},
+		{Name: "ConsumeAccountRateLimitResetCreditResponse", Type: reflect.TypeFor[ConsumeAccountRateLimitResetCreditResponse]()},
 		{Name: "ContextCompactionItem", Type: reflect.TypeFor[ContextCompactionItem]()},
+		{Name: "CreditsSnapshot", Type: reflect.TypeFor[CreditsSnapshot]()},
 		{Name: "DaemonShutdownParams", Type: reflect.TypeFor[DaemonShutdownParams]()},
 		{Name: "DaemonShutdownState", Type: reflect.TypeFor[DaemonShutdownState]()},
 		{Name: "DaemonStartResult", Type: reflect.TypeFor[DaemonStartResult]()},
@@ -218,6 +223,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "FsCreateDirectoryResponse", Type: reflect.TypeFor[FsCreateDirectoryResponse]()},
 		{Name: "FsGetMetadataParams", Type: reflect.TypeFor[FsGetMetadataParams]()},
 		{Name: "FsGetMetadataResponse", Type: reflect.TypeFor[FsGetMetadataResponse]()},
+		{Name: "GetAccountRateLimitsResponse", Type: reflect.TypeFor[GetAccountRateLimitsResponse]()},
 		{Name: "FsReadDirectoryEntry", Type: reflect.TypeFor[FsReadDirectoryEntry]()},
 		{Name: "FsReadDirectoryParams", Type: reflect.TypeFor[FsReadDirectoryParams]()},
 		{Name: "FsReadDirectoryResponse", Type: reflect.TypeFor[FsReadDirectoryResponse]()},
@@ -337,12 +343,21 @@ func wireSchemaDefinitions() Schema {
 		{Name: "PatchChangeKind", Type: reflect.TypeFor[PatchChangeKind]()},
 		{Name: "Personality", Type: reflect.TypeFor[Personality]()},
 		{Name: "PlanDeltaNotification", Type: reflect.TypeFor[PlanDeltaNotification]()},
+		{Name: "PlanType", Type: reflect.TypeFor[PlanType]()},
 		{Name: "PluginsMigration", Type: reflect.TypeFor[PluginsMigration]()},
 		{Name: "ProcessExitedNotification", Type: reflect.TypeFor[ProcessExitedNotification]()},
 		{Name: "ProcessOutputDeltaNotification", Type: reflect.TypeFor[ProcessOutputDeltaNotification]()},
 		{Name: "ProcessOutputStream", Type: reflect.TypeFor[ProcessOutputStream]()},
 		{Name: "ProcessTerminalSize", Type: reflect.TypeFor[ProcessTerminalSize]()},
+		{Name: "RateLimitReachedType", Type: reflect.TypeFor[RateLimitReachedType]()},
+		{Name: "RateLimitResetCredit", Type: reflect.TypeFor[RateLimitResetCredit]()},
+		{Name: "RateLimitResetCreditsSummary", Type: reflect.TypeFor[RateLimitResetCreditsSummary]()},
+		{Name: "RateLimitResetCreditStatus", Type: reflect.TypeFor[RateLimitResetCreditStatus]()},
+		{Name: "RateLimitResetType", Type: reflect.TypeFor[RateLimitResetType]()},
+		{Name: "RateLimitSnapshot", Type: reflect.TypeFor[RateLimitSnapshot]()},
+		{Name: "RateLimitWindow", Type: reflect.TypeFor[RateLimitWindow]()},
 		{Name: "SkillMigration", Type: reflect.TypeFor[SkillMigration]()},
+		{Name: "SpendControlLimitSnapshot", Type: reflect.TypeFor[SpendControlLimitSnapshot]()},
 		{Name: "SessionMigration", Type: reflect.TypeFor[SessionMigration]()},
 		{Name: "HookMigration", Type: reflect.TypeFor[HookMigration]()},
 		{Name: "SubagentMigration", Type: reflect.TypeFor[SubagentMigration]()},
@@ -1007,6 +1022,9 @@ func wireSchemaDefinitions() Schema {
 	schemas["ProcessOutputDeltaNotification"] = processOutputDeltaNotificationSchema()
 	schemas["ProcessOutputStream"] = processOutputStreamSchema()
 	schemas["ProcessTerminalSize"] = processTerminalSizeSchema()
+	for name, schema := range accountRateLimitSchemas() {
+		schemas[name] = schema
+	}
 	schemas["McpServerToolCallParams"] = mcpServerToolCallParamsSchema()
 	schemas["McpServerToolCallResponse"] = mcpServerToolCallResponseSchema()
 	schemas["ResourceContent"] = resourceContentSchema()

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -36,6 +36,18 @@
       ],
       "type": "object"
     },
+    "AccountRateLimitsUpdatedNotification": {
+      "description": "Sparse rolling rate-limit update.\n\nClients should merge available values into the most recent `account/rateLimits/read` response or refetch that snapshot. Nullable account metadata may be unavailable in a rolling update and does not clear a previously observed value.",
+      "properties": {
+        "rateLimits": {
+          "$ref": "#/$defs/RateLimitSnapshot"
+        }
+      },
+      "required": [
+        "rateLimits"
+      ],
+      "type": "object"
+    },
     "AccountTokenUsageDailyBucket": {
       "additionalProperties": false,
       "properties": {
@@ -3492,6 +3504,68 @@
       ],
       "type": "object"
     },
+    "ConsumeAccountRateLimitResetCreditOutcome": {
+      "oneOf": [
+        {
+          "description": "A reset credit was consumed and the eligible rate-limit windows were reset.",
+          "enum": [
+            "reset"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "No current rate-limit window is eligible for a reset.",
+          "enum": [
+            "nothingToReset"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "The account has no earned reset credits available.",
+          "enum": [
+            "noCredit"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "The same idempotency key already completed a reset successfully.",
+          "enum": [
+            "alreadyRedeemed"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "ConsumeAccountRateLimitResetCreditParams": {
+      "properties": {
+        "creditId": {
+          "description": "Opaque reset-credit identifier to redeem. When omitted, the backend selects the next available credit.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "idempotencyKey": {
+          "description": "Identifies one logical reset attempt. A UUID is recommended; reuse the same value when retrying that attempt.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "idempotencyKey"
+      ],
+      "type": "object"
+    },
+    "ConsumeAccountRateLimitResetCreditResponse": {
+      "properties": {
+        "outcome": {
+          "$ref": "#/$defs/ConsumeAccountRateLimitResetCreditOutcome"
+        }
+      },
+      "required": [
+        "outcome"
+      ],
+      "type": "object"
+    },
     "ContentItem": {
       "oneOf": [
         {
@@ -3592,6 +3666,27 @@
       "required": [
         "type",
         "createdAt"
+      ],
+      "type": "object"
+    },
+    "CreditsSnapshot": {
+      "properties": {
+        "balance": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "hasCredits": {
+          "type": "boolean"
+        },
+        "unlimited": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "hasCredits",
+        "unlimited"
       ],
       "type": "object"
     },
@@ -5681,6 +5776,42 @@
         "sessionId",
         "query",
         "files"
+      ],
+      "type": "object"
+    },
+    "GetAccountRateLimitsResponse": {
+      "properties": {
+        "rateLimitResetCredits": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RateLimitResetCreditsSummary"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "rateLimits": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/RateLimitSnapshot"
+            }
+          ],
+          "description": "Backward-compatible single-bucket view; mirrors the historical payload."
+        },
+        "rateLimitsByLimitId": {
+          "additionalProperties": {
+            "$ref": "#/$defs/RateLimitSnapshot"
+          },
+          "description": "Multi-bucket view keyed by metered `limit_id` (for example, `codex`).",
+          "type": [
+            "object",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "rateLimits"
       ],
       "type": "object"
     },
@@ -9933,6 +10064,23 @@
       ],
       "type": "object"
     },
+    "PlanType": {
+      "enum": [
+        "free",
+        "go",
+        "plus",
+        "pro",
+        "prolite",
+        "team",
+        "self_serve_business_usage_based",
+        "business",
+        "enterprise_cbp_usage_based",
+        "enterprise",
+        "edu",
+        "unknown"
+      ],
+      "type": "string"
+    },
     "PluginsMigration": {
       "additionalProperties": false,
       "properties": {
@@ -10061,6 +10209,205 @@
       "required": [
         "cols",
         "rows"
+      ],
+      "type": "object"
+    },
+    "RateLimitReachedType": {
+      "enum": [
+        "rate_limit_reached",
+        "workspace_owner_credits_depleted",
+        "workspace_member_credits_depleted",
+        "workspace_owner_usage_limit_reached",
+        "workspace_member_usage_limit_reached"
+      ],
+      "type": "string"
+    },
+    "RateLimitResetCredit": {
+      "properties": {
+        "description": {
+          "description": "Backend-provided display description for this credit, or `null` when unavailable.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "expiresAt": {
+          "description": "Unix timestamp in seconds when the credit expires, or `null` if it does not expire.",
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "grantedAt": {
+          "description": "Unix timestamp in seconds when the credit was granted.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "id": {
+          "description": "Opaque backend identifier for this reset credit.",
+          "type": "string"
+        },
+        "resetType": {
+          "$ref": "#/$defs/RateLimitResetType"
+        },
+        "status": {
+          "$ref": "#/$defs/RateLimitResetCreditStatus"
+        },
+        "title": {
+          "description": "Backend-provided display title for this credit, or `null` when unavailable.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "grantedAt",
+        "id",
+        "resetType",
+        "status"
+      ],
+      "type": "object"
+    },
+    "RateLimitResetCreditStatus": {
+      "enum": [
+        "available",
+        "redeeming",
+        "redeemed",
+        "unknown"
+      ],
+      "type": "string"
+    },
+    "RateLimitResetCreditsSummary": {
+      "properties": {
+        "availableCount": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "credits": {
+          "description": "Detail rows for available reset credits, when the backend provides them.\n\n`null` means only `availableCount` is known, while an empty array means details were fetched and no available credits were returned. The backend may cap this list, so its length can be less than `availableCount`.",
+          "items": {
+            "$ref": "#/$defs/RateLimitResetCredit"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "availableCount"
+      ],
+      "type": "object"
+    },
+    "RateLimitResetType": {
+      "enum": [
+        "codexRateLimits",
+        "unknown"
+      ],
+      "type": "string"
+    },
+    "RateLimitSnapshot": {
+      "properties": {
+        "credits": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CreditsSnapshot"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "individualLimit": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SpendControlLimitSnapshot"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "limitId": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "limitName": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "planType": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PlanType"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "primary": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RateLimitWindow"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "rateLimitReachedType": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RateLimitReachedType"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "secondary": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RateLimitWindow"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "RateLimitWindow": {
+      "properties": {
+        "resetsAt": {
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "usedPercent": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "windowDurationMins": {
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "usedPercent"
       ],
       "type": "object"
     },
@@ -11498,6 +11845,31 @@
         "desc"
       ],
       "type": "string"
+    },
+    "SpendControlLimitSnapshot": {
+      "properties": {
+        "limit": {
+          "type": "string"
+        },
+        "remainingPercent": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "resetsAt": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "used": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "limit",
+        "remainingPercent",
+        "resetsAt",
+        "used"
+      ],
+      "type": "object"
     },
     "SubAgentActivityKind": {
       "enum": [

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 474 {
-		t.Fatalf("definition count = %d, want 474", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 489 {
+		t.Fatalf("definition count = %d, want 489", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 474 {
-		t.Fatalf("definition count = %d, want 474", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 489 {
+		t.Fatalf("definition count = %d, want 489", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 474 {
-		t.Fatalf("definition count = %d, want 474", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 489 {
+		t.Fatalf("definition count = %d, want 489", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -39,13 +39,17 @@ func MarshalTypeScript() ([]byte, error) {
 	sort.Strings(names)
 	for _, name := range names {
 		definition := defs[name]
-		if name == "AccountLoginCompletedNotification" || name == "AccountTokenUsageSummary" ||
+		if name == "AccountLoginCompletedNotification" || name == "AccountRateLimitsUpdatedNotification" ||
+			name == "AccountTokenUsageSummary" ||
 			name == "AppBranding" || name == "AppConfig" || name == "AppInfo" || name == "AppMetadata" || name == "AppScreenshot" ||
 			name == "AppSummary" || name == "AppTemplateSummary" || name == "AppsDefaultConfig" ||
 			name == "AppsListParams" || name == "AppsListResponse" ||
 			name == "AppToolConfig" ||
 			name == "ApplyPatchApprovalParams" ||
 			name == "ChatgptAuthTokensRefreshResponse" ||
+			name == "ConsumeAccountRateLimitResetCreditParams" ||
+			name == "ConsumeAccountRateLimitResetCreditResponse" || name == "CreditsSnapshot" ||
+			name == "GetAccountRateLimitsResponse" ||
 			name == "MigrationDetails" ||
 			name == "ExternalAgentConfigMigrationItem" ||
 			name == "ExternalAgentConfigImportItemTypeFailure" ||
@@ -57,6 +61,9 @@ func MarshalTypeScript() ([]byte, error) {
 			name == "GuardianApprovalReview" || name == "ParsedCommand" ||
 			name == "ProcessExitedNotification" || name == "ProcessOutputDeltaNotification" ||
 			name == "ProcessTerminalSize" ||
+			name == "RateLimitResetCredit" || name == "RateLimitResetCreditsSummary" ||
+			name == "RateLimitSnapshot" || name == "RateLimitWindow" ||
+			name == "SpendControlLimitSnapshot" ||
 			name == "ItemGuardianApprovalReviewCompletedNotification" ||
 			name == "ItemGuardianApprovalReviewStartedNotification" {
 			// Rust accepts omitted serde default/Option fields while generated
@@ -70,6 +77,9 @@ func MarshalTypeScript() ([]byte, error) {
 			switch name {
 			case "AccountLoginCompletedNotification":
 				schema["required"] = []string{"loginId", "success", "error"}
+			case "AccountRateLimitsUpdatedNotification":
+				schema["required"] = []string{"rateLimits"}
+				schema["x-gollem-typescript-ignore-additional-properties"] = true
 			case "AccountTokenUsageSummary":
 				schema["required"] = []string{
 					"lifetimeTokens", "peakDailyTokens", "longestRunningTurnSec",
@@ -128,6 +138,20 @@ func MarshalTypeScript() ([]byte, error) {
 				schema["required"] = []string{
 					"accessToken", "chatgptAccountId", "chatgptPlanType",
 				}
+			case "ConsumeAccountRateLimitResetCreditParams":
+				schema["required"] = []string{"idempotencyKey"}
+				schema["x-gollem-typescript-ignore-additional-properties"] = true
+			case "ConsumeAccountRateLimitResetCreditResponse":
+				schema["required"] = []string{"outcome"}
+				schema["x-gollem-typescript-ignore-additional-properties"] = true
+			case "CreditsSnapshot":
+				schema["required"] = []string{"balance", "hasCredits", "unlimited"}
+				schema["x-gollem-typescript-ignore-additional-properties"] = true
+			case "GetAccountRateLimitsResponse":
+				schema["required"] = []string{
+					"rateLimitResetCredits", "rateLimits", "rateLimitsByLimitId",
+				}
+				schema["x-gollem-typescript-ignore-additional-properties"] = true
 			case "ExecCommandApprovalParams":
 				schema["required"] = []string{
 					"conversationId", "callId", "approvalId", "command", "cwd", "reason", "parsedCmd",
@@ -185,6 +209,26 @@ func MarshalTypeScript() ([]byte, error) {
 					variants[index] = copy
 				}
 			case "ProcessExitedNotification", "ProcessOutputDeltaNotification", "ProcessTerminalSize":
+				schema["x-gollem-typescript-ignore-additional-properties"] = true
+			case "RateLimitResetCredit":
+				schema["required"] = []string{
+					"description", "expiresAt", "grantedAt", "id", "resetType", "status", "title",
+				}
+				schema["x-gollem-typescript-ignore-additional-properties"] = true
+			case "RateLimitResetCreditsSummary":
+				schema["required"] = []string{"availableCount", "credits"}
+				schema["x-gollem-typescript-ignore-additional-properties"] = true
+			case "RateLimitSnapshot":
+				schema["required"] = []string{
+					"credits", "individualLimit", "limitId", "limitName", "planType",
+					"primary", "rateLimitReachedType", "secondary",
+				}
+				schema["x-gollem-typescript-ignore-additional-properties"] = true
+			case "RateLimitWindow":
+				schema["required"] = []string{"resetsAt", "usedPercent", "windowDurationMins"}
+				schema["x-gollem-typescript-ignore-additional-properties"] = true
+			case "SpendControlLimitSnapshot":
+				schema["required"] = []string{"limit", "remainingPercent", "resetsAt", "used"}
 				schema["x-gollem-typescript-ignore-additional-properties"] = true
 			case "ItemGuardianApprovalReviewCompletedNotification":
 				schema["required"] = []string{
@@ -272,6 +316,54 @@ func MarshalTypeScript() ([]byte, error) {
 			// description. Render that property as the referenced Rust type.
 			definition = typeScriptDefinitionWithPropertySchemas(definition, Schema{
 				"stream": Schema{"$ref": "#/$defs/ProcessOutputStream"},
+			})
+		}
+		if name == "RateLimitWindow" {
+			definition = typeScriptDefinitionWithPropertySchemas(definition, Schema{
+				"resetsAt": nullableIntegerSchema(), "windowDurationMins": nullableIntegerSchema(),
+			})
+		}
+		if name == "CreditsSnapshot" {
+			definition = typeScriptDefinitionWithPropertySchemas(definition, Schema{
+				"balance": nullableStringSchema(),
+			})
+		}
+		if name == "RateLimitSnapshot" {
+			definition = typeScriptDefinitionWithPropertySchemas(definition, Schema{
+				"limitId": nullableStringSchema(), "limitName": nullableStringSchema(),
+			})
+		}
+		if name == "RateLimitResetCredit" {
+			definition = typeScriptDefinitionWithPropertySchemas(definition, Schema{
+				"description": nullableStringSchema(),
+				"expiresAt":   nullableIntegerSchema(),
+				"title":       nullableStringSchema(),
+			})
+		}
+		if name == "RateLimitResetCreditsSummary" {
+			definition = typeScriptDefinitionWithPropertySchemas(definition, Schema{
+				"credits": Schema{"anyOf": []any{
+					Schema{"type": "array", "items": Schema{"$ref": "#/$defs/RateLimitResetCredit"}},
+					Schema{"type": "null"},
+				}},
+			})
+			definition = typeScriptDefinitionWithBigIntProperties(definition, "availableCount")
+		}
+		if name == "GetAccountRateLimitsResponse" {
+			definition = typeScriptDefinitionWithPropertySchemas(definition, Schema{
+				"rateLimits": Schema{"$ref": "#/$defs/RateLimitSnapshot"},
+				"rateLimitsByLimitId": Schema{"anyOf": []any{
+					Schema{
+						"type": "object", "additionalProperties": Schema{"$ref": "#/$defs/RateLimitSnapshot"},
+						"x-gollem-typescript-optional-map": true,
+					},
+					Schema{"type": "null"},
+				}},
+			})
+		}
+		if name == "ConsumeAccountRateLimitResetCreditParams" {
+			definition = typeScriptDefinitionWithPropertySchemas(definition, Schema{
+				"creditId": nullableStringSchema(),
 			})
 		}
 		if name == "AppInfo" {

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -500,6 +500,10 @@ export type AccountLoginCompletedNotification = {
   "success": boolean;
 };
 
+export type AccountRateLimitsUpdatedNotification = {
+  "rateLimits": RateLimitSnapshot;
+};
+
 export type AccountTokenUsageDailyBucket = {
   "startDate": string;
   "tokens": bigint;
@@ -1146,6 +1150,17 @@ export type ConfiguredHookMatcherGroup = {
   "matcher": string | null;
 };
 
+export type ConsumeAccountRateLimitResetCreditOutcome = "reset" | "nothingToReset" | "noCredit" | "alreadyRedeemed";
+
+export type ConsumeAccountRateLimitResetCreditParams = {
+  "creditId"?: string | null;
+  "idempotencyKey": string;
+};
+
+export type ConsumeAccountRateLimitResetCreditResponse = {
+  "outcome": ConsumeAccountRateLimitResetCreditOutcome;
+};
+
 export type ContentItem = {
   "text": string;
   "type": "input_text";
@@ -1167,6 +1182,12 @@ export type ContextCompactionItem = {
   "createdAt": string;
   "summary"?: string;
   "type": "contextCompaction";
+};
+
+export type CreditsSnapshot = {
+  "balance": string | null;
+  "hasCredits": boolean;
+  "unlimited": boolean;
 };
 
 export type DaemonShutdownParams = {
@@ -1676,6 +1697,12 @@ export type FuzzyFileSearchSessionUpdatedNotification = {
   "files": Array<FuzzyFileSearchResult>;
   "query": string;
   "sessionId": string;
+};
+
+export type GetAccountRateLimitsResponse = {
+  "rateLimitResetCredits": RateLimitResetCreditsSummary | null;
+  "rateLimits": RateLimitSnapshot;
+  "rateLimitsByLimitId": { [key in string]?: RateLimitSnapshot } | null;
 };
 
 export type GitInfo = {
@@ -2560,6 +2587,8 @@ export type PlanDeltaNotification = {
   "turnId": string;
 };
 
+export type PlanType = "free" | "go" | "plus" | "pro" | "prolite" | "team" | "self_serve_business_usage_based" | "business" | "enterprise_cbp_usage_based" | "enterprise" | "edu" | "unknown";
+
 export type PluginsMigration = {
   "marketplaceName": string;
   "pluginNames": Array<string>;
@@ -2586,6 +2615,44 @@ export type ProcessOutputStream = "stdout" | "stderr";
 export type ProcessTerminalSize = {
   "cols": number;
   "rows": number;
+};
+
+export type RateLimitReachedType = "rate_limit_reached" | "workspace_owner_credits_depleted" | "workspace_member_credits_depleted" | "workspace_owner_usage_limit_reached" | "workspace_member_usage_limit_reached";
+
+export type RateLimitResetCredit = {
+  "description": string | null;
+  "expiresAt": number | null;
+  "grantedAt": number;
+  "id": string;
+  "resetType": RateLimitResetType;
+  "status": RateLimitResetCreditStatus;
+  "title": string | null;
+};
+
+export type RateLimitResetCreditStatus = "available" | "redeeming" | "redeemed" | "unknown";
+
+export type RateLimitResetCreditsSummary = {
+  "availableCount": bigint;
+  "credits": Array<RateLimitResetCredit> | null;
+};
+
+export type RateLimitResetType = "codexRateLimits" | "unknown";
+
+export type RateLimitSnapshot = {
+  "credits": CreditsSnapshot | null;
+  "individualLimit": SpendControlLimitSnapshot | null;
+  "limitId": string | null;
+  "limitName": string | null;
+  "planType": PlanType | null;
+  "primary": RateLimitWindow | null;
+  "rateLimitReachedType": RateLimitReachedType | null;
+  "secondary": RateLimitWindow | null;
+};
+
+export type RateLimitWindow = {
+  "resetsAt": number | null;
+  "usedPercent": number;
+  "windowDurationMins": number | null;
 };
 
 export type RawResponseItemCompletedNotification = {
@@ -2857,6 +2924,13 @@ export type SkillMigration = {
 };
 
 export type SortDirection = "asc" | "desc";
+
+export type SpendControlLimitSnapshot = {
+  "limit": string;
+  "remainingPercent": number;
+  "resetsAt": number;
+  "used": string;
+};
 
 export type SubAgentActivityKind = "started" | "interacted" | "interrupted";
 

--- a/appserver/protocol/typescript/testdata/account_rate_limits_contract.ts
+++ b/appserver/protocol/typescript/testdata/account_rate_limits_contract.ts
@@ -1,0 +1,144 @@
+import type {
+  AccountRateLimitsUpdatedNotification,
+  ConsumeAccountRateLimitResetCreditOutcome,
+  ConsumeAccountRateLimitResetCreditParams,
+  ConsumeAccountRateLimitResetCreditResponse,
+  CreditsSnapshot,
+  GetAccountRateLimitsResponse,
+  PlanType,
+  RateLimitReachedType,
+  RateLimitResetCredit,
+  RateLimitResetCreditsSummary,
+  RateLimitResetCreditStatus,
+  RateLimitResetType,
+  RateLimitSnapshot,
+  RateLimitWindow,
+  SpendControlLimitSnapshot,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2) ? true : false;
+type Expect<T extends true> = T;
+
+type Contracts = [
+  Expect<Equal<PlanType,
+    "free" | "go" | "plus" | "pro" | "prolite" | "team" |
+    "self_serve_business_usage_based" | "business" |
+    "enterprise_cbp_usage_based" | "enterprise" | "edu" | "unknown">>,
+  Expect<Equal<RateLimitReachedType,
+    "rate_limit_reached" | "workspace_owner_credits_depleted" |
+    "workspace_member_credits_depleted" | "workspace_owner_usage_limit_reached" |
+    "workspace_member_usage_limit_reached">>,
+  Expect<Equal<RateLimitResetType, "codexRateLimits" | "unknown">>,
+  Expect<Equal<RateLimitResetCreditStatus, "available" | "redeeming" | "redeemed" | "unknown">>,
+  Expect<Equal<ConsumeAccountRateLimitResetCreditOutcome,
+    "reset" | "nothingToReset" | "noCredit" | "alreadyRedeemed">>,
+  Expect<Equal<RateLimitWindow, {
+    usedPercent: number;
+    windowDurationMins: number | null;
+    resetsAt: number | null;
+  }>>,
+  Expect<Equal<CreditsSnapshot, {
+    hasCredits: boolean;
+    unlimited: boolean;
+    balance: string | null;
+  }>>,
+  Expect<Equal<SpendControlLimitSnapshot, {
+    limit: string;
+    used: string;
+    remainingPercent: number;
+    resetsAt: number;
+  }>>,
+  Expect<Equal<RateLimitSnapshot, {
+    limitId: string | null;
+    limitName: string | null;
+    primary: RateLimitWindow | null;
+    secondary: RateLimitWindow | null;
+    credits: CreditsSnapshot | null;
+    individualLimit: SpendControlLimitSnapshot | null;
+    planType: PlanType | null;
+    rateLimitReachedType: RateLimitReachedType | null;
+  }>>,
+  Expect<Equal<RateLimitResetCredit, {
+    id: string;
+    resetType: RateLimitResetType;
+    status: RateLimitResetCreditStatus;
+    grantedAt: number;
+    expiresAt: number | null;
+    title: string | null;
+    description: string | null;
+  }>>,
+  Expect<Equal<RateLimitResetCreditsSummary, {
+    availableCount: bigint;
+    credits: Array<RateLimitResetCredit> | null;
+  }>>,
+  Expect<Equal<GetAccountRateLimitsResponse, {
+    rateLimits: RateLimitSnapshot;
+    rateLimitsByLimitId: { [key in string]?: RateLimitSnapshot } | null;
+    rateLimitResetCredits: RateLimitResetCreditsSummary | null;
+  }>>,
+  Expect<Equal<ConsumeAccountRateLimitResetCreditParams, {
+    idempotencyKey: string;
+    creditId?: string | null;
+  }>>,
+  Expect<Equal<ConsumeAccountRateLimitResetCreditResponse, {
+    outcome: ConsumeAccountRateLimitResetCreditOutcome;
+  }>>,
+  Expect<Equal<AccountRateLimitsUpdatedNotification, {
+    rateLimits: RateLimitSnapshot;
+  }>>,
+];
+
+const sparse: RateLimitSnapshot = {
+  limitId: null,
+  limitName: null,
+  primary: null,
+  secondary: null,
+  credits: null,
+  individualLimit: null,
+  planType: null,
+  rateLimitReachedType: null,
+};
+({ usedPercent: 0, windowDurationMins: null, resetsAt: null }) satisfies RateLimitWindow;
+({ hasCredits: false, unlimited: true, balance: null }) satisfies CreditsSnapshot;
+({ limit: "", used: "", remainingPercent: -1, resetsAt: 0 }) satisfies SpendControlLimitSnapshot;
+({ availableCount: 0n, credits: null }) satisfies RateLimitResetCreditsSummary;
+({ rateLimits: sparse, rateLimitsByLimitId: { codex: sparse }, rateLimitResetCredits: null }) satisfies GetAccountRateLimitsResponse;
+({ idempotencyKey: "key" }) satisfies ConsumeAccountRateLimitResetCreditParams;
+({ idempotencyKey: "key", creditId: null }) satisfies ConsumeAccountRateLimitResetCreditParams;
+({ outcome: "reset" }) satisfies ConsumeAccountRateLimitResetCreditResponse;
+({ rateLimits: sparse }) satisfies AccountRateLimitsUpdatedNotification;
+
+// @ts-expect-error plan labels are exact.
+"future" satisfies PlanType;
+// @ts-expect-error reached reasons are exact.
+"unknown" satisfies RateLimitReachedType;
+// @ts-expect-error reset types are exact.
+"codex_rate_limits" satisfies RateLimitResetType;
+// @ts-expect-error reset statuses are exact.
+"pending" satisfies RateLimitResetCreditStatus;
+// @ts-expect-error outcomes are camel-case literals.
+"nothing_to_reset" satisfies ConsumeAccountRateLimitResetCreditOutcome;
+// @ts-expect-error nullable window fields remain required.
+({ usedPercent: 0 }) satisfies RateLimitWindow;
+// @ts-expect-error balance remains required.
+({ hasCredits: false, unlimited: false }) satisfies CreditsSnapshot;
+// @ts-expect-error resetsAt is numeric.
+({ limit: "1", used: "0", remainingPercent: 100, resetsAt: 0n }) satisfies SpendControlLimitSnapshot;
+// @ts-expect-error sparse fields remain explicit in TypeScript.
+({}) satisfies RateLimitSnapshot;
+// @ts-expect-error reset-credit nullable metadata remains explicit.
+({ id: "c", resetType: "unknown", status: "unknown", grantedAt: 0 }) satisfies RateLimitResetCredit;
+// @ts-expect-error availableCount is bigint.
+({ availableCount: 0, credits: null }) satisfies RateLimitResetCreditsSummary;
+// @ts-expect-error response nullable views remain required.
+({ rateLimits: sparse }) satisfies GetAccountRateLimitsResponse;
+// @ts-expect-error idempotencyKey is required.
+({ creditId: null }) satisfies ConsumeAccountRateLimitResetCreditParams;
+// @ts-expect-error outcomes are exact.
+({ outcome: "unknown" }) satisfies ConsumeAccountRateLimitResetCreditResponse;
+// @ts-expect-error rolling notification is closed.
+({ rateLimits: sparse, future: true }) satisfies AccountRateLimitsUpdatedNotification;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 474 {
-		t.Fatalf("definition count = %d, want 474", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
+		t.Fatalf("definition count = %d, want 489", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- export the complete 15-definition account rate-limit data graph from Codex `5c19155cbd93bfa099016e7487259f61669823ff`
- preserve serde fallback enums, sparse nullable snapshots, exact integer limits, reset-credit arrays, and last-wins limit maps
- keep `account/rateLimits/read`, `account/rateLimitResetCredit/consume`, and `account/rateLimits/updated` deferred and unbound
- generate exact JSON Schema and strict TypeScript declarations without adding account, billing, redemption, persistence, or notification runtime authority

## Verification
- deliberate red: focused package build failed on the missing rate-limit symbols before implementation
- pinned compact JSON roots and all 15 pinned TypeScript module hashes match; named TS aggregate is `138620e04bb32cb7b9d3e904c875e7e9a87f332eb58d8d7664f55b808b26075c`
- focused normal and race tests passed 30 repetitions each
- every function in `account_rate_limits_types.go` has 100% statement coverage under focused tests
- strict TypeScript project passed, including exact closed declarations and malformed boundaries
- generated schema/TypeScript are deterministic and reverse exactly to the parent after removing the 15 declarations
- all 59 non-Monty packages passed normal and race tests; local Monty tests were skipped per `hooks.skipMontyRace=true`
- `golangci-lint`, `go vet`, `go mod tidy` verification, `go mod verify`, `git diff --check`, and configured pre-push passed
- parent/current no-VCS binaries produced byte-identical initialize + initialized + MCP-status transcripts with empty stderr

## Contract inventory
- definitions: 489
- methods: 224
- method bindings: 59
- item bindings: 5