### PR TITLE
appserver: add exact MCP server status contracts

### DIFF
--- a/appserver/protocol/account_credit_nudge_values_contract_test.go
+++ b/appserver/protocol/account_credit_nudge_values_contract_test.go
@@ -119,8 +119,8 @@ func TestAccountCreditNudgeValuesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/sendAddCreditsNudgeEmail = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/account_envelope_contract_test.go
+++ b/appserver/protocol/account_envelope_contract_test.go
@@ -268,8 +268,8 @@ func TestAccountEnvelopeContractsRemainStandaloneAndDeferred(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred %s", methodName, method, ok, surface)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 224/59/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/account_login_completed_notification_contract_test.go
+++ b/appserver/protocol/account_login_completed_notification_contract_test.go
@@ -88,8 +88,8 @@ func TestAccountLoginCompletedNotificationRemainsStandaloneAndDeferred(t *testin
 	if !found {
 		t.Fatal("account/login/completed method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/account_rate_limits_contract_test.go
+++ b/appserver/protocol/account_rate_limits_contract_test.go
@@ -484,8 +484,8 @@ func TestAccountRateLimitContractsRemainStandaloneAndDeferred(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred %s", methodName, method, ok, surface)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/account_token_usage_contract_test.go
+++ b/appserver/protocol/account_token_usage_contract_test.go
@@ -146,8 +146,8 @@ func TestAccountTokenUsageRecordsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/usage/read = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(defs); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_config_contract_test.go
+++ b/appserver/protocol/app_config_contract_test.go
@@ -109,8 +109,8 @@ func TestAppConfigRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppConfig unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_info_contract_test.go
+++ b/appserver/protocol/app_info_contract_test.go
@@ -131,8 +131,8 @@ func TestAppInfoRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_list_updated_notification_contract_test.go
+++ b/appserver/protocol/app_list_updated_notification_contract_test.go
@@ -105,8 +105,8 @@ func TestAppListUpdatedNotificationRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceServerNotification || method.State != MethodDeferredStub {
 		t.Fatalf("app/list/updated = %#v, %v; want deferred server notification", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_metadata_contract_test.go
+++ b/appserver/protocol/app_metadata_contract_test.go
@@ -107,8 +107,8 @@ func TestAppMetadataRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_metadata_leaf_contract_test.go
+++ b/appserver/protocol/app_metadata_leaf_contract_test.go
@@ -157,8 +157,8 @@ func TestAppMetadataLeavesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_summary_contract_test.go
+++ b/appserver/protocol/app_summary_contract_test.go
@@ -87,8 +87,8 @@ func TestAppSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppSummary unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_template_summary_contract_test.go
+++ b/appserver/protocol/app_template_summary_contract_test.go
@@ -107,8 +107,8 @@ func TestAppTemplateSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppTemplateSummary unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_template_unavailable_reason_contract_test.go
+++ b/appserver/protocol/app_template_unavailable_reason_contract_test.go
@@ -71,8 +71,8 @@ func TestAppTemplateUnavailableReasonRemainsStandalone(t *testing.T) {
 			t.Fatalf("AppTemplateUnavailableReason unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_tool_approval_contract_test.go
+++ b/appserver/protocol/app_tool_approval_contract_test.go
@@ -73,8 +73,8 @@ func TestAppToolApprovalRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppToolApproval unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_tools_config_contract_test.go
+++ b/appserver/protocol/app_tools_config_contract_test.go
@@ -140,8 +140,8 @@ func TestAppToolConfigsRemainStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/apply_patch_approval_params_contract_test.go
+++ b/appserver/protocol/apply_patch_approval_params_contract_test.go
@@ -139,8 +139,8 @@ func TestApplyPatchApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ApplyPatchApprovalParams unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(defs); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(defs); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/apps_config_contract_test.go
+++ b/appserver/protocol/apps_config_contract_test.go
@@ -185,8 +185,8 @@ func TestAppsConfigsRemainStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/apps_list_contract_test.go
+++ b/appserver/protocol/apps_list_contract_test.go
@@ -168,8 +168,8 @@ func TestAppsListContractsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/attestation_contract_test.go
+++ b/appserver/protocol/attestation_contract_test.go
@@ -133,8 +133,8 @@ func TestAttestationContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("attestation/generate = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
+++ b/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
@@ -179,8 +179,8 @@ func TestChatgptAuthTokensRefreshRemainsStandaloneAndDeferred(t *testing.T) {
 	if !found {
 		t.Fatal("refresh method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/exec_command_approval_params_contract_test.go
+++ b/appserver/protocol/exec_command_approval_params_contract_test.go
@@ -137,8 +137,8 @@ func TestExecCommandApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ExecCommandApprovalParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(defs); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/experimental_feature_contract_test.go
+++ b/appserver/protocol/experimental_feature_contract_test.go
@@ -41,8 +41,8 @@ func TestExperimentalFeatureContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want implemented client request", methodName, method, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d/%d/%d, want 224/59/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,8 +217,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,8 +203,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -260,8 +260,8 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,8 +244,8 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -162,8 +162,8 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -175,8 +175,8 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_contract_test.go
+++ b/appserver/protocol/file_change_contract_test.go
@@ -108,8 +108,8 @@ func TestFileChangeRemainsStandalone(t *testing.T) {
 			t.Fatalf("FileChange unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_output_delta_notification_contract_test.go
+++ b/appserver/protocol/file_change_output_delta_notification_contract_test.go
@@ -100,8 +100,8 @@ func TestFileChangeOutputDeltaNotificationRemainsDeprecatedAndStandalone(t *test
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("item/fileChange/outputDelta = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -381,8 +381,8 @@ func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_action_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_action_contract_test.go
@@ -226,8 +226,8 @@ func TestGuardianApprovalReviewActionRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReviewAction unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
@@ -164,8 +164,8 @@ func TestGuardianApprovalReviewCompletedNotificationRemainsStandalone(t *testing
 			t.Fatalf("completed notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_contract_test.go
@@ -139,8 +139,8 @@ func TestGuardianApprovalReviewRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReview unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
@@ -175,8 +175,8 @@ func TestGuardianApprovalReviewStartedNotificationRemainsStandalone(t *testing.T
 			t.Fatalf("started notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_enum_foundation_contract_test.go
+++ b/appserver/protocol/guardian_enum_foundation_contract_test.go
@@ -89,8 +89,8 @@ func TestGuardianEnumFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_metadata_list_contract_test.go
+++ b/appserver/protocol/hook_metadata_list_contract_test.go
@@ -352,8 +352,8 @@ func TestHookMetadataListContractsStayStandalone(t *testing.T) {
 			t.Errorf("standalone definition %s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Errorf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Errorf("definition count = %d, want 510", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 {
 		t.Errorf("wire binding count = %d, want 59", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_run_notification_contract_test.go
+++ b/appserver/protocol/hook_run_notification_contract_test.go
@@ -297,8 +297,8 @@ func TestHookRunNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("surface changed: %d methods, %d wire bindings, %d item bindings", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/hook_value_foundation_contract_test.go
+++ b/appserver/protocol/hook_value_foundation_contract_test.go
@@ -167,8 +167,8 @@ func TestHookValueFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 505 {
-		t.Fatalf("definition count = %d, want 505", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 510 {
+		t.Fatalf("definition count = %d, want 510", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/legacy_approval_response_contract_test.go
+++ b/appserver/protocol/legacy_approval_response_contract_test.go
@@ -98,8 +98,8 @@ func TestLegacyApprovalResponsesRemainStandaloneAndNominal(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_contract_test.go
+++ b/appserver/protocol/mcp_server_status_contract_test.go
@@ -1,0 +1,318 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestMcpServerStatusSchemasAreExact(t *testing.T) {
+	jsonValue := Schema{"$ref": "#/$defs/JsonValue"}
+	optionalString := Schema{"type": []any{"string", "null"}}
+	wants := map[string]Schema{
+		"Resource": {
+			"type": "object", "description": "A known resource that the server is capable of reading.",
+			"properties": Schema{
+				"_meta": jsonValue, "annotations": jsonValue, "description": optionalString,
+				"icons":    Schema{"type": []any{"array", "null"}, "items": jsonValue},
+				"mimeType": optionalString, "name": Schema{"type": "string"},
+				"size":  Schema{"type": []any{"integer", "null"}, "format": "int64"},
+				"title": optionalString, "uri": Schema{"type": "string"},
+			},
+			"required": []string{"name", "uri"},
+		},
+		"ResourceTemplate": {
+			"type": "object", "description": "A template description for resources available on the server.",
+			"properties": Schema{
+				"annotations": jsonValue, "description": optionalString, "mimeType": optionalString,
+				"name": Schema{"type": "string"}, "title": optionalString,
+				"uriTemplate": Schema{"type": "string"},
+			},
+			"required": []string{"name", "uriTemplate"},
+		},
+		"Tool": {
+			"type": "object", "description": "Definition for a tool the client can call.",
+			"properties": Schema{
+				"_meta": jsonValue, "annotations": jsonValue, "description": optionalString,
+				"icons":       Schema{"type": []any{"array", "null"}, "items": jsonValue},
+				"inputSchema": jsonValue, "name": Schema{"type": "string"},
+				"outputSchema": jsonValue, "title": optionalString,
+			},
+			"required": []string{"inputSchema", "name"},
+		},
+		"McpServerStatus": {
+			"type": "object",
+			"properties": Schema{
+				"authStatus":        Schema{"$ref": "#/$defs/McpAuthStatus"},
+				"name":              Schema{"type": "string"},
+				"resourceTemplates": Schema{"type": "array", "items": Schema{"$ref": "#/$defs/ResourceTemplate"}},
+				"resources":         Schema{"type": "array", "items": Schema{"$ref": "#/$defs/Resource"}},
+				"serverInfo": Schema{"anyOf": []any{
+					Schema{"$ref": "#/$defs/McpServerInfo"}, Schema{"type": "null"},
+				}},
+				"tools": Schema{"type": "object", "additionalProperties": Schema{"$ref": "#/$defs/Tool"}},
+			},
+			"required": []string{"authStatus", "name", "resourceTemplates", "resources", "tools"},
+		},
+		"ListMcpServerStatusResponse": {
+			"type": "object",
+			"properties": Schema{
+				"data": Schema{"type": "array", "items": Schema{"$ref": "#/$defs/McpServerStatus"}},
+				"nextCursor": Schema{
+					"description": "Opaque cursor to pass to the next call to continue after the last item. If None, there are no more items to return.",
+					"type":        []any{"string", "null"},
+				},
+			},
+			"required": []string{"data"},
+		},
+	}
+	defs := JSONSchema()["$defs"].(Schema)
+	for name, want := range wants {
+		if got := defs[name]; !reflect.DeepEqual(got, want) {
+			t.Errorf("%s = %#v, want %#v", name, got, want)
+		}
+	}
+}
+
+func TestMcpResourcePreservesSerdeWireForms(t *testing.T) {
+	roundTripMcpStatus[Resource](t,
+		`{"name":"","uri":""}`,
+		`{"name":"","uri":""}`,
+	)
+	roundTripMcpStatus[Resource](t,
+		`{"future":1,"name":" resource ","title":"","description":" desc ","mimeType":"text/plain",`+
+			`"size":9223372036854775807,"uri":"scheme://value","annotations":{"z":2,"a":1},`+
+			`"icons":[],"_meta":[true,null]}`,
+		`{"annotations":{"a":1,"z":2},"description":" desc ","mimeType":"text/plain","name":" resource ",`+
+			`"size":9223372036854775807,"title":"","uri":"scheme://value","icons":[],"_meta":[true,null]}`,
+	)
+	roundTripMcpStatus[Resource](t,
+		`{"name":"r","uri":"u","title":null,"description":null,"mimeType":null,"size":null,`+
+			`"annotations":null,"icons":null,"_meta":null}`,
+		`{"name":"r","uri":"u"}`,
+	)
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`, `{}`, `{"name":"r"}`, `{"uri":"u"}`,
+		`{"name":null,"uri":"u"}`, `{"name":"r","uri":null}`, `{"name":"r","uri":"u","size":1.5}`,
+		`{"name":"r","uri":"u","size":9223372036854775808}`, `{"name":"r","uri":"u","icons":{}}`,
+		`{"name":"r","uri":"u","annotations":}`, `{"name":"a","name":"b","uri":"u"}`,
+		`{"name":"r","uri":"a","uri":"b"}`, `{"name":"r","uri":"u"} {}`,
+	} {
+		assertJSONRejects[Resource](t, input)
+	}
+}
+
+func TestMcpResourceTemplatePreservesSerdeWireForms(t *testing.T) {
+	roundTripMcpStatus[ResourceTemplate](t,
+		`{"name":"","uriTemplate":""}`,
+		`{"uriTemplate":"","name":""}`,
+	)
+	roundTripMcpStatus[ResourceTemplate](t,
+		`{"future":true,"annotations":{"b":2,"a":1},"uriTemplate":"file:///{path}","name":"template",`+
+			`"title":"Title","description":"Description","mimeType":"application/json"}`,
+		`{"annotations":{"a":1,"b":2},"uriTemplate":"file:///{path}","name":"template",`+
+			`"title":"Title","description":"Description","mimeType":"application/json"}`,
+	)
+	roundTripMcpStatus[ResourceTemplate](t,
+		`{"annotations":null,"uriTemplate":"u","name":"n","title":null,"description":null,"mimeType":null}`,
+		`{"uriTemplate":"u","name":"n"}`,
+	)
+	for _, input := range []string{
+		`null`, `{}`, `{"name":"n"}`, `{"uriTemplate":"u"}`, `{"name":null,"uriTemplate":"u"}`,
+		`{"name":"n","uriTemplate":null}`, `{"name":"n","uri_template":"u"}`,
+		`{"name":"n","uriTemplate":"u","annotations":}`, `{"name":"a","name":"b","uriTemplate":"u"}`,
+	} {
+		assertJSONRejects[ResourceTemplate](t, input)
+	}
+}
+
+func TestMcpToolPreservesSerdeWireForms(t *testing.T) {
+	roundTripMcpStatus[Tool](t,
+		`{"name":"","inputSchema":null}`,
+		`{"name":"","inputSchema":null}`,
+	)
+	roundTripMcpStatus[Tool](t,
+		`{"future":1,"name":"tool","title":"Title","description":"Description",`+
+			`"inputSchema":{"type":"object","properties":{"x":{"type":"string"}}},`+
+			`"outputSchema":{},"annotations":{"readOnlyHint":true},"icons":[],"_meta":{"z":2,"a":1}}`,
+		`{"name":"tool","title":"Title","description":"Description",`+
+			`"inputSchema":{"properties":{"x":{"type":"string"}},"type":"object"},`+
+			`"outputSchema":{},"annotations":{"readOnlyHint":true},"icons":[],"_meta":{"a":1,"z":2}}`,
+	)
+	roundTripMcpStatus[Tool](t,
+		`{"name":"tool","title":null,"description":null,"inputSchema":{},"outputSchema":null,`+
+			`"annotations":null,"icons":null,"_meta":null}`,
+		`{"name":"tool","inputSchema":{}}`,
+	)
+	for _, input := range []string{
+		`null`, `{}`, `{"name":"tool"}`, `{"inputSchema":{}}`, `{"name":null,"inputSchema":{}}`,
+		`{"name":"tool","inputSchema":}`, `{"name":"tool","input_schema":{}}`,
+		`{"name":"a","name":"b","inputSchema":{}}`, `{"name":"tool","inputSchema":{},"inputSchema":{}}`,
+	} {
+		assertJSONRejects[Tool](t, input)
+	}
+}
+
+func TestMcpServerStatusAndListResponsePreserveSerdeWireForms(t *testing.T) {
+	minimalStatus := `{"name":"server","tools":{},"resources":[],"resourceTemplates":[],"authStatus":"unsupported"}`
+	roundTripMcpStatus[McpServerStatus](t, minimalStatus,
+		`{"name":"server","serverInfo":null,"tools":{},"resources":[],"resourceTemplates":[],"authStatus":"unsupported"}`,
+	)
+	roundTripMcpStatus[McpServerStatus](t,
+		`{"future":true,"name":"server","serverInfo":null,"tools":{"z":{"name":"old","inputSchema":{}},`+
+			`"a":{"name":"a","inputSchema":null}},"resources":[{"name":"r","uri":"u"}],`+
+			`"resourceTemplates":[{"name":"t","uriTemplate":"x/{id}"}],"authStatus":"oAuth"}`,
+		`{"name":"server","serverInfo":null,"tools":{"a":{"name":"a","inputSchema":null},`+
+			`"z":{"name":"old","inputSchema":{}}},"resources":[{"name":"r","uri":"u"}],`+
+			`"resourceTemplates":[{"uriTemplate":"x/{id}","name":"t"}],"authStatus":"oAuth"}`,
+	)
+	roundTripMcpStatus[ListMcpServerStatusResponse](t,
+		`{"data":[`+minimalStatus+`],"future":1}`,
+		`{"data":[{"name":"server","serverInfo":null,"tools":{},"resources":[],"resourceTemplates":[],`+
+			`"authStatus":"unsupported"}],"nextCursor":null}`,
+	)
+	roundTripMcpStatus[ListMcpServerStatusResponse](t,
+		`{"data":[],"nextCursor":" next "}`,
+		`{"data":[],"nextCursor":" next "}`,
+	)
+	for _, input := range []string{
+		`null`, `{}`, `{"name":"server","tools":{},"resources":[],"resourceTemplates":[]}`,
+		`{"name":"server","tools":null,"resources":[],"resourceTemplates":[],"authStatus":"unsupported"}`,
+		`{"name":"server","tools":{},"resources":null,"resourceTemplates":[],"authStatus":"unsupported"}`,
+		`{"name":"server","tools":{},"resources":[],"resourceTemplates":null,"authStatus":"unsupported"}`,
+		`{"name":"server","tools":{"x":null},"resources":[],"resourceTemplates":[],"authStatus":"unsupported"}`,
+		`{"name":"server","tools":{},"resources":[null],"resourceTemplates":[],"authStatus":"unsupported"}`,
+		`{"name":"server","tools":{},"resources":[],"resourceTemplates":[],"authStatus":"unknown"}`,
+		`{"name":"a","name":"b","tools":{},"resources":[],"resourceTemplates":[],"authStatus":"unsupported"}`,
+	} {
+		assertJSONRejects[McpServerStatus](t, input)
+	}
+	for _, input := range []string{
+		`null`, `{}`, `{"data":null}`, `{"data":{}}`, `{"data":[null]}`, `{"data":[],"nextCursor":1}`,
+		`{"data":[],"data":[]}`, `{"data":[]} {}`,
+	} {
+		assertJSONRejects[ListMcpServerStatusResponse](t, input)
+	}
+}
+
+func TestMcpServerStatusToolMapUsesSerdeLastWins(t *testing.T) {
+	input := `{"name":"server","tools":{"same":{"name":"first","inputSchema":{}},` +
+		`"same":{"name":"second","inputSchema":null}},"resources":[],"resourceTemplates":[],"authStatus":"bearerToken"}`
+	var status McpServerStatus
+	if err := json.Unmarshal([]byte(input), &status); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got := status.Tools["same"].Name; got != "second" {
+		t.Fatalf("duplicate map key name = %q, want second", got)
+	}
+}
+
+func TestMcpServerStatusRejectsInvalidConstructedValues(t *testing.T) {
+	for name, value := range map[string]any{
+		"resource JSON": Resource{Name: "r", URI: "u", Annotations: &JsonValue{}},
+		"template JSON": ResourceTemplate{Name: "t", URITemplate: "u", Annotations: &JsonValue{}},
+		"tool JSON":     Tool{Name: "t", InputSchema: JsonValue{}},
+		"nil tools":     McpServerStatus{Name: "s", Resources: []Resource{}, ResourceTemplates: []ResourceTemplate{}, AuthStatus: McpAuthStatusUnsupported},
+		"nil resources": McpServerStatus{Name: "s", Tools: map[string]Tool{}, ResourceTemplates: []ResourceTemplate{}, AuthStatus: McpAuthStatusUnsupported},
+		"nil templates": McpServerStatus{Name: "s", Tools: map[string]Tool{}, Resources: []Resource{}, AuthStatus: McpAuthStatusUnsupported},
+		"nil data":      ListMcpServerStatusResponse{},
+	} {
+		if _, err := json.Marshal(value); err == nil {
+			t.Errorf("%s marshaled", name)
+		}
+	}
+	var nilIcons []JsonValue
+	if encoded, err := json.Marshal(Resource{Name: "r", URI: "u", Icons: &nilIcons}); err != nil ||
+		string(encoded) != `{"name":"r","uri":"u","icons":[]}` {
+		t.Errorf("resource nil icon slice = %s, %v", encoded, err)
+	}
+	inputSchema := mustMcpStatusJSONValue(t, `{}`)
+	if encoded, err := json.Marshal(Tool{Name: "t", InputSchema: inputSchema, Icons: &nilIcons}); err != nil ||
+		string(encoded) != `{"name":"t","inputSchema":{},"icons":[]}` {
+		t.Errorf("tool nil icon slice = %s, %v", encoded, err)
+	}
+	var resource *Resource
+	if err := resource.UnmarshalJSON([]byte(`{"name":"r","uri":"u"}`)); err == nil {
+		t.Error("nil Resource receiver succeeded")
+	}
+	var template *ResourceTemplate
+	if err := template.UnmarshalJSON([]byte(`{"name":"t","uriTemplate":"u"}`)); err == nil {
+		t.Error("nil ResourceTemplate receiver succeeded")
+	}
+	var tool *Tool
+	if err := tool.UnmarshalJSON([]byte(`{"name":"t","inputSchema":{}}`)); err == nil {
+		t.Error("nil Tool receiver succeeded")
+	}
+	var status *McpServerStatus
+	if err := status.UnmarshalJSON([]byte(`{}`)); err == nil {
+		t.Error("nil McpServerStatus receiver succeeded")
+	}
+	var response *ListMcpServerStatusResponse
+	if err := response.UnmarshalJSON([]byte(`{}`)); err == nil {
+		t.Error("nil ListMcpServerStatusResponse receiver succeeded")
+	}
+}
+
+func mustMcpStatusJSONValue(t *testing.T, input string) JsonValue {
+	t.Helper()
+	var value JsonValue
+	if err := json.Unmarshal([]byte(input), &value); err != nil {
+		t.Fatalf("decode JSON value: %v", err)
+	}
+	return value
+}
+
+func TestMcpServerStatusContractsRemainStandalone(t *testing.T) {
+	names := []string{"Resource", "ResourceTemplate", "Tool", "McpServerStatus", "ListMcpServerStatusResponse"}
+	for _, binding := range WireTypeBindings() {
+		for _, name := range names {
+			if slices.Contains(binding.Params, name) || slices.Contains(binding.Result, name) {
+				t.Fatalf("%s unexpectedly bound to %s", name, binding.Method)
+			}
+		}
+	}
+	method, ok := LookupMethod("mcpServerStatus/list")
+	if !ok || method.State != MethodImplemented {
+		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", method, ok)
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
+	}
+	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("counts = %d/%d/%d, want 224/59/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
+	}
+}
+
+func TestMcpServerStatusTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	for _, want := range []string{
+		`export type Resource = {`, `"annotations"?: JsonValue;`, `"icons"?: Array<JsonValue>;`,
+		`"size"?: number;`, `"uri": string;`, `export type ResourceTemplate = {`,
+		`"uriTemplate": string;`, `export type Tool = {`, `"inputSchema": JsonValue;`,
+		`"outputSchema"?: JsonValue;`, `export type McpServerStatus = {`,
+		`"serverInfo": McpServerInfo | null;`, `"tools": { [key in string]?: Tool };`,
+		`export type ListMcpServerStatusResponse = {`, `"data": Array<McpServerStatus>;`,
+		`"nextCursor": string | null;`,
+	} {
+		if !strings.Contains(string(generated), want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}
+
+func roundTripMcpStatus[T any](t *testing.T, input, want string) {
+	t.Helper()
+	var value T
+	if err := json.Unmarshal([]byte(input), &value); err != nil {
+		t.Fatalf("Unmarshal(%s): %v", input, err)
+	}
+	encoded, err := json.Marshal(value)
+	if err != nil || string(encoded) != want {
+		t.Fatalf("round trip %s = %s, %v; want %s", input, encoded, err, want)
+	}
+}

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_types.go
+++ b/appserver/protocol/mcp_server_status_types.go
@@ -1,0 +1,354 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// Resource is one exact public MCP resource descriptor.
+type Resource struct {
+	Annotations *JsonValue   `json:"annotations,omitempty"`
+	Description *string      `json:"description,omitempty"`
+	MimeType    *string      `json:"mimeType,omitempty"`
+	Name        string       `json:"name"`
+	Size        *int64       `json:"size,omitempty"`
+	Title       *string      `json:"title,omitempty"`
+	URI         string       `json:"uri"`
+	Icons       *[]JsonValue `json:"icons,omitempty"`
+	Meta        *JsonValue   `json:"_meta,omitempty"`
+}
+
+func (r Resource) MarshalJSON() ([]byte, error) {
+	if r.Icons != nil && *r.Icons == nil {
+		icons := []JsonValue{}
+		r.Icons = &icons
+	}
+	type wire Resource
+	return json.Marshal(wire(r))
+}
+
+func (r *Resource) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("decode MCP resource into nil receiver")
+	}
+	const objectName = "MCP resource"
+	payload, err := decodeRustSerdeObject(
+		data, objectName,
+		"annotations", "description", "mimeType", "name", "size", "title", "uri", "icons", "_meta",
+	)
+	if err != nil {
+		return err
+	}
+	name, err := decodeRequiredThreadItemValue[string](payload, objectName, "name")
+	if err != nil {
+		return err
+	}
+	uri, err := decodeRequiredThreadItemValue[string](payload, objectName, "uri")
+	if err != nil {
+		return err
+	}
+	annotations, err := decodeOptionalNullableMcpStatusValue[JsonValue](payload, objectName, "annotations")
+	if err != nil {
+		return err
+	}
+	description, err := decodeOptionalNullableMcpStatusValue[string](payload, objectName, "description")
+	if err != nil {
+		return err
+	}
+	mimeType, err := decodeOptionalNullableMcpStatusValue[string](payload, objectName, "mimeType")
+	if err != nil {
+		return err
+	}
+	size, err := decodeOptionalNullableMcpStatusValue[int64](payload, objectName, "size")
+	if err != nil {
+		return err
+	}
+	title, err := decodeOptionalNullableMcpStatusValue[string](payload, objectName, "title")
+	if err != nil {
+		return err
+	}
+	icons, err := decodeOptionalNullableMcpStatusValue[[]JsonValue](payload, objectName, "icons")
+	if err != nil {
+		return err
+	}
+	meta, err := decodeOptionalNullableMcpStatusValue[JsonValue](payload, objectName, "_meta")
+	if err != nil {
+		return err
+	}
+	*r = Resource{
+		Annotations: annotations, Description: description, MimeType: mimeType, Name: name,
+		Size: size, Title: title, URI: uri, Icons: icons, Meta: meta,
+	}
+	return nil
+}
+
+// ResourceTemplate is one exact public MCP resource-template descriptor.
+type ResourceTemplate struct {
+	Annotations *JsonValue `json:"annotations,omitempty"`
+	URITemplate string     `json:"uriTemplate"`
+	Name        string     `json:"name"`
+	Title       *string    `json:"title,omitempty"`
+	Description *string    `json:"description,omitempty"`
+	MimeType    *string    `json:"mimeType,omitempty"`
+}
+
+func (r *ResourceTemplate) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("decode MCP resource template into nil receiver")
+	}
+	const objectName = "MCP resource template"
+	payload, err := decodeRustSerdeObject(
+		data, objectName, "annotations", "uriTemplate", "name", "title", "description", "mimeType",
+	)
+	if err != nil {
+		return err
+	}
+	uriTemplate, err := decodeRequiredThreadItemValue[string](payload, objectName, "uriTemplate")
+	if err != nil {
+		return err
+	}
+	name, err := decodeRequiredThreadItemValue[string](payload, objectName, "name")
+	if err != nil {
+		return err
+	}
+	annotations, err := decodeOptionalNullableMcpStatusValue[JsonValue](payload, objectName, "annotations")
+	if err != nil {
+		return err
+	}
+	title, err := decodeOptionalNullableMcpStatusValue[string](payload, objectName, "title")
+	if err != nil {
+		return err
+	}
+	description, err := decodeOptionalNullableMcpStatusValue[string](payload, objectName, "description")
+	if err != nil {
+		return err
+	}
+	mimeType, err := decodeOptionalNullableMcpStatusValue[string](payload, objectName, "mimeType")
+	if err != nil {
+		return err
+	}
+	*r = ResourceTemplate{
+		Annotations: annotations, URITemplate: uriTemplate, Name: name,
+		Title: title, Description: description, MimeType: mimeType,
+	}
+	return nil
+}
+
+// Tool is one exact public MCP tool definition.
+type Tool struct {
+	Name         string       `json:"name"`
+	Title        *string      `json:"title,omitempty"`
+	Description  *string      `json:"description,omitempty"`
+	InputSchema  JsonValue    `json:"inputSchema"`
+	OutputSchema *JsonValue   `json:"outputSchema,omitempty"`
+	Annotations  *JsonValue   `json:"annotations,omitempty"`
+	Icons        *[]JsonValue `json:"icons,omitempty"`
+	Meta         *JsonValue   `json:"_meta,omitempty"`
+}
+
+func (t Tool) MarshalJSON() ([]byte, error) {
+	if t.Icons != nil && *t.Icons == nil {
+		icons := []JsonValue{}
+		t.Icons = &icons
+	}
+	type wire Tool
+	return json.Marshal(wire(t))
+}
+
+func (t *Tool) UnmarshalJSON(data []byte) error {
+	if t == nil {
+		return errors.New("decode MCP tool into nil receiver")
+	}
+	const objectName = "MCP tool"
+	payload, err := decodeRustSerdeObject(
+		data, objectName,
+		"name", "title", "description", "inputSchema", "outputSchema", "annotations", "icons", "_meta",
+	)
+	if err != nil {
+		return err
+	}
+	name, err := decodeRequiredThreadItemValue[string](payload, objectName, "name")
+	if err != nil {
+		return err
+	}
+	inputSchema, err := decodeRequiredMcpStatusJSONValue(payload, objectName, "inputSchema")
+	if err != nil {
+		return err
+	}
+	title, err := decodeOptionalNullableMcpStatusValue[string](payload, objectName, "title")
+	if err != nil {
+		return err
+	}
+	description, err := decodeOptionalNullableMcpStatusValue[string](payload, objectName, "description")
+	if err != nil {
+		return err
+	}
+	outputSchema, err := decodeOptionalNullableMcpStatusValue[JsonValue](payload, objectName, "outputSchema")
+	if err != nil {
+		return err
+	}
+	annotations, err := decodeOptionalNullableMcpStatusValue[JsonValue](payload, objectName, "annotations")
+	if err != nil {
+		return err
+	}
+	icons, err := decodeOptionalNullableMcpStatusValue[[]JsonValue](payload, objectName, "icons")
+	if err != nil {
+		return err
+	}
+	meta, err := decodeOptionalNullableMcpStatusValue[JsonValue](payload, objectName, "_meta")
+	if err != nil {
+		return err
+	}
+	*t = Tool{
+		Name: name, Title: title, Description: description, InputSchema: inputSchema,
+		OutputSchema: outputSchema, Annotations: annotations, Icons: icons, Meta: meta,
+	}
+	return nil
+}
+
+// McpServerStatus is the exact public MCP inventory projection. Gollem's live
+// status response remains a separate runtime contract until an adapter exists.
+type McpServerStatus struct {
+	Name              string             `json:"name"`
+	ServerInfo        *McpServerInfo     `json:"serverInfo"`
+	Tools             map[string]Tool    `json:"tools" jsonschema:"nonnullable=true"`
+	Resources         []Resource         `json:"resources" jsonschema:"nonnullable=true"`
+	ResourceTemplates []ResourceTemplate `json:"resourceTemplates" jsonschema:"nonnullable=true"`
+	AuthStatus        McpAuthStatus      `json:"authStatus"`
+}
+
+func (s McpServerStatus) MarshalJSON() ([]byte, error) {
+	if s.Tools == nil {
+		return nil, errors.New("MCP server status tools cannot be null")
+	}
+	if s.Resources == nil {
+		return nil, errors.New("MCP server status resources cannot be null")
+	}
+	if s.ResourceTemplates == nil {
+		return nil, errors.New("MCP server status resourceTemplates cannot be null")
+	}
+	type wire McpServerStatus
+	return json.Marshal(wire(s))
+}
+
+func (s *McpServerStatus) UnmarshalJSON(data []byte) error {
+	if s == nil {
+		return errors.New("decode MCP server status into nil receiver")
+	}
+	const objectName = "MCP server status"
+	payload, err := decodeRustSerdeObject(
+		data, objectName, "name", "serverInfo", "tools", "resources", "resourceTemplates", "authStatus",
+	)
+	if err != nil {
+		return err
+	}
+	name, err := decodeRequiredThreadItemValue[string](payload, objectName, "name")
+	if err != nil {
+		return err
+	}
+	serverInfo, err := decodeOptionalNullableMcpStatusValue[McpServerInfo](payload, objectName, "serverInfo")
+	if err != nil {
+		return err
+	}
+	tools, err := decodeRequiredThreadItemValue[map[string]Tool](payload, objectName, "tools")
+	if err != nil {
+		return err
+	}
+	resources, err := decodeRequiredThreadItemArray[Resource](payload, objectName, "resources")
+	if err != nil {
+		return err
+	}
+	resourceTemplates, err := decodeRequiredThreadItemArray[ResourceTemplate](payload, objectName, "resourceTemplates")
+	if err != nil {
+		return err
+	}
+	authStatus, err := decodeRequiredThreadItemValue[McpAuthStatus](payload, objectName, "authStatus")
+	if err != nil {
+		return err
+	}
+	*s = McpServerStatus{
+		Name: name, ServerInfo: serverInfo, Tools: tools, Resources: resources,
+		ResourceTemplates: resourceTemplates, AuthStatus: authStatus,
+	}
+	return nil
+}
+
+// ListMcpServerStatusResponse is one exact public MCP inventory page.
+type ListMcpServerStatusResponse struct {
+	Data       []McpServerStatus `json:"data" jsonschema:"nonnullable=true"`
+	NextCursor *string           `json:"nextCursor"`
+}
+
+func (r ListMcpServerStatusResponse) MarshalJSON() ([]byte, error) {
+	if r.Data == nil {
+		return nil, errors.New("MCP server status-list response data cannot be null")
+	}
+	type wire ListMcpServerStatusResponse
+	return json.Marshal(wire(r))
+}
+
+func (r *ListMcpServerStatusResponse) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("decode MCP server status-list response into nil receiver")
+	}
+	const objectName = "MCP server status-list response"
+	payload, err := decodeRustSerdeObject(data, objectName, "data", "nextCursor")
+	if err != nil {
+		return err
+	}
+	dataValues, err := decodeRequiredThreadItemArray[McpServerStatus](payload, objectName, "data")
+	if err != nil {
+		return err
+	}
+	nextCursor, err := decodeOptionalNullableMcpStatusValue[string](payload, objectName, "nextCursor")
+	if err != nil {
+		return err
+	}
+	*r = ListMcpServerStatusResponse{Data: dataValues, NextCursor: nextCursor}
+	return nil
+}
+
+func decodeOptionalNullableMcpStatusValue[T any](
+	payload map[string]json.RawMessage,
+	objectName string,
+	fieldName string,
+) (*T, error) {
+	raw, ok := payload[fieldName]
+	if !ok || isJSONNull(raw) {
+		return nil, nil
+	}
+	var value T
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return nil, fmt.Errorf("decode %s %s: %w", objectName, fieldName, err)
+	}
+	return &value, nil
+}
+
+func decodeRequiredMcpStatusJSONValue(
+	payload map[string]json.RawMessage,
+	objectName string,
+	fieldName string,
+) (JsonValue, error) {
+	raw, ok := payload[fieldName]
+	if !ok {
+		return JsonValue{}, fmt.Errorf("%s requires %s", objectName, fieldName)
+	}
+	var value JsonValue
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return JsonValue{}, fmt.Errorf("decode %s %s: %w", objectName, fieldName, err)
+	}
+	return value, nil
+}
+
+var (
+	_ json.Marshaler   = Resource{}
+	_ json.Unmarshaler = (*Resource)(nil)
+	_ json.Unmarshaler = (*ResourceTemplate)(nil)
+	_ json.Marshaler   = Tool{}
+	_ json.Unmarshaler = (*Tool)(nil)
+	_ json.Marshaler   = McpServerStatus{}
+	_ json.Unmarshaler = (*McpServerStatus)(nil)
+	_ json.Marshaler   = ListMcpServerStatusResponse{}
+	_ json.Unmarshaler = (*ListMcpServerStatusResponse)(nil)
+)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_approval_context_contract_test.go
+++ b/appserver/protocol/network_approval_context_contract_test.go
@@ -84,8 +84,8 @@ func TestNetworkApprovalContextRemainsStandalone(t *testing.T) {
 			t.Fatalf("NetworkApprovalContext unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/parsed_command_contract_test.go
+++ b/appserver/protocol/parsed_command_contract_test.go
@@ -120,8 +120,8 @@ func TestParsedCommandRemainsStandalone(t *testing.T) {
 			t.Fatalf("ParsedCommand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/process_contracts_contract_test.go
+++ b/appserver/protocol/process_contracts_contract_test.go
@@ -308,8 +308,8 @@ func TestProcessContractsRemainStandaloneFromLegacyRuntime(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want unchanged implemented notification", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 505 {
-		t.Fatalf("definition count = %d, want 505", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 510 {
+		t.Fatalf("definition count = %d, want 510", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 505 {
-		t.Fatalf("definition count = %d, want 505", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 510 {
+		t.Fatalf("definition count = %d, want 510", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 505 {
-		t.Fatalf("definition count = %d, want 505", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 510 {
+		t.Fatalf("definition count = %d, want 510", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 505 {
-		t.Fatalf("definition count = %d, want 505", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 510 {
+		t.Fatalf("definition count = %d, want 510", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 505 {
-		t.Fatalf("definition count = %d, want 505", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 510 {
+		t.Fatalf("definition count = %d, want 510", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/review_decision_contract_test.go
+++ b/appserver/protocol/review_decision_contract_test.go
@@ -136,8 +136,8 @@ func TestReviewDecisionRemainsStandalone(t *testing.T) {
 			t.Fatalf("ReviewDecision unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(defs); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -269,6 +269,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "ItemStartedNotification", Type: reflect.TypeFor[ItemStartedNotification]()},
 		{Name: "LegacyAppPathString", Type: reflect.TypeFor[LegacyAppPathString]()},
 		{Name: "ListMcpServerStatusParams", Type: reflect.TypeFor[ListMcpServerStatusParams]()},
+		{Name: "ListMcpServerStatusResponse", Type: reflect.TypeFor[ListMcpServerStatusResponse]()},
 		{Name: "LoginAccountParams", Type: reflect.TypeFor[LoginAccountParams]()},
 		{Name: "LoginAccountResponse", Type: reflect.TypeFor[LoginAccountResponse]()},
 		{Name: "LoginAppBrand", Type: reflect.TypeFor[LoginAppBrand]()},
@@ -293,6 +294,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "McpServerToolCallResponse", Type: reflect.TypeFor[McpServerToolCallResponse]()},
 		{Name: "McpServerStartupFailureReason", Type: reflect.TypeFor[McpServerStartupFailureReason]()},
 		{Name: "McpServerStartupState", Type: reflect.TypeFor[McpServerStartupState]()},
+		{Name: "McpServerStatus", Type: reflect.TypeFor[McpServerStatus]()},
 		{Name: "McpServerStatusDetail", Type: reflect.TypeFor[McpServerStatusDetail]()},
 		{Name: "McpServerStatusUpdatedNotification", Type: reflect.TypeFor[McpServerStatusUpdatedNotification]()},
 		{Name: "McpToolCallAppContext", Type: reflect.TypeFor[McpToolCallAppContext]()},
@@ -439,7 +441,9 @@ func wireSchemaDefinitions() Schema {
 		{Name: "ReasoningItemReasoningSummary", Type: reflect.TypeFor[ReasoningItemReasoningSummary]()},
 		{Name: "ResidencyRequirement", Type: reflect.TypeFor[ResidencyRequirement]()},
 		{Name: "RawResponseItemCompletedNotification", Type: reflect.TypeFor[RawResponseItemCompletedNotification]()},
+		{Name: "Resource", Type: reflect.TypeFor[Resource]()},
 		{Name: "ResourceContent", Type: reflect.TypeFor[ResourceContent]()},
+		{Name: "ResourceTemplate", Type: reflect.TypeFor[ResourceTemplate]()},
 		{Name: "ResponseItem", Type: reflect.TypeFor[ResponseItem]()},
 		{Name: "ReviewDecision", Type: reflect.TypeFor[ReviewDecision]()},
 		{Name: "ResponsesApiWebSearchAction", Type: reflect.TypeFor[ResponsesApiWebSearchAction]()},
@@ -528,6 +532,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "TimelineItem", Type: reflect.TypeFor[TimelineItem]()},
 		{Name: "TokenUsage", Type: reflect.TypeFor[TokenUsage]()},
 		{Name: "TokenUsageBreakdown", Type: reflect.TypeFor[TokenUsageBreakdown]()},
+		{Name: "Tool", Type: reflect.TypeFor[Tool]()},
 		{Name: "ToolPayloadSummary", Type: reflect.TypeFor[ToolPayloadSummary]()},
 		{Name: "ToolRequestUserInputAnswer", Type: reflect.TypeFor[ToolRequestUserInputAnswer]()},
 		{Name: "ToolRequestUserInputOption", Type: reflect.TypeFor[ToolRequestUserInputOption]()},
@@ -877,9 +882,14 @@ func wireSchemaDefinitions() Schema {
 		string(McpServerStatusDetailFull), string(McpServerStatusDetailToolsAndAuthOnly),
 	)
 	schemas["ListMcpServerStatusParams"] = listMcpServerStatusParamsSchema()
+	schemas["ListMcpServerStatusResponse"] = listMcpServerStatusResponseSchema()
 	schemas["McpResourceReadParams"] = mcpResourceReadParamsSchema()
 	schemas["McpResourceReadResponse"] = mcpResourceReadResponseSchema()
 	schemas["McpServerInfo"] = mcpServerInfoSchema()
+	schemas["McpServerStatus"] = mcpServerStatusSchema()
+	schemas["Resource"] = mcpResourceSchema()
+	schemas["ResourceTemplate"] = mcpResourceTemplateSchema()
+	schemas["Tool"] = mcpToolSchema()
 	schemas["McpServerMigration"] = mcpServerMigrationSchema()
 	schemas["PluginsMigration"] = pluginsMigrationSchema()
 	schemas["SkillMigration"] = skillMigrationSchema()
@@ -2737,6 +2747,96 @@ func mcpServerToolCallParamsSchema() Schema {
 		"arguments": Schema{"$ref": "#/$defs/JsonValue"},
 		"_meta":     Schema{"$ref": "#/$defs/JsonValue"},
 	}, []string{"server", "threadId", "tool"})
+}
+
+func mcpResourceSchema() Schema {
+	return Schema{
+		"type":        "object",
+		"description": "A known resource that the server is capable of reading.",
+		"properties": Schema{
+			"_meta":       Schema{"$ref": "#/$defs/JsonValue"},
+			"annotations": Schema{"$ref": "#/$defs/JsonValue"},
+			"description": Schema{"type": []any{"string", "null"}},
+			"icons": Schema{
+				"type": []any{"array", "null"}, "items": Schema{"$ref": "#/$defs/JsonValue"},
+			},
+			"mimeType": Schema{"type": []any{"string", "null"}},
+			"name":     Schema{"type": "string"},
+			"size":     Schema{"type": []any{"integer", "null"}, "format": "int64"},
+			"title":    Schema{"type": []any{"string", "null"}},
+			"uri":      Schema{"type": "string"},
+		},
+		"required": []string{"name", "uri"},
+	}
+}
+
+func mcpResourceTemplateSchema() Schema {
+	return Schema{
+		"type":        "object",
+		"description": "A template description for resources available on the server.",
+		"properties": Schema{
+			"annotations": Schema{"$ref": "#/$defs/JsonValue"},
+			"description": Schema{"type": []any{"string", "null"}},
+			"mimeType":    Schema{"type": []any{"string", "null"}},
+			"name":        Schema{"type": "string"},
+			"title":       Schema{"type": []any{"string", "null"}},
+			"uriTemplate": Schema{"type": "string"},
+		},
+		"required": []string{"name", "uriTemplate"},
+	}
+}
+
+func mcpToolSchema() Schema {
+	return Schema{
+		"type":        "object",
+		"description": "Definition for a tool the client can call.",
+		"properties": Schema{
+			"_meta":        Schema{"$ref": "#/$defs/JsonValue"},
+			"annotations":  Schema{"$ref": "#/$defs/JsonValue"},
+			"description":  Schema{"type": []any{"string", "null"}},
+			"icons":        Schema{"type": []any{"array", "null"}, "items": Schema{"$ref": "#/$defs/JsonValue"}},
+			"inputSchema":  Schema{"$ref": "#/$defs/JsonValue"},
+			"name":         Schema{"type": "string"},
+			"outputSchema": Schema{"$ref": "#/$defs/JsonValue"},
+			"title":        Schema{"type": []any{"string", "null"}},
+		},
+		"required": []string{"inputSchema", "name"},
+	}
+}
+
+func mcpServerStatusSchema() Schema {
+	return Schema{
+		"type": "object",
+		"properties": Schema{
+			"authStatus": Schema{"$ref": "#/$defs/McpAuthStatus"},
+			"name":       Schema{"type": "string"},
+			"resourceTemplates": Schema{
+				"type": "array", "items": Schema{"$ref": "#/$defs/ResourceTemplate"},
+			},
+			"resources": Schema{"type": "array", "items": Schema{"$ref": "#/$defs/Resource"}},
+			"serverInfo": Schema{"anyOf": []any{
+				Schema{"$ref": "#/$defs/McpServerInfo"}, Schema{"type": "null"},
+			}},
+			"tools": Schema{
+				"type": "object", "additionalProperties": Schema{"$ref": "#/$defs/Tool"},
+			},
+		},
+		"required": []string{"authStatus", "name", "resourceTemplates", "resources", "tools"},
+	}
+}
+
+func listMcpServerStatusResponseSchema() Schema {
+	return Schema{
+		"type": "object",
+		"properties": Schema{
+			"data": Schema{"type": "array", "items": Schema{"$ref": "#/$defs/McpServerStatus"}},
+			"nextCursor": Schema{
+				"description": "Opaque cursor to pass to the next call to continue after the last item. If None, there are no more items to return.",
+				"type":        []any{"string", "null"},
+			},
+		},
+		"required": []string{"data"},
+	}
 }
 
 func mcpServerToolCallResponseSchema() Schema {

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -7324,6 +7324,27 @@
       },
       "type": "object"
     },
+    "ListMcpServerStatusResponse": {
+      "properties": {
+        "data": {
+          "items": {
+            "$ref": "#/$defs/McpServerStatus"
+          },
+          "type": "array"
+        },
+        "nextCursor": {
+          "description": "Opaque cursor to pass to the next call to continue after the last item. If None, there are no more items to return.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "data"
+      ],
+      "type": "object"
+    },
     "LocalShellAction": {
       "oneOf": [
         {
@@ -8760,6 +8781,52 @@
         "cancelled"
       ],
       "type": "string"
+    },
+    "McpServerStatus": {
+      "properties": {
+        "authStatus": {
+          "$ref": "#/$defs/McpAuthStatus"
+        },
+        "name": {
+          "type": "string"
+        },
+        "resourceTemplates": {
+          "items": {
+            "$ref": "#/$defs/ResourceTemplate"
+          },
+          "type": "array"
+        },
+        "resources": {
+          "items": {
+            "$ref": "#/$defs/Resource"
+          },
+          "type": "array"
+        },
+        "serverInfo": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/McpServerInfo"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "tools": {
+          "additionalProperties": {
+            "$ref": "#/$defs/Tool"
+          },
+          "type": "object"
+        }
+      },
+      "required": [
+        "authStatus",
+        "name",
+        "resourceTemplates",
+        "resources",
+        "tools"
+      ],
+      "type": "object"
     },
     "McpServerStatusDetail": {
       "enum": [
@@ -11151,6 +11218,62 @@
       ],
       "type": "string"
     },
+    "Resource": {
+      "description": "A known resource that the server is capable of reading.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/JsonValue"
+        },
+        "annotations": {
+          "$ref": "#/$defs/JsonValue"
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "icons": {
+          "items": {
+            "$ref": "#/$defs/JsonValue"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "mimeType": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "size": {
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "uri"
+      ],
+      "type": "object"
+    },
     "ResourceContent": {
       "oneOf": [
         {
@@ -11214,6 +11337,43 @@
           "type": "object"
         }
       ]
+    },
+    "ResourceTemplate": {
+      "description": "A template description for resources available on the server.",
+      "properties": {
+        "annotations": {
+          "$ref": "#/$defs/JsonValue"
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "mimeType": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "uriTemplate": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "uriTemplate"
+      ],
+      "type": "object"
     },
     "Response": {
       "additionalProperties": false,
@@ -15684,6 +15844,52 @@
         "cachedInputTokens",
         "outputTokens",
         "reasoningOutputTokens"
+      ],
+      "type": "object"
+    },
+    "Tool": {
+      "description": "Definition for a tool the client can call.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/JsonValue"
+        },
+        "annotations": {
+          "$ref": "#/$defs/JsonValue"
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "icons": {
+          "items": {
+            "$ref": "#/$defs/JsonValue"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "inputSchema": {
+          "$ref": "#/$defs/JsonValue"
+        },
+        "name": {
+          "type": "string"
+        },
+        "outputSchema": {
+          "$ref": "#/$defs/JsonValue"
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "inputSchema",
+        "name"
       ],
       "type": "object"
     },

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 505 {
-		t.Fatalf("definition count = %d, want 505", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 510 {
+		t.Fatalf("definition count = %d, want 510", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 505 {
-		t.Fatalf("definition count = %d, want 505", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 510 {
+		t.Fatalf("definition count = %d, want 510", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 505 {
-		t.Fatalf("definition count = %d, want 505", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 510 {
+		t.Fatalf("definition count = %d, want 510", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -321,6 +321,10 @@ func MarshalTypeScript() ([]byte, error) {
 				},
 			})
 		}
+		switch name {
+		case "Resource", "ResourceTemplate", "Tool", "McpServerStatus", "ListMcpServerStatusResponse":
+			definition = mcpServerStatusTypeScriptDefinition(name, definition)
+		}
 		if name == "AppToolConfig" {
 			definition = typeScriptDefinitionWithPropertySchemas(definition, Schema{
 				"enabled": nullableBooleanSchema(),
@@ -526,6 +530,66 @@ func MarshalTypeScript() ([]byte, error) {
 	writeTypeScriptWireBindings(&out)
 	writeTypeScriptItemBindings(&out)
 	return out.Bytes(), nil
+}
+
+func mcpServerStatusTypeScriptDefinition(name string, definition any) Schema {
+	schema, _ := typeScriptSchema(definition)
+	replacements := Schema{}
+	switch name {
+	case "Resource":
+		replacements = Schema{
+			"description": optionalNonNullTypeScriptSchema(Schema{"type": "string"}),
+			"icons": optionalNonNullTypeScriptSchema(Schema{
+				"type": "array", "items": Schema{"$ref": "#/$defs/JsonValue"},
+			}),
+			"mimeType": optionalNonNullTypeScriptSchema(Schema{"type": "string"}),
+			"size": optionalNonNullTypeScriptSchema(Schema{
+				"type": "integer", "format": "int64",
+			}),
+			"title": optionalNonNullTypeScriptSchema(Schema{"type": "string"}),
+		}
+	case "ResourceTemplate":
+		replacements = Schema{
+			"description": optionalNonNullTypeScriptSchema(Schema{"type": "string"}),
+			"mimeType":    optionalNonNullTypeScriptSchema(Schema{"type": "string"}),
+			"title":       optionalNonNullTypeScriptSchema(Schema{"type": "string"}),
+		}
+	case "Tool":
+		replacements = Schema{
+			"description": optionalNonNullTypeScriptSchema(Schema{"type": "string"}),
+			"icons": optionalNonNullTypeScriptSchema(Schema{
+				"type": "array", "items": Schema{"$ref": "#/$defs/JsonValue"},
+			}),
+			"title": optionalNonNullTypeScriptSchema(Schema{"type": "string"}),
+		}
+	case "McpServerStatus":
+		replacements = Schema{
+			"tools": Schema{
+				"type": "object", "additionalProperties": Schema{"$ref": "#/$defs/Tool"},
+				"x-gollem-typescript-optional-map": true,
+			},
+		}
+	case "ListMcpServerStatusResponse":
+		replacements = Schema{"nextCursor": nullableStringSchema()}
+	}
+	renderSchema := typeScriptDefinitionWithPropertySchemas(schema, replacements)
+	renderSchema["x-gollem-typescript-ignore-additional-properties"] = true
+	if name == "McpServerStatus" {
+		renderSchema["required"] = []string{
+			"authStatus", "name", "resourceTemplates", "resources", "serverInfo", "tools",
+		}
+	}
+	if name == "ListMcpServerStatusResponse" {
+		renderSchema["required"] = []string{"data", "nextCursor"}
+	}
+	return renderSchema
+}
+
+func optionalNonNullTypeScriptSchema(value Schema) Schema {
+	return Schema{
+		"anyOf":                          []any{value, Schema{"type": "null"}},
+		typeScriptOptionalNonNullKeyword: true,
+	}
 }
 
 func writeTypeScriptProtocolMetadata(out *bytes.Buffer) {

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -2033,6 +2033,11 @@ export type ListMcpServerStatusParams = {
   "threadId"?: string | null;
 };
 
+export type ListMcpServerStatusResponse = {
+  "data": Array<McpServerStatus>;
+  "nextCursor": string | null;
+};
+
 export type LocalShellAction = {
   "command": Array<string>;
   "env": Record<string, string> | null;
@@ -2343,6 +2348,15 @@ export type McpServerRefreshResponse = Record<string, never>;
 export type McpServerStartupFailureReason = "reauthenticationRequired";
 
 export type McpServerStartupState = "starting" | "ready" | "failed" | "cancelled";
+
+export type McpServerStatus = {
+  "authStatus": McpAuthStatus;
+  "name": string;
+  "resourceTemplates": Array<ResourceTemplate>;
+  "resources": Array<Resource>;
+  "serverInfo": McpServerInfo | null;
+  "tools": { [key in string]?: Tool };
+};
 
 export type McpServerStatusDetail = "full" | "toolsAndAuthOnly";
 
@@ -2789,6 +2803,18 @@ export type RequestPermissionProfile = {
 
 export type ResidencyRequirement = "us";
 
+export type Resource = {
+  "_meta"?: JsonValue;
+  "annotations"?: JsonValue;
+  "description"?: string;
+  "icons"?: Array<JsonValue>;
+  "mimeType"?: string;
+  "name": string;
+  "size"?: number;
+  "title"?: string;
+  "uri": string;
+};
+
 export type ResourceContent = {
   "_meta"?: JsonValue;
   "mimeType"?: string;
@@ -2799,6 +2825,15 @@ export type ResourceContent = {
   "blob": string;
   "mimeType"?: string;
   "uri": string;
+};
+
+export type ResourceTemplate = {
+  "annotations"?: JsonValue;
+  "description"?: string;
+  "mimeType"?: string;
+  "name": string;
+  "title"?: string;
+  "uriTemplate": string;
 };
 
 export type Response = {
@@ -3656,6 +3691,17 @@ export type TokenUsageBreakdown = {
   "outputTokens": number;
   "reasoningOutputTokens": number;
   "totalTokens": number;
+};
+
+export type Tool = {
+  "_meta"?: JsonValue;
+  "annotations"?: JsonValue;
+  "description"?: string;
+  "icons"?: Array<JsonValue>;
+  "inputSchema": JsonValue;
+  "name": string;
+  "outputSchema"?: JsonValue;
+  "title"?: string;
 };
 
 export type ToolPayloadSummary = {

--- a/appserver/protocol/typescript/testdata/mcp_server_status_contract.ts
+++ b/appserver/protocol/typescript/testdata/mcp_server_status_contract.ts
@@ -1,0 +1,86 @@
+import type {
+  JsonValue,
+  ListMcpServerStatusResponse,
+  McpAuthStatus,
+  McpServerInfo,
+  McpServerStatus,
+  MethodParamsByName,
+  MethodResultsByName,
+  Resource,
+  ResourceTemplate,
+  Tool,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2) ? true : false;
+type Expect<T extends true> = T;
+
+type Contracts = [
+  Expect<Equal<Resource, {
+    annotations?: JsonValue;
+    description?: string;
+    mimeType?: string;
+    name: string;
+    size?: number;
+    title?: string;
+    uri: string;
+    icons?: Array<JsonValue>;
+    _meta?: JsonValue;
+  }>>,
+  Expect<Equal<ResourceTemplate, {
+    annotations?: JsonValue;
+    uriTemplate: string;
+    name: string;
+    title?: string;
+    description?: string;
+    mimeType?: string;
+  }>>,
+  Expect<Equal<Tool, {
+    name: string;
+    title?: string;
+    description?: string;
+    inputSchema: JsonValue;
+    outputSchema?: JsonValue;
+    annotations?: JsonValue;
+    icons?: Array<JsonValue>;
+    _meta?: JsonValue;
+  }>>,
+  Expect<Equal<McpServerStatus, {
+    name: string;
+    serverInfo: McpServerInfo | null;
+    tools: { [key in string]?: Tool };
+    resources: Array<Resource>;
+    resourceTemplates: Array<ResourceTemplate>;
+    authStatus: McpAuthStatus;
+  }>>,
+  Expect<Equal<ListMcpServerStatusResponse, {
+    data: Array<McpServerStatus>;
+    nextCursor: string | null;
+  }>>,
+  Expect<Equal<"mcpServerStatus/list" extends keyof MethodParamsByName ? true : false, false>>,
+  Expect<Equal<"mcpServerStatus/list" extends keyof MethodResultsByName ? true : false, false>>,
+];
+
+({ name: "", uri: "" }) satisfies Resource;
+({ name: "", uriTemplate: "" }) satisfies ResourceTemplate;
+({ name: "", inputSchema: null }) satisfies Tool;
+({ name: "", serverInfo: null, tools: {}, resources: [], resourceTemplates: [], authStatus: "unsupported" }) satisfies McpServerStatus;
+({ data: [], nextCursor: null }) satisfies ListMcpServerStatusResponse;
+
+// @ts-expect-error resource uri is required.
+({ name: "" }) satisfies Resource;
+// @ts-expect-error optional resource strings are non-null when present.
+({ name: "", uri: "", mimeType: null }) satisfies Resource;
+// @ts-expect-error the private snake-case adapter is not public.
+({ name: "", uri_template: "" }) satisfies ResourceTemplate;
+// @ts-expect-error inputSchema is required.
+({ name: "" }) satisfies Tool;
+// @ts-expect-error map values are strict tools.
+({ name: "", serverInfo: null, tools: { bad: null }, resources: [], resourceTemplates: [], authStatus: "unsupported" }) satisfies McpServerStatus;
+// @ts-expect-error serverInfo is explicit nullable.
+({ name: "", tools: {}, resources: [], resourceTemplates: [], authStatus: "unsupported" }) satisfies McpServerStatus;
+// @ts-expect-error nextCursor is explicit nullable.
+({ data: [] }) satisfies ListMcpServerStatusResponse;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/workspace_messages_contract_test.go
+++ b/appserver/protocol/workspace_messages_contract_test.go
@@ -209,8 +209,8 @@ func TestWorkspaceMessageContractsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/workspaceMessages/read = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 505 {
-		t.Fatalf("definition count = %d, want 505", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
+		t.Fatalf("definition count = %d, want 510", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 224/59/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- add exact standalone `Resource`, `ResourceTemplate`, `Tool`, `McpServerStatus`, and `ListMcpServerStatusResponse` contracts
- preserve Rust serde omission/null, strict required collection, duplicate-field, and map last-wins behavior
- register exact schemas and generated TypeScript without binding the broader live `mcpServerStatus/list` wire

## Verification
- `go test ./appserver/protocol -count=1`
- all non-Monty packages: normal, race, and coverage tests
- `golangci-lint run ./...`
- `go vet ./...`
- `tsc --project appserver/protocol/typescript/tsconfig.json --noEmit`
- deterministic `go generate ./appserver/protocol`
- normalized schema equality and pinned TypeScript hashes against OpenAI Codex `5c19155cbd93bfa099016e7487259f61669823ff`

Local Monty tests were intentionally skipped per project workflow guidance.