### PR TITLE
feat(protocol): export account envelope contracts

### DIFF
--- a/appserver/protocol/account_credit_nudge_values_contract_test.go
+++ b/appserver/protocol/account_credit_nudge_values_contract_test.go
@@ -119,8 +119,8 @@ func TestAccountCreditNudgeValuesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/sendAddCreditsNudgeEmail = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/account_envelope_contract_test.go
+++ b/appserver/protocol/account_envelope_contract_test.go
@@ -1,0 +1,338 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestAccountEnvelopeSchemasAreExact(t *testing.T) {
+	nullableRef := func(name string) Schema {
+		return Schema{"anyOf": []any{Schema{"$ref": "#/$defs/" + name}, Schema{"type": "null"}}}
+	}
+	object := func(properties Schema, required ...string) Schema {
+		out := Schema{"type": "object", "properties": properties}
+		if len(required) != 0 {
+			out["required"] = required
+		}
+		return out
+	}
+	want := map[string]Schema{
+		"Account": {"oneOf": []any{
+			Schema{
+				"properties": Schema{"type": Schema{"enum": []any{"apiKey"}, "title": "ApiKeyAccountType", "type": "string"}},
+				"required":   []string{"type"}, "title": "ApiKeyAccount", "type": "object",
+			},
+			Schema{
+				"properties": Schema{
+					"email":    Schema{"type": []any{"string", "null"}},
+					"planType": Schema{"$ref": "#/$defs/PlanType"},
+					"type":     Schema{"enum": []any{"chatgpt"}, "title": "ChatgptAccountType", "type": "string"},
+				},
+				"required": []string{"email", "planType", "type"}, "title": "ChatgptAccount", "type": "object",
+			},
+			Schema{
+				"properties": Schema{
+					"credentialSource": Schema{
+						"allOf":   []any{Schema{"$ref": "#/$defs/AmazonBedrockCredentialSource"}},
+						"default": "awsManaged",
+					},
+					"type": Schema{"enum": []any{"amazonBedrock"}, "title": "AmazonBedrockAccountType", "type": "string"},
+				},
+				"required": []string{"type"}, "title": "AmazonBedrockAccount", "type": "object",
+			},
+		}},
+		"AccountUpdatedNotification": object(Schema{
+			"authMode": nullableRef("AuthMode"), "planType": nullableRef("PlanType"),
+		}),
+		"GetAccountParams": object(Schema{
+			"refreshToken": Schema{
+				"description": "When `true`, requests a proactive token refresh before returning.\n\n" +
+					"In managed auth mode this triggers the normal refresh-token flow. In external auth mode this flag is ignored. Clients should refresh tokens themselves and call `account/login/start` with `chatgptAuthTokens`.",
+				"type": "boolean",
+			},
+		}),
+		"GetAccountResponse": object(Schema{
+			"account": nullableRef("Account"), "requiresOpenaiAuth": Schema{"type": "boolean"},
+		}, "requiresOpenaiAuth"),
+		"GetAccountTokenUsageResponse": object(Schema{
+			"dailyUsageBuckets": Schema{
+				"items": Schema{"$ref": "#/$defs/AccountTokenUsageDailyBucket"},
+				"type":  []any{"array", "null"},
+			},
+			"summary": Schema{"$ref": "#/$defs/AccountTokenUsageSummary"},
+		}, "summary"),
+		"SendAddCreditsNudgeEmailParams": object(Schema{
+			"creditType": Schema{"$ref": "#/$defs/AddCreditsNudgeCreditType"},
+		}, "creditType"),
+		"SendAddCreditsNudgeEmailResponse": object(Schema{
+			"status": Schema{"$ref": "#/$defs/AddCreditsNudgeEmailStatus"},
+		}, "status"),
+	}
+	definitions := JSONSchema()["$defs"].(Schema)
+	for name, expected := range want {
+		if got := definitions[name]; !reflect.DeepEqual(got, expected) {
+			t.Errorf("%s = %#v, want %#v", name, got, expected)
+		}
+	}
+}
+
+func TestAccountAcceptsExactSerdeWireForms(t *testing.T) {
+	for _, tc := range []struct {
+		input    string
+		want     string
+		wantType string
+	}{
+		{`{"type":"apiKey"}`, `{"type":"apiKey"}`, "apiKey"},
+		{`{"future":1,"future":2,"type":"apiKey","email":"ignored"}`, `{"type":"apiKey"}`, "apiKey"},
+		{`{"type":"chatgpt","planType":"free"}`, `{"type":"chatgpt","email":null,"planType":"free"}`, "chatgpt"},
+		{`{"type":"chatgpt","email":null,"planType":"future-plan"}`, `{"type":"chatgpt","email":null,"planType":"unknown"}`, "chatgpt"},
+		{`{"type":"chatgpt","email":" user@example.invalid ","planType":"enterprise"}`, `{"type":"chatgpt","email":" user@example.invalid ","planType":"enterprise"}`, "chatgpt"},
+		{`{"type":"amazonBedrock"}`, `{"type":"amazonBedrock","credentialSource":"awsManaged"}`, "amazonBedrock"},
+		{`{"type":"amazonBedrock","credentialSource":"codexManaged"}`, `{"type":"amazonBedrock","credentialSource":"codexManaged"}`, "amazonBedrock"},
+	} {
+		var value Account
+		if err := json.Unmarshal([]byte(tc.input), &value); err != nil {
+			t.Errorf("unmarshal %s: %v", tc.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(value)
+		if err != nil || string(encoded) != tc.want || value.Type() != tc.wantType {
+			t.Errorf("round trip %s = %s, %v, type %q; want %s, %q", tc.input, encoded, err, value.Type(), tc.want, tc.wantType)
+		}
+	}
+}
+
+func TestAccountRejectsMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`, `{}`,
+		`{"type":null}`, `{"type":1}`, `{"type":"future"}`, `{"type":"api_key"}`,
+		`{"type":"chatgpt"}`, `{"type":"chatgpt","email":1,"planType":"free"}`,
+		`{"type":"chatgpt","email":null,"planType":null}`,
+		`{"type":"chatgpt","email":null,"planType":1}`,
+		`{"type":"amazonBedrock","credentialSource":null}`,
+		`{"type":"amazonBedrock","credentialSource":"future"}`,
+		`{"type":"apiKey","type":"chatgpt"}`,
+		`{"type":"chatgpt","email":null,"email":"value","planType":"free"}`,
+		`{"type":"amazonBedrock","credentialSource":"awsManaged","credentialSource":"codexManaged"}`,
+		`{"type":"apiKey"} {}`, `{"type":"apiKey"} x`,
+	} {
+		assertJSONRejects[Account](t, input)
+	}
+}
+
+func TestGetAccountParamsPreservesSerdeDefault(t *testing.T) {
+	for _, tc := range []struct{ input, want string }{
+		{`{}`, `{}`},
+		{`{"refreshToken":false}`, `{}`},
+		{`{"refreshToken":true}`, `{"refreshToken":true}`},
+		{`{"future":1,"future":2,"refreshToken":true}`, `{"refreshToken":true}`},
+	} {
+		var value GetAccountParams
+		if err := json.Unmarshal([]byte(tc.input), &value); err != nil {
+			t.Errorf("unmarshal %s: %v", tc.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(value)
+		if err != nil || string(encoded) != tc.want {
+			t.Errorf("round trip %s = %s, %v; want %s", tc.input, encoded, err, tc.want)
+		}
+	}
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`, `{"refreshToken":null}`,
+		`{"refreshToken":1}`, `{"refreshToken":"true"}`,
+		`{"refreshToken":false,"refreshToken":true}`, `{} {}`, `{} x`,
+	} {
+		assertJSONRejects[GetAccountParams](t, input)
+	}
+}
+
+func TestAccountEnvelopeObjectsPreserveExactSerdeWireForms(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		input string
+		want  string
+		run   func([]byte) ([]byte, error)
+	}{
+		{"get account absent", `{"requiresOpenaiAuth":false}`, `{"account":null,"requiresOpenaiAuth":false}`, roundTripAccountResponse},
+		{"get account null", `{"account":null,"requiresOpenaiAuth":true}`, `{"account":null,"requiresOpenaiAuth":true}`, roundTripAccountResponse},
+		{"get account value", `{"future":1,"account":{"type":"amazonBedrock"},"requiresOpenaiAuth":false}`, `{"account":{"type":"amazonBedrock","credentialSource":"awsManaged"},"requiresOpenaiAuth":false}`, roundTripAccountResponse},
+		{"updated absent", `{}`, `{"authMode":null,"planType":null}`, roundTripAccountUpdated},
+		{"updated null", `{"authMode":null,"planType":null}`, `{"authMode":null,"planType":null}`, roundTripAccountUpdated},
+		{"updated value", `{"future":true,"authMode":"chatgpt","planType":"future"}`, `{"authMode":"chatgpt","planType":"unknown"}`, roundTripAccountUpdated},
+		{"usage absent", `{"summary":{}}`, `{"summary":{"lifetimeTokens":null,"peakDailyTokens":null,"longestRunningTurnSec":null,"currentStreakDays":null,"longestStreakDays":null},"dailyUsageBuckets":null}`, roundTripAccountUsage},
+		{"usage null", `{"summary":{},"dailyUsageBuckets":null}`, `{"summary":{"lifetimeTokens":null,"peakDailyTokens":null,"longestRunningTurnSec":null,"currentStreakDays":null,"longestStreakDays":null},"dailyUsageBuckets":null}`, roundTripAccountUsage},
+		{"usage values", `{"summary":{"lifetimeTokens":-9223372036854775808},"dailyUsageBuckets":[{"startDate":"","tokens":9223372036854775807},{"startDate":"","tokens":9223372036854775807}]}`, `{"summary":{"lifetimeTokens":-9223372036854775808,"peakDailyTokens":null,"longestRunningTurnSec":null,"currentStreakDays":null,"longestStreakDays":null},"dailyUsageBuckets":[{"startDate":"","tokens":9223372036854775807},{"startDate":"","tokens":9223372036854775807}]}`, roundTripAccountUsage},
+		{"nudge params", `{"future":true,"creditType":"usage_limit"}`, `{"creditType":"usage_limit"}`, roundTripNudgeParams},
+		{"nudge response", `{"future":true,"status":"cooldown_active"}`, `{"status":"cooldown_active"}`, roundTripNudgeResponse},
+	} {
+		got, err := tc.run([]byte(tc.input))
+		if err != nil || string(got) != tc.want {
+			t.Errorf("%s round trip = %s, %v; want %s", tc.name, got, err, tc.want)
+		}
+	}
+}
+
+func TestAccountEnvelopeObjectsRejectMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `[]`, `{`, `{}`, `{"account":null}`, `{"requiresOpenaiAuth":null}`,
+		`{"requiresOpenaiAuth":0}`, `{"account":{"type":"future"},"requiresOpenaiAuth":false}`,
+		`{"requiresOpenaiAuth":false,"requiresOpenaiAuth":true}`, `{"requiresOpenaiAuth":false} {}`,
+	} {
+		assertJSONRejects[GetAccountResponse](t, input)
+	}
+	for _, input := range []string{
+		``, `null`, `[]`, `{`, `{"authMode":"future"}`, `{"authMode":1}`,
+		`{"planType":1}`, `{"authMode":null,"authMode":"chatgpt"}`, `{} {}`,
+	} {
+		assertJSONRejects[AccountUpdatedNotification](t, input)
+	}
+	for _, input := range []string{
+		``, `null`, `[]`, `{`, `{}`, `{"summary":null}`, `{"summary":[]}`,
+		`{"summary":{},"dailyUsageBuckets":{}}`, `{"summary":{},"dailyUsageBuckets":[null]}`,
+		`{"summary":{},"summary":{}}`, `{"summary":{},"dailyUsageBuckets":null,"dailyUsageBuckets":[]}`,
+		`{"summary":{}} {}`,
+	} {
+		assertJSONRejects[GetAccountTokenUsageResponse](t, input)
+	}
+	for _, input := range []string{
+		``, `null`, `[]`, `{`, `{}`, `{"creditType":null}`, `{"creditType":"future"}`,
+		`{"creditType":"credits","creditType":"usage_limit"}`, `{"creditType":"credits"} {}`,
+	} {
+		assertJSONRejects[SendAddCreditsNudgeEmailParams](t, input)
+	}
+	for _, input := range []string{
+		``, `null`, `[]`, `{`, `{}`, `{"status":null}`, `{"status":"future"}`,
+		`{"status":"sent","status":"cooldown_active"}`, `{"status":"sent"} {}`,
+	} {
+		assertJSONRejects[SendAddCreditsNudgeEmailResponse](t, input)
+	}
+}
+
+func TestAccountEnvelopeNilReceiversAndInvalidMarshal(t *testing.T) {
+	checks := map[string]func() error{
+		"Account":          func() error { var v *Account; return v.UnmarshalJSON([]byte(`{"type":"apiKey"}`)) },
+		"GetAccountParams": func() error { var v *GetAccountParams; return v.UnmarshalJSON([]byte(`{}`)) },
+		"GetAccountResponse": func() error {
+			var v *GetAccountResponse
+			return v.UnmarshalJSON([]byte(`{"requiresOpenaiAuth":false}`))
+		},
+		"AccountUpdatedNotification":   func() error { var v *AccountUpdatedNotification; return v.UnmarshalJSON([]byte(`{}`)) },
+		"GetAccountTokenUsageResponse": func() error { var v *GetAccountTokenUsageResponse; return v.UnmarshalJSON([]byte(`{"summary":{}}`)) },
+		"SendAddCreditsNudgeEmailParams": func() error {
+			var v *SendAddCreditsNudgeEmailParams
+			return v.UnmarshalJSON([]byte(`{"creditType":"credits"}`))
+		},
+		"SendAddCreditsNudgeEmailResponse": func() error {
+			var v *SendAddCreditsNudgeEmailResponse
+			return v.UnmarshalJSON([]byte(`{"status":"sent"}`))
+		},
+	}
+	for name, check := range checks {
+		if err := check(); err == nil {
+			t.Errorf("nil %s receiver succeeded", name)
+		}
+	}
+	if _, err := json.Marshal(Account{}); err == nil {
+		t.Fatal("empty Account marshaled")
+	}
+}
+
+func TestAccountEnvelopeContractsRemainStandaloneAndDeferred(t *testing.T) {
+	names := []string{
+		"Account", "AccountUpdatedNotification", "GetAccountParams", "GetAccountResponse",
+		"GetAccountTokenUsageResponse", "SendAddCreditsNudgeEmailParams", "SendAddCreditsNudgeEmailResponse",
+	}
+	for _, binding := range WireTypeBindings() {
+		for _, name := range names {
+			if slices.Contains(binding.Params, name) || slices.Contains(binding.Result, name) {
+				t.Fatalf("%s unexpectedly bound to %s", name, binding.Method)
+			}
+		}
+	}
+	for _, binding := range ItemPayloadBindings() {
+		if slices.Contains(names, binding.Type) {
+			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
+		}
+	}
+	for methodName, surface := range map[string]Surface{
+		"account/read":                     SurfaceClientRequest,
+		"account/usage/read":               SurfaceClientRequest,
+		"account/sendAddCreditsNudgeEmail": SurfaceClientRequest,
+		"account/updated":                  SurfaceServerNotification,
+	} {
+		method, ok := LookupMethod(methodName)
+		if !ok || method.Surface != surface || method.State != MethodDeferredStub {
+			t.Errorf("%s = %#v, %v; want deferred %s", methodName, method, ok, surface)
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
+	}
+	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 224/59/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
+	}
+}
+
+func TestAccountEnvelopeTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	source := string(generated)
+	for _, want := range []string{
+		"export type Account = {\n  \"type\": \"apiKey\";\n} | {\n  \"email\": string | null;\n  \"planType\": PlanType;\n  \"type\": \"chatgpt\";\n} | {\n  \"credentialSource\": AmazonBedrockCredentialSource;\n  \"type\": \"amazonBedrock\";\n};",
+		"export type AccountUpdatedNotification = {\n  \"authMode\": AuthMode | null;\n  \"planType\": PlanType | null;\n};",
+		"export type GetAccountParams = {\n  \"refreshToken\"?: boolean;\n};",
+		"export type GetAccountResponse = {\n  \"account\": Account | null;\n  \"requiresOpenaiAuth\": boolean;\n};",
+		"export type GetAccountTokenUsageResponse = {\n  \"dailyUsageBuckets\": Array<AccountTokenUsageDailyBucket> | null;\n  \"summary\": AccountTokenUsageSummary;\n};",
+		"export type SendAddCreditsNudgeEmailParams = {\n  \"creditType\": AddCreditsNudgeCreditType;\n};",
+		"export type SendAddCreditsNudgeEmailResponse = {\n  \"status\": AddCreditsNudgeEmailStatus;\n};",
+	} {
+		if !strings.Contains(source, want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}
+
+func roundTripAccountResponse(data []byte) ([]byte, error) {
+	var value GetAccountResponse
+	if err := json.Unmarshal(data, &value); err != nil {
+		return nil, err
+	}
+	return json.Marshal(value)
+}
+
+func roundTripAccountUpdated(data []byte) ([]byte, error) {
+	var value AccountUpdatedNotification
+	if err := json.Unmarshal(data, &value); err != nil {
+		return nil, err
+	}
+	return json.Marshal(value)
+}
+
+func roundTripAccountUsage(data []byte) ([]byte, error) {
+	var value GetAccountTokenUsageResponse
+	if err := json.Unmarshal(data, &value); err != nil {
+		return nil, err
+	}
+	return json.Marshal(value)
+}
+
+func roundTripNudgeParams(data []byte) ([]byte, error) {
+	var value SendAddCreditsNudgeEmailParams
+	if err := json.Unmarshal(data, &value); err != nil {
+		return nil, err
+	}
+	return json.Marshal(value)
+}
+
+func roundTripNudgeResponse(data []byte) ([]byte, error) {
+	var value SendAddCreditsNudgeEmailResponse
+	if err := json.Unmarshal(data, &value); err != nil {
+		return nil, err
+	}
+	return json.Marshal(value)
+}

--- a/appserver/protocol/account_envelope_types.go
+++ b/appserver/protocol/account_envelope_types.go
@@ -1,0 +1,318 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// Account is exact standalone public account identity data. It does not expose
+// credentials or imply that Gollem owns authentication state.
+type Account struct{ raw json.RawMessage }
+
+func (a Account) MarshalJSON() ([]byte, error) {
+	if len(a.raw) == 0 {
+		return nil, errors.New("account is empty")
+	}
+	return validateAccountJSON(a.raw)
+}
+
+func (a *Account) UnmarshalJSON(data []byte) error {
+	if a == nil {
+		return errors.New("decode account into nil receiver")
+	}
+	canonical, err := validateAccountJSON(data)
+	if err != nil {
+		return err
+	}
+	a.raw = canonical
+	return nil
+}
+
+// Type returns the public account discriminant, or an empty string for an
+// uninitialized or invalid internal value.
+func (a Account) Type() string { return loginAccountDiscriminant(a.raw) }
+
+func validateAccountJSON(data []byte) ([]byte, error) {
+	discriminant, err := decodeRustSerdeObject(data, "account", "type")
+	if err != nil {
+		return nil, err
+	}
+	typeName, err := decodeRequiredThreadItemValue[string](discriminant, "account", "type")
+	if err != nil {
+		return nil, err
+	}
+	switch typeName {
+	case "apiKey":
+		return marshalLoginAccountType(typeName)
+	case "chatgpt":
+		payload, err := decodeRustSerdeObject(data, "chatgpt account", "type", "email", "planType")
+		if err != nil {
+			return nil, err
+		}
+		email, err := decodeOptionalNullableConfigValue[string](payload, "chatgpt account", "email")
+		if err != nil {
+			return nil, err
+		}
+		planType, err := decodeRequiredThreadItemValue[PlanType](payload, "chatgpt account", "planType")
+		if err != nil {
+			return nil, err
+		}
+		return json.Marshal(struct {
+			Type     string   `json:"type"`
+			Email    *string  `json:"email"`
+			PlanType PlanType `json:"planType"`
+		}{Type: typeName, Email: email, PlanType: planType})
+	case "amazonBedrock":
+		payload, err := decodeRustSerdeObject(data, "amazonBedrock account", "type", "credentialSource")
+		if err != nil {
+			return nil, err
+		}
+		credentialSource := AmazonBedrockCredentialSourceAWSManaged
+		if raw, ok := payload["credentialSource"]; ok {
+			if isJSONNull(raw) {
+				return nil, errors.New("amazonBedrock account credentialSource cannot be null")
+			}
+			if err := json.Unmarshal(raw, &credentialSource); err != nil {
+				return nil, fmt.Errorf("decode amazonBedrock account credentialSource: %w", err)
+			}
+		}
+		return json.Marshal(struct {
+			Type             string                        `json:"type"`
+			CredentialSource AmazonBedrockCredentialSource `json:"credentialSource"`
+		}{Type: typeName, CredentialSource: credentialSource})
+	default:
+		return nil, fmt.Errorf("unsupported account type %q", typeName)
+	}
+}
+
+// GetAccountParams is the exact standalone account-read request.
+type GetAccountParams struct {
+	RefreshToken bool `json:"refreshToken,omitempty"`
+}
+
+func (p *GetAccountParams) UnmarshalJSON(data []byte) error {
+	if p == nil {
+		return errors.New("decode get-account params into nil receiver")
+	}
+	payload, err := decodeRustSerdeObject(data, "get-account params", "refreshToken")
+	if err != nil {
+		return err
+	}
+	refreshToken := false
+	if raw, ok := payload["refreshToken"]; ok {
+		if isJSONNull(raw) {
+			return errors.New("get-account params refreshToken cannot be null")
+		}
+		if err := json.Unmarshal(raw, &refreshToken); err != nil {
+			return fmt.Errorf("decode get-account params refreshToken: %w", err)
+		}
+	}
+	*p = GetAccountParams{RefreshToken: refreshToken}
+	return nil
+}
+
+// GetAccountResponse is exact standalone account-read data.
+type GetAccountResponse struct {
+	Account            *Account `json:"account,omitempty"`
+	RequiresOpenAIAuth bool     `json:"requiresOpenaiAuth"`
+}
+
+func (r GetAccountResponse) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Account            *Account `json:"account"`
+		RequiresOpenAIAuth bool     `json:"requiresOpenaiAuth"`
+	}{Account: r.Account, RequiresOpenAIAuth: r.RequiresOpenAIAuth})
+}
+
+func (r *GetAccountResponse) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("decode get-account response into nil receiver")
+	}
+	const objectName = "get-account response"
+	payload, err := decodeRustSerdeObject(data, objectName, "account", "requiresOpenaiAuth")
+	if err != nil {
+		return err
+	}
+	account, err := decodeOptionalNullableConfigValue[Account](payload, objectName, "account")
+	if err != nil {
+		return err
+	}
+	requiresOpenAIAuth, err := decodeRequiredThreadItemValue[bool](payload, objectName, "requiresOpenaiAuth")
+	if err != nil {
+		return err
+	}
+	*r = GetAccountResponse{Account: account, RequiresOpenAIAuth: requiresOpenAIAuth}
+	return nil
+}
+
+// AccountUpdatedNotification is exact standalone account metadata.
+type AccountUpdatedNotification struct {
+	AuthMode *AuthMode `json:"authMode,omitempty"`
+	PlanType *PlanType `json:"planType,omitempty"`
+}
+
+func (n AccountUpdatedNotification) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		AuthMode *AuthMode `json:"authMode"`
+		PlanType *PlanType `json:"planType"`
+	}{AuthMode: n.AuthMode, PlanType: n.PlanType})
+}
+
+func (n *AccountUpdatedNotification) UnmarshalJSON(data []byte) error {
+	if n == nil {
+		return errors.New("decode account-updated notification into nil receiver")
+	}
+	const objectName = "account-updated notification"
+	payload, err := decodeRustSerdeObject(data, objectName, "authMode", "planType")
+	if err != nil {
+		return err
+	}
+	authMode, err := decodeOptionalNullableConfigValue[AuthMode](payload, objectName, "authMode")
+	if err != nil {
+		return err
+	}
+	planType, err := decodeOptionalNullableConfigValue[PlanType](payload, objectName, "planType")
+	if err != nil {
+		return err
+	}
+	*n = AccountUpdatedNotification{AuthMode: authMode, PlanType: planType}
+	return nil
+}
+
+// GetAccountTokenUsageResponse is exact standalone usage-read data.
+type GetAccountTokenUsageResponse struct {
+	Summary           AccountTokenUsageSummary       `json:"summary"`
+	DailyUsageBuckets []AccountTokenUsageDailyBucket `json:"dailyUsageBuckets,omitempty"`
+}
+
+func (r GetAccountTokenUsageResponse) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Summary           AccountTokenUsageSummary       `json:"summary"`
+		DailyUsageBuckets []AccountTokenUsageDailyBucket `json:"dailyUsageBuckets"`
+	}{Summary: r.Summary, DailyUsageBuckets: r.DailyUsageBuckets})
+}
+
+func (r *GetAccountTokenUsageResponse) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("decode account token-usage response into nil receiver")
+	}
+	const objectName = "account token-usage response"
+	payload, err := decodeRustSerdeObject(data, objectName, "summary", "dailyUsageBuckets")
+	if err != nil {
+		return err
+	}
+	summary, err := decodeRequiredThreadItemValue[AccountTokenUsageSummary](payload, objectName, "summary")
+	if err != nil {
+		return err
+	}
+	dailyUsageBuckets, err := decodeOptionalNullableRateLimitValue[[]AccountTokenUsageDailyBucket](payload, objectName, "dailyUsageBuckets")
+	if err != nil {
+		return err
+	}
+	*r = GetAccountTokenUsageResponse{Summary: summary, DailyUsageBuckets: dailyUsageBuckets}
+	return nil
+}
+
+// SendAddCreditsNudgeEmailParams is exact standalone nudge request data.
+type SendAddCreditsNudgeEmailParams struct {
+	CreditType AddCreditsNudgeCreditType `json:"creditType"`
+}
+
+func (p *SendAddCreditsNudgeEmailParams) UnmarshalJSON(data []byte) error {
+	if p == nil {
+		return errors.New("decode send-add-credits-nudge-email params into nil receiver")
+	}
+	const objectName = "send-add-credits-nudge-email params"
+	payload, err := decodeRustSerdeObject(data, objectName, "creditType")
+	if err != nil {
+		return err
+	}
+	creditType, err := decodeRequiredThreadItemValue[AddCreditsNudgeCreditType](payload, objectName, "creditType")
+	if err != nil {
+		return err
+	}
+	*p = SendAddCreditsNudgeEmailParams{CreditType: creditType}
+	return nil
+}
+
+// SendAddCreditsNudgeEmailResponse is exact standalone nudge outcome data.
+type SendAddCreditsNudgeEmailResponse struct {
+	Status AddCreditsNudgeEmailStatus `json:"status"`
+}
+
+func (r *SendAddCreditsNudgeEmailResponse) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("decode send-add-credits-nudge-email response into nil receiver")
+	}
+	const objectName = "send-add-credits-nudge-email response"
+	payload, err := decodeRustSerdeObject(data, objectName, "status")
+	if err != nil {
+		return err
+	}
+	status, err := decodeRequiredThreadItemValue[AddCreditsNudgeEmailStatus](payload, objectName, "status")
+	if err != nil {
+		return err
+	}
+	*r = SendAddCreditsNudgeEmailResponse{Status: status}
+	return nil
+}
+
+func accountEnvelopeSchemas() map[string]Schema {
+	nullableRef := func(name string) Schema {
+		return Schema{"anyOf": []any{Schema{"$ref": "#/$defs/" + name}, Schema{"type": "null"}}}
+	}
+	object := func(properties Schema, required ...string) Schema {
+		out := Schema{"type": "object", "properties": properties}
+		if len(required) != 0 {
+			out["required"] = required
+		}
+		return out
+	}
+	return map[string]Schema{
+		"Account": {"oneOf": []any{
+			Schema{"properties": Schema{"type": Schema{"enum": []any{"apiKey"}, "title": "ApiKeyAccountType", "type": "string"}}, "required": []string{"type"}, "title": "ApiKeyAccount", "type": "object"},
+			Schema{
+				"properties": Schema{
+					"email": Schema{"type": []any{"string", "null"}}, "planType": Schema{"$ref": "#/$defs/PlanType"},
+					"type": Schema{"enum": []any{"chatgpt"}, "title": "ChatgptAccountType", "type": "string"},
+				},
+				"required": []string{"email", "planType", "type"}, "title": "ChatgptAccount", "type": "object",
+			},
+			Schema{
+				"properties": Schema{
+					"credentialSource": Schema{"allOf": []any{Schema{"$ref": "#/$defs/AmazonBedrockCredentialSource"}}, "default": "awsManaged"},
+					"type":             Schema{"enum": []any{"amazonBedrock"}, "title": "AmazonBedrockAccountType", "type": "string"},
+				},
+				"required": []string{"type"}, "title": "AmazonBedrockAccount", "type": "object",
+			},
+		}},
+		"AccountUpdatedNotification": object(Schema{"authMode": nullableRef("AuthMode"), "planType": nullableRef("PlanType")}),
+		"GetAccountParams": object(Schema{"refreshToken": Schema{
+			"description": "When `true`, requests a proactive token refresh before returning.\n\n" +
+				"In managed auth mode this triggers the normal refresh-token flow. In external auth mode this flag is ignored. Clients should refresh tokens themselves and call `account/login/start` with `chatgptAuthTokens`.",
+			"type": "boolean",
+		}}),
+		"GetAccountResponse": object(Schema{"account": nullableRef("Account"), "requiresOpenaiAuth": Schema{"type": "boolean"}}, "requiresOpenaiAuth"),
+		"GetAccountTokenUsageResponse": object(Schema{
+			"dailyUsageBuckets": Schema{"items": Schema{"$ref": "#/$defs/AccountTokenUsageDailyBucket"}, "type": []any{"array", "null"}},
+			"summary":           Schema{"$ref": "#/$defs/AccountTokenUsageSummary"},
+		}, "summary"),
+		"SendAddCreditsNudgeEmailParams":   object(Schema{"creditType": Schema{"$ref": "#/$defs/AddCreditsNudgeCreditType"}}, "creditType"),
+		"SendAddCreditsNudgeEmailResponse": object(Schema{"status": Schema{"$ref": "#/$defs/AddCreditsNudgeEmailStatus"}}, "status"),
+	}
+}
+
+var (
+	_ json.Marshaler   = Account{}
+	_ json.Unmarshaler = (*Account)(nil)
+	_ json.Unmarshaler = (*GetAccountParams)(nil)
+	_ json.Marshaler   = GetAccountResponse{}
+	_ json.Unmarshaler = (*GetAccountResponse)(nil)
+	_ json.Marshaler   = AccountUpdatedNotification{}
+	_ json.Unmarshaler = (*AccountUpdatedNotification)(nil)
+	_ json.Marshaler   = GetAccountTokenUsageResponse{}
+	_ json.Unmarshaler = (*GetAccountTokenUsageResponse)(nil)
+	_ json.Unmarshaler = (*SendAddCreditsNudgeEmailParams)(nil)
+	_ json.Unmarshaler = (*SendAddCreditsNudgeEmailResponse)(nil)
+)

--- a/appserver/protocol/account_login_completed_notification_contract_test.go
+++ b/appserver/protocol/account_login_completed_notification_contract_test.go
@@ -88,8 +88,8 @@ func TestAccountLoginCompletedNotificationRemainsStandaloneAndDeferred(t *testin
 	if !found {
 		t.Fatal("account/login/completed method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/account_rate_limits_contract_test.go
+++ b/appserver/protocol/account_rate_limits_contract_test.go
@@ -484,8 +484,8 @@ func TestAccountRateLimitContractsRemainStandaloneAndDeferred(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred %s", methodName, method, ok, surface)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/account_token_usage_contract_test.go
+++ b/appserver/protocol/account_token_usage_contract_test.go
@@ -146,8 +146,8 @@ func TestAccountTokenUsageRecordsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/usage/read = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(defs); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_config_contract_test.go
+++ b/appserver/protocol/app_config_contract_test.go
@@ -109,8 +109,8 @@ func TestAppConfigRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppConfig unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_info_contract_test.go
+++ b/appserver/protocol/app_info_contract_test.go
@@ -131,8 +131,8 @@ func TestAppInfoRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_list_updated_notification_contract_test.go
+++ b/appserver/protocol/app_list_updated_notification_contract_test.go
@@ -105,8 +105,8 @@ func TestAppListUpdatedNotificationRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceServerNotification || method.State != MethodDeferredStub {
 		t.Fatalf("app/list/updated = %#v, %v; want deferred server notification", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_metadata_contract_test.go
+++ b/appserver/protocol/app_metadata_contract_test.go
@@ -107,8 +107,8 @@ func TestAppMetadataRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_metadata_leaf_contract_test.go
+++ b/appserver/protocol/app_metadata_leaf_contract_test.go
@@ -157,8 +157,8 @@ func TestAppMetadataLeavesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_summary_contract_test.go
+++ b/appserver/protocol/app_summary_contract_test.go
@@ -87,8 +87,8 @@ func TestAppSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppSummary unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_template_summary_contract_test.go
+++ b/appserver/protocol/app_template_summary_contract_test.go
@@ -107,8 +107,8 @@ func TestAppTemplateSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppTemplateSummary unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_template_unavailable_reason_contract_test.go
+++ b/appserver/protocol/app_template_unavailable_reason_contract_test.go
@@ -71,8 +71,8 @@ func TestAppTemplateUnavailableReasonRemainsStandalone(t *testing.T) {
 			t.Fatalf("AppTemplateUnavailableReason unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_tool_approval_contract_test.go
+++ b/appserver/protocol/app_tool_approval_contract_test.go
@@ -73,8 +73,8 @@ func TestAppToolApprovalRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppToolApproval unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_tools_config_contract_test.go
+++ b/appserver/protocol/app_tools_config_contract_test.go
@@ -140,8 +140,8 @@ func TestAppToolConfigsRemainStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/apply_patch_approval_params_contract_test.go
+++ b/appserver/protocol/apply_patch_approval_params_contract_test.go
@@ -139,8 +139,8 @@ func TestApplyPatchApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ApplyPatchApprovalParams unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(defs); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(defs); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/apps_config_contract_test.go
+++ b/appserver/protocol/apps_config_contract_test.go
@@ -185,8 +185,8 @@ func TestAppsConfigsRemainStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/apps_list_contract_test.go
+++ b/appserver/protocol/apps_list_contract_test.go
@@ -168,8 +168,8 @@ func TestAppsListContractsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/attestation_contract_test.go
+++ b/appserver/protocol/attestation_contract_test.go
@@ -133,8 +133,8 @@ func TestAttestationContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("attestation/generate = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
+++ b/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
@@ -179,8 +179,8 @@ func TestChatgptAuthTokensRefreshRemainsStandaloneAndDeferred(t *testing.T) {
 	if !found {
 		t.Fatal("refresh method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/exec_command_approval_params_contract_test.go
+++ b/appserver/protocol/exec_command_approval_params_contract_test.go
@@ -137,8 +137,8 @@ func TestExecCommandApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ExecCommandApprovalParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(defs); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,8 +217,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,8 +203,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -260,8 +260,8 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,8 +244,8 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -162,8 +162,8 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -175,8 +175,8 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_contract_test.go
+++ b/appserver/protocol/file_change_contract_test.go
@@ -108,8 +108,8 @@ func TestFileChangeRemainsStandalone(t *testing.T) {
 			t.Fatalf("FileChange unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_output_delta_notification_contract_test.go
+++ b/appserver/protocol/file_change_output_delta_notification_contract_test.go
@@ -100,8 +100,8 @@ func TestFileChangeOutputDeltaNotificationRemainsDeprecatedAndStandalone(t *test
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("item/fileChange/outputDelta = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -381,8 +381,8 @@ func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_action_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_action_contract_test.go
@@ -226,8 +226,8 @@ func TestGuardianApprovalReviewActionRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReviewAction unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
@@ -164,8 +164,8 @@ func TestGuardianApprovalReviewCompletedNotificationRemainsStandalone(t *testing
 			t.Fatalf("completed notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_contract_test.go
@@ -139,8 +139,8 @@ func TestGuardianApprovalReviewRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReview unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
@@ -175,8 +175,8 @@ func TestGuardianApprovalReviewStartedNotificationRemainsStandalone(t *testing.T
 			t.Fatalf("started notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_enum_foundation_contract_test.go
+++ b/appserver/protocol/guardian_enum_foundation_contract_test.go
@@ -89,8 +89,8 @@ func TestGuardianEnumFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_metadata_list_contract_test.go
+++ b/appserver/protocol/hook_metadata_list_contract_test.go
@@ -352,8 +352,8 @@ func TestHookMetadataListContractsStayStandalone(t *testing.T) {
 			t.Errorf("standalone definition %s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Errorf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Errorf("definition count = %d, want 496", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 {
 		t.Errorf("wire binding count = %d, want 59", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_run_notification_contract_test.go
+++ b/appserver/protocol/hook_run_notification_contract_test.go
@@ -297,8 +297,8 @@ func TestHookRunNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("surface changed: %d methods, %d wire bindings, %d item bindings", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/hook_value_foundation_contract_test.go
+++ b/appserver/protocol/hook_value_foundation_contract_test.go
@@ -167,8 +167,8 @@ func TestHookValueFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 489 {
-		t.Fatalf("definition count = %d, want 489", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 496 {
+		t.Fatalf("definition count = %d, want 496", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/legacy_approval_response_contract_test.go
+++ b/appserver/protocol/legacy_approval_response_contract_test.go
@@ -98,8 +98,8 @@ func TestLegacyApprovalResponsesRemainStandaloneAndNominal(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_approval_context_contract_test.go
+++ b/appserver/protocol/network_approval_context_contract_test.go
@@ -84,8 +84,8 @@ func TestNetworkApprovalContextRemainsStandalone(t *testing.T) {
 			t.Fatalf("NetworkApprovalContext unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/parsed_command_contract_test.go
+++ b/appserver/protocol/parsed_command_contract_test.go
@@ -120,8 +120,8 @@ func TestParsedCommandRemainsStandalone(t *testing.T) {
 			t.Fatalf("ParsedCommand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/process_contracts_contract_test.go
+++ b/appserver/protocol/process_contracts_contract_test.go
@@ -308,8 +308,8 @@ func TestProcessContractsRemainStandaloneFromLegacyRuntime(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want unchanged implemented notification", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 489 {
-		t.Fatalf("definition count = %d, want 489", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 496 {
+		t.Fatalf("definition count = %d, want 496", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 489 {
-		t.Fatalf("definition count = %d, want 489", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 496 {
+		t.Fatalf("definition count = %d, want 496", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 489 {
-		t.Fatalf("definition count = %d, want 489", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 496 {
+		t.Fatalf("definition count = %d, want 496", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 489 {
-		t.Fatalf("definition count = %d, want 489", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 496 {
+		t.Fatalf("definition count = %d, want 496", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 489 {
-		t.Fatalf("definition count = %d, want 489", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 496 {
+		t.Fatalf("definition count = %d, want 496", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/review_decision_contract_test.go
+++ b/appserver/protocol/review_decision_contract_test.go
@@ -136,8 +136,8 @@ func TestReviewDecisionRemainsStandalone(t *testing.T) {
 			t.Fatalf("ReviewDecision unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(defs); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -91,10 +91,12 @@ func wireSchemaDefinitions() Schema {
 		{Name: "AdditionalFileSystemPermissions", Type: reflect.TypeFor[AdditionalFileSystemPermissions]()},
 		{Name: "AdditionalNetworkPermissions", Type: reflect.TypeFor[AdditionalNetworkPermissions]()},
 		{Name: "AdditionalPermissionProfile", Type: reflect.TypeFor[AdditionalPermissionProfile]()},
+		{Name: "Account", Type: reflect.TypeFor[Account]()},
 		{Name: "AccountLoginCompletedNotification", Type: reflect.TypeFor[AccountLoginCompletedNotification]()},
 		{Name: "AccountRateLimitsUpdatedNotification", Type: reflect.TypeFor[AccountRateLimitsUpdatedNotification]()},
 		{Name: "AccountTokenUsageDailyBucket", Type: reflect.TypeFor[AccountTokenUsageDailyBucket]()},
 		{Name: "AccountTokenUsageSummary", Type: reflect.TypeFor[AccountTokenUsageSummary]()},
+		{Name: "AccountUpdatedNotification", Type: reflect.TypeFor[AccountUpdatedNotification]()},
 		{Name: "AddCreditsNudgeCreditType", Type: reflect.TypeFor[AddCreditsNudgeCreditType]()},
 		{Name: "AddCreditsNudgeEmailStatus", Type: reflect.TypeFor[AddCreditsNudgeEmailStatus]()},
 		{Name: "AmazonBedrockCredentialSource", Type: reflect.TypeFor[AmazonBedrockCredentialSource]()},
@@ -223,7 +225,10 @@ func wireSchemaDefinitions() Schema {
 		{Name: "FsCreateDirectoryResponse", Type: reflect.TypeFor[FsCreateDirectoryResponse]()},
 		{Name: "FsGetMetadataParams", Type: reflect.TypeFor[FsGetMetadataParams]()},
 		{Name: "FsGetMetadataResponse", Type: reflect.TypeFor[FsGetMetadataResponse]()},
+		{Name: "GetAccountParams", Type: reflect.TypeFor[GetAccountParams]()},
 		{Name: "GetAccountRateLimitsResponse", Type: reflect.TypeFor[GetAccountRateLimitsResponse]()},
+		{Name: "GetAccountResponse", Type: reflect.TypeFor[GetAccountResponse]()},
+		{Name: "GetAccountTokenUsageResponse", Type: reflect.TypeFor[GetAccountTokenUsageResponse]()},
 		{Name: "FsReadDirectoryEntry", Type: reflect.TypeFor[FsReadDirectoryEntry]()},
 		{Name: "FsReadDirectoryParams", Type: reflect.TypeFor[FsReadDirectoryParams]()},
 		{Name: "FsReadDirectoryResponse", Type: reflect.TypeFor[FsReadDirectoryResponse]()},
@@ -434,6 +439,8 @@ func wireSchemaDefinitions() Schema {
 		{Name: "SandboxMode", Type: reflect.TypeFor[SandboxMode]()},
 		{Name: "SandboxPolicy", Type: reflect.TypeFor[SandboxPolicy]()},
 		{Name: "SandboxWorkspaceWrite", Type: reflect.TypeFor[SandboxWorkspaceWrite]()},
+		{Name: "SendAddCreditsNudgeEmailParams", Type: reflect.TypeFor[SendAddCreditsNudgeEmailParams]()},
+		{Name: "SendAddCreditsNudgeEmailResponse", Type: reflect.TypeFor[SendAddCreditsNudgeEmailResponse]()},
 		{Name: "ServerRequestResolvedNotificationParams", Type: reflect.TypeFor[ServerRequestResolvedNotificationParams]()},
 		{Name: "ServerCapabilities", Type: reflect.TypeFor[ServerCapabilities]()},
 		{Name: "SessionSource", Type: reflect.TypeFor[SessionSource]()},
@@ -1023,6 +1030,9 @@ func wireSchemaDefinitions() Schema {
 	schemas["ProcessOutputStream"] = processOutputStreamSchema()
 	schemas["ProcessTerminalSize"] = processTerminalSizeSchema()
 	for name, schema := range accountRateLimitSchemas() {
+		schemas[name] = schema
+	}
+	for name, schema := range accountEnvelopeSchemas() {
 		schemas[name] = schema
 	}
 	schemas["McpServerToolCallParams"] = mcpServerToolCallParamsSchema()

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -4,6 +4,77 @@
       "description": "An absolute, lexically normalized local path.",
       "type": "string"
     },
+    "Account": {
+      "oneOf": [
+        {
+          "properties": {
+            "type": {
+              "enum": [
+                "apiKey"
+              ],
+              "title": "ApiKeyAccountType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "title": "ApiKeyAccount",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "email": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "planType": {
+              "$ref": "#/$defs/PlanType"
+            },
+            "type": {
+              "enum": [
+                "chatgpt"
+              ],
+              "title": "ChatgptAccountType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "email",
+            "planType",
+            "type"
+          ],
+          "title": "ChatgptAccount",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "credentialSource": {
+              "allOf": [
+                {
+                  "$ref": "#/$defs/AmazonBedrockCredentialSource"
+                }
+              ],
+              "default": "awsManaged"
+            },
+            "type": {
+              "enum": [
+                "amazonBedrock"
+              ],
+              "title": "AmazonBedrockAccountType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "title": "AmazonBedrockAccount",
+          "type": "object"
+        }
+      ]
+    },
     "AccountLoginCompletedNotification": {
       "additionalProperties": false,
       "properties": {
@@ -101,6 +172,31 @@
           "type": [
             "integer",
             "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "AccountUpdatedNotification": {
+      "properties": {
+        "authMode": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AuthMode"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "planType": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PlanType"
+            },
+            {
+              "type": "null"
+            }
           ]
         }
       },
@@ -5779,6 +5875,15 @@
       ],
       "type": "object"
     },
+    "GetAccountParams": {
+      "properties": {
+        "refreshToken": {
+          "description": "When `true`, requests a proactive token refresh before returning.\n\nIn managed auth mode this triggers the normal refresh-token flow. In external auth mode this flag is ignored. Clients should refresh tokens themselves and call `account/login/start` with `chatgptAuthTokens`.",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
     "GetAccountRateLimitsResponse": {
       "properties": {
         "rateLimitResetCredits": {
@@ -5812,6 +5917,47 @@
       },
       "required": [
         "rateLimits"
+      ],
+      "type": "object"
+    },
+    "GetAccountResponse": {
+      "properties": {
+        "account": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Account"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "requiresOpenaiAuth": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "requiresOpenaiAuth"
+      ],
+      "type": "object"
+    },
+    "GetAccountTokenUsageResponse": {
+      "properties": {
+        "dailyUsageBuckets": {
+          "items": {
+            "$ref": "#/$defs/AccountTokenUsageDailyBucket"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "summary": {
+          "$ref": "#/$defs/AccountTokenUsageSummary"
+        }
+      },
+      "required": [
+        "summary"
       ],
       "type": "object"
     },
@@ -11713,6 +11859,28 @@
       ],
       "type": "object",
       "x-gollem-typescript-ignore-additional-properties": true
+    },
+    "SendAddCreditsNudgeEmailParams": {
+      "properties": {
+        "creditType": {
+          "$ref": "#/$defs/AddCreditsNudgeCreditType"
+        }
+      },
+      "required": [
+        "creditType"
+      ],
+      "type": "object"
+    },
+    "SendAddCreditsNudgeEmailResponse": {
+      "properties": {
+        "status": {
+          "$ref": "#/$defs/AddCreditsNudgeEmailStatus"
+        }
+      },
+      "required": [
+        "status"
+      ],
+      "type": "object"
     },
     "ServerCapabilities": {
       "additionalProperties": false,

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 489 {
-		t.Fatalf("definition count = %d, want 489", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 496 {
+		t.Fatalf("definition count = %d, want 496", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 489 {
-		t.Fatalf("definition count = %d, want 489", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 496 {
+		t.Fatalf("definition count = %d, want 496", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 489 {
-		t.Fatalf("definition count = %d, want 489", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 496 {
+		t.Fatalf("definition count = %d, want 496", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -39,7 +39,8 @@ func MarshalTypeScript() ([]byte, error) {
 	sort.Strings(names)
 	for _, name := range names {
 		definition := defs[name]
-		if name == "AccountLoginCompletedNotification" || name == "AccountRateLimitsUpdatedNotification" ||
+		if name == "Account" || name == "AccountLoginCompletedNotification" || name == "AccountRateLimitsUpdatedNotification" ||
+			name == "AccountUpdatedNotification" ||
 			name == "AccountTokenUsageSummary" ||
 			name == "AppBranding" || name == "AppConfig" || name == "AppInfo" || name == "AppMetadata" || name == "AppScreenshot" ||
 			name == "AppSummary" || name == "AppTemplateSummary" || name == "AppsDefaultConfig" ||
@@ -49,7 +50,8 @@ func MarshalTypeScript() ([]byte, error) {
 			name == "ChatgptAuthTokensRefreshResponse" ||
 			name == "ConsumeAccountRateLimitResetCreditParams" ||
 			name == "ConsumeAccountRateLimitResetCreditResponse" || name == "CreditsSnapshot" ||
-			name == "GetAccountRateLimitsResponse" ||
+			name == "GetAccountParams" || name == "GetAccountRateLimitsResponse" || name == "GetAccountResponse" ||
+			name == "GetAccountTokenUsageResponse" ||
 			name == "MigrationDetails" ||
 			name == "ExternalAgentConfigMigrationItem" ||
 			name == "ExternalAgentConfigImportItemTypeFailure" ||
@@ -63,6 +65,7 @@ func MarshalTypeScript() ([]byte, error) {
 			name == "ProcessTerminalSize" ||
 			name == "RateLimitResetCredit" || name == "RateLimitResetCreditsSummary" ||
 			name == "RateLimitSnapshot" || name == "RateLimitWindow" ||
+			name == "SendAddCreditsNudgeEmailParams" || name == "SendAddCreditsNudgeEmailResponse" ||
 			name == "SpendControlLimitSnapshot" ||
 			name == "ItemGuardianApprovalReviewCompletedNotification" ||
 			name == "ItemGuardianApprovalReviewStartedNotification" {
@@ -75,6 +78,19 @@ func MarshalTypeScript() ([]byte, error) {
 			}
 			schema = renderSchema
 			switch name {
+			case "Account":
+				// ts-rs requires the defaulted Bedrock credential source even
+				// though serde accepts its omission.
+				variants := schema["oneOf"].([]any)
+				for _, rawVariant := range variants {
+					rawVariant.(Schema)["x-gollem-typescript-ignore-additional-properties"] = true
+				}
+				variants[1].(Schema)["properties"].(Schema)["email"] = nullableStringSchema()
+				bedrock := variants[2].(Schema)
+				bedrock["required"] = []string{"credentialSource", "type"}
+				bedrock["properties"].(Schema)["credentialSource"] = Schema{
+					"$ref": "#/$defs/AmazonBedrockCredentialSource",
+				}
 			case "AccountLoginCompletedNotification":
 				schema["required"] = []string{"loginId", "success", "error"}
 			case "AccountRateLimitsUpdatedNotification":
@@ -85,6 +101,9 @@ func MarshalTypeScript() ([]byte, error) {
 					"lifetimeTokens", "peakDailyTokens", "longestRunningTurnSec",
 					"currentStreakDays", "longestStreakDays",
 				}
+			case "AccountUpdatedNotification":
+				schema["required"] = []string{"authMode", "planType"}
+				schema["x-gollem-typescript-ignore-additional-properties"] = true
 			case "AppBranding":
 				schema["required"] = []string{
 					"category", "developer", "website", "privacyPolicy", "termsOfService", "isDiscoverableApp",
@@ -152,6 +171,18 @@ func MarshalTypeScript() ([]byte, error) {
 					"rateLimitResetCredits", "rateLimits", "rateLimitsByLimitId",
 				}
 				schema["x-gollem-typescript-ignore-additional-properties"] = true
+			case "GetAccountParams":
+				schema["x-gollem-typescript-ignore-additional-properties"] = true
+			case "GetAccountResponse":
+				schema["required"] = []string{"account", "requiresOpenaiAuth"}
+				schema["x-gollem-typescript-ignore-additional-properties"] = true
+			case "GetAccountTokenUsageResponse":
+				schema["required"] = []string{"dailyUsageBuckets", "summary"}
+				schema["x-gollem-typescript-ignore-additional-properties"] = true
+				schema["properties"].(Schema)["dailyUsageBuckets"] = Schema{"anyOf": []any{
+					Schema{"type": "array", "items": Schema{"$ref": "#/$defs/AccountTokenUsageDailyBucket"}},
+					Schema{"type": "null"},
+				}}
 			case "ExecCommandApprovalParams":
 				schema["required"] = []string{
 					"conversationId", "callId", "approvalId", "command", "cwd", "reason", "parsedCmd",
@@ -226,6 +257,8 @@ func MarshalTypeScript() ([]byte, error) {
 				schema["x-gollem-typescript-ignore-additional-properties"] = true
 			case "RateLimitWindow":
 				schema["required"] = []string{"resetsAt", "usedPercent", "windowDurationMins"}
+				schema["x-gollem-typescript-ignore-additional-properties"] = true
+			case "SendAddCreditsNudgeEmailParams", "SendAddCreditsNudgeEmailResponse":
 				schema["x-gollem-typescript-ignore-additional-properties"] = true
 			case "SpendControlLimitSnapshot":
 				schema["required"] = []string{"limit", "remainingPercent", "resetsAt", "used"}

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -494,6 +494,17 @@ export type KnownMethod =
 
 export type AbsolutePathBuf = string;
 
+export type Account = {
+  "type": "apiKey";
+} | {
+  "email": string | null;
+  "planType": PlanType;
+  "type": "chatgpt";
+} | {
+  "credentialSource": AmazonBedrockCredentialSource;
+  "type": "amazonBedrock";
+};
+
 export type AccountLoginCompletedNotification = {
   "error": string | null;
   "loginId": string | null;
@@ -515,6 +526,11 @@ export type AccountTokenUsageSummary = {
   "longestRunningTurnSec": bigint | null;
   "longestStreakDays": bigint | null;
   "peakDailyTokens": bigint | null;
+};
+
+export type AccountUpdatedNotification = {
+  "authMode": AuthMode | null;
+  "planType": PlanType | null;
 };
 
 export type ActivePermissionProfile = {
@@ -1699,10 +1715,24 @@ export type FuzzyFileSearchSessionUpdatedNotification = {
   "sessionId": string;
 };
 
+export type GetAccountParams = {
+  "refreshToken"?: boolean;
+};
+
 export type GetAccountRateLimitsResponse = {
   "rateLimitResetCredits": RateLimitResetCreditsSummary | null;
   "rateLimits": RateLimitSnapshot;
   "rateLimitsByLimitId": { [key in string]?: RateLimitSnapshot } | null;
+};
+
+export type GetAccountResponse = {
+  "account": Account | null;
+  "requiresOpenaiAuth": boolean;
+};
+
+export type GetAccountTokenUsageResponse = {
+  "dailyUsageBuckets": Array<AccountTokenUsageDailyBucket> | null;
+  "summary": AccountTokenUsageSummary;
 };
 
 export type GitInfo = {
@@ -2892,6 +2922,14 @@ export type SandboxWorkspaceWrite = {
   "exclude_tmpdir_env_var": boolean;
   "network_access": boolean;
   "writable_roots": Array<string>;
+};
+
+export type SendAddCreditsNudgeEmailParams = {
+  "creditType": AddCreditsNudgeCreditType;
+};
+
+export type SendAddCreditsNudgeEmailResponse = {
+  "status": AddCreditsNudgeEmailStatus;
 };
 
 export type ServerCapabilities = {

--- a/appserver/protocol/typescript/testdata/account_envelope_contract.ts
+++ b/appserver/protocol/typescript/testdata/account_envelope_contract.ts
@@ -1,0 +1,89 @@
+import type {
+  Account,
+  AccountTokenUsageDailyBucket,
+  AccountTokenUsageSummary,
+  AccountUpdatedNotification,
+  AddCreditsNudgeCreditType,
+  AddCreditsNudgeEmailStatus,
+  AmazonBedrockCredentialSource,
+  AuthMode,
+  GetAccountParams,
+  GetAccountResponse,
+  GetAccountTokenUsageResponse,
+  PlanType,
+  SendAddCreditsNudgeEmailParams,
+  SendAddCreditsNudgeEmailResponse,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2) ? true : false;
+type Expect<T extends true> = T;
+
+type ExpectedAccount =
+  | { type: "apiKey" }
+  | { type: "chatgpt"; email: string | null; planType: PlanType }
+  | { type: "amazonBedrock"; credentialSource: AmazonBedrockCredentialSource };
+
+type Contracts = [
+  Expect<Equal<Account, ExpectedAccount>>,
+  Expect<Equal<AccountUpdatedNotification, {
+    authMode: AuthMode | null;
+    planType: PlanType | null;
+  }>>,
+  Expect<Equal<GetAccountParams, { refreshToken?: boolean }>>,
+  Expect<Equal<GetAccountResponse, {
+    account: Account | null;
+    requiresOpenaiAuth: boolean;
+  }>>,
+  Expect<Equal<GetAccountTokenUsageResponse, {
+    dailyUsageBuckets: Array<AccountTokenUsageDailyBucket> | null;
+    summary: AccountTokenUsageSummary;
+  }>>,
+  Expect<Equal<SendAddCreditsNudgeEmailParams, {
+    creditType: AddCreditsNudgeCreditType;
+  }>>,
+  Expect<Equal<SendAddCreditsNudgeEmailResponse, {
+    status: AddCreditsNudgeEmailStatus;
+  }>>,
+];
+
+({ type: "apiKey" }) satisfies Account;
+({ type: "chatgpt", email: null, planType: "unknown" }) satisfies Account;
+({ type: "amazonBedrock", credentialSource: "awsManaged" }) satisfies Account;
+({ authMode: null, planType: null }) satisfies AccountUpdatedNotification;
+({}) satisfies GetAccountParams;
+({ refreshToken: true }) satisfies GetAccountParams;
+({ account: null, requiresOpenaiAuth: false }) satisfies GetAccountResponse;
+({ summary: {
+  lifetimeTokens: null,
+  peakDailyTokens: null,
+  longestRunningTurnSec: null,
+  currentStreakDays: null,
+  longestStreakDays: null,
+}, dailyUsageBuckets: [] }) satisfies GetAccountTokenUsageResponse;
+({ creditType: "credits" }) satisfies SendAddCreditsNudgeEmailParams;
+({ status: "sent" }) satisfies SendAddCreditsNudgeEmailResponse;
+
+// @ts-expect-error account discriminants are exact.
+({ type: "api_key" }) satisfies Account;
+// @ts-expect-error chatgpt email remains explicit and nullable.
+({ type: "chatgpt", planType: "free" }) satisfies Account;
+// @ts-expect-error chatgpt plan labels are exact.
+({ type: "chatgpt", email: null, planType: "future" }) satisfies Account;
+// @ts-expect-error Bedrock credential source is required in TypeScript.
+({ type: "amazonBedrock" }) satisfies Account;
+// @ts-expect-error account updates require both nullable fields.
+({ authMode: null }) satisfies AccountUpdatedNotification;
+// @ts-expect-error refresh is boolean.
+({ refreshToken: "true" }) satisfies GetAccountParams;
+// @ts-expect-error response account is explicit.
+({ requiresOpenaiAuth: false }) satisfies GetAccountResponse;
+// @ts-expect-error usage buckets are explicit.
+({ summary: {} as AccountTokenUsageSummary }) satisfies GetAccountTokenUsageResponse;
+// @ts-expect-error nudge credit labels are exact.
+({ creditType: "usageLimit" }) satisfies SendAddCreditsNudgeEmailParams;
+// @ts-expect-error nudge statuses are exact.
+({ status: "cooldownActive" }) satisfies SendAddCreditsNudgeEmailResponse;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 489 {
-		t.Fatalf("definition count = %d, want 489", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
+		t.Fatalf("definition count = %d, want 496", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- export exact standalone `Account`, account read/update, token-usage response, and add-credits nudge envelopes
- preserve serde defaults, nullable canonicalization, tagged variants, integer boundaries, and pinned TypeScript shapes
- keep `account/read`, `account/usage/read`, `account/sendAddCreditsNudgeEmail`, and `account/updated` deferred and unbound
- add exact schema, codec, generation, strict TypeScript, and malformed-wire coverage

## Verification
- focused normal/race x30 tests
- 100% statement coverage for every new production function
- exact normalized comparison against all seven pinned Codex schema roots
- strict TypeScript fixture and deterministic generation
- all 59 non-Monty packages, normal and race
- golangci-lint, go vet, go mod tidy/verify, go mod verify
- configured pre-push hook
- parent/feature app-server transcript equality
- exact schema and TypeScript structural reversal

Local `ext/monty` tests remain skipped per project direction; hosted CI is unchanged.