### PR TITLE
Redact and bound OpenAI provider errors

### DIFF
--- a/provider/openai/openai.go
+++ b/provider/openai/openai.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -558,15 +557,10 @@ func (p *Provider) doRequest(ctx context.Context, endpoint string, body []byte) 
 		return resp, nil
 	}
 
-	respBody, _ := io.ReadAll(resp.Body)
+	classification := readProviderErrorClassification(resp.Body)
 	resp.Body.Close()
 
-	httpErr := &core.ModelHTTPError{
-		Message:    "openai API error: " + string(respBody),
-		StatusCode: resp.StatusCode,
-		Body:       string(respBody),
-		ModelName:  p.model,
-	}
+	httpErr := sanitizedProviderHTTPError("openai API error", resp.StatusCode, classification, p.model)
 
 	// Parse Retry-After header for 429 responses so the model-level
 	// retry (modelutil.RetryModel) can use appropriate backoff.
@@ -768,14 +762,12 @@ func isChatCompletionsMismatch(err error) bool {
 	if !errors.As(err, &httpErr) {
 		return false
 	}
-	body := strings.ToLower(httpErr.Body)
-	msg := strings.ToLower(httpErr.Message)
-	combined := body + " " + msg
+	combined := strings.ToLower(httpErr.Body + " " + httpErr.Message)
 	if httpErr.StatusCode == http.StatusNotFound {
-		return strings.Contains(combined, "not a chat model")
+		return strings.Contains(combined, "not_chat_model")
 	}
 	if httpErr.StatusCode == http.StatusBadRequest {
-		return strings.Contains(combined, "please use /v1/responses")
+		return strings.Contains(combined, "use_responses")
 	}
 	return false
 }

--- a/provider/openai/openai_test.go
+++ b/provider/openai/openai_test.go
@@ -1574,11 +1574,11 @@ data: [DONE]
 	if err == nil {
 		t.Fatal("expected error from stream")
 	}
-	if !strings.Contains(err.Error(), "Rate limit exceeded") {
-		t.Errorf("expected error to contain 'Rate limit exceeded', got: %v", err)
+	if strings.Contains(err.Error(), "Rate limit exceeded") {
+		t.Errorf("stream error leaked provider message: %v", err)
 	}
-	if !strings.Contains(err.Error(), "rate_limit_error") {
-		t.Errorf("expected error to contain 'rate_limit_error', got: %v", err)
+	if !strings.Contains(err.Error(), "rate_limited") {
+		t.Errorf("expected source-free rate classification, got: %v", err)
 	}
 }
 
@@ -1595,8 +1595,11 @@ func TestParseSSEStreamErrorOnly(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error from stream")
 	}
-	if !strings.Contains(err.Error(), "Server overloaded") {
-		t.Errorf("expected error to contain 'Server overloaded', got: %v", err)
+	if strings.Contains(err.Error(), "Server overloaded") {
+		t.Errorf("stream error leaked provider message: %v", err)
+	}
+	if !strings.Contains(err.Error(), "server_error") {
+		t.Errorf("expected source-free server classification, got: %v", err)
 	}
 }
 

--- a/provider/openai/provider_error.go
+++ b/provider/openai/provider_error.go
@@ -1,0 +1,81 @@
+package openai
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/fugue-labs/gollem/core"
+)
+
+// Provider error payloads are untrusted and may echo request data. Keep them
+// bounded for classification and expose only fixed, source-free markers.
+const maxProviderErrorBodyBytes = 64 << 10
+
+var providerErrorMarkers = []struct {
+	marker string
+	terms  []string
+}{
+	{marker: "previous_response_not_found", terms: []string{"previous_response_not_found", "previous response with id"}},
+	{marker: "websocket_connection_limit_reached", terms: []string{"websocket_connection_limit_reached", "connection limit reached"}},
+	{marker: "not_chat_model", terms: []string{"not a chat model"}},
+	{marker: "use_responses", terms: []string{"please use /v1/responses", "use the /v1/responses", "use /v1/responses"}},
+	{marker: "max_output_tokens", terms: []string{"max_output_tokens"}},
+	{marker: "context_length_exceeded", terms: []string{"context_length_exceeded", "context length exceeded"}},
+	{marker: "rate_limited", terms: []string{"resource_exhausted", "rate_limit", "rate limit", "too many requests"}},
+	{marker: "unauthorized", terms: []string{"unauthorized", "authentication_error", "invalid_api_key"}},
+	{marker: "forbidden", terms: []string{"forbidden", "permission_error"}},
+	{marker: "timeout", terms: []string{"timeout", "timed out"}},
+	{marker: "server_error", terms: []string{"server_error", "internal server error"}},
+	{marker: "invalid_request", terms: []string{"invalid_request", "bad request"}},
+	{marker: "response_incomplete", terms: []string{"response.incomplete"}},
+	{marker: "response_failed", terms: []string{"response.failed"}},
+}
+
+func classifyProviderError(values ...string) string {
+	combined := strings.ToLower(strings.Join(values, " "))
+	markers := make([]string, 0, 2)
+	for _, candidate := range providerErrorMarkers {
+		for _, term := range candidate.terms {
+			if strings.Contains(combined, term) {
+				markers = append(markers, candidate.marker)
+				break
+			}
+		}
+	}
+	if len(markers) == 0 {
+		return "provider_error"
+	}
+	return strings.Join(markers, ",")
+}
+
+func readProviderErrorClassification(reader io.Reader) string {
+	if reader == nil {
+		return "response_unreadable"
+	}
+	body, err := io.ReadAll(io.LimitReader(reader, maxProviderErrorBodyBytes+1))
+	if err != nil {
+		return "response_unreadable"
+	}
+	oversized := len(body) > maxProviderErrorBodyBytes
+	if oversized {
+		body = body[:maxProviderErrorBodyBytes]
+	}
+	classification := classifyProviderError(string(body))
+	if oversized {
+		return classification + ",response_too_large"
+	}
+	return classification
+}
+
+func sanitizedProviderHTTPError(prefix string, status int, classification, model string) *core.ModelHTTPError {
+	if classification == "" {
+		classification = "provider_error"
+	}
+	return &core.ModelHTTPError{
+		Message:    fmt.Sprintf("%s (HTTP %d; %s)", prefix, status, classification),
+		StatusCode: status,
+		Body:       classification,
+		ModelName:  model,
+	}
+}

--- a/provider/openai/provider_error_test.go
+++ b/provider/openai/provider_error_test.go
@@ -1,0 +1,84 @@
+package openai
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/fugue-labs/gollem/core"
+)
+
+func TestReadProviderErrorClassificationBoundsAndRedacts(t *testing.T) {
+	const secret = "source-fragment-must-not-escape"
+	body := `{"error":{"type":"authentication_error","message":"` +
+		secret + `"}}` + strings.Repeat("x", maxProviderErrorBodyBytes)
+	got := readProviderErrorClassification(strings.NewReader(body))
+	if strings.Contains(got, secret) {
+		t.Fatalf("classification leaked provider payload: %q", got)
+	}
+	if !strings.Contains(got, "unauthorized") || !strings.Contains(got, "response_too_large") {
+		t.Fatalf("classification = %q, want unauthorized and response_too_large", got)
+	}
+}
+
+func TestReadProviderErrorClassificationRejectsUnreadableBodies(t *testing.T) {
+	if got := readProviderErrorClassification(nil); got != "response_unreadable" {
+		t.Fatalf("nil classification = %q", got)
+	}
+	if got := readProviderErrorClassification(providerErrorReader{}); got != "response_unreadable" {
+		t.Fatalf("reader failure classification = %q", got)
+	}
+}
+
+func TestProviderHTTPErrorRedactsResponsePayload(t *testing.T) {
+	const secret = "private-source-in-provider-error"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, `{"error":{"type":"authentication_error","message":"`+secret+`"}}`)
+	}))
+	defer server.Close()
+
+	p := New(WithAPIKey("key"), WithBaseURL(server.URL), WithModel("gpt-4o"))
+	_, err := p.Request(context.Background(), []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "sensitive request"}}},
+	}, nil, nil)
+	var httpErr *core.ModelHTTPError
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("Request() error = %v, want ModelHTTPError", err)
+	}
+	if strings.Contains(err.Error(), secret) || strings.Contains(httpErr.Body, secret) {
+		t.Fatalf("provider error leaked response payload: %#v", httpErr)
+	}
+	if httpErr.Body != "unauthorized" || !strings.Contains(httpErr.Message, "HTTP 401") {
+		t.Fatalf("sanitized provider error = %#v", httpErr)
+	}
+}
+
+func TestResponsesWebSocketErrorsRedactProviderPayload(t *testing.T) {
+	const secret = "private-source-in-websocket-error"
+	err := responsesWebSocketError(responsesWSEvent{
+		Status:  http.StatusTooManyRequests,
+		Code:    "rate_limit_exceeded",
+		Message: secret,
+	}, "gpt-5")
+	var httpErr *core.ModelHTTPError
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("responsesWebSocketError() = %v, want ModelHTTPError", err)
+	}
+	if strings.Contains(err.Error(), secret) || strings.Contains(httpErr.Body, secret) {
+		t.Fatalf("websocket error leaked response payload: %#v", httpErr)
+	}
+	if httpErr.Body != "rate_limited" {
+		t.Fatalf("Body = %q, want rate_limited", httpErr.Body)
+	}
+}
+
+type providerErrorReader struct{}
+
+func (providerErrorReader) Read([]byte) (int, error) {
+	return 0, errors.New("read failed")
+}

--- a/provider/openai/responses_stream.go
+++ b/provider/openai/responses_stream.go
@@ -185,8 +185,9 @@ func (s *responsesStreamedResponse) processEvent(event *responsesStreamEvent) []
 					Code    string `json:"code"`
 				} `json:"error"`
 			}
-			if json.Unmarshal(event.Response, &failedResp) == nil && failedResp.Error.Message != "" {
-				s.streamErr = fmt.Errorf("openai: response failed (%s): %s", failedResp.Error.Code, failedResp.Error.Message)
+			if json.Unmarshal(event.Response, &failedResp) == nil {
+				classification := classifyProviderError("response.failed", failedResp.Error.Code, failedResp.Error.Message)
+				s.streamErr = fmt.Errorf("openai: response failed (%s)", classification)
 			} else {
 				s.streamErr = errors.New("openai: response failed")
 			}

--- a/provider/openai/responses_stream_test.go
+++ b/provider/openai/responses_stream_test.go
@@ -152,8 +152,11 @@ data: [DONE]
 	if err == nil {
 		t.Fatal("expected error from response.failed, got nil")
 	}
-	if !strings.Contains(err.Error(), "context length exceeded") {
-		t.Errorf("expected error to contain failure reason, got: %v", err)
+	if strings.Contains(err.Error(), "context length exceeded") {
+		t.Errorf("response failure leaked provider message: %v", err)
+	}
+	if !strings.Contains(err.Error(), "context_length_exceeded") {
+		t.Errorf("expected source-free failure classification, got: %v", err)
 	}
 }
 

--- a/provider/openai/responses_ws.go
+++ b/provider/openai/responses_ws.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"net/http"
 	"os"
@@ -197,17 +196,11 @@ func (p *Provider) ensureResponsesWebSocketLocked(ctx context.Context) (*respons
 		body := ""
 		if resp != nil {
 			statusCode = resp.StatusCode
-			respBody, _ := io.ReadAll(resp.Body)
+			body = readProviderErrorClassification(resp.Body)
 			resp.Body.Close()
-			body = string(respBody)
 		}
 		if statusCode != 0 {
-			return nil, &core.ModelHTTPError{
-				Message:    "openai websocket connect error: " + body,
-				StatusCode: statusCode,
-				Body:       body,
-				ModelName:  p.model,
-			}
+			return nil, sanitizedProviderHTTPError("openai websocket connect error", statusCode, body, p.model)
 		}
 		return nil, fmt.Errorf("openai websocket connect failed: %w", err)
 	}
@@ -414,13 +407,8 @@ func responsesWebSocketError(event responsesWSEvent, model string) error {
 	if status == 0 {
 		status = inferResponsesWSErrorStatus(code, typ, msg)
 	}
-	raw, _ := json.Marshal(event)
-	return &core.ModelHTTPError{
-		Message:    "openai websocket error: " + msg,
-		StatusCode: status,
-		Body:       string(raw),
-		ModelName:  model,
-	}
+	classification := classifyProviderError(code, typ, msg)
+	return sanitizedProviderHTTPError("openai websocket error", status, classification, model)
 }
 
 func responsesIncompleteError(event responsesWSEvent, model string) error {
@@ -431,13 +419,8 @@ func responsesIncompleteError(event responsesWSEvent, model string) error {
 	if reason == "" {
 		reason = "response.incomplete"
 	}
-	raw, _ := json.Marshal(event)
-	return &core.ModelHTTPError{
-		Message:    "openai websocket response incomplete: " + reason,
-		StatusCode: http.StatusBadRequest,
-		Body:       string(raw),
-		ModelName:  model,
-	}
+	classification := classifyProviderError("response.incomplete", reason)
+	return sanitizedProviderHTTPError("openai websocket response incomplete", http.StatusBadRequest, classification, model)
 }
 
 func responsesFailedError(event responsesWSEvent, model string) error {
@@ -448,13 +431,8 @@ func responsesFailedError(event responsesWSEvent, model string) error {
 	if reason == "" {
 		reason = "response.failed"
 	}
-	raw, _ := json.Marshal(event)
-	return &core.ModelHTTPError{
-		Message:    "openai websocket response failed: " + reason,
-		StatusCode: http.StatusBadRequest,
-		Body:       string(raw),
-		ModelName:  model,
-	}
+	classification := classifyProviderError("response.failed", reason)
+	return sanitizedProviderHTTPError("openai websocket response failed", http.StatusBadRequest, classification, model)
 }
 
 func inferResponsesWSErrorStatus(code, typ, message string) int {

--- a/provider/openai/responses_ws_test.go
+++ b/provider/openai/responses_ws_test.go
@@ -1165,7 +1165,8 @@ func TestRequestViaResponsesWebSocketResponseFailed(t *testing.T) {
 	if httpErr.StatusCode != http.StatusBadRequest {
 		t.Fatalf("expected status 400, got %d", httpErr.StatusCode)
 	}
-	if !strings.Contains(httpErr.Message, "response failed: max_output_tokens") {
+	if !strings.Contains(httpErr.Message, "max_output_tokens") ||
+		!strings.Contains(httpErr.Message, "response_failed") {
 		t.Fatalf("unexpected error message: %q", httpErr.Message)
 	}
 }

--- a/provider/openai/stream.go
+++ b/provider/openai/stream.go
@@ -176,7 +176,8 @@ func (s *streamedResponse) Next() (core.ModelResponseStreamEvent, error) {
 		if chunk.Error != nil {
 			s.done = true
 			s.finalizeAll()
-			s.streamErr = fmt.Errorf("openai stream error (%s): %s", chunk.Error.Type, chunk.Error.Message)
+			classification := classifyProviderError(chunk.Error.Type, chunk.Error.Message)
+			s.streamErr = fmt.Errorf("openai stream error (%s)", classification)
 			return nil, s.streamErr
 		}
 


### PR DESCRIPTION
## Summary
- cap HTTP and WebSocket handshake error bodies before classification
- expose only fixed source-free error markers instead of raw provider messages or payloads
- preserve retry, endpoint-fallback, continuation-reset, status, and Retry-After behavior
- redact JSON, SSE, and WebSocket failure events consistently

## Verification
- `go test -race -count=1 ./provider/openai`
- `golangci-lint run --new-from-rev=origin/main ./...`
- `go vet ./provider/openai`
- existing chat-to-Responses fallback and WebSocket retry suites remain green