### PR TITLE
appserver: add exact MCP OAuth login contracts

### DIFF
--- a/appserver/protocol/account_credit_nudge_values_contract_test.go
+++ b/appserver/protocol/account_credit_nudge_values_contract_test.go
@@ -119,8 +119,8 @@ func TestAccountCreditNudgeValuesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/sendAddCreditsNudgeEmail = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/account_envelope_contract_test.go
+++ b/appserver/protocol/account_envelope_contract_test.go
@@ -268,8 +268,8 @@ func TestAccountEnvelopeContractsRemainStandaloneAndDeferred(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred %s", methodName, method, ok, surface)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 224/59/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/account_login_completed_notification_contract_test.go
+++ b/appserver/protocol/account_login_completed_notification_contract_test.go
@@ -88,8 +88,8 @@ func TestAccountLoginCompletedNotificationRemainsStandaloneAndDeferred(t *testin
 	if !found {
 		t.Fatal("account/login/completed method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/account_rate_limits_contract_test.go
+++ b/appserver/protocol/account_rate_limits_contract_test.go
@@ -484,8 +484,8 @@ func TestAccountRateLimitContractsRemainStandaloneAndDeferred(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred %s", methodName, method, ok, surface)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/account_token_usage_contract_test.go
+++ b/appserver/protocol/account_token_usage_contract_test.go
@@ -146,8 +146,8 @@ func TestAccountTokenUsageRecordsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/usage/read = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(defs); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_config_contract_test.go
+++ b/appserver/protocol/app_config_contract_test.go
@@ -109,8 +109,8 @@ func TestAppConfigRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppConfig unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_info_contract_test.go
+++ b/appserver/protocol/app_info_contract_test.go
@@ -131,8 +131,8 @@ func TestAppInfoRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_list_updated_notification_contract_test.go
+++ b/appserver/protocol/app_list_updated_notification_contract_test.go
@@ -105,8 +105,8 @@ func TestAppListUpdatedNotificationRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceServerNotification || method.State != MethodDeferredStub {
 		t.Fatalf("app/list/updated = %#v, %v; want deferred server notification", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_metadata_contract_test.go
+++ b/appserver/protocol/app_metadata_contract_test.go
@@ -107,8 +107,8 @@ func TestAppMetadataRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_metadata_leaf_contract_test.go
+++ b/appserver/protocol/app_metadata_leaf_contract_test.go
@@ -157,8 +157,8 @@ func TestAppMetadataLeavesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_summary_contract_test.go
+++ b/appserver/protocol/app_summary_contract_test.go
@@ -87,8 +87,8 @@ func TestAppSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppSummary unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_template_summary_contract_test.go
+++ b/appserver/protocol/app_template_summary_contract_test.go
@@ -107,8 +107,8 @@ func TestAppTemplateSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppTemplateSummary unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_template_unavailable_reason_contract_test.go
+++ b/appserver/protocol/app_template_unavailable_reason_contract_test.go
@@ -71,8 +71,8 @@ func TestAppTemplateUnavailableReasonRemainsStandalone(t *testing.T) {
 			t.Fatalf("AppTemplateUnavailableReason unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_tool_approval_contract_test.go
+++ b/appserver/protocol/app_tool_approval_contract_test.go
@@ -73,8 +73,8 @@ func TestAppToolApprovalRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppToolApproval unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_tools_config_contract_test.go
+++ b/appserver/protocol/app_tools_config_contract_test.go
@@ -140,8 +140,8 @@ func TestAppToolConfigsRemainStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/apply_patch_approval_params_contract_test.go
+++ b/appserver/protocol/apply_patch_approval_params_contract_test.go
@@ -139,8 +139,8 @@ func TestApplyPatchApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ApplyPatchApprovalParams unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(defs); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(defs); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/apps_config_contract_test.go
+++ b/appserver/protocol/apps_config_contract_test.go
@@ -185,8 +185,8 @@ func TestAppsConfigsRemainStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/apps_list_contract_test.go
+++ b/appserver/protocol/apps_list_contract_test.go
@@ -168,8 +168,8 @@ func TestAppsListContractsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/attestation_contract_test.go
+++ b/appserver/protocol/attestation_contract_test.go
@@ -133,8 +133,8 @@ func TestAttestationContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("attestation/generate = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
+++ b/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
@@ -179,8 +179,8 @@ func TestChatgptAuthTokensRefreshRemainsStandaloneAndDeferred(t *testing.T) {
 	if !found {
 		t.Fatal("refresh method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/exec_command_approval_params_contract_test.go
+++ b/appserver/protocol/exec_command_approval_params_contract_test.go
@@ -137,8 +137,8 @@ func TestExecCommandApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ExecCommandApprovalParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(defs); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/experimental_feature_contract_test.go
+++ b/appserver/protocol/experimental_feature_contract_test.go
@@ -41,8 +41,8 @@ func TestExperimentalFeatureContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want implemented client request", methodName, method, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d/%d/%d, want 224/59/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,8 +217,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,8 +203,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -260,8 +260,8 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,8 +244,8 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -162,8 +162,8 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -175,8 +175,8 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_contract_test.go
+++ b/appserver/protocol/file_change_contract_test.go
@@ -108,8 +108,8 @@ func TestFileChangeRemainsStandalone(t *testing.T) {
 			t.Fatalf("FileChange unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_output_delta_notification_contract_test.go
+++ b/appserver/protocol/file_change_output_delta_notification_contract_test.go
@@ -100,8 +100,8 @@ func TestFileChangeOutputDeltaNotificationRemainsDeprecatedAndStandalone(t *test
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("item/fileChange/outputDelta = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -381,8 +381,8 @@ func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_action_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_action_contract_test.go
@@ -226,8 +226,8 @@ func TestGuardianApprovalReviewActionRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReviewAction unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
@@ -164,8 +164,8 @@ func TestGuardianApprovalReviewCompletedNotificationRemainsStandalone(t *testing
 			t.Fatalf("completed notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_contract_test.go
@@ -139,8 +139,8 @@ func TestGuardianApprovalReviewRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReview unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
@@ -175,8 +175,8 @@ func TestGuardianApprovalReviewStartedNotificationRemainsStandalone(t *testing.T
 			t.Fatalf("started notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_enum_foundation_contract_test.go
+++ b/appserver/protocol/guardian_enum_foundation_contract_test.go
@@ -89,8 +89,8 @@ func TestGuardianEnumFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_metadata_list_contract_test.go
+++ b/appserver/protocol/hook_metadata_list_contract_test.go
@@ -352,8 +352,8 @@ func TestHookMetadataListContractsStayStandalone(t *testing.T) {
 			t.Errorf("standalone definition %s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Errorf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Errorf("definition count = %d, want 513", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 {
 		t.Errorf("wire binding count = %d, want 59", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_run_notification_contract_test.go
+++ b/appserver/protocol/hook_run_notification_contract_test.go
@@ -297,8 +297,8 @@ func TestHookRunNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("surface changed: %d methods, %d wire bindings, %d item bindings", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/hook_value_foundation_contract_test.go
+++ b/appserver/protocol/hook_value_foundation_contract_test.go
@@ -167,8 +167,8 @@ func TestHookValueFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 510 {
-		t.Fatalf("definition count = %d, want 510", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 513 {
+		t.Fatalf("definition count = %d, want 513", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/legacy_approval_response_contract_test.go
+++ b/appserver/protocol/legacy_approval_response_contract_test.go
@@ -98,8 +98,8 @@ func TestLegacyApprovalResponsesRemainStandaloneAndNominal(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_oauth_login_contract_test.go
+++ b/appserver/protocol/mcp_server_oauth_login_contract_test.go
@@ -1,0 +1,265 @@
+package protocol
+
+import (
+	"encoding/json"
+	"math"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestMcpServerOauthLoginSchemasAreExact(t *testing.T) {
+	nullableString := Schema{"type": []any{"string", "null"}}
+	wants := map[string]Schema{
+		"McpServerOauthLoginParams": {
+			"type": "object",
+			"properties": Schema{
+				"name": Schema{"type": "string"},
+				"scopes": Schema{
+					"type":  []any{"array", "null"},
+					"items": Schema{"type": "string"},
+				},
+				"threadId": nullableString,
+				"timeoutSecs": Schema{
+					"type": []any{"integer", "null"}, "format": "int64",
+				},
+			},
+			"required": []string{"name"},
+		},
+		"McpServerOauthLoginResponse": {
+			"type": "object",
+			"properties": Schema{
+				"authorizationUrl": Schema{"type": "string"},
+			},
+			"required": []string{"authorizationUrl"},
+		},
+		"McpServerOauthLoginCompletedNotification": {
+			"type": "object",
+			"properties": Schema{
+				"error":    nullableString,
+				"name":     Schema{"type": "string"},
+				"success":  Schema{"type": "boolean"},
+				"threadId": nullableString,
+			},
+			"required": []string{"name", "success"},
+		},
+	}
+	definitions := JSONSchema()["$defs"].(Schema)
+	for name, want := range wants {
+		if got := definitions[name]; !reflect.DeepEqual(got, want) {
+			t.Errorf("%s = %#v, want %#v", name, got, want)
+		}
+	}
+}
+
+func TestMcpServerOauthLoginParamsPreserveSerdeWireForms(t *testing.T) {
+	minimum, maximum := int64(math.MinInt64), int64(math.MaxInt64)
+	for _, tc := range []struct {
+		input string
+		want  McpServerOauthLoginParams
+		json  string
+	}{
+		{
+			`{"name":""}`,
+			McpServerOauthLoginParams{},
+			`{"name":"","threadId":null}`,
+		},
+		{
+			`{"name":"server","threadId":null,"scopes":null,"timeoutSecs":null}`,
+			McpServerOauthLoginParams{Name: "server"},
+			`{"name":"server","threadId":null}`,
+		},
+		{
+			`{"future":1,"future":2,"name":" server ","threadId":" thread ","scopes":["","scope","scope"],"timeoutSecs":-9223372036854775808}`,
+			McpServerOauthLoginParams{
+				Name: " server ", ThreadID: stringPointer(" thread "),
+				Scopes: &[]string{"", "scope", "scope"}, TimeoutSecs: &minimum,
+			},
+			`{"name":" server ","threadId":" thread ","scopes":["","scope","scope"],"timeoutSecs":-9223372036854775808}`,
+		},
+		{
+			`{"name":"server","scopes":[],"timeoutSecs":9223372036854775807}`,
+			McpServerOauthLoginParams{Name: "server", Scopes: &[]string{}, TimeoutSecs: &maximum},
+			`{"name":"server","threadId":null,"scopes":[],"timeoutSecs":9223372036854775807}`,
+		},
+	} {
+		var params McpServerOauthLoginParams
+		if err := json.Unmarshal([]byte(tc.input), &params); err != nil {
+			t.Errorf("unmarshal %s: %v", tc.input, err)
+			continue
+		}
+		if !reflect.DeepEqual(params, tc.want) {
+			t.Errorf("params %s = %#v, want %#v", tc.input, params, tc.want)
+		}
+		encoded, err := json.Marshal(params)
+		if err != nil || string(encoded) != tc.json {
+			t.Errorf("marshal %#v = %s, %v; want %s", params, encoded, err, tc.json)
+		}
+	}
+
+	var nilScopes []string
+	encoded, err := json.Marshal(McpServerOauthLoginParams{Name: "server", Scopes: &nilScopes})
+	if err != nil || string(encoded) != `{"name":"server","threadId":null,"scopes":[]}` {
+		t.Fatalf("marshal nil scope slice = %s, %v", encoded, err)
+	}
+}
+
+func TestMcpServerOauthLoginParamsRejectMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`, `{}`,
+		`{"name":null}`, `{"name":1}`, `{"name":true}`,
+		`{"name":"server","threadId":1}`, `{"name":"server","threadId":true}`,
+		`{"name":"server","scopes":{}}`, `{"name":"server","scopes":[null]}`,
+		`{"name":"server","scopes":[1]}`, `{"name":"server","scopes":[true]}`,
+		`{"name":"server","timeoutSecs":"0"}`, `{"name":"server","timeoutSecs":true}`,
+		`{"name":"server","timeoutSecs":0.5}`, `{"name":"server","timeoutSecs":1e3}`,
+		`{"name":"server","timeoutSecs":9223372036854775808}`,
+		`{"name":"server","timeoutSecs":-9223372036854775809}`,
+		`{"name":"a","name":"b"}`, `{"name":"server","threadId":null,"threadId":"id"}`,
+		`{"name":"server","scopes":null,"scopes":[]}`,
+		`{"name":"server","timeoutSecs":null,"timeoutSecs":0}`,
+		`{"name":"server"} {}`, `{"name":"server"} x`,
+	} {
+		assertJSONRejects[McpServerOauthLoginParams](t, input)
+	}
+}
+
+func TestMcpServerOauthLoginResponsePreservesSerdeWireForms(t *testing.T) {
+	for _, tc := range []struct{ input, want string }{
+		{`{"authorizationUrl":""}`, `{"authorizationUrl":""}`},
+		{`{"future":true,"authorizationUrl":" https://example.test/callback?x=1 "}`, `{"authorizationUrl":" https://example.test/callback?x=1 "}`},
+	} {
+		var response McpServerOauthLoginResponse
+		if err := json.Unmarshal([]byte(tc.input), &response); err != nil {
+			t.Errorf("unmarshal %s: %v", tc.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(response)
+		if err != nil || string(encoded) != tc.want {
+			t.Errorf("round trip %s = %s, %v; want %s", tc.input, encoded, err, tc.want)
+		}
+	}
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`, `{}`,
+		`{"authorizationUrl":null}`, `{"authorizationUrl":1}`,
+		`{"authorizationUrl":"a","authorizationUrl":"b"}`,
+		`{"authorizationUrl":"url"} {}`, `{"authorizationUrl":"url"} x`,
+	} {
+		assertJSONRejects[McpServerOauthLoginResponse](t, input)
+	}
+}
+
+func TestMcpServerOauthLoginCompletionPreservesSerdeWireForms(t *testing.T) {
+	for _, tc := range []struct {
+		input string
+		want  string
+	}{
+		{`{"name":"","success":false}`, `{"name":"","threadId":null,"success":false}`},
+		{`{"name":"server","threadId":null,"success":true,"error":null}`, `{"name":"server","threadId":null,"success":true}`},
+		{`{"future":true,"name":" server ","threadId":" thread ","success":false,"error":" denied "}`, `{"name":" server ","threadId":" thread ","success":false,"error":" denied "}`},
+		{`{"name":"server","success":false,"error":""}`, `{"name":"server","threadId":null,"success":false,"error":""}`},
+	} {
+		var notification McpServerOauthLoginCompletedNotification
+		if err := json.Unmarshal([]byte(tc.input), &notification); err != nil {
+			t.Errorf("unmarshal %s: %v", tc.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(notification)
+		if err != nil || string(encoded) != tc.want {
+			t.Errorf("round trip %s = %s, %v; want %s", tc.input, encoded, err, tc.want)
+		}
+	}
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`, `{}`,
+		`{"success":true}`, `{"name":"server"}`,
+		`{"name":null,"success":true}`, `{"name":1,"success":true}`,
+		`{"name":"server","success":null}`, `{"name":"server","success":"true"}`,
+		`{"name":"server","threadId":1,"success":true}`,
+		`{"name":"server","success":true,"error":1}`,
+		`{"name":"a","name":"b","success":true}`,
+		`{"name":"server","threadId":null,"threadId":"id","success":true}`,
+		`{"name":"server","success":true,"success":false}`,
+		`{"name":"server","success":true,"error":null,"error":"failure"}`,
+		`{"name":"server","success":true} {}`, `{"name":"server","success":true} x`,
+	} {
+		assertJSONRejects[McpServerOauthLoginCompletedNotification](t, input)
+	}
+}
+
+func TestMcpServerOauthLoginNilReceiversFailClosed(t *testing.T) {
+	var params *McpServerOauthLoginParams
+	if err := params.UnmarshalJSON([]byte(`{"name":"server"}`)); err == nil {
+		t.Fatal("nil params receiver succeeded")
+	}
+	var response *McpServerOauthLoginResponse
+	if err := response.UnmarshalJSON([]byte(`{"authorizationUrl":"url"}`)); err == nil {
+		t.Fatal("nil response receiver succeeded")
+	}
+	var notification *McpServerOauthLoginCompletedNotification
+	if err := notification.UnmarshalJSON([]byte(`{"name":"server","success":true}`)); err == nil {
+		t.Fatal("nil notification receiver succeeded")
+	}
+}
+
+func TestMcpServerOauthLoginContractsRemainStandaloneAndBlocked(t *testing.T) {
+	names := []string{
+		"McpServerOauthLoginParams",
+		"McpServerOauthLoginResponse",
+		"McpServerOauthLoginCompletedNotification",
+	}
+	for _, binding := range WireTypeBindings() {
+		for _, name := range names {
+			if slices.Contains(binding.Params, name) || slices.Contains(binding.Result, name) {
+				t.Fatalf("%s unexpectedly bound to %s", name, binding.Method)
+			}
+		}
+	}
+	for _, binding := range ItemPayloadBindings() {
+		if slices.Contains(names, binding.Type) {
+			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
+		}
+	}
+	request, ok := LookupMethod("mcpServer/oauth/login")
+	if !ok || request.Surface != SurfaceClientRequest || request.State != MethodBlocked {
+		t.Fatalf("mcpServer/oauth/login = %#v, %v; want blocked client request", request, ok)
+	}
+	notification, ok := LookupMethod("mcpServer/oauthLogin/completed")
+	if !ok || notification.Surface != SurfaceServerNotification || notification.State != MethodBlocked {
+		t.Fatalf("mcpServer/oauthLogin/completed = %#v, %v; want blocked server notification", notification, ok)
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
+	}
+	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("counts = %d/%d/%d, want 224/59/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
+	}
+}
+
+func TestMcpServerOauthLoginTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	for _, want := range []string{
+		"export type McpServerOauthLoginParams = {\n" +
+			"  \"name\": string;\n" +
+			"  \"scopes\"?: Array<string> | null;\n" +
+			"  \"threadId\"?: string | null;\n" +
+			"  \"timeoutSecs\"?: bigint | null;\n" +
+			"};",
+		"export type McpServerOauthLoginResponse = {\n" +
+			"  \"authorizationUrl\": string;\n" +
+			"};",
+		"export type McpServerOauthLoginCompletedNotification = {\n" +
+			"  \"error\"?: string;\n" +
+			"  \"name\": string;\n" +
+			"  \"success\": boolean;\n" +
+			"  \"threadId\": string | null;\n" +
+			"};",
+	} {
+		if !strings.Contains(string(generated), want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}

--- a/appserver/protocol/mcp_server_oauth_login_types.go
+++ b/appserver/protocol/mcp_server_oauth_login_types.go
@@ -1,0 +1,205 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// McpServerOauthLoginParams is exact standalone public OAuth-login request
+// data. It does not launch a browser, own credentials, or authorize a server.
+type McpServerOauthLoginParams struct {
+	Name        string    `json:"name"`
+	ThreadID    *string   `json:"threadId"`
+	Scopes      *[]string `json:"scopes,omitempty"`
+	TimeoutSecs *int64    `json:"timeoutSecs,omitempty"`
+}
+
+func (p McpServerOauthLoginParams) MarshalJSON() ([]byte, error) {
+	scopes := p.Scopes
+	if scopes != nil && *scopes == nil {
+		empty := []string{}
+		scopes = &empty
+	}
+	return json.Marshal(struct {
+		Name        string    `json:"name"`
+		ThreadID    *string   `json:"threadId"`
+		Scopes      *[]string `json:"scopes,omitempty"`
+		TimeoutSecs *int64    `json:"timeoutSecs,omitempty"`
+	}{
+		Name: p.Name, ThreadID: p.ThreadID, Scopes: scopes, TimeoutSecs: p.TimeoutSecs,
+	})
+}
+
+func (p *McpServerOauthLoginParams) UnmarshalJSON(data []byte) error {
+	if p == nil {
+		return errors.New("decode MCP server OAuth login params into nil receiver")
+	}
+	const objectName = "MCP server OAuth login params"
+	payload, err := decodeRustSerdeObject(
+		data, objectName, "name", "threadId", "scopes", "timeoutSecs",
+	)
+	if err != nil {
+		return err
+	}
+	name, err := decodeRequiredThreadItemValue[string](payload, objectName, "name")
+	if err != nil {
+		return err
+	}
+	threadID, err := decodeOptionalNullableConfigValue[string](payload, objectName, "threadId")
+	if err != nil {
+		return err
+	}
+	scopes, err := decodeOptionalNullableMcpOauthScopes(payload, objectName, "scopes")
+	if err != nil {
+		return err
+	}
+	timeoutSecs, err := decodeOptionalNullableConfigValue[int64](payload, objectName, "timeoutSecs")
+	if err != nil {
+		return err
+	}
+	*p = McpServerOauthLoginParams{
+		Name: name, ThreadID: threadID, Scopes: scopes, TimeoutSecs: timeoutSecs,
+	}
+	return nil
+}
+
+func decodeOptionalNullableMcpOauthScopes(
+	payload map[string]json.RawMessage,
+	objectName string,
+	fieldName string,
+) (*[]string, error) {
+	raw, ok := payload[fieldName]
+	if !ok || isJSONNull(raw) {
+		return nil, nil
+	}
+	values, err := decodeRequiredThreadItemArray[string](payload, objectName, fieldName)
+	if err != nil {
+		return nil, err
+	}
+	return &values, nil
+}
+
+// McpServerOauthLoginResponse is exact standalone public OAuth authorization
+// URL data. The URL remains opaque to Gollem's protocol package.
+type McpServerOauthLoginResponse struct {
+	AuthorizationURL string `json:"authorizationUrl"`
+}
+
+func (r McpServerOauthLoginResponse) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		AuthorizationURL string `json:"authorizationUrl"`
+	}{AuthorizationURL: r.AuthorizationURL})
+}
+
+func (r *McpServerOauthLoginResponse) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("decode MCP server OAuth login response into nil receiver")
+	}
+	const objectName = "MCP server OAuth login response"
+	payload, err := decodeRustSerdeObject(data, objectName, "authorizationUrl")
+	if err != nil {
+		return err
+	}
+	authorizationURL, err := decodeRequiredThreadItemValue[string](payload, objectName, "authorizationUrl")
+	if err != nil {
+		return err
+	}
+	*r = McpServerOauthLoginResponse{AuthorizationURL: authorizationURL}
+	return nil
+}
+
+// McpServerOauthLoginCompletedNotification is exact standalone public OAuth
+// completion data. The corresponding notification remains producerless.
+type McpServerOauthLoginCompletedNotification struct {
+	Name     string  `json:"name"`
+	ThreadID *string `json:"threadId"`
+	Success  bool    `json:"success"`
+	Error    *string `json:"error,omitempty"`
+}
+
+func (n McpServerOauthLoginCompletedNotification) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Name     string  `json:"name"`
+		ThreadID *string `json:"threadId"`
+		Success  bool    `json:"success"`
+		Error    *string `json:"error,omitempty"`
+	}{Name: n.Name, ThreadID: n.ThreadID, Success: n.Success, Error: n.Error})
+}
+
+func (n *McpServerOauthLoginCompletedNotification) UnmarshalJSON(data []byte) error {
+	if n == nil {
+		return errors.New("decode MCP server OAuth login completion into nil receiver")
+	}
+	const objectName = "MCP server OAuth login completion"
+	payload, err := decodeRustSerdeObject(data, objectName, "name", "threadId", "success", "error")
+	if err != nil {
+		return err
+	}
+	name, err := decodeRequiredThreadItemValue[string](payload, objectName, "name")
+	if err != nil {
+		return err
+	}
+	threadID, err := decodeOptionalNullableConfigValue[string](payload, objectName, "threadId")
+	if err != nil {
+		return err
+	}
+	success, err := decodeRequiredThreadItemValue[bool](payload, objectName, "success")
+	if err != nil {
+		return err
+	}
+	errorMessage, err := decodeOptionalNullableConfigValue[string](payload, objectName, "error")
+	if err != nil {
+		return err
+	}
+	*n = McpServerOauthLoginCompletedNotification{
+		Name: name, ThreadID: threadID, Success: success, Error: errorMessage,
+	}
+	return nil
+}
+
+func mcpServerOauthLoginSchemas() map[string]Schema {
+	nullableString := Schema{"type": []any{"string", "null"}}
+	return map[string]Schema{
+		"McpServerOauthLoginParams": {
+			"type": "object",
+			"properties": Schema{
+				"name": Schema{"type": "string"},
+				"scopes": Schema{
+					"type":  []any{"array", "null"},
+					"items": Schema{"type": "string"},
+				},
+				"threadId": nullableString,
+				"timeoutSecs": Schema{
+					"type": []any{"integer", "null"}, "format": "int64",
+				},
+			},
+			"required": []string{"name"},
+		},
+		"McpServerOauthLoginResponse": {
+			"type": "object",
+			"properties": Schema{
+				"authorizationUrl": Schema{"type": "string"},
+			},
+			"required": []string{"authorizationUrl"},
+		},
+		"McpServerOauthLoginCompletedNotification": {
+			"type": "object",
+			"properties": Schema{
+				"error":    nullableString,
+				"name":     Schema{"type": "string"},
+				"success":  Schema{"type": "boolean"},
+				"threadId": nullableString,
+			},
+			"required": []string{"name", "success"},
+		},
+	}
+}
+
+var (
+	_ json.Marshaler   = McpServerOauthLoginParams{}
+	_ json.Unmarshaler = (*McpServerOauthLoginParams)(nil)
+	_ json.Marshaler   = McpServerOauthLoginResponse{}
+	_ json.Unmarshaler = (*McpServerOauthLoginResponse)(nil)
+	_ json.Marshaler   = McpServerOauthLoginCompletedNotification{}
+	_ json.Unmarshaler = (*McpServerOauthLoginCompletedNotification)(nil)
+)

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_contract_test.go
+++ b/appserver/protocol/mcp_server_status_contract_test.go
@@ -277,8 +277,8 @@ func TestMcpServerStatusContractsRemainStandalone(t *testing.T) {
 	if !ok || method.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d/%d/%d, want 224/59/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_approval_context_contract_test.go
+++ b/appserver/protocol/network_approval_context_contract_test.go
@@ -84,8 +84,8 @@ func TestNetworkApprovalContextRemainsStandalone(t *testing.T) {
 			t.Fatalf("NetworkApprovalContext unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/parsed_command_contract_test.go
+++ b/appserver/protocol/parsed_command_contract_test.go
@@ -120,8 +120,8 @@ func TestParsedCommandRemainsStandalone(t *testing.T) {
 			t.Fatalf("ParsedCommand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/process_contracts_contract_test.go
+++ b/appserver/protocol/process_contracts_contract_test.go
@@ -308,8 +308,8 @@ func TestProcessContractsRemainStandaloneFromLegacyRuntime(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want unchanged implemented notification", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 510 {
-		t.Fatalf("definition count = %d, want 510", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 513 {
+		t.Fatalf("definition count = %d, want 513", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 510 {
-		t.Fatalf("definition count = %d, want 510", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 513 {
+		t.Fatalf("definition count = %d, want 513", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 510 {
-		t.Fatalf("definition count = %d, want 510", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 513 {
+		t.Fatalf("definition count = %d, want 513", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 510 {
-		t.Fatalf("definition count = %d, want 510", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 513 {
+		t.Fatalf("definition count = %d, want 513", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 510 {
-		t.Fatalf("definition count = %d, want 510", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 513 {
+		t.Fatalf("definition count = %d, want 513", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/review_decision_contract_test.go
+++ b/appserver/protocol/review_decision_contract_test.go
@@ -136,8 +136,8 @@ func TestReviewDecisionRemainsStandalone(t *testing.T) {
 			t.Fatalf("ReviewDecision unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(defs); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -289,6 +289,9 @@ func wireSchemaDefinitions() Schema {
 		{Name: "McpResourceReadResponse", Type: reflect.TypeFor[McpResourceReadResponse]()},
 		{Name: "McpServerInfo", Type: reflect.TypeFor[McpServerInfo]()},
 		{Name: "McpServerMigration", Type: reflect.TypeFor[McpServerMigration]()},
+		{Name: "McpServerOauthLoginCompletedNotification", Type: reflect.TypeFor[McpServerOauthLoginCompletedNotification]()},
+		{Name: "McpServerOauthLoginParams", Type: reflect.TypeFor[McpServerOauthLoginParams]()},
+		{Name: "McpServerOauthLoginResponse", Type: reflect.TypeFor[McpServerOauthLoginResponse]()},
 		{Name: "McpServerRefreshResponse", Type: reflect.TypeFor[McpServerRefreshResponse]()},
 		{Name: "McpServerToolCallParams", Type: reflect.TypeFor[McpServerToolCallParams]()},
 		{Name: "McpServerToolCallResponse", Type: reflect.TypeFor[McpServerToolCallResponse]()},
@@ -886,6 +889,9 @@ func wireSchemaDefinitions() Schema {
 	schemas["McpResourceReadParams"] = mcpResourceReadParamsSchema()
 	schemas["McpResourceReadResponse"] = mcpResourceReadResponseSchema()
 	schemas["McpServerInfo"] = mcpServerInfoSchema()
+	for name, schema := range mcpServerOauthLoginSchemas() {
+		schemas[name] = schema
+	}
 	schemas["McpServerStatus"] = mcpServerStatusSchema()
 	schemas["Resource"] = mcpResourceSchema()
 	schemas["ResourceTemplate"] = mcpResourceTemplateSchema()

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -8763,6 +8763,77 @@
       ],
       "type": "object"
     },
+    "McpServerOauthLoginCompletedNotification": {
+      "properties": {
+        "error": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "success": {
+          "type": "boolean"
+        },
+        "threadId": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "success"
+      ],
+      "type": "object"
+    },
+    "McpServerOauthLoginParams": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "scopes": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "threadId": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "timeoutSecs": {
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "McpServerOauthLoginResponse": {
+      "properties": {
+        "authorizationUrl": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "authorizationUrl"
+      ],
+      "type": "object"
+    },
     "McpServerRefreshResponse": {
       "additionalProperties": false,
       "type": "object"

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 510 {
-		t.Fatalf("definition count = %d, want 510", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 513 {
+		t.Fatalf("definition count = %d, want 513", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 510 {
-		t.Fatalf("definition count = %d, want 510", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 513 {
+		t.Fatalf("definition count = %d, want 513", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 510 {
-		t.Fatalf("definition count = %d, want 510", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 513 {
+		t.Fatalf("definition count = %d, want 513", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -471,6 +471,41 @@ func MarshalTypeScript() ([]byte, error) {
 				"currentStreakDays", "longestStreakDays",
 			)
 		}
+		if name == "McpServerOauthLoginParams" {
+			// ts-rs maps the optional Rust i64 timeout to nullable bigint.
+			// Keep the render hint out of the exact public JSON Schema.
+			definition = typeScriptDefinitionWithBigIntProperties(definition, "timeoutSecs")
+			definition = typeScriptDefinitionWithPropertySchemas(definition, Schema{
+				"scopes": Schema{"anyOf": []any{
+					Schema{"type": "array", "items": Schema{"type": "string"}},
+					Schema{"type": "null"},
+				}},
+				"threadId": Schema{"anyOf": []any{
+					Schema{"type": "string"}, Schema{"type": "null"},
+				}},
+			})
+		}
+		if name == "McpServerOauthLoginCompletedNotification" {
+			// ts-rs requires the nullable thread id while rendering the
+			// skip-serialized error as an optional non-null string.
+			definition = typeScriptDefinitionWithPropertySchemas(definition, Schema{
+				"error": optionalNonNullTypeScriptSchema(Schema{"type": "string"}),
+				"threadId": Schema{"anyOf": []any{
+					Schema{"type": "string"}, Schema{"type": "null"},
+				}},
+			})
+			schema, _ := typeScriptSchema(definition)
+			required, _ := schema["required"].([]string)
+			schema["required"] = append(append([]string(nil), required...), "threadId")
+			definition = schema
+		}
+		if name == "McpServerOauthLoginParams" ||
+			name == "McpServerOauthLoginResponse" ||
+			name == "McpServerOauthLoginCompletedNotification" {
+			schema, _ := typeScriptSchema(definition)
+			schema["x-gollem-typescript-ignore-additional-properties"] = true
+			definition = schema
+		}
 		if name == "HookRunSummary" {
 			// ts-rs maps each Rust i64 field to bigint, including nullable i64
 			// options. Keep these hints out of the public JSON Schema.

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -2343,6 +2343,24 @@ export type McpServerMigration = {
   "name": string;
 };
 
+export type McpServerOauthLoginCompletedNotification = {
+  "error"?: string;
+  "name": string;
+  "success": boolean;
+  "threadId": string | null;
+};
+
+export type McpServerOauthLoginParams = {
+  "name": string;
+  "scopes"?: Array<string> | null;
+  "threadId"?: string | null;
+  "timeoutSecs"?: bigint | null;
+};
+
+export type McpServerOauthLoginResponse = {
+  "authorizationUrl": string;
+};
+
 export type McpServerRefreshResponse = Record<string, never>;
 
 export type McpServerStartupFailureReason = "reauthenticationRequired";

--- a/appserver/protocol/typescript/testdata/mcp_server_oauth_login_contract.ts
+++ b/appserver/protocol/typescript/testdata/mcp_server_oauth_login_contract.ts
@@ -1,0 +1,55 @@
+import type {
+  McpServerOauthLoginCompletedNotification,
+  McpServerOauthLoginParams,
+  McpServerOauthLoginResponse,
+  MethodParamsByName,
+  MethodResultsByName,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2) ? true : false;
+type Expect<T extends true> = T;
+
+type Contracts = [
+  Expect<Equal<McpServerOauthLoginParams, {
+    name: string;
+    threadId?: string | null;
+    scopes?: Array<string> | null;
+    timeoutSecs?: bigint | null;
+  }>>,
+  Expect<Equal<McpServerOauthLoginResponse, {
+    authorizationUrl: string;
+  }>>,
+  Expect<Equal<McpServerOauthLoginCompletedNotification, {
+    name: string;
+    threadId: string | null;
+    success: boolean;
+    error?: string;
+  }>>,
+  Expect<Equal<"mcpServer/oauth/login" extends keyof MethodParamsByName ? true : false, false>>,
+  Expect<Equal<"mcpServer/oauth/login" extends keyof MethodResultsByName ? true : false, false>>,
+  Expect<Equal<"mcpServer/oauthLogin/completed" extends keyof MethodParamsByName ? true : false, false>>,
+  Expect<Equal<"mcpServer/oauthLogin/completed" extends keyof MethodResultsByName ? true : false, false>>,
+];
+
+({ name: "" }) satisfies McpServerOauthLoginParams;
+({ name: "server", threadId: null, scopes: ["", "scope", "scope"], timeoutSecs: 9223372036854775807n }) satisfies McpServerOauthLoginParams;
+({ authorizationUrl: "" }) satisfies McpServerOauthLoginResponse;
+({ name: "server", threadId: null, success: true }) satisfies McpServerOauthLoginCompletedNotification;
+({ name: "server", threadId: "thread", success: false, error: "" }) satisfies McpServerOauthLoginCompletedNotification;
+
+// @ts-expect-error name is required.
+({}) satisfies McpServerOauthLoginParams;
+// @ts-expect-error timeout is a signed-int64 bigint in pinned TypeScript.
+({ name: "server", timeoutSecs: 1 }) satisfies McpServerOauthLoginParams;
+// @ts-expect-error scope elements are strings.
+({ name: "server", scopes: [null] }) satisfies McpServerOauthLoginParams;
+// @ts-expect-error authorizationUrl is required.
+({}) satisfies McpServerOauthLoginResponse;
+// @ts-expect-error completion threadId is explicit nullable.
+({ name: "server", success: true }) satisfies McpServerOauthLoginCompletedNotification;
+// @ts-expect-error completion error omits rather than retaining null.
+({ name: "server", threadId: null, success: false, error: null }) satisfies McpServerOauthLoginCompletedNotification;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/workspace_messages_contract_test.go
+++ b/appserver/protocol/workspace_messages_contract_test.go
@@ -209,8 +209,8 @@ func TestWorkspaceMessageContractsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/workspaceMessages/read = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 510 {
-		t.Fatalf("definition count = %d, want 510", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
+		t.Fatalf("definition count = %d, want 513", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 224/59/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- export exact standalone `McpServerOauthLoginParams`, `McpServerOauthLoginResponse`, and `McpServerOauthLoginCompletedNotification`
- preserve pinned serde omission/null, strict string-array, signed-int64, duplicate-field, schema, and ts-rs semantics
- keep `mcpServer/oauth/login` and `mcpServer/oauthLogin/completed` blocked, producerless, and outside generated bindings

## Verification
- deliberate-red missing-type compile proof
- focused tests x30 and focused race x10
- 100% statement coverage for every new production function
- normalized generated definitions match pinned Codex `5c19155cbd93bfa099016e7487259f61669823ff`
- strict TypeScript fixture and compiler gate
- all 59 non-Monty packages: normal, race, and coverage (protocol 97.7%)
- `golangci-lint run ./...`: 0 issues
- `go vet`, `go mod verify`, and tidy cleanliness
- deterministic generation and generated-artifact structural reversal
- configured pre-push gate with `hooks.skipMontyRace=true`

Local Monty normal/race/coverage tests were intentionally skipped; hosted CI is unchanged.