### PR TITLE
test: reuse compiled Monty sandbox

### DIFF
--- a/ext/monty/monty_test.go
+++ b/ext/monty/monty_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
+	"sync"
 	"testing"
 
 	montygo "github.com/fugue-labs/monty-go"
@@ -12,15 +14,45 @@ import (
 	"github.com/fugue-labs/gollem/core"
 )
 
-// newRunner creates a monty-go Runner for tests.
+var (
+	sharedRunnerOnce sync.Once
+	sharedRunner     *montygo.Runner
+	sharedRunnerErr  error
+)
+
+// newRunner reuses one compiled Monty WASM runtime across the package's
+// tests. Runner.Execute still instantiates a fresh isolated WASM module for
+// every execution.
 func newRunner(t *testing.T) *montygo.Runner {
 	t.Helper()
-	runner, err := montygo.New()
-	if err != nil {
-		t.Fatal(err)
+	sharedRunnerOnce.Do(func() {
+		sharedRunner, sharedRunnerErr = montygo.New()
+	})
+	if sharedRunnerErr != nil {
+		t.Fatal(sharedRunnerErr)
 	}
-	t.Cleanup(func() { runner.Close() })
-	return runner
+	return sharedRunner
+}
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+	if sharedRunner != nil {
+		if err := sharedRunner.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "close shared Monty test runner: %v\n", err)
+			if code == 0 {
+				code = 1
+			}
+		}
+	}
+	os.Exit(code)
+}
+
+func TestNewRunnerReusesCompiledSandbox(t *testing.T) {
+	first := newRunner(t)
+	second := newRunner(t)
+	if first != second {
+		t.Fatal("newRunner compiled a second Monty sandbox")
+	}
 }
 
 type searchParams struct {


### PR DESCRIPTION
## What changed

- reuse one lazily initialized `monty-go` runner across the `ext/monty` test package
- close the shared runner once from `TestMain`
- add a regression test proving the helper does not compile a second sandbox

Each `Runner.Execute` call still instantiates a fresh isolated WASM module, so execution isolation is unchanged.

## Root cause and impact

`newRunner(t)` called `montygo.New()` for each test. `montygo.New()` creates a wazero runtime and recompiles the embedded Monty WASM module, so 20 tests repeated an expensive package-level setup operation.

Paired local timings:

- normal `ext/monty`: 20.9s -> 1.43s
- race `ext/monty`: 262s -> 15.3s

Gollem CI currently runs Monty outside the race shard, so the immediate hosted PR saving is about 19 seconds. Full-race and pre-push executions avoid roughly four minutes of redundant compilation.

## Validation

- regression test verified red before the fix and green afterward
- exact GitHub PR test sequence
- `go test -count=1 ./ext/monty`
- `go test -race -count=1 ./ext/monty`
- ten shuffled normal and race repetitions
- `go vet ./...`
- `golangci-lint run ./...`
- `go mod tidy` with no diff
