### PR TITLE
Harden OpenAI OAuth and model provenance

### DIFF
--- a/auth/openai/oauth.go
+++ b/auth/openai/oauth.go
@@ -43,6 +43,11 @@ const (
 
 	// OAuth scopes.
 	oauthScopes = "openid profile email offline_access api.connectors.read api.connectors.invoke"
+
+	// OAuth endpoints are not expected to return large payloads. Bounding the
+	// body prevents a failed or compromised endpoint from turning token
+	// refresh into an unbounded allocation.
+	maxOAuthResponseBytes = 1 << 20
 )
 
 // Credentials stores OAuth tokens for ChatGPT subscription access.
@@ -212,9 +217,12 @@ func loginDeviceCode(ctx context.Context) (*Credentials, error) {
 	}
 	defer resp.Body.Close()
 
+	body, err := readOAuthResponse(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading device code response: %w", err)
+	}
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("device code request failed (HTTP %d): %s", resp.StatusCode, body)
+		return nil, fmt.Errorf("device code request failed (HTTP %d)", resp.StatusCode)
 	}
 
 	var deviceResp struct {
@@ -222,7 +230,7 @@ func loginDeviceCode(ctx context.Context) (*Credentials, error) {
 		UserCode     string `json:"user_code"`
 		Interval     string `json:"interval"` // seconds, sent as a string
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&deviceResp); err != nil {
+	if err := json.Unmarshal(body, &deviceResp); err != nil {
 		return nil, fmt.Errorf("decoding device code response: %w", err)
 	}
 	if deviceResp.DeviceAuthID == "" || deviceResp.UserCode == "" {
@@ -262,8 +270,11 @@ func loginDeviceCode(ctx context.Context) (*Credentials, error) {
 		if err != nil {
 			continue
 		}
-		body, _ := io.ReadAll(tokenResp.Body)
+		body, readErr := readOAuthResponse(tokenResp.Body)
 		tokenResp.Body.Close()
+		if readErr != nil {
+			return nil, fmt.Errorf("reading device authorization response: %w", readErr)
+		}
 
 		// Pending authorization is signaled by status, not body:
 		// 403/404 until the user enters the code.
@@ -271,7 +282,7 @@ func loginDeviceCode(ctx context.Context) (*Credentials, error) {
 			continue
 		}
 		if tokenResp.StatusCode != http.StatusOK {
-			return nil, fmt.Errorf("device authorization failed (HTTP %d): %s", tokenResp.StatusCode, body)
+			return nil, fmt.Errorf("device authorization failed (HTTP %d)", tokenResp.StatusCode)
 		}
 
 		var result struct {
@@ -282,8 +293,8 @@ func loginDeviceCode(ctx context.Context) (*Credentials, error) {
 		if err := json.Unmarshal(body, &result); err != nil {
 			return nil, fmt.Errorf("decoding device token response: %w", err)
 		}
-		if result.AuthorizationCode == "" {
-			return nil, fmt.Errorf("device token response missing authorization_code: %s", body)
+		if result.AuthorizationCode == "" || result.CodeVerifier == "" {
+			return nil, errors.New("device token response missing authorization_code or code_verifier")
 		}
 		return exchangeCode(ctx, result.AuthorizationCode, "https://auth.openai.com/deviceauth/callback", result.CodeVerifier)
 	}
@@ -313,13 +324,13 @@ func exchangeCode(ctx context.Context, code, redirectURI, codeVerifier string) (
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := readOAuthResponse(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("reading token response: %w", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("token exchange failed (HTTP %d): %s", resp.StatusCode, body)
+		return nil, fmt.Errorf("token exchange failed (HTTP %d)", resp.StatusCode)
 	}
 
 	var tokenResp struct {
@@ -331,8 +342,19 @@ func exchangeCode(ctx context.Context, code, redirectURI, codeVerifier string) (
 	if err := json.Unmarshal(body, &tokenResp); err != nil {
 		return nil, fmt.Errorf("decoding token response: %w", err)
 	}
+	if strings.TrimSpace(tokenResp.AccessToken) == "" ||
+		strings.TrimSpace(tokenResp.RefreshToken) == "" ||
+		strings.TrimSpace(tokenResp.IDToken) == "" {
+		return nil, errors.New("decoding token response: required token is empty")
+	}
+	if tokenResp.ExpiresIn < 0 {
+		return nil, errors.New("decoding token response: expires_in is negative")
+	}
 
 	accountID := extractAccountID(tokenResp.IDToken)
+	if accountID == "" {
+		return nil, errors.New("decoding token response: account identity is missing")
+	}
 
 	expiresAt := time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
 	if tokenResp.ExpiresIn == 0 {
@@ -352,9 +374,25 @@ func exchangeCode(ctx context.Context, code, redirectURI, codeVerifier string) (
 // RefreshIfNeeded refreshes the access token if expired or near-expiry.
 // Returns the same credentials if still valid, or new credentials if refreshed.
 func RefreshIfNeeded(creds *Credentials) (*Credentials, error) {
+	return refreshIfNeeded(creds, time.Now(), http.DefaultClient, tokenEndpoint)
+}
+
+func refreshIfNeeded(creds *Credentials, now time.Time, client *http.Client, endpoint string) (*Credentials, error) {
+	if creds == nil {
+		return nil, errors.New("refreshing token: credentials are nil")
+	}
+	if strings.TrimSpace(creds.AccessToken) == "" {
+		return nil, errors.New("refreshing token: access token is empty")
+	}
 	// Refresh if within 5 minutes of expiry.
-	if time.Until(creds.ExpiresAt) > 5*time.Minute {
+	if !creds.ExpiresAt.IsZero() && creds.ExpiresAt.Sub(now) > 5*time.Minute {
 		return creds, nil
+	}
+	if strings.TrimSpace(creds.RefreshToken) == "" {
+		return nil, errors.New("refreshing token: refresh token is empty")
+	}
+	if client == nil || strings.TrimSpace(endpoint) == "" {
+		return nil, errors.New("refreshing token: OAuth transport is unavailable")
 	}
 
 	data := url.Values{
@@ -367,25 +405,25 @@ func RefreshIfNeeded(creds *Credentials) (*Credentials, error) {
 	// indefinitely if the auth server is unresponsive.
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenEndpoint, strings.NewReader(data.Encode()))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(data.Encode()))
 	if err != nil {
 		return nil, fmt.Errorf("creating refresh request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("refreshing token: %w", err)
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := readOAuthResponse(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("reading refresh response: %w", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("token refresh failed (HTTP %d): %s", resp.StatusCode, body)
+		return nil, fmt.Errorf("token refresh failed (HTTP %d)", resp.StatusCode)
 	}
 
 	var tokenResp struct {
@@ -397,20 +435,61 @@ func RefreshIfNeeded(creds *Credentials) (*Credentials, error) {
 	if err := json.Unmarshal(body, &tokenResp); err != nil {
 		return nil, fmt.Errorf("decoding refresh response: %w", err)
 	}
+	if strings.TrimSpace(tokenResp.AccessToken) == "" {
+		return nil, errors.New("decoding refresh response: access token is empty")
+	}
+	if tokenResp.ExpiresIn < 0 {
+		return nil, errors.New("decoding refresh response: expires_in is negative")
+	}
 
-	expiresAt := time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
+	expiresAt := now.Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
 	if tokenResp.ExpiresIn == 0 {
-		expiresAt = time.Now().Add(1 * time.Hour)
+		expiresAt = now.Add(1 * time.Hour)
+	}
+	refreshToken := tokenResp.RefreshToken
+	if strings.TrimSpace(refreshToken) == "" {
+		// OAuth refresh responses may omit refresh_token. Retain the previous
+		// token instead of destroying the next refresh path.
+		refreshToken = creds.RefreshToken
+	}
+	idToken := tokenResp.IDToken
+	if strings.TrimSpace(idToken) == "" {
+		idToken = creds.IDToken
+	}
+	accountID := creds.AccountID
+	if refreshedAccountID := extractAccountID(idToken); refreshedAccountID != "" {
+		if accountID != "" && refreshedAccountID != accountID {
+			return nil, errors.New("decoding refresh response: account identity changed")
+		}
+		accountID = refreshedAccountID
+	}
+	authMode := creds.AuthMode
+	if authMode == "" {
+		authMode = "chatgpt"
 	}
 
 	return &Credentials{
 		AccessToken:  tokenResp.AccessToken,
-		RefreshToken: tokenResp.RefreshToken,
-		IDToken:      tokenResp.IDToken,
-		AccountID:    creds.AccountID,
-		AuthMode:     "chatgpt",
+		RefreshToken: refreshToken,
+		IDToken:      idToken,
+		AccountID:    accountID,
+		AuthMode:     authMode,
 		ExpiresAt:    expiresAt,
 	}, nil
+}
+
+func readOAuthResponse(reader io.Reader) ([]byte, error) {
+	if reader == nil {
+		return nil, errors.New("response body is nil")
+	}
+	body, err := io.ReadAll(io.LimitReader(reader, maxOAuthResponseBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(body) > maxOAuthResponseBytes {
+		return nil, errors.New("response exceeds limit")
+	}
+	return body, nil
 }
 
 // credentialsPath returns the path to the credentials file.

--- a/auth/openai/oauth_test.go
+++ b/auth/openai/oauth_test.go
@@ -3,8 +3,13 @@ package openai
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -81,6 +86,277 @@ func TestRefreshIfNeeded_NotExpired(t *testing.T) {
 	// Should return the same credentials without making any HTTP calls.
 	if result != creds {
 		t.Error("expected same credentials pointer when not expired")
+	}
+}
+
+func TestRefreshIfNeededRejectsInvalidCredentials(t *testing.T) {
+	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name  string
+		creds *Credentials
+		want  string
+	}{
+		{name: "nil", want: "credentials are nil"},
+		{
+			name:  "empty access token",
+			creds: &Credentials{RefreshToken: "refresh", ExpiresAt: now.Add(time.Hour)},
+			want:  "access token is empty",
+		},
+		{
+			name:  "expired without refresh token",
+			creds: &Credentials{AccessToken: "expired", ExpiresAt: now.Add(-time.Minute)},
+			want:  "refresh token is empty",
+		},
+		{
+			name:  "unknown expiry without refresh token",
+			creds: &Credentials{AccessToken: "unknown-expiry"},
+			want:  "refresh token is empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := refreshIfNeeded(tt.creds, now, http.DefaultClient, "https://invalid.example")
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("refreshIfNeeded() error = %v, want containing %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestRefreshIfNeededPreservesOmittedRotatingTokens(t *testing.T) {
+	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	idToken := makeTestJWT(map[string]any{"account_id": "acct-1"})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.FormValue("refresh_token"); got != "refresh-old" {
+			t.Errorf("refresh_token = %q, want refresh-old", got)
+		}
+		if got := r.FormValue("client_id"); got != ClientID {
+			t.Errorf("client_id = %q, want %q", got, ClientID)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "access-new",
+			"expires_in":   3600,
+		})
+	}))
+	defer server.Close()
+
+	got, err := refreshIfNeeded(&Credentials{
+		AccessToken:  "access-old",
+		RefreshToken: "refresh-old",
+		IDToken:      idToken,
+		AccountID:    "acct-1",
+		AuthMode:     "chatgpt",
+		ExpiresAt:    now.Add(-time.Minute),
+	}, now, server.Client(), server.URL)
+	if err != nil {
+		t.Fatalf("refreshIfNeeded: %v", err)
+	}
+	if got.AccessToken != "access-new" {
+		t.Errorf("AccessToken = %q, want access-new", got.AccessToken)
+	}
+	if got.RefreshToken != "refresh-old" {
+		t.Errorf("RefreshToken = %q, want preserved refresh-old", got.RefreshToken)
+	}
+	if got.IDToken != idToken {
+		t.Error("IDToken was not preserved")
+	}
+	if got.AccountID != "acct-1" {
+		t.Errorf("AccountID = %q, want acct-1", got.AccountID)
+	}
+	if got.AuthMode != "chatgpt" {
+		t.Errorf("AuthMode = %q, want chatgpt", got.AuthMode)
+	}
+	if want := now.Add(time.Hour); !got.ExpiresAt.Equal(want) {
+		t.Errorf("ExpiresAt = %v, want %v", got.ExpiresAt, want)
+	}
+}
+
+func TestRefreshIfNeededAcceptsSameAccountRotation(t *testing.T) {
+	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	idToken := makeTestJWT(map[string]any{"account_id": "acct-1"})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "access-new",
+			"refresh_token": "refresh-new",
+			"id_token":      idToken,
+			"expires_in":    1200,
+		})
+	}))
+	defer server.Close()
+
+	got, err := refreshIfNeeded(&Credentials{
+		AccessToken:  "access-old",
+		RefreshToken: "refresh-old",
+		AccountID:    "acct-1",
+		ExpiresAt:    now.Add(-time.Minute),
+	}, now, server.Client(), server.URL)
+	if err != nil {
+		t.Fatalf("refreshIfNeeded: %v", err)
+	}
+	if got.RefreshToken != "refresh-new" || got.IDToken != idToken || got.AccountID != "acct-1" {
+		t.Fatalf("rotated credentials not retained: %#v", got)
+	}
+}
+
+func TestRefreshIfNeededRejectsAccountIdentityChange(t *testing.T) {
+	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "access-new",
+			"id_token":     makeTestJWT(map[string]any{"account_id": "acct-2"}),
+			"expires_in":   3600,
+		})
+	}))
+	defer server.Close()
+
+	_, err := refreshIfNeeded(&Credentials{
+		AccessToken:  "access-old",
+		RefreshToken: "refresh-old",
+		AccountID:    "acct-1",
+		ExpiresAt:    now.Add(-time.Minute),
+	}, now, server.Client(), server.URL)
+	if err == nil || !strings.Contains(err.Error(), "account identity changed") {
+		t.Fatalf("refreshIfNeeded() error = %v, want account identity changed", err)
+	}
+}
+
+func TestRefreshIfNeededBoundsAndRedactsErrorResponses(t *testing.T) {
+	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	baseCreds := &Credentials{
+		AccessToken:  "access-old",
+		RefreshToken: "refresh-secret",
+		ExpiresAt:    now.Add(-time.Minute),
+	}
+
+	t.Run("redacts response body", func(t *testing.T) {
+		const secret = "server-echoed-secret"
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, secret, http.StatusUnauthorized)
+		}))
+		defer server.Close()
+
+		_, err := refreshIfNeeded(baseCreds, now, server.Client(), server.URL)
+		if err == nil {
+			t.Fatal("expected refresh error")
+		}
+		if strings.Contains(err.Error(), secret) {
+			t.Fatalf("refresh error leaked response body: %v", err)
+		}
+		if !strings.Contains(err.Error(), "HTTP 401") {
+			t.Fatalf("refresh error = %v, want HTTP status", err)
+		}
+	})
+
+	t.Run("bounds response", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(strings.Repeat("x", maxOAuthResponseBytes+1)))
+		}))
+		defer server.Close()
+
+		_, err := refreshIfNeeded(baseCreds, now, server.Client(), server.URL)
+		if err == nil || !strings.Contains(err.Error(), "response exceeds limit") {
+			t.Fatalf("refreshIfNeeded() error = %v, want response limit error", err)
+		}
+	})
+}
+
+func TestRefreshIfNeededRejectsMalformedSuccessfulResponse(t *testing.T) {
+	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "empty access token", body: `{"expires_in":3600}`, want: "access token is empty"},
+		{name: "negative expiry", body: `{"access_token":"new","expires_in":-1}`, want: "expires_in is negative"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			_, err := refreshIfNeeded(&Credentials{
+				AccessToken:  "old",
+				RefreshToken: "refresh",
+				ExpiresAt:    now.Add(-time.Minute),
+			}, now, server.Client(), server.URL)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("refreshIfNeeded() error = %v, want containing %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestRefreshIfNeededDefaultsZeroExpiry(t *testing.T) {
+	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"access_token":"new","expires_in":0}`)
+	}))
+	defer server.Close()
+
+	got, err := refreshIfNeeded(&Credentials{
+		AccessToken:  "old",
+		RefreshToken: "refresh",
+		ExpiresAt:    now.Add(-time.Minute),
+	}, now, server.Client(), server.URL)
+	if err != nil {
+		t.Fatalf("refreshIfNeeded: %v", err)
+	}
+	if want := now.Add(time.Hour); !got.ExpiresAt.Equal(want) {
+		t.Fatalf("ExpiresAt = %v, want %v", got.ExpiresAt, want)
+	}
+}
+
+func TestRefreshIfNeededRejectsUnavailableTransport(t *testing.T) {
+	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	creds := &Credentials{
+		AccessToken:  "old",
+		RefreshToken: "refresh",
+		ExpiresAt:    now.Add(-time.Minute),
+	}
+	for _, tt := range []struct {
+		name     string
+		client   *http.Client
+		endpoint string
+	}{
+		{name: "nil client", endpoint: "https://auth.invalid"},
+		{name: "empty endpoint", client: http.DefaultClient},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := refreshIfNeeded(creds, now, tt.client, tt.endpoint)
+			if err == nil || !strings.Contains(err.Error(), "OAuth transport is unavailable") {
+				t.Fatalf("refreshIfNeeded() error = %v, want unavailable transport", err)
+			}
+		})
+	}
+}
+
+func TestReadOAuthResponseRejectsNilAndReaderFailure(t *testing.T) {
+	if _, err := readOAuthResponse(nil); err == nil || !strings.Contains(err.Error(), "nil") {
+		t.Fatalf("readOAuthResponse(nil) error = %v", err)
+	}
+	_, err := readOAuthResponse(failingOAuthReader{})
+	if err == nil || !strings.Contains(err.Error(), "read failed") {
+		t.Fatalf("readOAuthResponse(failing) error = %v", err)
+	}
+}
+
+func TestRefreshIfNeededPropagatesTransportError(t *testing.T) {
+	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	client := &http.Client{Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("transport failed")
+	})}
+	_, err := refreshIfNeeded(&Credentials{
+		AccessToken:  "old",
+		RefreshToken: "refresh",
+		ExpiresAt:    now.Add(-time.Minute),
+	}, now, client, "https://auth.invalid")
+	if err == nil || !strings.Contains(err.Error(), "transport failed") {
+		t.Fatalf("refreshIfNeeded() error = %v, want transport failure", err)
 	}
 }
 
@@ -186,4 +462,16 @@ func makeTestJWT(claims map[string]any) string {
 	payload, _ := json.Marshal(claims)
 	payloadEnc := base64.RawURLEncoding.EncodeToString(payload)
 	return header + "." + payloadEnc + ".signature"
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type failingOAuthReader struct{}
+
+func (failingOAuthReader) Read([]byte) (int, error) {
+	return 0, errors.New("read failed")
 }

--- a/provider/openai/openai.go
+++ b/provider/openai/openai.go
@@ -84,7 +84,9 @@ type Provider struct {
 	wsHTTPFallbackSet       bool
 	useResponses            bool
 	disableToolSearch       bool
+	strictModelBinding      bool
 	wsConn                  *responsesWebSocketConn
+	wsAuthToken             string
 	wsPrevResponseID        string
 	wsLastInputSigs         []string
 	wsMu                    sync.Mutex
@@ -224,6 +226,16 @@ func WithChatGPTAuth(accessToken, accountID string) Option {
 func WithTokenRefresher(refresher TokenRefresher) Option {
 	return func(p *Provider) {
 		p.tokenRefresher = refresher
+	}
+}
+
+// WithStrictModelBinding requires every successful response to identify the
+// requested model (or a dated/tagged snapshot of that exact model family).
+// Missing or conflicting provider model identity fails the request. This is
+// intended for provenance-sensitive source-bearing workloads.
+func WithStrictModelBinding() Option {
+	return func(p *Provider) {
+		p.strictModelBinding = true
 	}
 }
 
@@ -409,6 +421,7 @@ func (p *Provider) NewSession() core.Model {
 		wsHTTPFallbackSet:       p.wsHTTPFallbackSet,
 		useResponses:            p.useResponses,
 		disableToolSearch:       p.disableToolSearch,
+		strictModelBinding:      p.strictModelBinding,
 		reasoningSummary:        p.reasoningSummary,
 		textVerbosity:           p.textVerbosity,
 		chatgptAccountID:        p.chatgptAccountID,
@@ -424,12 +437,14 @@ func (p *Provider) Close() error {
 	defer p.wsMu.Unlock()
 	if p.wsConn == nil || p.wsConn.conn == nil {
 		p.wsConn = nil
+		p.wsAuthToken = ""
 		p.wsPrevResponseID = ""
 		p.wsLastInputSigs = nil
 		return nil
 	}
 	err := p.wsConn.conn.Close()
 	p.wsConn = nil
+	p.wsAuthToken = ""
 	p.wsPrevResponseID = ""
 	p.wsLastInputSigs = nil
 	return err
@@ -474,8 +489,11 @@ func (p *Provider) Request(ctx context.Context, messages []core.ModelMessage, se
 	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
 		return nil, fmt.Errorf("openai: failed to decode response: %w", err)
 	}
-
-	return parseResponse(&apiResp, p.model), nil
+	responseModel, err := p.resolveResponseModel(apiResp.Model)
+	if err != nil {
+		return nil, err
+	}
+	return parseResponse(&apiResp, responseModel), nil
 }
 
 // RequestStream sends messages and returns a streaming response.
@@ -506,7 +524,7 @@ func (p *Provider) RequestStream(ctx context.Context, messages []core.ModelMessa
 		return nil, err
 	}
 
-	return newStreamedResponse(resp.Body, p.model), nil
+	return newBoundStreamedResponse(resp.Body, p.model, p.resolveResponseModel), nil
 }
 
 // responsesEP returns the Responses API endpoint path. ChatGPT subscription
@@ -527,7 +545,9 @@ func (p *Provider) doRequest(ctx context.Context, endpoint string, body []byte) 
 	if err != nil {
 		return nil, fmt.Errorf("openai: failed to create HTTP request: %w", err)
 	}
-	p.setHeaders(httpReq)
+	if err := p.setHeaders(httpReq); err != nil {
+		return nil, err
+	}
 
 	resp, err := p.httpClient.Do(httpReq)
 	if err != nil {
@@ -561,16 +581,80 @@ func (p *Provider) doRequest(ctx context.Context, endpoint string, body []byte) 
 	return nil, httpErr
 }
 
-func (p *Provider) setHeaders(req *http.Request) {
-	token := p.apiKey
-	if p.tokenRefresher != nil {
-		// On error, fall back to the current apiKey. The caller's refresher
-		// is expected to handle transient failures (e.g., return the existing
-		// token). We intentionally do not propagate errors here because
-		// setHeaders is called from many paths that cannot return errors.
-		if refreshed, err := p.tokenRefresher(); err == nil && refreshed != "" {
-			token = refreshed
+func (p *Provider) authorizationToken() (string, error) {
+	if p.tokenRefresher == nil {
+		return p.apiKey, nil
+	}
+	token, err := p.tokenRefresher()
+	if err != nil {
+		return "", fmt.Errorf("openai: refreshing access token: %w", err)
+	}
+	if strings.TrimSpace(token) == "" {
+		return "", errors.New("openai: refreshing access token: empty token")
+	}
+	return token, nil
+}
+
+// ModelIdentityError means the provider answered with a model identity that
+// cannot be bound to the requested route.
+type ModelIdentityError struct {
+	Requested string
+	Actual    string
+}
+
+func (e *ModelIdentityError) Error() string {
+	if strings.TrimSpace(e.Actual) == "" {
+		return fmt.Sprintf("openai: response omitted model identity for requested model %q", e.Requested)
+	}
+	return fmt.Sprintf("openai: response model identity %q does not match requested model %q", e.Actual, e.Requested)
+}
+
+func compatibleResponseModel(requested, actual string) bool {
+	requested = strings.TrimSpace(requested)
+	actual = strings.TrimSpace(actual)
+	if requested == "" || actual == "" {
+		return false
+	}
+	if actual == requested {
+		return true
+	}
+	// OpenAI aliases commonly resolve to dated snapshots (model-YYYY-MM-DD).
+	// OpenAI-compatible local runtimes commonly report an explicit tag
+	// (model:latest). Neither rule admits a different model family.
+	if snapshot, ok := strings.CutPrefix(actual, requested+"-"); ok {
+		if _, err := time.Parse("2006-01-02", snapshot); err == nil {
+			return true
 		}
+	}
+	if tag, ok := strings.CutPrefix(actual, requested+":"); ok {
+		return tag != "" && !strings.ContainsAny(tag, " \t\r\n")
+	}
+	return false
+}
+
+func (p *Provider) resolveResponseModel(actual string) (string, error) {
+	actual = strings.TrimSpace(actual)
+	if p.strictModelBinding && !compatibleResponseModel(p.model, actual) {
+		return "", &ModelIdentityError{Requested: p.model, Actual: actual}
+	}
+	if actual != "" {
+		return actual, nil
+	}
+	return p.model, nil
+}
+
+func (p *Provider) parseBoundResponsesResponse(resp *responsesAPIResponse) (*core.ModelResponse, error) {
+	responseModel, err := p.resolveResponseModel(resp.Model)
+	if err != nil {
+		return nil, err
+	}
+	return parseResponsesResponse(resp, responseModel), nil
+}
+
+func (p *Provider) setHeaders(req *http.Request) error {
+	token, err := p.authorizationToken()
+	if err != nil {
+		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+token)
@@ -586,6 +670,7 @@ func (p *Provider) setHeaders(req *http.Request) {
 			req.Header.Set(chatgptResponsesLiteHdr, "true")
 		}
 	}
+	return nil
 }
 
 func (p *Provider) shouldUseResponsesAPI() bool {

--- a/provider/openai/openai_test.go
+++ b/provider/openai/openai_test.go
@@ -3,6 +3,7 @@ package openai
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -2728,13 +2729,365 @@ func TestTokenRefresher(t *testing.T) {
 	}
 }
 
+func TestTokenRefresherFailsClosedBeforeTransport(t *testing.T) {
+	messages := []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "hi"}}},
+	}
+	tests := []struct {
+		name      string
+		transport string
+		refresher TokenRefresher
+		want      string
+	}{
+		{
+			name:      "http error",
+			transport: transportHTTP,
+			refresher: func() (string, error) { return "", fmt.Errorf("refresh failed") },
+			want:      "refresh failed",
+		},
+		{
+			name:      "http empty token",
+			transport: transportHTTP,
+			refresher: func() (string, error) { return "", nil },
+			want:      "empty token",
+		},
+		{
+			name:      "websocket error",
+			transport: transportWebSocket,
+			refresher: func() (string, error) { return "", fmt.Errorf("refresh failed") },
+			want:      "refresh failed",
+		},
+		{
+			name:      "websocket empty token",
+			transport: transportWebSocket,
+			refresher: func() (string, error) { return "", nil },
+			want:      "empty token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hits := 0
+			server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+				hits++
+			}))
+			defer server.Close()
+
+			p := New(
+				WithChatGPTAuth("stale-token", "acct"),
+				WithBaseURL(server.URL),
+				WithTransport(tt.transport),
+				WithTokenRefresher(tt.refresher),
+			)
+			_, err := p.Request(context.Background(), messages, nil, nil)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Request() error = %v, want containing %q", err, tt.want)
+			}
+			if hits != 0 {
+				t.Fatalf("transport received %d requests after auth preflight failed", hits)
+			}
+		})
+	}
+}
+
+func TestStrictModelBinding(t *testing.T) {
+	tests := []struct {
+		name      string
+		actual    string
+		wantModel string
+		wantErr   bool
+	}{
+		{name: "exact", actual: "gpt-5", wantModel: "gpt-5"},
+		{name: "dated snapshot", actual: "gpt-5-2026-07-23", wantModel: "gpt-5-2026-07-23"},
+		{name: "tagged local model", actual: "gpt-5:latest", wantModel: "gpt-5:latest"},
+		{name: "prefix collision", actual: "gpt-5-mini", wantErr: true},
+		{name: "non-date suffix", actual: "gpt-5-preview", wantErr: true},
+		{name: "different family", actual: "gpt-5.1", wantErr: true},
+		{name: "missing identity", actual: "", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != responsesEndpoint {
+					t.Fatalf("request path = %q, want %q", r.URL.Path, responsesEndpoint)
+				}
+				_ = json.NewEncoder(w).Encode(responsesAPIResponse{
+					ID:    "response",
+					Model: tt.actual,
+					Output: []responsesOutputItem{{
+						Type:    "message",
+						Content: []responsesContentItem{{Type: "output_text", Text: "ok"}},
+					}},
+				})
+			}))
+			defer server.Close()
+
+			p := New(
+				WithAPIKey("key"),
+				WithBaseURL(server.URL),
+				WithModel("gpt-5"),
+				WithStrictModelBinding(),
+			)
+			resp, err := p.Request(context.Background(), []core.ModelMessage{
+				core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "hi"}}},
+			}, nil, nil)
+			if tt.wantErr {
+				var identityErr *ModelIdentityError
+				if !errors.As(err, &identityErr) {
+					t.Fatalf("Request() error = %v, want ModelIdentityError", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Request: %v", err)
+			}
+			if resp.ModelName != tt.wantModel {
+				t.Fatalf("ModelName = %q, want %q", resp.ModelName, tt.wantModel)
+			}
+		})
+	}
+}
+
+func TestModelIdentityErrorMessages(t *testing.T) {
+	missing := (&ModelIdentityError{Requested: "gpt-5"}).Error()
+	if !strings.Contains(missing, "omitted model identity") || !strings.Contains(missing, "gpt-5") {
+		t.Fatalf("missing identity message = %q", missing)
+	}
+	mismatch := (&ModelIdentityError{Requested: "gpt-5", Actual: "gpt-5-mini"}).Error()
+	if !strings.Contains(mismatch, "gpt-5-mini") || !strings.Contains(mismatch, "does not match") {
+		t.Fatalf("mismatch identity message = %q", mismatch)
+	}
+}
+
+func TestStrictModelBindingChatCompletionsJSONRejectsMismatch(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != chatCompletionsEndpoint {
+			t.Fatalf("request path = %q, want %q", r.URL.Path, chatCompletionsEndpoint)
+		}
+		_, _ = io.WriteString(w, `{"id":"chatcmpl","model":"gpt-4o-mini","choices":[{"message":{"role":"assistant","content":"wrong route"},"finish_reason":"stop"}]}`)
+	}))
+	defer server.Close()
+
+	p := New(
+		WithAPIKey("key"),
+		WithBaseURL(server.URL),
+		WithModel("gpt-4o"),
+		WithStrictModelBinding(),
+	)
+	_, err := p.Request(context.Background(), []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "hi"}}},
+	}, nil, nil)
+	var identityErr *ModelIdentityError
+	if !errors.As(err, &identityErr) {
+		t.Fatalf("Request() error = %v, want ModelIdentityError", err)
+	}
+}
+
+func TestStrictModelBindingChatGPTSSERejectsMismatch(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `data: {"type":"response.completed","response":{"id":"response","model":"gpt-5.1","output":[{"type":"message","content":[{"type":"output_text","text":"wrong route"}]}]}}
+
+data: [DONE]
+
+`)
+	}))
+	defer server.Close()
+
+	p := New(
+		WithChatGPTAuth("token", "acct"),
+		WithBaseURL(server.URL+"/chatgpt.com"),
+		WithModel("gpt-5"),
+		WithStrictModelBinding(),
+	)
+	_, err := p.Request(context.Background(), []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "hi"}}},
+	}, nil, nil)
+	var identityErr *ModelIdentityError
+	if !errors.As(err, &identityErr) {
+		t.Fatalf("Request() error = %v, want ModelIdentityError", err)
+	}
+}
+
+func TestStrictModelBindingStreamingRejectsMismatch(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, `data: {"type":"response.output_text.delta","delta":"wrong route"}
+
+data: {"type":"response.completed","response":{"id":"response","model":"gpt-5.1","output":[]}}
+
+`)
+	}))
+	defer server.Close()
+
+	p := New(
+		WithAPIKey("key"),
+		WithBaseURL(server.URL),
+		WithModel("gpt-5"),
+		WithStrictModelBinding(),
+	)
+	stream, err := p.RequestStream(context.Background(), []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "hi"}}},
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("RequestStream: %v", err)
+	}
+	defer stream.Close()
+
+	for {
+		_, err = stream.Next()
+		if err != nil {
+			break
+		}
+	}
+	var identityErr *ModelIdentityError
+	if !errors.As(err, &identityErr) {
+		t.Fatalf("stream error = %v, want ModelIdentityError", err)
+	}
+}
+
+func TestStrictModelBindingStreamingRejectsMissingTerminalIdentity(t *testing.T) {
+	tests := []struct {
+		name     string
+		terminal string
+	}{
+		{
+			name:     "completed",
+			terminal: `{"type":"response.completed","response":{"id":"response","output":[]}}`,
+		},
+		{
+			name:     "incomplete",
+			terminal: `{"type":"response.incomplete","response":{"id":"response","output":[]}}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "text/event-stream")
+				_, _ = fmt.Fprintf(w, "data: %s\n\n", tt.terminal)
+			}))
+			defer server.Close()
+
+			p := New(
+				WithAPIKey("key"),
+				WithBaseURL(server.URL),
+				WithModel("gpt-5"),
+				WithStrictModelBinding(),
+			)
+			stream, err := p.RequestStream(context.Background(), []core.ModelMessage{
+				core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "hi"}}},
+			}, nil, nil)
+			if err != nil {
+				t.Fatalf("RequestStream: %v", err)
+			}
+			defer stream.Close()
+
+			for {
+				_, err = stream.Next()
+				if err != nil {
+					break
+				}
+			}
+			var identityErr *ModelIdentityError
+			if !errors.As(err, &identityErr) {
+				t.Fatalf("stream error = %v, want ModelIdentityError", err)
+			}
+		})
+	}
+}
+
+func TestStrictModelBindingResponsesJSONStreamFallbackRejectsMismatch(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"response","model":"gpt-5-mini","output":[]}`)
+	}))
+	defer server.Close()
+
+	p := New(
+		WithAPIKey("key"),
+		WithBaseURL(server.URL),
+		WithModel("gpt-5"),
+		WithStrictModelBinding(),
+	)
+	_, err := p.RequestStream(context.Background(), []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "hi"}}},
+	}, nil, nil)
+	var identityErr *ModelIdentityError
+	if !errors.As(err, &identityErr) {
+		t.Fatalf("RequestStream() error = %v, want ModelIdentityError", err)
+	}
+}
+
+func TestStrictModelBindingChatCompletionStreamTerminalPaths(t *testing.T) {
+	p := New(WithModel("gpt-4o"), WithStrictModelBinding())
+	tests := []struct {
+		name string
+		sse  string
+	}{
+		{
+			name: "mismatch",
+			sse:  "data: {\"id\":\"chatcmpl\",\"model\":\"gpt-4o-mini\",\"choices\":[]}\n\n",
+		},
+		{
+			name: "missing at done",
+			sse:  "data: [DONE]\n\n",
+		},
+		{
+			name: "missing at eof",
+			sse:  "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stream := newBoundStreamedResponse(
+				io.NopCloser(strings.NewReader(tt.sse)),
+				"gpt-4o",
+				p.resolveResponseModel,
+			)
+			defer stream.Close()
+			_, err := stream.Next()
+			var identityErr *ModelIdentityError
+			if !errors.As(err, &identityErr) {
+				t.Fatalf("Next() error = %v, want ModelIdentityError", err)
+			}
+		})
+	}
+}
+
+func TestStrictModelBindingResponsesStreamBareTerminalPaths(t *testing.T) {
+	p := New(WithModel("gpt-5"), WithStrictModelBinding())
+	for _, tt := range []struct {
+		name string
+		sse  string
+	}{
+		{name: "done", sse: "data: [DONE]\n\n"},
+		{name: "eof"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			stream := newBoundResponsesStreamedResponse(
+				io.NopCloser(strings.NewReader(tt.sse)),
+				"gpt-5",
+				p.resolveResponseModel,
+			)
+			defer stream.Close()
+			_, err := stream.Next()
+			var identityErr *ModelIdentityError
+			if !errors.As(err, &identityErr) {
+				t.Fatalf("Next() error = %v, want ModelIdentityError", err)
+			}
+		})
+	}
+}
+
 func TestNewSession_PreservesChatGPTAuth(t *testing.T) {
-	p := New(WithChatGPTAuth("token", "acct-123"))
+	p := New(WithChatGPTAuth("token", "acct-123"), WithStrictModelBinding())
 	session := p.NewSession().(*Provider)
 	if session.chatgptAccountID != "acct-123" {
 		t.Errorf("expected chatgptAccountID preserved, got %q", session.chatgptAccountID)
 	}
 	if session.tokenRefresher != nil {
 		t.Error("expected nil tokenRefresher when none was set")
+	}
+	if session.strictModelBinding != p.strictModelBinding {
+		t.Error("strict model binding was not preserved")
 	}
 }

--- a/provider/openai/responses.go
+++ b/provider/openai/responses.go
@@ -227,10 +227,14 @@ func (p *Provider) requestStreamViaResponses(ctx context.Context, messages []cor
 		if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
 			return nil, fmt.Errorf("openai: failed to decode responses API response: %w", err)
 		}
-		return newPrebuiltResponsesStream(parseResponsesResponse(&apiResp, p.model)), nil
+		bound, bindErr := p.parseBoundResponsesResponse(&apiResp)
+		if bindErr != nil {
+			return nil, bindErr
+		}
+		return newPrebuiltResponsesStream(bound), nil
 	}
 
-	return newResponsesStreamedResponse(resp.Body, p.model), nil
+	return newBoundResponsesStreamedResponse(resp.Body, p.model, p.resolveResponseModel), nil
 }
 
 // applyChatGPTRequirements modifies a request for the ChatGPT backend:
@@ -382,7 +386,7 @@ func (p *Provider) requestViaResponsesHTTP(ctx context.Context, req *responsesRe
 		return nil, fmt.Errorf("openai: failed to decode responses API response: %w", err)
 	}
 
-	return parseResponsesResponse(&apiResp, p.model), nil
+	return p.parseBoundResponsesResponse(&apiResp)
 }
 
 // parseSSEResponses reads an SSE stream and returns the final response.
@@ -448,7 +452,7 @@ func (p *Provider) parseSSEResponses(resp *http.Response) (*core.ModelResponse, 
 	if len(finalResp.Output) == 0 && len(streamedItems) > 0 {
 		finalResp.Output = streamedItems
 	}
-	return parseResponsesResponse(finalResp, p.model), nil
+	return p.parseBoundResponsesResponse(finalResp)
 }
 
 func buildResponsesRequest(messages []core.ModelMessage, settings *core.ModelSettings, params *core.ModelRequestParameters, model string, defaultMaxTokens int, disableToolSearch bool) (*responsesRequest, error) {

--- a/provider/openai/responses_stream.go
+++ b/provider/openai/responses_stream.go
@@ -28,10 +28,12 @@ type responsesStreamEvent struct {
 // response.output_item.done, and terminal response events, yielding PartStartEvent
 // and PartDeltaEvent as they arrive.
 type responsesStreamedResponse struct {
-	scanner *bufio.Scanner
-	body    io.ReadCloser
-	model   string
-	usage   core.Usage
+	scanner      *bufio.Scanner
+	body         io.ReadCloser
+	model        string
+	resolveModel func(string) (string, error)
+	modelSeen    bool
+	usage        core.Usage
 
 	stopReason core.FinishReason
 	done       bool
@@ -61,12 +63,21 @@ type responsesStreamedResponse struct {
 }
 
 func newResponsesStreamedResponse(body io.ReadCloser, model string) *responsesStreamedResponse {
+	return newBoundResponsesStreamedResponse(body, model, nil)
+}
+
+func newBoundResponsesStreamedResponse(
+	body io.ReadCloser,
+	model string,
+	resolveModel func(string) (string, error),
+) *responsesStreamedResponse {
 	scanner := bufio.NewScanner(body)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	return &responsesStreamedResponse{
 		scanner:              scanner,
 		body:                 body,
 		model:                model,
+		resolveModel:         resolveModel,
 		stopReason:           core.FinishReasonStop,
 		partsByIndex:         make(map[int]core.ModelResponsePart),
 		toolCallByOutputIdx:  make(map[int]int),
@@ -103,6 +114,10 @@ func (s *responsesStreamedResponse) Next() (core.ModelResponseStreamEvent, error
 			}
 			// Scanner exhausted without a terminal response event.
 			s.done = true
+			if err := s.finalizeModelIdentity(); err != nil {
+				s.streamErr = err
+				return nil, err
+			}
 			s.finalize()
 			return nil, io.EOF
 		}
@@ -115,6 +130,10 @@ func (s *responsesStreamedResponse) Next() (core.ModelResponseStreamEvent, error
 		data = strings.TrimPrefix(data, " ")
 		if data == "[DONE]" {
 			s.done = true
+			if err := s.finalizeModelIdentity(); err != nil {
+				s.streamErr = err
+				return nil, err
+			}
 			s.finalize()
 			return nil, io.EOF
 		}
@@ -185,7 +204,13 @@ func (s *responsesStreamedResponse) processEvent(event *responsesStreamEvent) []
 			var resp responsesAPIResponse
 			if json.Unmarshal(event.Response, &resp) == nil {
 				s.usage = mapResponsesUsage(resp.Usage)
+				if err := s.bindResponseModel(resp.Model); err != nil {
+					s.streamErr = err
+				}
 			}
+		}
+		if err := s.finalizeModelIdentity(); err != nil {
+			s.streamErr = err
 		}
 		s.finalize()
 		return nil
@@ -424,14 +449,43 @@ func (s *responsesStreamedResponse) handleCompleted(respJSON json.RawMessage) {
 	if respJSON != nil {
 		var resp responsesAPIResponse
 		if json.Unmarshal(respJSON, &resp) == nil {
+			if err := s.bindResponseModel(resp.Model); err != nil {
+				s.streamErr = err
+			}
 			s.usage = mapResponsesUsage(resp.Usage)
 			if resp.IncompleteDetails != nil && strings.Contains(resp.IncompleteDetails.Reason, "max_output_tokens") {
 				s.stopReason = core.FinishReasonLength
 			}
 		}
 	}
+	if err := s.finalizeModelIdentity(); err != nil {
+		s.streamErr = err
+	}
 	s.done = true
 	s.finalize()
+}
+
+func (s *responsesStreamedResponse) bindResponseModel(actual string) error {
+	resolved := strings.TrimSpace(actual)
+	if s.resolveModel != nil {
+		var err error
+		resolved, err = s.resolveModel(actual)
+		if err != nil {
+			return err
+		}
+	}
+	if resolved != "" {
+		s.model = resolved
+	}
+	s.modelSeen = strings.TrimSpace(actual) != ""
+	return nil
+}
+
+func (s *responsesStreamedResponse) finalizeModelIdentity() error {
+	if s.resolveModel == nil || s.modelSeen {
+		return nil
+	}
+	return s.bindResponseModel("")
 }
 
 func (s *responsesStreamedResponse) finalize() {

--- a/provider/openai/responses_ws.go
+++ b/provider/openai/responses_ws.go
@@ -151,12 +151,21 @@ func (p *Provider) requestViaResponsesWebSocket(ctx context.Context, req *respon
 		}
 	}
 
-	return parseResponsesResponse(apiResp, p.model), nil
+	return p.parseBoundResponsesResponse(apiResp)
 }
 
 func (p *Provider) ensureResponsesWebSocketLocked(ctx context.Context) (*responsesWebSocketConn, error) {
-	if p.wsConn != nil {
+	token, err := p.authorizationToken()
+	if err != nil {
+		return nil, err
+	}
+	if p.wsConn != nil && token == p.wsAuthToken {
 		return p.wsConn, nil
+	}
+	if p.wsConn != nil {
+		// A rotated OAuth token must not leave a long-lived connection bound
+		// to stale authentication.
+		p.resetResponsesWebSocketLocked()
 	}
 
 	wsURL, err := responsesWebSocketURL(p.baseURL, p.responsesEP())
@@ -164,12 +173,6 @@ func (p *Provider) ensureResponsesWebSocketLocked(ctx context.Context) (*respons
 		return nil, err
 	}
 
-	token := p.apiKey
-	if p.tokenRefresher != nil {
-		if refreshed, err := p.tokenRefresher(); err == nil && refreshed != "" {
-			token = refreshed
-		}
-	}
 	headers := make(http.Header)
 	headers.Set("Authorization", "Bearer "+token)
 	if p.hasChatGPTAuth() {
@@ -210,6 +213,7 @@ func (p *Provider) ensureResponsesWebSocketLocked(ctx context.Context) (*respons
 	}
 
 	p.wsConn = &responsesWebSocketConn{conn: conn}
+	p.wsAuthToken = token
 	return p.wsConn, nil
 }
 
@@ -218,6 +222,7 @@ func (p *Provider) resetResponsesWebSocketLocked() {
 		_ = p.wsConn.conn.Close()
 	}
 	p.wsConn = nil
+	p.wsAuthToken = ""
 	p.wsPrevResponseID = ""
 	p.wsLastInputSigs = nil
 }

--- a/provider/openai/responses_ws_test.go
+++ b/provider/openai/responses_ws_test.go
@@ -290,6 +290,126 @@ func TestRequestViaResponsesWebSocketAcceptsResponseCompletedEvent(t *testing.T)
 	}
 }
 
+func TestResponsesWebSocketReconnectsWhenTokenRotates(t *testing.T) {
+	var (
+		mu          sync.Mutex
+		authHeaders []string
+		token       = "token-1"
+	)
+	upgrader := websocket.Upgrader{
+		CheckOrigin: func(*http.Request) bool { return true },
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("websocket upgrade failed: %v", err)
+			return
+		}
+		defer conn.Close()
+
+		mu.Lock()
+		authHeaders = append(authHeaders, r.Header.Get("Authorization"))
+		mu.Unlock()
+
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+			if err := conn.WriteJSON(responsesWSEvent{
+				Type: "response.completed",
+				Response: &responsesAPIResponse{
+					ID:    "response",
+					Model: "gpt-5.3-codex",
+					Output: []responsesOutputItem{{
+						Type:    "message",
+						Content: []responsesContentItem{{Type: "output_text", Text: "ok"}},
+					}},
+				},
+			}); err != nil {
+				return
+			}
+		}
+	}))
+	defer server.Close()
+
+	p := New(
+		WithChatGPTAuth("initial", "acct"),
+		WithBaseURL(server.URL),
+		WithTransport(transportWebSocket),
+		WithTokenRefresher(func() (string, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			return token, nil
+		}),
+	)
+	messages := []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "hi"}}},
+	}
+	if _, err := p.Request(context.Background(), messages, nil, nil); err != nil {
+		t.Fatalf("first Request: %v", err)
+	}
+	mu.Lock()
+	token = "token-2"
+	mu.Unlock()
+	if _, err := p.Request(context.Background(), messages, nil, nil); err != nil {
+		t.Fatalf("second Request: %v", err)
+	}
+	if err := p.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	want := []string{"Bearer token-1", "Bearer token-2"}
+	if !reflect.DeepEqual(authHeaders, want) {
+		t.Fatalf("websocket Authorization headers = %v, want %v", authHeaders, want)
+	}
+}
+
+func TestStrictModelBindingWebSocketRejectsMismatch(t *testing.T) {
+	upgrader := websocket.Upgrader{
+		CheckOrigin: func(*http.Request) bool { return true },
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("websocket upgrade failed: %v", err)
+			return
+		}
+		defer conn.Close()
+		if _, _, err := conn.ReadMessage(); err != nil {
+			return
+		}
+		_ = conn.WriteJSON(responsesWSEvent{
+			Type: "response.completed",
+			Response: &responsesAPIResponse{
+				ID:    "response",
+				Model: "gpt-5.1",
+				Output: []responsesOutputItem{{
+					Type:    "message",
+					Content: []responsesContentItem{{Type: "output_text", Text: "wrong route"}},
+				}},
+			},
+		})
+	}))
+	defer server.Close()
+
+	p := New(
+		WithAPIKey("key"),
+		WithBaseURL(server.URL),
+		WithModel("gpt-5"),
+		WithTransport(transportWebSocket),
+		WithStrictModelBinding(),
+	)
+	_, err := p.Request(context.Background(), []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "hi"}}},
+	}, nil, nil)
+	var identityErr *ModelIdentityError
+	if !errors.As(err, &identityErr) {
+		t.Fatalf("Request() error = %v, want ModelIdentityError", err)
+	}
+}
+
 func TestRequestViaResponsesWebSocketFallsBackToHTTP(t *testing.T) {
 	var (
 		getHits  int

--- a/provider/openai/stream.go
+++ b/provider/openai/stream.go
@@ -3,6 +3,7 @@ package openai
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"sort"
@@ -14,14 +15,16 @@ import (
 
 // streamedResponse implements core.StreamedResponse for OpenAI SSE streams.
 type streamedResponse struct {
-	reader     *bufio.Reader
-	body       io.ReadCloser
-	model      string
-	usage      core.Usage
-	parts      []core.ModelResponsePart
-	stopReason core.FinishReason
-	done       bool
-	streamErr  error // non-nil if server sent an error mid-stream
+	reader       *bufio.Reader
+	body         io.ReadCloser
+	model        string
+	resolveModel func(string) (string, error)
+	modelSeen    bool
+	usage        core.Usage
+	parts        []core.ModelResponsePart
+	stopReason   core.FinishReason
+	done         bool
+	streamErr    error // non-nil if server sent an error mid-stream
 
 	// State for tracking tool calls being built across deltas.
 	currentParts map[int]core.ModelResponsePart
@@ -33,10 +36,19 @@ type streamedResponse struct {
 }
 
 func newStreamedResponse(body io.ReadCloser, model string) *streamedResponse {
+	return newBoundStreamedResponse(body, model, nil)
+}
+
+func newBoundStreamedResponse(
+	body io.ReadCloser,
+	model string,
+	resolveModel func(string) (string, error),
+) *streamedResponse {
 	return &streamedResponse{
 		reader:            bufio.NewReader(body),
 		body:              body,
 		model:             model,
+		resolveModel:      resolveModel,
 		currentParts:      make(map[int]core.ModelResponsePart),
 		argsBuffers:       make(map[int]*strings.Builder),
 		toolCallPartIndex: make(map[int]int),
@@ -48,6 +60,7 @@ func newStreamedResponse(body io.ReadCloser, model string) *streamedResponse {
 type apiChunk struct {
 	ID      string           `json:"id"`
 	Object  string           `json:"object"`
+	Model   string           `json:"model,omitempty"`
 	Choices []apiChunkChoice `json:"choices"`
 	Usage   *apiUsage        `json:"usage,omitempty"`
 	Error   *apiStreamError  `json:"error,omitempty"`
@@ -103,9 +116,13 @@ func (s *streamedResponse) Next() (core.ModelResponseStreamEvent, error) {
 
 		line, err := s.reader.ReadString('\n')
 		if err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				if strings.TrimSpace(line) == "" {
 					s.done = true
+					if modelErr := s.finalizeModelIdentity(); modelErr != nil {
+						s.streamErr = modelErr
+						return nil, modelErr
+					}
 					s.finalizeAll()
 					return nil, io.EOF
 				}
@@ -129,6 +146,10 @@ func (s *streamedResponse) Next() (core.ModelResponseStreamEvent, error) {
 		// Check for stream termination.
 		if data == "[DONE]" {
 			s.done = true
+			if err := s.finalizeModelIdentity(); err != nil {
+				s.streamErr = err
+				return nil, err
+			}
 			s.finalizeAll()
 			return nil, io.EOF
 		}
@@ -136,6 +157,19 @@ func (s *streamedResponse) Next() (core.ModelResponseStreamEvent, error) {
 		var chunk apiChunk
 		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
 			continue
+		}
+		if chunk.Model != "" {
+			resolved := chunk.Model
+			if s.resolveModel != nil {
+				resolved, err = s.resolveModel(chunk.Model)
+				if err != nil {
+					s.done = true
+					s.streamErr = err
+					return nil, err
+				}
+			}
+			s.model = resolved
+			s.modelSeen = true
 		}
 
 		// Check for error in stream data (sent by some OpenAI-compatible APIs).
@@ -184,6 +218,18 @@ func (s *streamedResponse) Next() (core.ModelResponseStreamEvent, error) {
 			return events[0], nil
 		}
 	}
+}
+
+func (s *streamedResponse) finalizeModelIdentity() error {
+	if s.resolveModel == nil || s.modelSeen {
+		return nil
+	}
+	resolved, err := s.resolveModel("")
+	if err != nil {
+		return err
+	}
+	s.model = resolved
+	return nil
 }
 
 // handleTextDelta processes a text content delta.


### PR DESCRIPTION
## Summary
- fail closed when OAuth token refresh fails or returns an empty token, and rotate long-lived WebSocket authentication
- bound and redact OAuth endpoint responses while preserving refresh/id-token rotation and rejecting account drift
- add opt-in strict response-model binding across JSON, SSE, and WebSocket transports
- preserve actual provider model provenance in non-strict mode

## Verification
- `go test -race -count=1 ./...` on the contained base before the final rebase
- `go test -race -count=1 ./auth/openai ./provider/openai` on current upstream `main` after the final changes
- `go vet ./...`
- `golangci-lint run --new-from-rev=origin/main ./...` (0 issues)
- `go mod tidy` left `go.mod` and `go.sum` unchanged

The PR is one commit touching only the nine intended OAuth/provider files.