### PR TITLE
appserver/protocol: export experimental feature contracts

### DIFF
--- a/appserver/protocol/account_credit_nudge_values_contract_test.go
+++ b/appserver/protocol/account_credit_nudge_values_contract_test.go
@@ -119,8 +119,8 @@ func TestAccountCreditNudgeValuesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/sendAddCreditsNudgeEmail = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/account_envelope_contract_test.go
+++ b/appserver/protocol/account_envelope_contract_test.go
@@ -268,8 +268,8 @@ func TestAccountEnvelopeContractsRemainStandaloneAndDeferred(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred %s", methodName, method, ok, surface)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 224/59/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/account_login_completed_notification_contract_test.go
+++ b/appserver/protocol/account_login_completed_notification_contract_test.go
@@ -88,8 +88,8 @@ func TestAccountLoginCompletedNotificationRemainsStandaloneAndDeferred(t *testin
 	if !found {
 		t.Fatal("account/login/completed method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/account_rate_limits_contract_test.go
+++ b/appserver/protocol/account_rate_limits_contract_test.go
@@ -484,8 +484,8 @@ func TestAccountRateLimitContractsRemainStandaloneAndDeferred(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred %s", methodName, method, ok, surface)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/account_token_usage_contract_test.go
+++ b/appserver/protocol/account_token_usage_contract_test.go
@@ -146,8 +146,8 @@ func TestAccountTokenUsageRecordsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/usage/read = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(defs); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_config_contract_test.go
+++ b/appserver/protocol/app_config_contract_test.go
@@ -109,8 +109,8 @@ func TestAppConfigRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppConfig unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_info_contract_test.go
+++ b/appserver/protocol/app_info_contract_test.go
@@ -131,8 +131,8 @@ func TestAppInfoRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_list_updated_notification_contract_test.go
+++ b/appserver/protocol/app_list_updated_notification_contract_test.go
@@ -105,8 +105,8 @@ func TestAppListUpdatedNotificationRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceServerNotification || method.State != MethodDeferredStub {
 		t.Fatalf("app/list/updated = %#v, %v; want deferred server notification", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_metadata_contract_test.go
+++ b/appserver/protocol/app_metadata_contract_test.go
@@ -107,8 +107,8 @@ func TestAppMetadataRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_metadata_leaf_contract_test.go
+++ b/appserver/protocol/app_metadata_leaf_contract_test.go
@@ -157,8 +157,8 @@ func TestAppMetadataLeavesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_summary_contract_test.go
+++ b/appserver/protocol/app_summary_contract_test.go
@@ -87,8 +87,8 @@ func TestAppSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppSummary unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_template_summary_contract_test.go
+++ b/appserver/protocol/app_template_summary_contract_test.go
@@ -107,8 +107,8 @@ func TestAppTemplateSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppTemplateSummary unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_template_unavailable_reason_contract_test.go
+++ b/appserver/protocol/app_template_unavailable_reason_contract_test.go
@@ -71,8 +71,8 @@ func TestAppTemplateUnavailableReasonRemainsStandalone(t *testing.T) {
 			t.Fatalf("AppTemplateUnavailableReason unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_tool_approval_contract_test.go
+++ b/appserver/protocol/app_tool_approval_contract_test.go
@@ -73,8 +73,8 @@ func TestAppToolApprovalRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppToolApproval unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_tools_config_contract_test.go
+++ b/appserver/protocol/app_tools_config_contract_test.go
@@ -140,8 +140,8 @@ func TestAppToolConfigsRemainStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/apply_patch_approval_params_contract_test.go
+++ b/appserver/protocol/apply_patch_approval_params_contract_test.go
@@ -139,8 +139,8 @@ func TestApplyPatchApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ApplyPatchApprovalParams unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(defs); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(defs); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/apps_config_contract_test.go
+++ b/appserver/protocol/apps_config_contract_test.go
@@ -185,8 +185,8 @@ func TestAppsConfigsRemainStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/apps_list_contract_test.go
+++ b/appserver/protocol/apps_list_contract_test.go
@@ -168,8 +168,8 @@ func TestAppsListContractsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/attestation_contract_test.go
+++ b/appserver/protocol/attestation_contract_test.go
@@ -133,8 +133,8 @@ func TestAttestationContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("attestation/generate = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
+++ b/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
@@ -179,8 +179,8 @@ func TestChatgptAuthTokensRefreshRemainsStandaloneAndDeferred(t *testing.T) {
 	if !found {
 		t.Fatal("refresh method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/exec_command_approval_params_contract_test.go
+++ b/appserver/protocol/exec_command_approval_params_contract_test.go
@@ -137,8 +137,8 @@ func TestExecCommandApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ExecCommandApprovalParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(defs); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/experimental_feature_contract_test.go
+++ b/appserver/protocol/experimental_feature_contract_test.go
@@ -1,0 +1,223 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestExperimentalFeatureSchemasAreExact(t *testing.T) {
+	want := experimentalFeatureSchemas()
+	definitions := JSONSchema()["$defs"].(Schema)
+	for _, name := range []string{
+		"ExperimentalFeatureStage", "ExperimentalFeature", "ExperimentalFeatureListParams",
+		"ExperimentalFeatureListResponse", "ExperimentalFeatureEnablementSetParams",
+		"ExperimentalFeatureEnablementSetResponse",
+	} {
+		if got := definitions[name]; !reflect.DeepEqual(got, want[name]) {
+			t.Errorf("%s = %#v, want %#v", name, got, want[name])
+		}
+	}
+}
+
+func TestExperimentalFeatureContractsRemainStandalone(t *testing.T) {
+	names := []string{
+		"ExperimentalFeatureStage", "ExperimentalFeature", "ExperimentalFeatureListParams",
+		"ExperimentalFeatureListResponse", "ExperimentalFeatureEnablementSetParams",
+		"ExperimentalFeatureEnablementSetResponse",
+	}
+	for _, binding := range WireTypeBindings() {
+		for _, name := range names {
+			if slices.Contains(binding.Params, name) || slices.Contains(binding.Result, name) {
+				t.Fatalf("%s unexpectedly bound to %s", name, binding.Method)
+			}
+		}
+	}
+	for _, methodName := range []string{"experimentalFeature/list", "experimentalFeature/enablement/set"} {
+		method, ok := LookupMethod(methodName)
+		if !ok || method.Surface != SurfaceClientRequest || method.State != MethodImplemented {
+			t.Fatalf("%s = %#v, %v; want implemented client request", methodName, method, ok)
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
+	}
+	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("counts = %d/%d/%d, want 224/59/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
+	}
+}
+
+func TestExperimentalFeatureTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	for _, want := range []string{
+		`export type ExperimentalFeatureStage = "beta" | "underDevelopment" | "stable" | "deprecated" | "removed";`,
+		`export type ExperimentalFeatureEnablementSetParams = {`,
+		`export type ExperimentalFeatureEnablementSetResponse = {`,
+		`export type ExperimentalFeatureListParams = {`,
+		`export type ExperimentalFeatureListResponse = {`,
+	} {
+		if !strings.Contains(string(generated), want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}
+
+func TestExperimentalFeatureStageIsClosed(t *testing.T) {
+	for _, value := range []string{"beta", "underDevelopment", "stable", "deprecated", "removed"} {
+		roundTripExperimentalFeature[ExperimentalFeatureStage](t, `"`+value+`"`, `"`+value+`"`)
+	}
+	for _, input := range []string{``, `null`, `1`, `true`, `[]`, `{}`, `"unknown"`, `"beta" "stable"`} {
+		assertJSONRejects[ExperimentalFeatureStage](t, input)
+	}
+	if _, err := json.Marshal(ExperimentalFeatureStage("unknown")); err == nil {
+		t.Fatal("invalid experimental feature stage marshaled")
+	}
+	var receiver *ExperimentalFeatureStage
+	if err := receiver.UnmarshalJSON([]byte(`"beta"`)); err == nil {
+		t.Fatal("nil stage receiver succeeded")
+	}
+}
+
+func TestExperimentalFeaturePreservesSerdeWireForms(t *testing.T) {
+	canonicalNulls := `{"name":"","stage":"beta","displayName":null,"description":null,"announcement":null,"enabled":false,"defaultEnabled":false}`
+	roundTripExperimentalFeature[ExperimentalFeature](t,
+		`{"name":"","stage":"beta","enabled":false,"defaultEnabled":false}`,
+		canonicalNulls,
+	)
+	roundTripExperimentalFeature[ExperimentalFeature](t,
+		`{"future":1,"future":2,"name":" name ","stage":"removed","displayName":"","description":" desc ","announcement":" note ","enabled":true,"defaultEnabled":false}`,
+		`{"name":" name ","stage":"removed","displayName":"","description":" desc ","announcement":" note ","enabled":true,"defaultEnabled":false}`,
+	)
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`, `{}`,
+		`{"stage":"beta","enabled":false,"defaultEnabled":false}`,
+		`{"name":"x","enabled":false,"defaultEnabled":false}`,
+		`{"name":"x","stage":"beta","defaultEnabled":false}`,
+		`{"name":"x","stage":"beta","enabled":false}`,
+		`{"name":null,"stage":"beta","enabled":false,"defaultEnabled":false}`,
+		`{"name":"x","stage":"unknown","enabled":false,"defaultEnabled":false}`,
+		`{"name":"x","stage":"beta","displayName":1,"enabled":false,"defaultEnabled":false}`,
+		`{"name":"x","stage":"beta","description":true,"enabled":false,"defaultEnabled":false}`,
+		`{"name":"x","stage":"beta","announcement":[],"enabled":false,"defaultEnabled":false}`,
+		`{"name":"x","stage":"beta","enabled":0,"defaultEnabled":false}`,
+		`{"name":"x","stage":"beta","enabled":false,"defaultEnabled":null}`,
+		`{"name":"a","name":"b","stage":"beta","enabled":false,"defaultEnabled":false}`,
+		`{"name":"x","stage":"beta","stage":"stable","enabled":false,"defaultEnabled":false}`,
+		`{"name":"x","stage":"beta","enabled":false,"enabled":true,"defaultEnabled":false}`,
+		`{"name":"x","stage":"beta","enabled":false,"defaultEnabled":false} {}`,
+	} {
+		assertJSONRejects[ExperimentalFeature](t, input)
+	}
+	var receiver *ExperimentalFeature
+	if err := receiver.UnmarshalJSON([]byte(`{}`)); err == nil {
+		t.Fatal("nil feature receiver succeeded")
+	}
+}
+
+func TestExperimentalFeatureListParamsPreserveOptionalNullableBoundaries(t *testing.T) {
+	roundTripExperimentalFeature[ExperimentalFeatureListParams](t, `{}`, `{}`)
+	roundTripExperimentalFeature[ExperimentalFeatureListParams](t,
+		`{"cursor":null,"limit":null,"threadId":null}`,
+		`{}`,
+	)
+	roundTripExperimentalFeature[ExperimentalFeatureListParams](t,
+		`{"future":1,"cursor":" cursor ","limit":4294967295,"threadId":" thread "}`,
+		`{"cursor":" cursor ","limit":4294967295,"threadId":" thread "}`,
+	)
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`,
+		`{"cursor":1}`, `{"threadId":false}`, `{"limit":-1}`, `{"limit":4294967296}`,
+		`{"limit":1.5}`, `{"limit":"1"}`, `{"cursor":null,"cursor":"x"}`,
+		`{"threadId":"x","threadId":"y"}`, `{} {}`,
+	} {
+		assertJSONRejects[ExperimentalFeatureListParams](t, input)
+	}
+	var receiver *ExperimentalFeatureListParams
+	if err := receiver.UnmarshalJSON([]byte(`{}`)); err == nil {
+		t.Fatal("nil list params receiver succeeded")
+	}
+}
+
+func TestExperimentalFeatureListResponsePreservesOrderAndNulls(t *testing.T) {
+	feature := `{"name":"x","stage":"stable","enabled":true,"defaultEnabled":false}`
+	canonical := `{"name":"x","stage":"stable","displayName":null,"description":null,"announcement":null,"enabled":true,"defaultEnabled":false}`
+	roundTripExperimentalFeature[ExperimentalFeatureListResponse](t,
+		`{"data":[]}`,
+		`{"data":[],"nextCursor":null}`,
+	)
+	roundTripExperimentalFeature[ExperimentalFeatureListResponse](t,
+		`{"future":1,"data":[`+feature+`,`+feature+`],"nextCursor":" next "}`,
+		`{"data":[`+canonical+`,`+canonical+`],"nextCursor":" next "}`,
+	)
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`, `{}`,
+		`{"data":null}`, `{"data":{}}`, `{"data":[null]}`, `{"data":[{}]}`,
+		`{"data":[],"nextCursor":1}`, `{"data":[],"data":[]}`, `{"data":[]} {}`,
+	} {
+		assertJSONRejects[ExperimentalFeatureListResponse](t, input)
+	}
+	if _, err := json.Marshal(ExperimentalFeatureListResponse{}); err == nil {
+		t.Fatal("nil feature data marshaled")
+	}
+	var receiver *ExperimentalFeatureListResponse
+	if err := receiver.UnmarshalJSON([]byte(`{}`)); err == nil {
+		t.Fatal("nil list response receiver succeeded")
+	}
+}
+
+func TestExperimentalFeatureEnablementMapsAreStrictAndLastWins(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		run  func(*testing.T, string, string)
+	}{
+		{"params", roundTripExperimentalFeature[ExperimentalFeatureEnablementSetParams]},
+		{"response", roundTripExperimentalFeature[ExperimentalFeatureEnablementSetResponse]},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			test.run(t, `{"enablement":{}}`, `{"enablement":{}}`)
+			test.run(t,
+				`{"future":1,"enablement":{"":true,"feature":false,"feature":true}}`,
+				`{"enablement":{"":true,"feature":true}}`,
+			)
+		})
+	}
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`, `{}`, `{"enablement":null}`,
+		`{"enablement":[]}`, `{"enablement":{"feature":"true"}}`,
+		`{"enablement":{},"enablement":{}}`, `{"enablement":{}} {}`,
+	} {
+		assertJSONRejects[ExperimentalFeatureEnablementSetParams](t, input)
+		assertJSONRejects[ExperimentalFeatureEnablementSetResponse](t, input)
+	}
+	if _, err := json.Marshal(ExperimentalFeatureEnablementSetParams{}); err == nil {
+		t.Fatal("nil params map marshaled")
+	}
+	if _, err := json.Marshal(ExperimentalFeatureEnablementSetResponse{}); err == nil {
+		t.Fatal("nil response map marshaled")
+	}
+	var params *ExperimentalFeatureEnablementSetParams
+	if err := params.UnmarshalJSON([]byte(`{}`)); err == nil {
+		t.Fatal("nil params receiver succeeded")
+	}
+	var response *ExperimentalFeatureEnablementSetResponse
+	if err := response.UnmarshalJSON([]byte(`{}`)); err == nil {
+		t.Fatal("nil response receiver succeeded")
+	}
+}
+
+func roundTripExperimentalFeature[T any](t *testing.T, input, want string) {
+	t.Helper()
+	var value T
+	if err := json.Unmarshal([]byte(input), &value); err != nil {
+		t.Fatalf("unmarshal %s: %v", input, err)
+	}
+	encoded, err := json.Marshal(value)
+	if err != nil || string(encoded) != want {
+		t.Fatalf("round trip %s = %s, %v; want %s", input, encoded, err, want)
+	}
+}

--- a/appserver/protocol/experimental_feature_types.go
+++ b/appserver/protocol/experimental_feature_types.go
@@ -1,0 +1,310 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// ExperimentalFeatureStage is the exact closed public feature lifecycle.
+type ExperimentalFeatureStage string
+
+const (
+	ExperimentalFeatureStageBeta             ExperimentalFeatureStage = "beta"
+	ExperimentalFeatureStageUnderDevelopment ExperimentalFeatureStage = "underDevelopment"
+	ExperimentalFeatureStageStable           ExperimentalFeatureStage = "stable"
+	ExperimentalFeatureStageDeprecated       ExperimentalFeatureStage = "deprecated"
+	ExperimentalFeatureStageRemoved          ExperimentalFeatureStage = "removed"
+)
+
+func (s ExperimentalFeatureStage) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(s, "experimental feature stage", ExperimentalFeatureStage.valid)
+}
+
+func (s *ExperimentalFeatureStage) UnmarshalJSON(data []byte) error {
+	return unmarshalThreadTurnLeafEnum(data, s, "experimental feature stage", ExperimentalFeatureStage.valid)
+}
+
+func (s ExperimentalFeatureStage) valid() bool {
+	return s == ExperimentalFeatureStageBeta ||
+		s == ExperimentalFeatureStageUnderDevelopment ||
+		s == ExperimentalFeatureStageStable ||
+		s == ExperimentalFeatureStageDeprecated ||
+		s == ExperimentalFeatureStageRemoved
+}
+
+// ExperimentalFeature is exact standalone feature metadata.
+type ExperimentalFeature struct {
+	Name           string                   `json:"name"`
+	Stage          ExperimentalFeatureStage `json:"stage"`
+	DisplayName    *string                  `json:"displayName,omitempty"`
+	Description    *string                  `json:"description,omitempty"`
+	Announcement   *string                  `json:"announcement,omitempty"`
+	Enabled        bool                     `json:"enabled"`
+	DefaultEnabled bool                     `json:"defaultEnabled"`
+}
+
+func (f ExperimentalFeature) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Name           string                   `json:"name"`
+		Stage          ExperimentalFeatureStage `json:"stage"`
+		DisplayName    *string                  `json:"displayName"`
+		Description    *string                  `json:"description"`
+		Announcement   *string                  `json:"announcement"`
+		Enabled        bool                     `json:"enabled"`
+		DefaultEnabled bool                     `json:"defaultEnabled"`
+	}{
+		Name: f.Name, Stage: f.Stage, DisplayName: f.DisplayName,
+		Description: f.Description, Announcement: f.Announcement,
+		Enabled: f.Enabled, DefaultEnabled: f.DefaultEnabled,
+	})
+}
+
+func (f *ExperimentalFeature) UnmarshalJSON(data []byte) error {
+	if f == nil {
+		return errors.New("decode experimental feature into nil receiver")
+	}
+	const objectName = "experimental feature"
+	payload, err := decodeRustSerdeObject(
+		data, objectName, "name", "stage", "displayName", "description", "announcement", "enabled", "defaultEnabled",
+	)
+	if err != nil {
+		return err
+	}
+	name, err := decodeRequiredThreadItemValue[string](payload, objectName, "name")
+	if err != nil {
+		return err
+	}
+	stage, err := decodeRequiredThreadItemValue[ExperimentalFeatureStage](payload, objectName, "stage")
+	if err != nil {
+		return err
+	}
+	displayName, err := decodeOptionalNullableConfigValue[string](payload, objectName, "displayName")
+	if err != nil {
+		return err
+	}
+	description, err := decodeOptionalNullableConfigValue[string](payload, objectName, "description")
+	if err != nil {
+		return err
+	}
+	announcement, err := decodeOptionalNullableConfigValue[string](payload, objectName, "announcement")
+	if err != nil {
+		return err
+	}
+	enabled, err := decodeRequiredThreadItemValue[bool](payload, objectName, "enabled")
+	if err != nil {
+		return err
+	}
+	defaultEnabled, err := decodeRequiredThreadItemValue[bool](payload, objectName, "defaultEnabled")
+	if err != nil {
+		return err
+	}
+	*f = ExperimentalFeature{
+		Name: name, Stage: stage, DisplayName: displayName, Description: description,
+		Announcement: announcement, Enabled: enabled, DefaultEnabled: defaultEnabled,
+	}
+	return nil
+}
+
+// ExperimentalFeatureListParams is exact optional pagination/thread context.
+type ExperimentalFeatureListParams struct {
+	Cursor   *string `json:"cursor,omitempty"`
+	Limit    *uint32 `json:"limit,omitempty"`
+	ThreadID *string `json:"threadId,omitempty"`
+}
+
+func (p *ExperimentalFeatureListParams) UnmarshalJSON(data []byte) error {
+	if p == nil {
+		return errors.New("decode experimental feature list params into nil receiver")
+	}
+	const objectName = "experimental feature list params"
+	payload, err := decodeRustSerdeObject(data, objectName, "cursor", "limit", "threadId")
+	if err != nil {
+		return err
+	}
+	cursor, err := decodeOptionalNullableConfigValue[string](payload, objectName, "cursor")
+	if err != nil {
+		return err
+	}
+	limit, err := decodeOptionalNullableConfigValue[uint32](payload, objectName, "limit")
+	if err != nil {
+		return err
+	}
+	threadID, err := decodeOptionalNullableConfigValue[string](payload, objectName, "threadId")
+	if err != nil {
+		return err
+	}
+	*p = ExperimentalFeatureListParams{Cursor: cursor, Limit: limit, ThreadID: threadID}
+	return nil
+}
+
+// ExperimentalFeatureListResponse is exact standalone paginated feature data.
+type ExperimentalFeatureListResponse struct {
+	Data       []ExperimentalFeature `json:"data"`
+	NextCursor *string               `json:"nextCursor,omitempty"`
+}
+
+func (r ExperimentalFeatureListResponse) MarshalJSON() ([]byte, error) {
+	if r.Data == nil {
+		return nil, errors.New("experimental feature list response data cannot be null")
+	}
+	return json.Marshal(struct {
+		Data       []ExperimentalFeature `json:"data"`
+		NextCursor *string               `json:"nextCursor"`
+	}{Data: r.Data, NextCursor: r.NextCursor})
+}
+
+func (r *ExperimentalFeatureListResponse) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("decode experimental feature list response into nil receiver")
+	}
+	const objectName = "experimental feature list response"
+	payload, err := decodeRustSerdeObject(data, objectName, "data", "nextCursor")
+	if err != nil {
+		return err
+	}
+	values, err := decodeRequiredThreadItemArray[ExperimentalFeature](payload, objectName, "data")
+	if err != nil {
+		return err
+	}
+	nextCursor, err := decodeOptionalNullableConfigValue[string](payload, objectName, "nextCursor")
+	if err != nil {
+		return err
+	}
+	*r = ExperimentalFeatureListResponse{Data: values, NextCursor: nextCursor}
+	return nil
+}
+
+// ExperimentalFeatureEnablementSetParams is exact standalone enablement input.
+type ExperimentalFeatureEnablementSetParams struct {
+	Enablement map[string]bool `json:"enablement"`
+}
+
+func (p ExperimentalFeatureEnablementSetParams) MarshalJSON() ([]byte, error) {
+	return marshalExperimentalFeatureEnablement("params", p.Enablement)
+}
+
+func (p *ExperimentalFeatureEnablementSetParams) UnmarshalJSON(data []byte) error {
+	if p == nil {
+		return errors.New("decode experimental feature enablement params into nil receiver")
+	}
+	enablement, err := unmarshalExperimentalFeatureEnablement(data, "experimental feature enablement params")
+	if err != nil {
+		return err
+	}
+	*p = ExperimentalFeatureEnablementSetParams{Enablement: enablement}
+	return nil
+}
+
+// ExperimentalFeatureEnablementSetResponse is exact standalone enablement output.
+type ExperimentalFeatureEnablementSetResponse struct {
+	Enablement map[string]bool `json:"enablement"`
+}
+
+func (r ExperimentalFeatureEnablementSetResponse) MarshalJSON() ([]byte, error) {
+	return marshalExperimentalFeatureEnablement("response", r.Enablement)
+}
+
+func (r *ExperimentalFeatureEnablementSetResponse) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("decode experimental feature enablement response into nil receiver")
+	}
+	enablement, err := unmarshalExperimentalFeatureEnablement(data, "experimental feature enablement response")
+	if err != nil {
+		return err
+	}
+	*r = ExperimentalFeatureEnablementSetResponse{Enablement: enablement}
+	return nil
+}
+
+func marshalExperimentalFeatureEnablement(kind string, enablement map[string]bool) ([]byte, error) {
+	if enablement == nil {
+		return nil, fmt.Errorf("experimental feature enablement %s map cannot be null", kind)
+	}
+	return json.Marshal(struct {
+		Enablement map[string]bool `json:"enablement"`
+	}{Enablement: enablement})
+}
+
+func unmarshalExperimentalFeatureEnablement(data []byte, objectName string) (map[string]bool, error) {
+	payload, err := decodeRustSerdeObject(data, objectName, "enablement")
+	if err != nil {
+		return nil, err
+	}
+	enablement, err := decodeRequiredThreadItemValue[map[string]bool](payload, objectName, "enablement")
+	if err != nil {
+		return nil, err
+	}
+	return enablement, nil
+}
+
+func experimentalFeatureSchemas() map[string]Schema {
+	stage := func(description, value string) Schema {
+		return Schema{"description": description, "enum": []any{value}, "type": "string"}
+	}
+	mapSchema := func(description string) Schema {
+		return Schema{
+			"type": "object",
+			"properties": Schema{"enablement": Schema{
+				"additionalProperties": Schema{"type": "boolean"},
+				"description":          description,
+				"type":                 "object",
+			}},
+			"required": []string{"enablement"},
+		}
+	}
+	return map[string]Schema{
+		"ExperimentalFeatureStage": {"oneOf": []any{
+			stage("Feature is available for user testing and feedback.", "beta"),
+			stage("Feature is still being built and not ready for broad use.", "underDevelopment"),
+			stage("Feature is production-ready.", "stable"),
+			stage("Feature is deprecated and should be avoided.", "deprecated"),
+			stage("Feature flag is retained only for backwards compatibility.", "removed"),
+		}},
+		"ExperimentalFeature": {
+			"type": "object",
+			"properties": Schema{
+				"announcement":   Schema{"description": "Announcement copy shown to users when the feature is introduced. Null when this feature is not in beta.", "type": []any{"string", "null"}},
+				"defaultEnabled": Schema{"description": "Whether this feature is enabled by default.", "type": "boolean"},
+				"description":    Schema{"description": "Short summary describing what the feature does. Null when this feature is not in beta.", "type": []any{"string", "null"}},
+				"displayName":    Schema{"description": "User-facing display name shown in the experimental features UI. Null when this feature is not in beta.", "type": []any{"string", "null"}},
+				"enabled":        Schema{"description": "Whether this feature is currently enabled in the loaded config.", "type": "boolean"},
+				"name":           Schema{"description": "Stable key used in config.toml and CLI flag toggles.", "type": "string"},
+				"stage":          Schema{"allOf": []any{Schema{"$ref": "#/$defs/ExperimentalFeatureStage"}}, "description": "Lifecycle stage of this feature flag."},
+			},
+			"required": []string{"defaultEnabled", "enabled", "name", "stage"},
+		},
+		"ExperimentalFeatureListParams": {
+			"type": "object",
+			"properties": Schema{
+				"cursor":   Schema{"description": "Opaque pagination cursor returned by a previous call.", "type": []any{"string", "null"}},
+				"limit":    Schema{"description": "Optional page size; defaults to a reasonable server-side value.", "format": "uint32", "minimum": float64(0), "type": []any{"integer", "null"}},
+				"threadId": Schema{"description": "Optional loaded thread id. Pass this when showing feature state for an existing thread so enablement is computed from that thread's refreshed config, including project-local config for the thread's cwd.", "type": []any{"string", "null"}},
+			},
+		},
+		"ExperimentalFeatureListResponse": {
+			"type": "object",
+			"properties": Schema{
+				"data":       Schema{"items": Schema{"$ref": "#/$defs/ExperimentalFeature"}, "type": "array"},
+				"nextCursor": Schema{"description": "Opaque cursor to pass to the next call to continue after the last item. If None, there are no more items to return.", "type": []any{"string", "null"}},
+			},
+			"required": []string{"data"},
+		},
+		"ExperimentalFeatureEnablementSetParams":   mapSchema("Process-wide runtime feature enablement keyed by canonical feature name.\n\nOnly named features are updated. Omitted features are left unchanged. Send an empty map for a no-op."),
+		"ExperimentalFeatureEnablementSetResponse": mapSchema("Feature enablement entries updated by this request."),
+	}
+}
+
+var (
+	_ json.Marshaler   = ExperimentalFeatureStage("")
+	_ json.Unmarshaler = (*ExperimentalFeatureStage)(nil)
+	_ json.Marshaler   = ExperimentalFeature{}
+	_ json.Unmarshaler = (*ExperimentalFeature)(nil)
+	_ json.Unmarshaler = (*ExperimentalFeatureListParams)(nil)
+	_ json.Marshaler   = ExperimentalFeatureListResponse{}
+	_ json.Unmarshaler = (*ExperimentalFeatureListResponse)(nil)
+	_ json.Marshaler   = ExperimentalFeatureEnablementSetParams{}
+	_ json.Unmarshaler = (*ExperimentalFeatureEnablementSetParams)(nil)
+	_ json.Marshaler   = ExperimentalFeatureEnablementSetResponse{}
+	_ json.Unmarshaler = (*ExperimentalFeatureEnablementSetResponse)(nil)
+)

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,8 +217,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,8 +203,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -260,8 +260,8 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,8 +244,8 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -162,8 +162,8 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -175,8 +175,8 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_contract_test.go
+++ b/appserver/protocol/file_change_contract_test.go
@@ -108,8 +108,8 @@ func TestFileChangeRemainsStandalone(t *testing.T) {
 			t.Fatalf("FileChange unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_output_delta_notification_contract_test.go
+++ b/appserver/protocol/file_change_output_delta_notification_contract_test.go
@@ -100,8 +100,8 @@ func TestFileChangeOutputDeltaNotificationRemainsDeprecatedAndStandalone(t *test
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("item/fileChange/outputDelta = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -381,8 +381,8 @@ func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_action_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_action_contract_test.go
@@ -226,8 +226,8 @@ func TestGuardianApprovalReviewActionRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReviewAction unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
@@ -164,8 +164,8 @@ func TestGuardianApprovalReviewCompletedNotificationRemainsStandalone(t *testing
 			t.Fatalf("completed notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_contract_test.go
@@ -139,8 +139,8 @@ func TestGuardianApprovalReviewRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReview unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
@@ -175,8 +175,8 @@ func TestGuardianApprovalReviewStartedNotificationRemainsStandalone(t *testing.T
 			t.Fatalf("started notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_enum_foundation_contract_test.go
+++ b/appserver/protocol/guardian_enum_foundation_contract_test.go
@@ -89,8 +89,8 @@ func TestGuardianEnumFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_metadata_list_contract_test.go
+++ b/appserver/protocol/hook_metadata_list_contract_test.go
@@ -352,8 +352,8 @@ func TestHookMetadataListContractsStayStandalone(t *testing.T) {
 			t.Errorf("standalone definition %s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Errorf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Errorf("definition count = %d, want 505", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 {
 		t.Errorf("wire binding count = %d, want 59", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_run_notification_contract_test.go
+++ b/appserver/protocol/hook_run_notification_contract_test.go
@@ -297,8 +297,8 @@ func TestHookRunNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("surface changed: %d methods, %d wire bindings, %d item bindings", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/hook_value_foundation_contract_test.go
+++ b/appserver/protocol/hook_value_foundation_contract_test.go
@@ -167,8 +167,8 @@ func TestHookValueFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 499 {
-		t.Fatalf("definition count = %d, want 499", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 505 {
+		t.Fatalf("definition count = %d, want 505", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/legacy_approval_response_contract_test.go
+++ b/appserver/protocol/legacy_approval_response_contract_test.go
@@ -98,8 +98,8 @@ func TestLegacyApprovalResponsesRemainStandaloneAndNominal(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_approval_context_contract_test.go
+++ b/appserver/protocol/network_approval_context_contract_test.go
@@ -84,8 +84,8 @@ func TestNetworkApprovalContextRemainsStandalone(t *testing.T) {
 			t.Fatalf("NetworkApprovalContext unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/parsed_command_contract_test.go
+++ b/appserver/protocol/parsed_command_contract_test.go
@@ -120,8 +120,8 @@ func TestParsedCommandRemainsStandalone(t *testing.T) {
 			t.Fatalf("ParsedCommand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/process_contracts_contract_test.go
+++ b/appserver/protocol/process_contracts_contract_test.go
@@ -308,8 +308,8 @@ func TestProcessContractsRemainStandaloneFromLegacyRuntime(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want unchanged implemented notification", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 499 {
-		t.Fatalf("definition count = %d, want 499", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 505 {
+		t.Fatalf("definition count = %d, want 505", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 499 {
-		t.Fatalf("definition count = %d, want 499", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 505 {
+		t.Fatalf("definition count = %d, want 505", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 499 {
-		t.Fatalf("definition count = %d, want 499", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 505 {
+		t.Fatalf("definition count = %d, want 505", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 499 {
-		t.Fatalf("definition count = %d, want 499", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 505 {
+		t.Fatalf("definition count = %d, want 505", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 499 {
-		t.Fatalf("definition count = %d, want 499", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 505 {
+		t.Fatalf("definition count = %d, want 505", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/review_decision_contract_test.go
+++ b/appserver/protocol/review_decision_contract_test.go
@@ -136,8 +136,8 @@ func TestReviewDecisionRemainsStandalone(t *testing.T) {
 			t.Fatalf("ReviewDecision unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(defs); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -200,6 +200,12 @@ func wireSchemaDefinitions() Schema {
 		{Name: "DynamicToolCallItemStartedNotificationParams", Type: reflect.TypeFor[DynamicToolCallItemStartedNotificationParams]()},
 		{Name: "ErrorNotification", Type: reflect.TypeFor[ErrorNotification]()},
 		{Name: "ExecPolicyAmendment", Type: reflect.TypeFor[ExecPolicyAmendment]()},
+		{Name: "ExperimentalFeature", Type: reflect.TypeFor[ExperimentalFeature]()},
+		{Name: "ExperimentalFeatureEnablementSetParams", Type: reflect.TypeFor[ExperimentalFeatureEnablementSetParams]()},
+		{Name: "ExperimentalFeatureEnablementSetResponse", Type: reflect.TypeFor[ExperimentalFeatureEnablementSetResponse]()},
+		{Name: "ExperimentalFeatureListParams", Type: reflect.TypeFor[ExperimentalFeatureListParams]()},
+		{Name: "ExperimentalFeatureListResponse", Type: reflect.TypeFor[ExperimentalFeatureListResponse]()},
+		{Name: "ExperimentalFeatureStage", Type: reflect.TypeFor[ExperimentalFeatureStage]()},
 		{Name: "FileChange", Type: reflect.TypeFor[FileChange]()},
 		{Name: "FileChangeOutputDeltaNotification", Type: reflect.TypeFor[FileChangeOutputDeltaNotification]()},
 		{Name: "FileChangeApprovalRequestParams", Type: reflect.TypeFor[FileChangeApprovalRequestParams]()},
@@ -1039,6 +1045,9 @@ func wireSchemaDefinitions() Schema {
 		schemas[name] = schema
 	}
 	for name, schema := range workspaceMessageSchemas() {
+		schemas[name] = schema
+	}
+	for name, schema := range experimentalFeatureSchemas() {
 		schemas[name] = schema
 	}
 	schemas["McpServerToolCallParams"] = mcpServerToolCallParamsSchema()

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -4364,6 +4364,176 @@
       },
       "type": "array"
     },
+    "ExperimentalFeature": {
+      "properties": {
+        "announcement": {
+          "description": "Announcement copy shown to users when the feature is introduced. Null when this feature is not in beta.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "defaultEnabled": {
+          "description": "Whether this feature is enabled by default.",
+          "type": "boolean"
+        },
+        "description": {
+          "description": "Short summary describing what the feature does. Null when this feature is not in beta.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "displayName": {
+          "description": "User-facing display name shown in the experimental features UI. Null when this feature is not in beta.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "enabled": {
+          "description": "Whether this feature is currently enabled in the loaded config.",
+          "type": "boolean"
+        },
+        "name": {
+          "description": "Stable key used in config.toml and CLI flag toggles.",
+          "type": "string"
+        },
+        "stage": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/ExperimentalFeatureStage"
+            }
+          ],
+          "description": "Lifecycle stage of this feature flag."
+        }
+      },
+      "required": [
+        "defaultEnabled",
+        "enabled",
+        "name",
+        "stage"
+      ],
+      "type": "object"
+    },
+    "ExperimentalFeatureEnablementSetParams": {
+      "properties": {
+        "enablement": {
+          "additionalProperties": {
+            "type": "boolean"
+          },
+          "description": "Process-wide runtime feature enablement keyed by canonical feature name.\n\nOnly named features are updated. Omitted features are left unchanged. Send an empty map for a no-op.",
+          "type": "object"
+        }
+      },
+      "required": [
+        "enablement"
+      ],
+      "type": "object"
+    },
+    "ExperimentalFeatureEnablementSetResponse": {
+      "properties": {
+        "enablement": {
+          "additionalProperties": {
+            "type": "boolean"
+          },
+          "description": "Feature enablement entries updated by this request.",
+          "type": "object"
+        }
+      },
+      "required": [
+        "enablement"
+      ],
+      "type": "object"
+    },
+    "ExperimentalFeatureListParams": {
+      "properties": {
+        "cursor": {
+          "description": "Opaque pagination cursor returned by a previous call.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "limit": {
+          "description": "Optional page size; defaults to a reasonable server-side value.",
+          "format": "uint32",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "threadId": {
+          "description": "Optional loaded thread id. Pass this when showing feature state for an existing thread so enablement is computed from that thread's refreshed config, including project-local config for the thread's cwd.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "ExperimentalFeatureListResponse": {
+      "properties": {
+        "data": {
+          "items": {
+            "$ref": "#/$defs/ExperimentalFeature"
+          },
+          "type": "array"
+        },
+        "nextCursor": {
+          "description": "Opaque cursor to pass to the next call to continue after the last item. If None, there are no more items to return.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "data"
+      ],
+      "type": "object"
+    },
+    "ExperimentalFeatureStage": {
+      "oneOf": [
+        {
+          "description": "Feature is available for user testing and feedback.",
+          "enum": [
+            "beta"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Feature is still being built and not ready for broad use.",
+          "enum": [
+            "underDevelopment"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Feature is production-ready.",
+          "enum": [
+            "stable"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Feature is deprecated and should be avoided.",
+          "enum": [
+            "deprecated"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Feature flag is retained only for backwards compatibility.",
+          "enum": [
+            "removed"
+          ],
+          "type": "string"
+        }
+      ]
+    },
     "ExternalAgentConfigDetectParams": {
       "additionalProperties": false,
       "properties": {

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 499 {
-		t.Fatalf("definition count = %d, want 499", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 505 {
+		t.Fatalf("definition count = %d, want 505", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 499 {
-		t.Fatalf("definition count = %d, want 499", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 505 {
+		t.Fatalf("definition count = %d, want 505", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 499 {
-		t.Fatalf("definition count = %d, want 499", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 505 {
+		t.Fatalf("definition count = %d, want 505", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -57,6 +57,9 @@ func MarshalTypeScript() ([]byte, error) {
 			name == "ExternalAgentConfigImportItemTypeFailure" ||
 			name == "ExternalAgentConfigImportItemTypeSuccess" ||
 			name == "ExecCommandApprovalParams" ||
+			name == "ExperimentalFeature" || name == "ExperimentalFeatureEnablementSetParams" ||
+			name == "ExperimentalFeatureEnablementSetResponse" || name == "ExperimentalFeatureListParams" ||
+			name == "ExperimentalFeatureListResponse" ||
 			name == "FuzzyFileSearchParams" || name == "FuzzyFileSearchResult" ||
 			name == "HookRunSummary" || name == "HookStartedNotification" ||
 			name == "HookCompletedNotification" || name == "HookMetadata" ||
@@ -190,6 +193,28 @@ func MarshalTypeScript() ([]byte, error) {
 				schema["required"] = []string{
 					"conversationId", "callId", "approvalId", "command", "cwd", "reason", "parsedCmd",
 				}
+			case "ExperimentalFeature":
+				schema["required"] = []string{
+					"announcement", "defaultEnabled", "description", "displayName", "enabled", "name", "stage",
+				}
+				schema["x-gollem-typescript-ignore-additional-properties"] = true
+				properties := schema["properties"].(Schema)
+				properties["announcement"] = nullableStringSchema()
+				properties["description"] = nullableStringSchema()
+				properties["displayName"] = nullableStringSchema()
+				properties["stage"] = Schema{"$ref": "#/$defs/ExperimentalFeatureStage"}
+			case "ExperimentalFeatureListResponse":
+				schema["required"] = []string{"data", "nextCursor"}
+				schema["x-gollem-typescript-ignore-additional-properties"] = true
+				schema["properties"].(Schema)["nextCursor"] = nullableStringSchema()
+			case "ExperimentalFeatureListParams":
+				schema["x-gollem-typescript-ignore-additional-properties"] = true
+				properties := schema["properties"].(Schema)
+				properties["cursor"] = nullableStringSchema()
+				properties["limit"] = nullableIntegerSchema()
+				properties["threadId"] = nullableStringSchema()
+			case "ExperimentalFeatureEnablementSetParams", "ExperimentalFeatureEnablementSetResponse":
+				schema["x-gollem-typescript-ignore-additional-properties"] = true
 			case "MigrationDetails":
 				schema["required"] = []string{
 					"plugins", "skills", "sessions", "mcpServers", "hooks", "subagents", "commands",

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -1350,6 +1350,37 @@ export type ExecCommandApprovalResponse = {
 
 export type ExecPolicyAmendment = Array<string>;
 
+export type ExperimentalFeature = {
+  "announcement": string | null;
+  "defaultEnabled": boolean;
+  "description": string | null;
+  "displayName": string | null;
+  "enabled": boolean;
+  "name": string;
+  "stage": ExperimentalFeatureStage;
+};
+
+export type ExperimentalFeatureEnablementSetParams = {
+  "enablement": Record<string, boolean>;
+};
+
+export type ExperimentalFeatureEnablementSetResponse = {
+  "enablement": Record<string, boolean>;
+};
+
+export type ExperimentalFeatureListParams = {
+  "cursor"?: string | null;
+  "limit"?: number | null;
+  "threadId"?: string | null;
+};
+
+export type ExperimentalFeatureListResponse = {
+  "data": Array<ExperimentalFeature>;
+  "nextCursor": string | null;
+};
+
+export type ExperimentalFeatureStage = "beta" | "underDevelopment" | "stable" | "deprecated" | "removed";
+
 export type ExternalAgentConfigDetectParams = {
   "cwds"?: Array<string> | null;
   "includeHome"?: boolean;

--- a/appserver/protocol/typescript/testdata/experimental_feature_contract.ts
+++ b/appserver/protocol/typescript/testdata/experimental_feature_contract.ts
@@ -1,0 +1,58 @@
+import type {
+  ExperimentalFeature,
+  ExperimentalFeatureEnablementSetParams,
+  ExperimentalFeatureEnablementSetResponse,
+  ExperimentalFeatureListParams,
+  ExperimentalFeatureListResponse,
+  ExperimentalFeatureStage,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2) ? true : false;
+type Expect<T extends true> = T;
+
+type Contracts = [
+  Expect<Equal<ExperimentalFeatureStage, "beta" | "underDevelopment" | "stable" | "deprecated" | "removed">>,
+  Expect<Equal<ExperimentalFeature, {
+    announcement: string | null;
+    defaultEnabled: boolean;
+    description: string | null;
+    displayName: string | null;
+    enabled: boolean;
+    name: string;
+    stage: ExperimentalFeatureStage;
+  }>>,
+  Expect<Equal<ExperimentalFeatureListParams, {
+    cursor?: string | null;
+    limit?: number | null;
+    threadId?: string | null;
+  }>>,
+  Expect<Equal<ExperimentalFeatureListResponse, {
+    data: Array<ExperimentalFeature>;
+    nextCursor: string | null;
+  }>>,
+  Expect<Equal<ExperimentalFeatureEnablementSetParams, { enablement: { [key: string]: boolean } }>>,
+  Expect<Equal<ExperimentalFeatureEnablementSetResponse, { enablement: { [key: string]: boolean } }>>,
+];
+
+({ announcement: null, defaultEnabled: false, description: null, displayName: null, enabled: true, name: "", stage: "beta" }) satisfies ExperimentalFeature;
+({}) satisfies ExperimentalFeatureListParams;
+({ cursor: null, limit: 4294967295, threadId: null }) satisfies ExperimentalFeatureListParams;
+({ data: [], nextCursor: null }) satisfies ExperimentalFeatureListResponse;
+({ enablement: { "": true, feature: false } }) satisfies ExperimentalFeatureEnablementSetParams;
+
+// @ts-expect-error stages are closed.
+"unknown" satisfies ExperimentalFeatureStage;
+// @ts-expect-error nullable display fields remain explicit.
+({ defaultEnabled: false, enabled: true, name: "x", stage: "stable" }) satisfies ExperimentalFeature;
+// @ts-expect-error limit is numeric rather than bigint.
+({ limit: 1n }) satisfies ExperimentalFeatureListParams;
+// @ts-expect-error data is required and non-null.
+({ data: null, nextCursor: null }) satisfies ExperimentalFeatureListResponse;
+// @ts-expect-error nextCursor remains explicit.
+({ data: [] }) satisfies ExperimentalFeatureListResponse;
+// @ts-expect-error map values are boolean.
+({ enablement: { feature: "true" } }) satisfies ExperimentalFeatureEnablementSetResponse;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/workspace_messages_contract_test.go
+++ b/appserver/protocol/workspace_messages_contract_test.go
@@ -209,8 +209,8 @@ func TestWorkspaceMessageContractsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/workspaceMessages/read = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 499 {
-		t.Fatalf("definition count = %d, want 499", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
+		t.Fatalf("definition count = %d, want 505", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 224/59/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary

- export the six exact standalone experimental-feature definitions
- preserve closed stage labels, nullable presentation fields, uint32 pagination, ordered feature arrays, and strict boolean enablement maps
- keep the existing live experimental-feature handlers unchanged and outside generated type bindings
- regenerate the deterministic JSON Schema and framework-neutral TypeScript contract at 505 definitions

## Verification

- `.githooks/pre-push` (golangci-lint, all non-Monty packages under `go test -race`, `go vet`, tidy check)
- `go generate ./appserver/protocol` twice with stable schema and TypeScript hashes
- `go test ./appserver/protocol -count=1`
- focused contract tests repeated under normal/race execution and new production functions covered at 100% during implementation
- parent/feature initialize + initialized + MCP-status runtime transcripts are byte-identical with empty stderr
- `git diff --check`

Local Monty tests remain skipped via `hooks.skipMontyRace=true`; hosted CI is unchanged.
