### PR TITLE
feat(protocol): export workspace message contracts

### DIFF
--- a/appserver/protocol/account_credit_nudge_values_contract_test.go
+++ b/appserver/protocol/account_credit_nudge_values_contract_test.go
@@ -119,8 +119,8 @@ func TestAccountCreditNudgeValuesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/sendAddCreditsNudgeEmail = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/account_envelope_contract_test.go
+++ b/appserver/protocol/account_envelope_contract_test.go
@@ -268,8 +268,8 @@ func TestAccountEnvelopeContractsRemainStandaloneAndDeferred(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred %s", methodName, method, ok, surface)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 224/59/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/account_login_completed_notification_contract_test.go
+++ b/appserver/protocol/account_login_completed_notification_contract_test.go
@@ -88,8 +88,8 @@ func TestAccountLoginCompletedNotificationRemainsStandaloneAndDeferred(t *testin
 	if !found {
 		t.Fatal("account/login/completed method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/account_rate_limits_contract_test.go
+++ b/appserver/protocol/account_rate_limits_contract_test.go
@@ -484,8 +484,8 @@ func TestAccountRateLimitContractsRemainStandaloneAndDeferred(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred %s", methodName, method, ok, surface)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/account_token_usage_contract_test.go
+++ b/appserver/protocol/account_token_usage_contract_test.go
@@ -146,8 +146,8 @@ func TestAccountTokenUsageRecordsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/usage/read = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(defs); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_config_contract_test.go
+++ b/appserver/protocol/app_config_contract_test.go
@@ -109,8 +109,8 @@ func TestAppConfigRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppConfig unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_info_contract_test.go
+++ b/appserver/protocol/app_info_contract_test.go
@@ -131,8 +131,8 @@ func TestAppInfoRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_list_updated_notification_contract_test.go
+++ b/appserver/protocol/app_list_updated_notification_contract_test.go
@@ -105,8 +105,8 @@ func TestAppListUpdatedNotificationRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceServerNotification || method.State != MethodDeferredStub {
 		t.Fatalf("app/list/updated = %#v, %v; want deferred server notification", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_metadata_contract_test.go
+++ b/appserver/protocol/app_metadata_contract_test.go
@@ -107,8 +107,8 @@ func TestAppMetadataRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_metadata_leaf_contract_test.go
+++ b/appserver/protocol/app_metadata_leaf_contract_test.go
@@ -157,8 +157,8 @@ func TestAppMetadataLeavesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_summary_contract_test.go
+++ b/appserver/protocol/app_summary_contract_test.go
@@ -87,8 +87,8 @@ func TestAppSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppSummary unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_template_summary_contract_test.go
+++ b/appserver/protocol/app_template_summary_contract_test.go
@@ -107,8 +107,8 @@ func TestAppTemplateSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppTemplateSummary unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_template_unavailable_reason_contract_test.go
+++ b/appserver/protocol/app_template_unavailable_reason_contract_test.go
@@ -71,8 +71,8 @@ func TestAppTemplateUnavailableReasonRemainsStandalone(t *testing.T) {
 			t.Fatalf("AppTemplateUnavailableReason unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_tool_approval_contract_test.go
+++ b/appserver/protocol/app_tool_approval_contract_test.go
@@ -73,8 +73,8 @@ func TestAppToolApprovalRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppToolApproval unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_tools_config_contract_test.go
+++ b/appserver/protocol/app_tools_config_contract_test.go
@@ -140,8 +140,8 @@ func TestAppToolConfigsRemainStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/apply_patch_approval_params_contract_test.go
+++ b/appserver/protocol/apply_patch_approval_params_contract_test.go
@@ -139,8 +139,8 @@ func TestApplyPatchApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ApplyPatchApprovalParams unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(defs); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(defs); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/apps_config_contract_test.go
+++ b/appserver/protocol/apps_config_contract_test.go
@@ -185,8 +185,8 @@ func TestAppsConfigsRemainStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/apps_list_contract_test.go
+++ b/appserver/protocol/apps_list_contract_test.go
@@ -168,8 +168,8 @@ func TestAppsListContractsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/attestation_contract_test.go
+++ b/appserver/protocol/attestation_contract_test.go
@@ -133,8 +133,8 @@ func TestAttestationContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("attestation/generate = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
+++ b/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
@@ -179,8 +179,8 @@ func TestChatgptAuthTokensRefreshRemainsStandaloneAndDeferred(t *testing.T) {
 	if !found {
 		t.Fatal("refresh method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/exec_command_approval_params_contract_test.go
+++ b/appserver/protocol/exec_command_approval_params_contract_test.go
@@ -137,8 +137,8 @@ func TestExecCommandApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ExecCommandApprovalParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(defs); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,8 +217,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,8 +203,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -260,8 +260,8 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,8 +244,8 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -162,8 +162,8 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -175,8 +175,8 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_contract_test.go
+++ b/appserver/protocol/file_change_contract_test.go
@@ -108,8 +108,8 @@ func TestFileChangeRemainsStandalone(t *testing.T) {
 			t.Fatalf("FileChange unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_output_delta_notification_contract_test.go
+++ b/appserver/protocol/file_change_output_delta_notification_contract_test.go
@@ -100,8 +100,8 @@ func TestFileChangeOutputDeltaNotificationRemainsDeprecatedAndStandalone(t *test
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("item/fileChange/outputDelta = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -381,8 +381,8 @@ func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_action_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_action_contract_test.go
@@ -226,8 +226,8 @@ func TestGuardianApprovalReviewActionRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReviewAction unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
@@ -164,8 +164,8 @@ func TestGuardianApprovalReviewCompletedNotificationRemainsStandalone(t *testing
 			t.Fatalf("completed notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_contract_test.go
@@ -139,8 +139,8 @@ func TestGuardianApprovalReviewRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReview unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
@@ -175,8 +175,8 @@ func TestGuardianApprovalReviewStartedNotificationRemainsStandalone(t *testing.T
 			t.Fatalf("started notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_enum_foundation_contract_test.go
+++ b/appserver/protocol/guardian_enum_foundation_contract_test.go
@@ -89,8 +89,8 @@ func TestGuardianEnumFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_metadata_list_contract_test.go
+++ b/appserver/protocol/hook_metadata_list_contract_test.go
@@ -352,8 +352,8 @@ func TestHookMetadataListContractsStayStandalone(t *testing.T) {
 			t.Errorf("standalone definition %s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Errorf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Errorf("definition count = %d, want 499", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 {
 		t.Errorf("wire binding count = %d, want 59", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_run_notification_contract_test.go
+++ b/appserver/protocol/hook_run_notification_contract_test.go
@@ -297,8 +297,8 @@ func TestHookRunNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("surface changed: %d methods, %d wire bindings, %d item bindings", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/hook_value_foundation_contract_test.go
+++ b/appserver/protocol/hook_value_foundation_contract_test.go
@@ -167,8 +167,8 @@ func TestHookValueFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 496 {
-		t.Fatalf("definition count = %d, want 496", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 499 {
+		t.Fatalf("definition count = %d, want 499", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/legacy_approval_response_contract_test.go
+++ b/appserver/protocol/legacy_approval_response_contract_test.go
@@ -98,8 +98,8 @@ func TestLegacyApprovalResponsesRemainStandaloneAndNominal(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_approval_context_contract_test.go
+++ b/appserver/protocol/network_approval_context_contract_test.go
@@ -84,8 +84,8 @@ func TestNetworkApprovalContextRemainsStandalone(t *testing.T) {
 			t.Fatalf("NetworkApprovalContext unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/parsed_command_contract_test.go
+++ b/appserver/protocol/parsed_command_contract_test.go
@@ -120,8 +120,8 @@ func TestParsedCommandRemainsStandalone(t *testing.T) {
 			t.Fatalf("ParsedCommand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/process_contracts_contract_test.go
+++ b/appserver/protocol/process_contracts_contract_test.go
@@ -308,8 +308,8 @@ func TestProcessContractsRemainStandaloneFromLegacyRuntime(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want unchanged implemented notification", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 496 {
-		t.Fatalf("definition count = %d, want 496", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 499 {
+		t.Fatalf("definition count = %d, want 499", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 496 {
-		t.Fatalf("definition count = %d, want 496", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 499 {
+		t.Fatalf("definition count = %d, want 499", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 496 {
-		t.Fatalf("definition count = %d, want 496", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 499 {
+		t.Fatalf("definition count = %d, want 499", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 496 {
-		t.Fatalf("definition count = %d, want 496", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 499 {
+		t.Fatalf("definition count = %d, want 499", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 496 {
-		t.Fatalf("definition count = %d, want 496", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 499 {
+		t.Fatalf("definition count = %d, want 499", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/review_decision_contract_test.go
+++ b/appserver/protocol/review_decision_contract_test.go
@@ -136,8 +136,8 @@ func TestReviewDecisionRemainsStandalone(t *testing.T) {
 			t.Fatalf("ReviewDecision unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(defs); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -229,6 +229,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "GetAccountRateLimitsResponse", Type: reflect.TypeFor[GetAccountRateLimitsResponse]()},
 		{Name: "GetAccountResponse", Type: reflect.TypeFor[GetAccountResponse]()},
 		{Name: "GetAccountTokenUsageResponse", Type: reflect.TypeFor[GetAccountTokenUsageResponse]()},
+		{Name: "GetWorkspaceMessagesResponse", Type: reflect.TypeFor[GetWorkspaceMessagesResponse]()},
 		{Name: "FsReadDirectoryEntry", Type: reflect.TypeFor[FsReadDirectoryEntry]()},
 		{Name: "FsReadDirectoryParams", Type: reflect.TypeFor[FsReadDirectoryParams]()},
 		{Name: "FsReadDirectoryResponse", Type: reflect.TypeFor[FsReadDirectoryResponse]()},
@@ -558,6 +559,8 @@ func wireSchemaDefinitions() Schema {
 		{Name: "WebSearchToolConfig", Type: reflect.TypeFor[WebSearchToolConfig]()},
 		{Name: "WarningNotification", Type: reflect.TypeFor[WarningNotification]()},
 		{Name: "WindowsSandboxSetupMode", Type: reflect.TypeFor[WindowsSandboxSetupMode]()},
+		{Name: "WorkspaceMessage", Type: reflect.TypeFor[WorkspaceMessage]()},
+		{Name: "WorkspaceMessageType", Type: reflect.TypeFor[WorkspaceMessageType]()},
 		{Name: "WriteStatus", Type: reflect.TypeFor[WriteStatus]()},
 		// Register exact public names after their aliases so nested schemas refer
 		// to the public names. JSON and TypeScript output remain key-sorted.
@@ -1033,6 +1036,9 @@ func wireSchemaDefinitions() Schema {
 		schemas[name] = schema
 	}
 	for name, schema := range accountEnvelopeSchemas() {
+		schemas[name] = schema
+	}
+	for name, schema := range workspaceMessageSchemas() {
 		schemas[name] = schema
 	}
 	schemas["McpServerToolCallParams"] = mcpServerToolCallParamsSchema()

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -5961,6 +5961,26 @@
       ],
       "type": "object"
     },
+    "GetWorkspaceMessagesResponse": {
+      "properties": {
+        "featureEnabled": {
+          "description": "Whether the workspace-message backend route is available for this client.",
+          "type": "boolean"
+        },
+        "messages": {
+          "description": "Active workspace messages returned by the backend.",
+          "items": {
+            "$ref": "#/$defs/WorkspaceMessage"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "featureEnabled",
+        "messages"
+      ],
+      "type": "object"
+    },
     "GitInfo": {
       "additionalProperties": false,
       "properties": {
@@ -16706,6 +16726,49 @@
       "enum": [
         "elevated",
         "unelevated"
+      ],
+      "type": "string"
+    },
+    "WorkspaceMessage": {
+      "properties": {
+        "archivedAt": {
+          "description": "Unix timestamp (in seconds) when the message was archived.",
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "createdAt": {
+          "description": "Unix timestamp (in seconds) when the message was created.",
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "messageBody": {
+          "type": "string"
+        },
+        "messageId": {
+          "type": "string"
+        },
+        "messageType": {
+          "$ref": "#/$defs/WorkspaceMessageType"
+        }
+      },
+      "required": [
+        "messageBody",
+        "messageId",
+        "messageType"
+      ],
+      "type": "object"
+    },
+    "WorkspaceMessageType": {
+      "enum": [
+        "headline",
+        "announcement",
+        "unknown"
       ],
       "type": "string"
     },

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 496 {
-		t.Fatalf("definition count = %d, want 496", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 499 {
+		t.Fatalf("definition count = %d, want 499", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 496 {
-		t.Fatalf("definition count = %d, want 496", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 499 {
+		t.Fatalf("definition count = %d, want 499", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 496 {
-		t.Fatalf("definition count = %d, want 496", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 499 {
+		t.Fatalf("definition count = %d, want 499", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -51,7 +51,7 @@ func MarshalTypeScript() ([]byte, error) {
 			name == "ConsumeAccountRateLimitResetCreditParams" ||
 			name == "ConsumeAccountRateLimitResetCreditResponse" || name == "CreditsSnapshot" ||
 			name == "GetAccountParams" || name == "GetAccountRateLimitsResponse" || name == "GetAccountResponse" ||
-			name == "GetAccountTokenUsageResponse" ||
+			name == "GetAccountTokenUsageResponse" || name == "GetWorkspaceMessagesResponse" ||
 			name == "MigrationDetails" ||
 			name == "ExternalAgentConfigMigrationItem" ||
 			name == "ExternalAgentConfigImportItemTypeFailure" ||
@@ -67,6 +67,7 @@ func MarshalTypeScript() ([]byte, error) {
 			name == "RateLimitSnapshot" || name == "RateLimitWindow" ||
 			name == "SendAddCreditsNudgeEmailParams" || name == "SendAddCreditsNudgeEmailResponse" ||
 			name == "SpendControlLimitSnapshot" ||
+			name == "WorkspaceMessage" ||
 			name == "ItemGuardianApprovalReviewCompletedNotification" ||
 			name == "ItemGuardianApprovalReviewStartedNotification" {
 			// Rust accepts omitted serde default/Option fields while generated
@@ -183,6 +184,8 @@ func MarshalTypeScript() ([]byte, error) {
 					Schema{"type": "array", "items": Schema{"$ref": "#/$defs/AccountTokenUsageDailyBucket"}},
 					Schema{"type": "null"},
 				}}
+			case "GetWorkspaceMessagesResponse":
+				schema["x-gollem-typescript-ignore-additional-properties"] = true
 			case "ExecCommandApprovalParams":
 				schema["required"] = []string{
 					"conversationId", "callId", "approvalId", "command", "cwd", "reason", "parsedCmd",
@@ -263,6 +266,13 @@ func MarshalTypeScript() ([]byte, error) {
 			case "SpendControlLimitSnapshot":
 				schema["required"] = []string{"limit", "remainingPercent", "resetsAt", "used"}
 				schema["x-gollem-typescript-ignore-additional-properties"] = true
+			case "WorkspaceMessage":
+				schema["required"] = []string{
+					"archivedAt", "createdAt", "messageBody", "messageId", "messageType",
+				}
+				schema["x-gollem-typescript-ignore-additional-properties"] = true
+				schema["properties"].(Schema)["archivedAt"] = nullableIntegerSchema()
+				schema["properties"].(Schema)["createdAt"] = nullableIntegerSchema()
 			case "ItemGuardianApprovalReviewCompletedNotification":
 				schema["required"] = []string{
 					"threadId", "turnId", "startedAtMs", "completedAtMs", "reviewId",

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -1735,6 +1735,11 @@ export type GetAccountTokenUsageResponse = {
   "summary": AccountTokenUsageSummary;
 };
 
+export type GetWorkspaceMessagesResponse = {
+  "featureEnabled": boolean;
+  "messages": Array<WorkspaceMessage>;
+};
+
 export type GitInfo = {
   "branch": string | null;
   "originUrl": string | null;
@@ -3860,6 +3865,16 @@ export type WebSearchToolConfig = {
 };
 
 export type WindowsSandboxSetupMode = "elevated" | "unelevated";
+
+export type WorkspaceMessage = {
+  "archivedAt": number | null;
+  "createdAt": number | null;
+  "messageBody": string;
+  "messageId": string;
+  "messageType": WorkspaceMessageType;
+};
+
+export type WorkspaceMessageType = "headline" | "announcement" | "unknown";
 
 export type WriteStatus = "ok" | "okOverridden";
 

--- a/appserver/protocol/typescript/testdata/workspace_messages_contract.ts
+++ b/appserver/protocol/typescript/testdata/workspace_messages_contract.ts
@@ -1,0 +1,49 @@
+import type {
+  GetWorkspaceMessagesResponse,
+  WorkspaceMessage,
+  WorkspaceMessageType,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2) ? true : false;
+type Expect<T extends true> = T;
+
+type Contracts = [
+  Expect<Equal<WorkspaceMessageType, "headline" | "announcement" | "unknown">>,
+  Expect<Equal<WorkspaceMessage, {
+    archivedAt: number | null;
+    createdAt: number | null;
+    messageBody: string;
+    messageId: string;
+    messageType: WorkspaceMessageType;
+  }>>,
+  Expect<Equal<GetWorkspaceMessagesResponse, {
+    featureEnabled: boolean;
+    messages: Array<WorkspaceMessage>;
+  }>>,
+];
+
+"headline" satisfies WorkspaceMessageType;
+"unknown" satisfies WorkspaceMessageType;
+({
+  archivedAt: null,
+  createdAt: null,
+  messageBody: "",
+  messageId: "",
+  messageType: "announcement",
+}) satisfies WorkspaceMessage;
+({ featureEnabled: false, messages: [] }) satisfies GetWorkspaceMessagesResponse;
+
+// @ts-expect-error message labels are exact.
+"future" satisfies WorkspaceMessageType;
+// @ts-expect-error nullable timestamps remain explicit.
+({ messageId: "id", messageType: "headline", messageBody: "body" }) satisfies WorkspaceMessage;
+// @ts-expect-error timestamps are emitted as number rather than bigint.
+({ archivedAt: null, createdAt: 0n, messageBody: "body", messageId: "id", messageType: "headline" }) satisfies WorkspaceMessage;
+// @ts-expect-error feature availability is required.
+({ messages: [] }) satisfies GetWorkspaceMessagesResponse;
+// @ts-expect-error messages are required and non-null.
+({ featureEnabled: false, messages: null }) satisfies GetWorkspaceMessagesResponse;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 496 {
-		t.Fatalf("definition count = %d, want 496", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/workspace_messages_contract_test.go
+++ b/appserver/protocol/workspace_messages_contract_test.go
@@ -1,0 +1,235 @@
+package protocol
+
+import (
+	"encoding/json"
+	"math"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestWorkspaceMessageSchemasAreExact(t *testing.T) {
+	want := map[string]Schema{
+		"WorkspaceMessageType": stringEnumSchema("headline", "announcement", "unknown"),
+		"WorkspaceMessage": {
+			"type": "object",
+			"properties": Schema{
+				"archivedAt": Schema{
+					"description": "Unix timestamp (in seconds) when the message was archived.",
+					"format":      "int64", "type": []any{"integer", "null"},
+				},
+				"createdAt": Schema{
+					"description": "Unix timestamp (in seconds) when the message was created.",
+					"format":      "int64", "type": []any{"integer", "null"},
+				},
+				"messageBody": Schema{"type": "string"},
+				"messageId":   Schema{"type": "string"},
+				"messageType": Schema{"$ref": "#/$defs/WorkspaceMessageType"},
+			},
+			"required": []string{"messageBody", "messageId", "messageType"},
+		},
+		"GetWorkspaceMessagesResponse": {
+			"type": "object",
+			"properties": Schema{
+				"featureEnabled": Schema{
+					"description": "Whether the workspace-message backend route is available for this client.",
+					"type":        "boolean",
+				},
+				"messages": Schema{
+					"description": "Active workspace messages returned by the backend.",
+					"items":       Schema{"$ref": "#/$defs/WorkspaceMessage"}, "type": "array",
+				},
+			},
+			"required": []string{"featureEnabled", "messages"},
+		},
+	}
+	definitions := JSONSchema()["$defs"].(Schema)
+	for name, expected := range want {
+		if got := definitions[name]; !reflect.DeepEqual(got, expected) {
+			t.Errorf("%s = %#v, want %#v", name, got, expected)
+		}
+	}
+}
+
+func TestWorkspaceMessageTypePreservesSerdeFallback(t *testing.T) {
+	for _, tc := range []struct{ input, want string }{
+		{`"headline"`, `"headline"`},
+		{`"announcement"`, `"announcement"`},
+		{`"unknown"`, `"unknown"`},
+		{`"future"`, `"unknown"`},
+		{`""`, `"unknown"`},
+	} {
+		var value WorkspaceMessageType
+		if err := json.Unmarshal([]byte(tc.input), &value); err != nil {
+			t.Errorf("unmarshal %s: %v", tc.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(value)
+		if err != nil || string(encoded) != tc.want {
+			t.Errorf("round trip %s = %s, %v; want %s", tc.input, encoded, err, tc.want)
+		}
+	}
+	for _, input := range []string{``, `null`, `1`, `true`, `[]`, `{}`, `"headline" "announcement"`} {
+		assertJSONRejects[WorkspaceMessageType](t, input)
+	}
+	if _, err := json.Marshal(WorkspaceMessageType("future")); err == nil {
+		t.Fatal("invalid workspace message type marshaled")
+	}
+}
+
+func TestWorkspaceMessageAcceptsExactSerdeWireForms(t *testing.T) {
+	for _, tc := range []struct{ input, want string }{
+		{
+			`{"messageId":"","messageType":"headline","messageBody":""}`,
+			`{"messageId":"","messageType":"headline","messageBody":"","createdAt":null,"archivedAt":null}`,
+		},
+		{
+			`{"future":1,"future":2,"messageId":" id ","messageType":"future","messageBody":" body ","createdAt":null,"archivedAt":null}`,
+			`{"messageId":" id ","messageType":"unknown","messageBody":" body ","createdAt":null,"archivedAt":null}`,
+		},
+		{
+			`{"messageId":"id","messageType":"announcement","messageBody":"body","createdAt":-9223372036854775808,"archivedAt":9223372036854775807}`,
+			`{"messageId":"id","messageType":"announcement","messageBody":"body","createdAt":-9223372036854775808,"archivedAt":9223372036854775807}`,
+		},
+	} {
+		var value WorkspaceMessage
+		if err := json.Unmarshal([]byte(tc.input), &value); err != nil {
+			t.Errorf("unmarshal %s: %v", tc.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(value)
+		if err != nil || string(encoded) != tc.want {
+			t.Errorf("round trip %s = %s, %v; want %s", tc.input, encoded, err, tc.want)
+		}
+	}
+	min, max := int64(math.MinInt64), int64(math.MaxInt64)
+	encoded, err := json.Marshal(WorkspaceMessage{
+		MessageID: "id", MessageType: WorkspaceMessageTypeHeadline, MessageBody: "body",
+		CreatedAt: &min, ArchivedAt: &max,
+	})
+	if err != nil || !strings.Contains(string(encoded), `"createdAt":-9223372036854775808`) ||
+		!strings.Contains(string(encoded), `"archivedAt":9223372036854775807`) {
+		t.Fatalf("boundary message = %s, %v", encoded, err)
+	}
+}
+
+func TestWorkspaceMessageRejectsMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`, `{}`,
+		`{"messageType":"headline","messageBody":"body"}`,
+		`{"messageId":"id","messageBody":"body"}`,
+		`{"messageId":"id","messageType":"headline"}`,
+		`{"messageId":null,"messageType":"headline","messageBody":"body"}`,
+		`{"messageId":"id","messageType":null,"messageBody":"body"}`,
+		`{"messageId":"id","messageType":"headline","messageBody":null}`,
+		`{"messageId":"id","messageType":"headline","messageBody":"body","createdAt":"0"}`,
+		`{"messageId":"id","messageType":"headline","messageBody":"body","createdAt":1.5}`,
+		`{"messageId":"id","messageType":"headline","messageBody":"body","createdAt":9223372036854775808}`,
+		`{"messageId":"id","messageType":"headline","messageBody":"body","archivedAt":-9223372036854775809}`,
+		`{"messageId":"a","messageId":"b","messageType":"headline","messageBody":"body"}`,
+		`{"messageId":"id","messageType":"headline","messageType":"announcement","messageBody":"body"}`,
+		`{"messageId":"id","messageType":"headline","messageBody":"a","messageBody":"b"}`,
+		`{"messageId":"id","messageType":"headline","messageBody":"body","createdAt":null,"createdAt":0}`,
+		`{"messageId":"id","messageType":"headline","messageBody":"body"} {}`,
+		`{"messageId":"id","messageType":"headline","messageBody":"body"} x`,
+	} {
+		assertJSONRejects[WorkspaceMessage](t, input)
+	}
+}
+
+func TestGetWorkspaceMessagesResponsePreservesOrderedStrictMessages(t *testing.T) {
+	message := `{"messageId":"id","messageType":"headline","messageBody":"body"}`
+	canonical := `{"messageId":"id","messageType":"headline","messageBody":"body","createdAt":null,"archivedAt":null}`
+	for _, tc := range []struct{ input, want string }{
+		{`{"featureEnabled":false,"messages":[]}`, `{"featureEnabled":false,"messages":[]}`},
+		{`{"future":1,"future":2,"featureEnabled":true,"messages":[` + message + `]}`, `{"featureEnabled":true,"messages":[` + canonical + `]}`},
+		{`{"featureEnabled":true,"messages":[` + message + `,` + message + `]}`, `{"featureEnabled":true,"messages":[` + canonical + `,` + canonical + `]}`},
+	} {
+		var value GetWorkspaceMessagesResponse
+		if err := json.Unmarshal([]byte(tc.input), &value); err != nil {
+			t.Errorf("unmarshal %s: %v", tc.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(value)
+		if err != nil || string(encoded) != tc.want {
+			t.Errorf("round trip %s = %s, %v; want %s", tc.input, encoded, err, tc.want)
+		}
+	}
+}
+
+func TestGetWorkspaceMessagesResponseRejectsMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`, `{}`,
+		`{"messages":[]}`, `{"featureEnabled":false}`,
+		`{"featureEnabled":null,"messages":[]}`, `{"featureEnabled":0,"messages":[]}`,
+		`{"featureEnabled":false,"messages":null}`, `{"featureEnabled":false,"messages":{}}`,
+		`{"featureEnabled":false,"messages":[null]}`, `{"featureEnabled":false,"messages":[{}]}`,
+		`{"featureEnabled":false,"featureEnabled":true,"messages":[]}`,
+		`{"featureEnabled":false,"messages":[],"messages":[]}`,
+		`{"featureEnabled":false,"messages":[]} {}`, `{"featureEnabled":false,"messages":[]} x`,
+	} {
+		assertJSONRejects[GetWorkspaceMessagesResponse](t, input)
+	}
+}
+
+func TestWorkspaceMessageNilReceiversAndInvalidMarshal(t *testing.T) {
+	var messageType *WorkspaceMessageType
+	if err := messageType.UnmarshalJSON([]byte(`"headline"`)); err == nil {
+		t.Fatal("nil WorkspaceMessageType receiver succeeded")
+	}
+	var message *WorkspaceMessage
+	if err := message.UnmarshalJSON([]byte(`{}`)); err == nil {
+		t.Fatal("nil WorkspaceMessage receiver succeeded")
+	}
+	var response *GetWorkspaceMessagesResponse
+	if err := response.UnmarshalJSON([]byte(`{}`)); err == nil {
+		t.Fatal("nil GetWorkspaceMessagesResponse receiver succeeded")
+	}
+	if _, err := json.Marshal(GetWorkspaceMessagesResponse{}); err == nil {
+		t.Fatal("nil message array marshaled")
+	}
+}
+
+func TestWorkspaceMessageContractsRemainStandaloneAndDeferred(t *testing.T) {
+	names := []string{"WorkspaceMessageType", "WorkspaceMessage", "GetWorkspaceMessagesResponse"}
+	for _, binding := range WireTypeBindings() {
+		for _, name := range names {
+			if slices.Contains(binding.Params, name) || slices.Contains(binding.Result, name) {
+				t.Fatalf("%s unexpectedly bound to %s", name, binding.Method)
+			}
+		}
+	}
+	for _, binding := range ItemPayloadBindings() {
+		if slices.Contains(names, binding.Type) {
+			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
+		}
+	}
+	method, ok := LookupMethod("account/workspaceMessages/read")
+	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
+		t.Fatalf("account/workspaceMessages/read = %#v, %v; want deferred client request", method, ok)
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
+		t.Fatalf("definition count = %d, want 499", got)
+	}
+	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 224/59/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
+	}
+}
+
+func TestWorkspaceMessageTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	source := string(generated)
+	for _, want := range []string{
+		`export type WorkspaceMessageType = "headline" | "announcement" | "unknown";`,
+		"export type WorkspaceMessage = {\n  \"archivedAt\": number | null;\n  \"createdAt\": number | null;\n  \"messageBody\": string;\n  \"messageId\": string;\n  \"messageType\": WorkspaceMessageType;\n};",
+		"export type GetWorkspaceMessagesResponse = {\n  \"featureEnabled\": boolean;\n  \"messages\": Array<WorkspaceMessage>;\n};",
+	} {
+		if !strings.Contains(source, want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}

--- a/appserver/protocol/workspace_messages_types.go
+++ b/appserver/protocol/workspace_messages_types.go
@@ -1,0 +1,188 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// WorkspaceMessageType is the public workspace-message category. Unknown
+// backend strings collapse to the serde fallback literal.
+type WorkspaceMessageType string
+
+const (
+	WorkspaceMessageTypeHeadline     WorkspaceMessageType = "headline"
+	WorkspaceMessageTypeAnnouncement WorkspaceMessageType = "announcement"
+	WorkspaceMessageTypeUnknown      WorkspaceMessageType = "unknown"
+)
+
+func (t WorkspaceMessageType) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(t, "workspace message type", WorkspaceMessageType.valid)
+}
+
+func (t *WorkspaceMessageType) UnmarshalJSON(data []byte) error {
+	if t == nil {
+		return errors.New("decode workspace message type into nil receiver")
+	}
+	if isJSONNull(data) {
+		return errors.New("decode workspace message type: value cannot be null")
+	}
+	var literal string
+	if err := json.Unmarshal(data, &literal); err != nil {
+		return fmt.Errorf("decode workspace message type: %w", err)
+	}
+	value := WorkspaceMessageType(literal)
+	if !value.valid() {
+		value = WorkspaceMessageTypeUnknown
+	}
+	*t = value
+	return nil
+}
+
+func (t WorkspaceMessageType) valid() bool {
+	return t == WorkspaceMessageTypeHeadline ||
+		t == WorkspaceMessageTypeAnnouncement ||
+		t == WorkspaceMessageTypeUnknown
+}
+
+// WorkspaceMessage is exact standalone backend message data.
+type WorkspaceMessage struct {
+	MessageID   string               `json:"messageId"`
+	MessageType WorkspaceMessageType `json:"messageType"`
+	MessageBody string               `json:"messageBody"`
+	CreatedAt   *int64               `json:"createdAt,omitempty"`
+	ArchivedAt  *int64               `json:"archivedAt,omitempty"`
+}
+
+func (m WorkspaceMessage) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		MessageID   string               `json:"messageId"`
+		MessageType WorkspaceMessageType `json:"messageType"`
+		MessageBody string               `json:"messageBody"`
+		CreatedAt   *int64               `json:"createdAt"`
+		ArchivedAt  *int64               `json:"archivedAt"`
+	}{
+		MessageID: m.MessageID, MessageType: m.MessageType, MessageBody: m.MessageBody,
+		CreatedAt: m.CreatedAt, ArchivedAt: m.ArchivedAt,
+	})
+}
+
+func (m *WorkspaceMessage) UnmarshalJSON(data []byte) error {
+	if m == nil {
+		return errors.New("decode workspace message into nil receiver")
+	}
+	const objectName = "workspace message"
+	payload, err := decodeRustSerdeObject(
+		data, objectName, "messageId", "messageType", "messageBody", "createdAt", "archivedAt",
+	)
+	if err != nil {
+		return err
+	}
+	messageID, err := decodeRequiredThreadItemValue[string](payload, objectName, "messageId")
+	if err != nil {
+		return err
+	}
+	messageType, err := decodeRequiredThreadItemValue[WorkspaceMessageType](payload, objectName, "messageType")
+	if err != nil {
+		return err
+	}
+	messageBody, err := decodeRequiredThreadItemValue[string](payload, objectName, "messageBody")
+	if err != nil {
+		return err
+	}
+	createdAt, err := decodeOptionalNullableConfigValue[int64](payload, objectName, "createdAt")
+	if err != nil {
+		return err
+	}
+	archivedAt, err := decodeOptionalNullableConfigValue[int64](payload, objectName, "archivedAt")
+	if err != nil {
+		return err
+	}
+	*m = WorkspaceMessage{
+		MessageID: messageID, MessageType: messageType, MessageBody: messageBody,
+		CreatedAt: createdAt, ArchivedAt: archivedAt,
+	}
+	return nil
+}
+
+// GetWorkspaceMessagesResponse is exact standalone workspace-message list
+// data. It does not imply that Gollem owns a workspace-message backend.
+type GetWorkspaceMessagesResponse struct {
+	FeatureEnabled bool               `json:"featureEnabled"`
+	Messages       []WorkspaceMessage `json:"messages"`
+}
+
+func (r GetWorkspaceMessagesResponse) MarshalJSON() ([]byte, error) {
+	if r.Messages == nil {
+		return nil, errors.New("workspace messages response messages cannot be null")
+	}
+	type wire GetWorkspaceMessagesResponse
+	return json.Marshal(wire(r))
+}
+
+func (r *GetWorkspaceMessagesResponse) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("decode workspace messages response into nil receiver")
+	}
+	const objectName = "workspace messages response"
+	payload, err := decodeRustSerdeObject(data, objectName, "featureEnabled", "messages")
+	if err != nil {
+		return err
+	}
+	featureEnabled, err := decodeRequiredThreadItemValue[bool](payload, objectName, "featureEnabled")
+	if err != nil {
+		return err
+	}
+	messages, err := decodeRequiredThreadItemArray[WorkspaceMessage](payload, objectName, "messages")
+	if err != nil {
+		return err
+	}
+	*r = GetWorkspaceMessagesResponse{FeatureEnabled: featureEnabled, Messages: messages}
+	return nil
+}
+
+func workspaceMessageSchemas() map[string]Schema {
+	return map[string]Schema{
+		"WorkspaceMessageType": stringEnumSchema("headline", "announcement", "unknown"),
+		"WorkspaceMessage": {
+			"type": "object",
+			"properties": Schema{
+				"archivedAt": Schema{
+					"description": "Unix timestamp (in seconds) when the message was archived.",
+					"format":      "int64", "type": []any{"integer", "null"},
+				},
+				"createdAt": Schema{
+					"description": "Unix timestamp (in seconds) when the message was created.",
+					"format":      "int64", "type": []any{"integer", "null"},
+				},
+				"messageBody": Schema{"type": "string"},
+				"messageId":   Schema{"type": "string"},
+				"messageType": Schema{"$ref": "#/$defs/WorkspaceMessageType"},
+			},
+			"required": []string{"messageBody", "messageId", "messageType"},
+		},
+		"GetWorkspaceMessagesResponse": {
+			"type": "object",
+			"properties": Schema{
+				"featureEnabled": Schema{
+					"description": "Whether the workspace-message backend route is available for this client.",
+					"type":        "boolean",
+				},
+				"messages": Schema{
+					"description": "Active workspace messages returned by the backend.",
+					"items":       Schema{"$ref": "#/$defs/WorkspaceMessage"}, "type": "array",
+				},
+			},
+			"required": []string{"featureEnabled", "messages"},
+		},
+	}
+}
+
+var (
+	_ json.Marshaler   = WorkspaceMessageType("")
+	_ json.Unmarshaler = (*WorkspaceMessageType)(nil)
+	_ json.Marshaler   = WorkspaceMessage{}
+	_ json.Unmarshaler = (*WorkspaceMessage)(nil)
+	_ json.Marshaler   = GetWorkspaceMessagesResponse{}
+	_ json.Unmarshaler = (*GetWorkspaceMessagesResponse)(nil)
+)


### PR DESCRIPTION
## Summary
- export exact standalone `WorkspaceMessageType`, `WorkspaceMessage`, and `GetWorkspaceMessagesResponse` contracts
- preserve serde fallback handling, required payload fields, nullable timestamp canonicalization, ordered non-null message arrays, and pinned TypeScript shapes
- keep `account/workspaceMessages/read` deferred and unbound
- add exact schema, codec, generation, strict TypeScript, malformed-wire, and count-invariant coverage

## Verification
- focused normal/race x30 tests
- 100% statement coverage for every new production function
- exact normalized comparison against all three pinned Codex schema roots
- strict TypeScript fixture and deterministic generation
- all 59 non-Monty packages, normal and race
- golangci-lint, go vet, go mod tidy/verify, and configured pre-push hook
- parent/feature app-server transcript equality
- exact schema and TypeScript structural reversal

Local `ext/monty` tests remain skipped per project direction; hosted CI is unchanged.