### PR TITLE
Export exact permission profile list contracts

### DIFF
--- a/appserver/protocol/account_credit_nudge_values_contract_test.go
+++ b/appserver/protocol/account_credit_nudge_values_contract_test.go
@@ -119,8 +119,8 @@ func TestAccountCreditNudgeValuesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/sendAddCreditsNudgeEmail = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/account_envelope_contract_test.go
+++ b/appserver/protocol/account_envelope_contract_test.go
@@ -268,8 +268,8 @@ func TestAccountEnvelopeContractsRemainStandaloneAndDeferred(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred %s", methodName, method, ok, surface)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 224/59/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/account_login_completed_notification_contract_test.go
+++ b/appserver/protocol/account_login_completed_notification_contract_test.go
@@ -88,8 +88,8 @@ func TestAccountLoginCompletedNotificationRemainsStandaloneAndDeferred(t *testin
 	if !found {
 		t.Fatal("account/login/completed method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/account_rate_limits_contract_test.go
+++ b/appserver/protocol/account_rate_limits_contract_test.go
@@ -484,8 +484,8 @@ func TestAccountRateLimitContractsRemainStandaloneAndDeferred(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred %s", methodName, method, ok, surface)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/account_token_usage_contract_test.go
+++ b/appserver/protocol/account_token_usage_contract_test.go
@@ -146,8 +146,8 @@ func TestAccountTokenUsageRecordsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/usage/read = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(defs); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_config_contract_test.go
+++ b/appserver/protocol/app_config_contract_test.go
@@ -109,8 +109,8 @@ func TestAppConfigRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppConfig unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_info_contract_test.go
+++ b/appserver/protocol/app_info_contract_test.go
@@ -131,8 +131,8 @@ func TestAppInfoRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_list_updated_notification_contract_test.go
+++ b/appserver/protocol/app_list_updated_notification_contract_test.go
@@ -105,8 +105,8 @@ func TestAppListUpdatedNotificationRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceServerNotification || method.State != MethodDeferredStub {
 		t.Fatalf("app/list/updated = %#v, %v; want deferred server notification", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_metadata_contract_test.go
+++ b/appserver/protocol/app_metadata_contract_test.go
@@ -107,8 +107,8 @@ func TestAppMetadataRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_metadata_leaf_contract_test.go
+++ b/appserver/protocol/app_metadata_leaf_contract_test.go
@@ -157,8 +157,8 @@ func TestAppMetadataLeavesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_summary_contract_test.go
+++ b/appserver/protocol/app_summary_contract_test.go
@@ -87,8 +87,8 @@ func TestAppSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppSummary unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_template_summary_contract_test.go
+++ b/appserver/protocol/app_template_summary_contract_test.go
@@ -107,8 +107,8 @@ func TestAppTemplateSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppTemplateSummary unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_template_unavailable_reason_contract_test.go
+++ b/appserver/protocol/app_template_unavailable_reason_contract_test.go
@@ -71,8 +71,8 @@ func TestAppTemplateUnavailableReasonRemainsStandalone(t *testing.T) {
 			t.Fatalf("AppTemplateUnavailableReason unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_tool_approval_contract_test.go
+++ b/appserver/protocol/app_tool_approval_contract_test.go
@@ -73,8 +73,8 @@ func TestAppToolApprovalRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppToolApproval unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_tools_config_contract_test.go
+++ b/appserver/protocol/app_tools_config_contract_test.go
@@ -140,8 +140,8 @@ func TestAppToolConfigsRemainStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/apply_patch_approval_params_contract_test.go
+++ b/appserver/protocol/apply_patch_approval_params_contract_test.go
@@ -139,8 +139,8 @@ func TestApplyPatchApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ApplyPatchApprovalParams unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(defs); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(defs); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/apps_config_contract_test.go
+++ b/appserver/protocol/apps_config_contract_test.go
@@ -185,8 +185,8 @@ func TestAppsConfigsRemainStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/apps_list_contract_test.go
+++ b/appserver/protocol/apps_list_contract_test.go
@@ -168,8 +168,8 @@ func TestAppsListContractsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/attestation_contract_test.go
+++ b/appserver/protocol/attestation_contract_test.go
@@ -133,8 +133,8 @@ func TestAttestationContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("attestation/generate = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
+++ b/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
@@ -179,8 +179,8 @@ func TestChatgptAuthTokensRefreshRemainsStandaloneAndDeferred(t *testing.T) {
 	if !found {
 		t.Fatal("refresh method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/exec_command_approval_params_contract_test.go
+++ b/appserver/protocol/exec_command_approval_params_contract_test.go
@@ -137,8 +137,8 @@ func TestExecCommandApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ExecCommandApprovalParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(defs); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/experimental_feature_contract_test.go
+++ b/appserver/protocol/experimental_feature_contract_test.go
@@ -41,8 +41,8 @@ func TestExperimentalFeatureContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want implemented client request", methodName, method, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d/%d/%d, want 224/59/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,8 +217,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,8 +203,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -260,8 +260,8 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,8 +244,8 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -162,8 +162,8 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -175,8 +175,8 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_contract_test.go
+++ b/appserver/protocol/file_change_contract_test.go
@@ -108,8 +108,8 @@ func TestFileChangeRemainsStandalone(t *testing.T) {
 			t.Fatalf("FileChange unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_output_delta_notification_contract_test.go
+++ b/appserver/protocol/file_change_output_delta_notification_contract_test.go
@@ -100,8 +100,8 @@ func TestFileChangeOutputDeltaNotificationRemainsDeprecatedAndStandalone(t *test
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("item/fileChange/outputDelta = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -381,8 +381,8 @@ func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_action_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_action_contract_test.go
@@ -226,8 +226,8 @@ func TestGuardianApprovalReviewActionRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReviewAction unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
@@ -164,8 +164,8 @@ func TestGuardianApprovalReviewCompletedNotificationRemainsStandalone(t *testing
 			t.Fatalf("completed notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_contract_test.go
@@ -139,8 +139,8 @@ func TestGuardianApprovalReviewRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReview unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
@@ -175,8 +175,8 @@ func TestGuardianApprovalReviewStartedNotificationRemainsStandalone(t *testing.T
 			t.Fatalf("started notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_enum_foundation_contract_test.go
+++ b/appserver/protocol/guardian_enum_foundation_contract_test.go
@@ -89,8 +89,8 @@ func TestGuardianEnumFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_metadata_list_contract_test.go
+++ b/appserver/protocol/hook_metadata_list_contract_test.go
@@ -352,8 +352,8 @@ func TestHookMetadataListContractsStayStandalone(t *testing.T) {
 			t.Errorf("standalone definition %s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Errorf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Errorf("definition count = %d, want 516", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 {
 		t.Errorf("wire binding count = %d, want 59", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_run_notification_contract_test.go
+++ b/appserver/protocol/hook_run_notification_contract_test.go
@@ -297,8 +297,8 @@ func TestHookRunNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("surface changed: %d methods, %d wire bindings, %d item bindings", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/hook_value_foundation_contract_test.go
+++ b/appserver/protocol/hook_value_foundation_contract_test.go
@@ -167,8 +167,8 @@ func TestHookValueFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 513 {
-		t.Fatalf("definition count = %d, want 513", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 516 {
+		t.Fatalf("definition count = %d, want 516", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/legacy_approval_response_contract_test.go
+++ b/appserver/protocol/legacy_approval_response_contract_test.go
@@ -98,8 +98,8 @@ func TestLegacyApprovalResponsesRemainStandaloneAndNominal(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_oauth_login_contract_test.go
+++ b/appserver/protocol/mcp_server_oauth_login_contract_test.go
@@ -228,8 +228,8 @@ func TestMcpServerOauthLoginContractsRemainStandaloneAndBlocked(t *testing.T) {
 	if !ok || notification.Surface != SurfaceServerNotification || notification.State != MethodBlocked {
 		t.Fatalf("mcpServer/oauthLogin/completed = %#v, %v; want blocked server notification", notification, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d/%d/%d, want 224/59/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_contract_test.go
+++ b/appserver/protocol/mcp_server_status_contract_test.go
@@ -277,8 +277,8 @@ func TestMcpServerStatusContractsRemainStandalone(t *testing.T) {
 	if !ok || method.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d/%d/%d, want 224/59/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_approval_context_contract_test.go
+++ b/appserver/protocol/network_approval_context_contract_test.go
@@ -84,8 +84,8 @@ func TestNetworkApprovalContextRemainsStandalone(t *testing.T) {
 			t.Fatalf("NetworkApprovalContext unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/parsed_command_contract_test.go
+++ b/appserver/protocol/parsed_command_contract_test.go
@@ -120,8 +120,8 @@ func TestParsedCommandRemainsStandalone(t *testing.T) {
 			t.Fatalf("ParsedCommand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/permission_profile_list_contract_test.go
+++ b/appserver/protocol/permission_profile_list_contract_test.go
@@ -1,0 +1,293 @@
+package protocol
+
+import (
+	"encoding/json"
+	"math"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestPermissionProfileListSchemasAreExact(t *testing.T) {
+	wants := map[string]Schema{
+		"PermissionProfileListParams": {
+			"type": "object",
+			"properties": Schema{
+				"cursor": Schema{
+					"description": "Opaque pagination cursor returned by a previous call.",
+					"type":        []any{"string", "null"},
+				},
+				"cwd": Schema{
+					"description": "Optional working directory to resolve project config layers.",
+					"type":        []any{"string", "null"},
+				},
+				"limit": Schema{
+					"description": "Optional page size; defaults to the full result set.",
+					"format":      "uint32",
+					"minimum":     float64(0),
+					"type":        []any{"integer", "null"},
+				},
+			},
+		},
+		"PermissionProfileSummary": {
+			"type": "object",
+			"properties": Schema{
+				"allowed": Schema{
+					"description": "Whether the effective requirements allow selecting this profile.",
+					"type":        "boolean",
+				},
+				"description": Schema{
+					"description": "Optional user-facing description for display in clients.",
+					"type":        []any{"string", "null"},
+				},
+				"id": Schema{
+					"description": "Available permission profile identifier.",
+					"type":        "string",
+				},
+			},
+			"required": []string{"allowed", "id"},
+		},
+		"PermissionProfileListResponse": {
+			"type": "object",
+			"properties": Schema{
+				"data": Schema{
+					"items": Schema{"$ref": "#/$defs/PermissionProfileSummary"},
+					"type":  "array",
+				},
+				"nextCursor": Schema{
+					"description": "Opaque cursor to pass to the next call to continue after the last item. If None, there are no more items to return.",
+					"type":        []any{"string", "null"},
+				},
+			},
+			"required": []string{"data"},
+		},
+	}
+	definitions := JSONSchema()["$defs"].(Schema)
+	for name, want := range wants {
+		if got := definitions[name]; !reflect.DeepEqual(got, want) {
+			t.Errorf("%s = %#v, want %#v", name, got, want)
+		}
+	}
+}
+
+func TestPermissionProfileListParamsPreserveSerdeWireForms(t *testing.T) {
+	for _, tc := range []struct {
+		input string
+		want  PermissionProfileListParams
+		json  string
+	}{
+		{`{}`, PermissionProfileListParams{}, `{"cursor":null,"limit":null,"cwd":null}`},
+		{
+			`{"cursor":null,"limit":null,"cwd":null}`,
+			PermissionProfileListParams{},
+			`{"cursor":null,"limit":null,"cwd":null}`,
+		},
+		{
+			`{"future":1,"future":2,"cursor":"","limit":0,"cwd":" "}`,
+			PermissionProfileListParams{
+				Cursor: stringPointer(""), Limit: uint32Pointer(0), CWD: stringPointer(" "),
+			},
+			`{"cursor":"","limit":0,"cwd":" "}`,
+		},
+		{
+			`{"cursor":" next ","limit":4294967295,"cwd":" /workspace "}`,
+			PermissionProfileListParams{
+				Cursor: stringPointer(" next "),
+				Limit:  uint32Pointer(math.MaxUint32),
+				CWD:    stringPointer(" /workspace "),
+			},
+			`{"cursor":" next ","limit":4294967295,"cwd":" /workspace "}`,
+		},
+	} {
+		var params PermissionProfileListParams
+		if err := json.Unmarshal([]byte(tc.input), &params); err != nil {
+			t.Errorf("unmarshal %s: %v", tc.input, err)
+			continue
+		}
+		if !reflect.DeepEqual(params, tc.want) {
+			t.Errorf("params %s = %#v, want %#v", tc.input, params, tc.want)
+		}
+		encoded, err := json.Marshal(params)
+		if err != nil || string(encoded) != tc.json {
+			t.Errorf("marshal %#v = %s, %v; want %s", params, encoded, err, tc.json)
+		}
+	}
+}
+
+func TestPermissionProfileListParamsRejectMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`,
+		`{"cursor":1}`, `{"cursor":true}`, `{"cwd":1}`, `{"cwd":false}`,
+		`{"limit":-1}`, `{"limit":0.5}`, `{"limit":1e3}`,
+		`{"limit":4294967296}`, `{"limit":"1"}`, `{"limit":true}`,
+		`{"cursor":null,"cursor":"next"}`, `{"limit":null,"limit":0}`,
+		`{"cwd":null,"cwd":"path"}`, `{} {}`, `{} x`,
+	} {
+		assertJSONRejects[PermissionProfileListParams](t, input)
+	}
+}
+
+func TestPermissionProfileSummaryPreservesSerdeWireForms(t *testing.T) {
+	for _, tc := range []struct {
+		input string
+		want  PermissionProfileSummary
+		json  string
+	}{
+		{
+			`{"id":"","allowed":false}`,
+			PermissionProfileSummary{},
+			`{"id":"","description":null,"allowed":false}`,
+		},
+		{
+			`{"id":"profile","description":null,"allowed":true}`,
+			PermissionProfileSummary{ID: "profile", Allowed: true},
+			`{"id":"profile","description":null,"allowed":true}`,
+		},
+		{
+			`{"future":1,"future":2,"id":" profile ","description":" description ","allowed":false}`,
+			PermissionProfileSummary{
+				ID: " profile ", Description: stringPointer(" description "), Allowed: false,
+			},
+			`{"id":" profile ","description":" description ","allowed":false}`,
+		},
+	} {
+		var summary PermissionProfileSummary
+		if err := json.Unmarshal([]byte(tc.input), &summary); err != nil {
+			t.Errorf("unmarshal %s: %v", tc.input, err)
+			continue
+		}
+		if !reflect.DeepEqual(summary, tc.want) {
+			t.Errorf("summary %s = %#v, want %#v", tc.input, summary, tc.want)
+		}
+		encoded, err := json.Marshal(summary)
+		if err != nil || string(encoded) != tc.json {
+			t.Errorf("marshal %#v = %s, %v; want %s", summary, encoded, err, tc.json)
+		}
+	}
+}
+
+func TestPermissionProfileSummaryRejectMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`, `{}`,
+		`{"allowed":true}`, `{"id":"profile"}`,
+		`{"id":null,"allowed":true}`, `{"id":1,"allowed":true}`,
+		`{"id":"profile","allowed":null}`, `{"id":"profile","allowed":"true"}`,
+		`{"id":"profile","description":1,"allowed":true}`,
+		`{"id":"a","id":"b","allowed":true}`,
+		`{"id":"profile","description":null,"description":"text","allowed":true}`,
+		`{"id":"profile","allowed":true,"allowed":false}`,
+		`{"id":"profile","allowed":true} {}`, `{"id":"profile","allowed":true} x`,
+	} {
+		assertJSONRejects[PermissionProfileSummary](t, input)
+	}
+}
+
+func TestPermissionProfileListResponsePreservesSerdeWireForms(t *testing.T) {
+	for _, tc := range []struct{ input, want string }{
+		{`{"data":[]}`, `{"data":[],"nextCursor":null}`},
+		{`{"future":true,"data":[],"nextCursor":null}`, `{"data":[],"nextCursor":null}`},
+		{
+			`{"data":[{"id":"a","allowed":true},{"id":"a","description":"","allowed":false}],"nextCursor":" next "}`,
+			`{"data":[{"id":"a","description":null,"allowed":true},{"id":"a","description":"","allowed":false}],"nextCursor":" next "}`,
+		},
+	} {
+		var response PermissionProfileListResponse
+		if err := json.Unmarshal([]byte(tc.input), &response); err != nil {
+			t.Errorf("unmarshal %s: %v", tc.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(response)
+		if err != nil || string(encoded) != tc.want {
+			t.Errorf("round trip %s = %s, %v; want %s", tc.input, encoded, err, tc.want)
+		}
+	}
+}
+
+func TestPermissionProfileListResponseRejectMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`, `{}`,
+		`{"data":null}`, `{"data":{}}`, `{"data":[null]}`, `{"data":[{}]}`,
+		`{"data":[{"id":"profile"}]}`, `{"data":[{"allowed":true}]}`,
+		`{"data":[],"nextCursor":1}`, `{"data":[],"nextCursor":false}`,
+		`{"data":[],"data":[]}`, `{"data":[],"nextCursor":null,"nextCursor":"next"}`,
+		`{"data":[]} {}`, `{"data":[]} x`,
+	} {
+		assertJSONRejects[PermissionProfileListResponse](t, input)
+	}
+}
+
+func TestPermissionProfileListNilReceiversAndInvalidMarshalFailClosed(t *testing.T) {
+	var params *PermissionProfileListParams
+	if err := params.UnmarshalJSON([]byte(`{}`)); err == nil {
+		t.Fatal("nil params receiver succeeded")
+	}
+	var summary *PermissionProfileSummary
+	if err := summary.UnmarshalJSON([]byte(`{"id":"profile","allowed":true}`)); err == nil {
+		t.Fatal("nil summary receiver succeeded")
+	}
+	var response *PermissionProfileListResponse
+	if err := response.UnmarshalJSON([]byte(`{"data":[]}`)); err == nil {
+		t.Fatal("nil response receiver succeeded")
+	}
+	if _, err := json.Marshal(PermissionProfileListResponse{}); err == nil {
+		t.Fatal("nil response data marshaled")
+	}
+}
+
+func TestPermissionProfileListContractsRemainStandalone(t *testing.T) {
+	names := []string{
+		"PermissionProfileListParams", "PermissionProfileSummary", "PermissionProfileListResponse",
+	}
+	for _, binding := range WireTypeBindings() {
+		for _, name := range names {
+			if slices.Contains(binding.Params, name) || slices.Contains(binding.Result, name) {
+				t.Fatalf("%s unexpectedly bound to %s", name, binding.Method)
+			}
+		}
+	}
+	for _, binding := range ItemPayloadBindings() {
+		if slices.Contains(names, binding.Type) {
+			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
+		}
+	}
+	method, ok := LookupMethod("permissionProfile/list")
+	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodImplemented {
+		t.Fatalf("permissionProfile/list = %#v, %v; want existing implemented client request", method, ok)
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
+	}
+	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("counts = %d/%d/%d, want 224/59/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
+	}
+}
+
+func TestPermissionProfileListTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	for _, want := range []string{
+		"export type PermissionProfileListParams = {\n" +
+			"  \"cursor\"?: string | null;\n" +
+			"  \"cwd\"?: string | null;\n" +
+			"  \"limit\"?: number | null;\n" +
+			"};",
+		"export type PermissionProfileSummary = {\n" +
+			"  \"allowed\": boolean;\n" +
+			"  \"description\": string | null;\n" +
+			"  \"id\": string;\n" +
+			"};",
+		"export type PermissionProfileListResponse = {\n" +
+			"  \"data\": Array<PermissionProfileSummary>;\n" +
+			"  \"nextCursor\": string | null;\n" +
+			"};",
+	} {
+		if !strings.Contains(string(generated), want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}
+
+func uint32Pointer(value uint32) *uint32 { return &value }

--- a/appserver/protocol/permission_profile_list_types.go
+++ b/appserver/protocol/permission_profile_list_types.go
@@ -1,0 +1,193 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// PermissionProfileListParams is the exact public permission-profile page
+// selector. It remains separate from Gollem's broader live catalog request.
+type PermissionProfileListParams struct {
+	Cursor *string `json:"cursor"`
+	Limit  *uint32 `json:"limit"`
+	CWD    *string `json:"cwd"`
+}
+
+func (p PermissionProfileListParams) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Cursor *string `json:"cursor"`
+		Limit  *uint32 `json:"limit"`
+		CWD    *string `json:"cwd"`
+	}{Cursor: p.Cursor, Limit: p.Limit, CWD: p.CWD})
+}
+
+func (p *PermissionProfileListParams) UnmarshalJSON(data []byte) error {
+	if p == nil {
+		return errors.New("decode permission-profile list params into nil receiver")
+	}
+	const objectName = "permission-profile list params"
+	payload, err := decodeRustSerdeObject(data, objectName, "cursor", "limit", "cwd")
+	if err != nil {
+		return err
+	}
+	cursor, err := decodeOptionalNullableConfigValue[string](payload, objectName, "cursor")
+	if err != nil {
+		return err
+	}
+	limit, err := decodeOptionalNullableConfigValue[uint32](payload, objectName, "limit")
+	if err != nil {
+		return err
+	}
+	cwd, err := decodeOptionalNullableConfigValue[string](payload, objectName, "cwd")
+	if err != nil {
+		return err
+	}
+	*p = PermissionProfileListParams{Cursor: cursor, Limit: limit, CWD: cwd}
+	return nil
+}
+
+// PermissionProfileSummary is exact public display and selectability data. It
+// does not grant permissions or prove that a profile is enforced.
+type PermissionProfileSummary struct {
+	ID          string  `json:"id"`
+	Description *string `json:"description"`
+	Allowed     bool    `json:"allowed"`
+}
+
+func (s PermissionProfileSummary) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		ID          string  `json:"id"`
+		Description *string `json:"description"`
+		Allowed     bool    `json:"allowed"`
+	}{ID: s.ID, Description: s.Description, Allowed: s.Allowed})
+}
+
+func (s *PermissionProfileSummary) UnmarshalJSON(data []byte) error {
+	if s == nil {
+		return errors.New("decode permission-profile summary into nil receiver")
+	}
+	const objectName = "permission-profile summary"
+	payload, err := decodeRustSerdeObject(data, objectName, "id", "description", "allowed")
+	if err != nil {
+		return err
+	}
+	id, err := decodeRequiredThreadItemValue[string](payload, objectName, "id")
+	if err != nil {
+		return err
+	}
+	description, err := decodeOptionalNullableConfigValue[string](payload, objectName, "description")
+	if err != nil {
+		return err
+	}
+	allowed, err := decodeRequiredThreadItemValue[bool](payload, objectName, "allowed")
+	if err != nil {
+		return err
+	}
+	*s = PermissionProfileSummary{ID: id, Description: description, Allowed: allowed}
+	return nil
+}
+
+// PermissionProfileListResponse is one exact public ordered profile-summary
+// page. The records remain descriptive and carry no permission authority.
+type PermissionProfileListResponse struct {
+	Data       []PermissionProfileSummary `json:"data"`
+	NextCursor *string                    `json:"nextCursor"`
+}
+
+func (r PermissionProfileListResponse) MarshalJSON() ([]byte, error) {
+	if r.Data == nil {
+		return nil, errors.New("permission-profile list response data cannot be null")
+	}
+	return json.Marshal(struct {
+		Data       []PermissionProfileSummary `json:"data"`
+		NextCursor *string                    `json:"nextCursor"`
+	}{Data: r.Data, NextCursor: r.NextCursor})
+}
+
+func (r *PermissionProfileListResponse) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("decode permission-profile list response into nil receiver")
+	}
+	const objectName = "permission-profile list response"
+	payload, err := decodeRustSerdeObject(data, objectName, "data", "nextCursor")
+	if err != nil {
+		return err
+	}
+	profiles, err := decodeRequiredThreadItemArray[PermissionProfileSummary](
+		payload, objectName, "data",
+	)
+	if err != nil {
+		return err
+	}
+	nextCursor, err := decodeOptionalNullableConfigValue[string](payload, objectName, "nextCursor")
+	if err != nil {
+		return err
+	}
+	*r = PermissionProfileListResponse{Data: profiles, NextCursor: nextCursor}
+	return nil
+}
+
+func permissionProfileListSchemas() map[string]Schema {
+	return map[string]Schema{
+		"PermissionProfileListParams": {
+			"type": "object",
+			"properties": Schema{
+				"cursor": Schema{
+					"description": "Opaque pagination cursor returned by a previous call.",
+					"type":        []any{"string", "null"},
+				},
+				"cwd": Schema{
+					"description": "Optional working directory to resolve project config layers.",
+					"type":        []any{"string", "null"},
+				},
+				"limit": Schema{
+					"description": "Optional page size; defaults to the full result set.",
+					"format":      "uint32",
+					"minimum":     float64(0),
+					"type":        []any{"integer", "null"},
+				},
+			},
+		},
+		"PermissionProfileSummary": {
+			"type": "object",
+			"properties": Schema{
+				"allowed": Schema{
+					"description": "Whether the effective requirements allow selecting this profile.",
+					"type":        "boolean",
+				},
+				"description": Schema{
+					"description": "Optional user-facing description for display in clients.",
+					"type":        []any{"string", "null"},
+				},
+				"id": Schema{
+					"description": "Available permission profile identifier.",
+					"type":        "string",
+				},
+			},
+			"required": []string{"allowed", "id"},
+		},
+		"PermissionProfileListResponse": {
+			"type": "object",
+			"properties": Schema{
+				"data": Schema{
+					"items": Schema{"$ref": "#/$defs/PermissionProfileSummary"},
+					"type":  "array",
+				},
+				"nextCursor": Schema{
+					"description": "Opaque cursor to pass to the next call to continue after the last item. If None, there are no more items to return.",
+					"type":        []any{"string", "null"},
+				},
+			},
+			"required": []string{"data"},
+		},
+	}
+}
+
+var (
+	_ json.Marshaler   = PermissionProfileListParams{}
+	_ json.Unmarshaler = (*PermissionProfileListParams)(nil)
+	_ json.Marshaler   = PermissionProfileSummary{}
+	_ json.Unmarshaler = (*PermissionProfileSummary)(nil)
+	_ json.Marshaler   = PermissionProfileListResponse{}
+	_ json.Unmarshaler = (*PermissionProfileListResponse)(nil)
+)

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/process_contracts_contract_test.go
+++ b/appserver/protocol/process_contracts_contract_test.go
@@ -308,8 +308,8 @@ func TestProcessContractsRemainStandaloneFromLegacyRuntime(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want unchanged implemented notification", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 513 {
-		t.Fatalf("definition count = %d, want 513", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 516 {
+		t.Fatalf("definition count = %d, want 516", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 513 {
-		t.Fatalf("definition count = %d, want 513", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 516 {
+		t.Fatalf("definition count = %d, want 516", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 513 {
-		t.Fatalf("definition count = %d, want 513", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 516 {
+		t.Fatalf("definition count = %d, want 516", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 513 {
-		t.Fatalf("definition count = %d, want 513", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 516 {
+		t.Fatalf("definition count = %d, want 516", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 513 {
-		t.Fatalf("definition count = %d, want 513", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 516 {
+		t.Fatalf("definition count = %d, want 516", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/review_decision_contract_test.go
+++ b/appserver/protocol/review_decision_contract_test.go
@@ -136,8 +136,8 @@ func TestReviewDecisionRemainsStandalone(t *testing.T) {
 			t.Fatalf("ReviewDecision unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(defs); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -429,6 +429,9 @@ func wireSchemaDefinitions() Schema {
 		{Name: "NetworkApprovalContext", Type: reflect.TypeFor[NetworkApprovalContext]()},
 		{Name: "NetworkApprovalProtocol", Type: reflect.TypeFor[NetworkApprovalProtocol]()},
 		{Name: "ParsedCommand", Type: reflect.TypeFor[ParsedCommand]()},
+		{Name: "PermissionProfileListParams", Type: reflect.TypeFor[PermissionProfileListParams]()},
+		{Name: "PermissionProfileListResponse", Type: reflect.TypeFor[PermissionProfileListResponse]()},
+		{Name: "PermissionProfileSummary", Type: reflect.TypeFor[PermissionProfileSummary]()},
 		{Name: "PermissionGrantScope", Type: reflect.TypeFor[PermissionGrantScope]()},
 		{Name: "PermissionsApprovalRequestParams", Type: reflect.TypeFor[PermissionsApprovalRequestParams]()},
 		{Name: "PermissionsRequestApprovalParams", Type: reflect.TypeFor[PermissionsRequestApprovalParams]()},
@@ -1050,6 +1053,9 @@ func wireSchemaDefinitions() Schema {
 		string(NetworkApprovalProtocolSocks5TCP), string(NetworkApprovalProtocolSocks5UDP),
 	)
 	schemas["ParsedCommand"] = parsedCommandSchema()
+	for name, schema := range permissionProfileListSchemas() {
+		schemas[name] = schema
+	}
 	schemas["ProcessExitedNotification"] = processExitedNotificationSchema()
 	schemas["ProcessOutputDeltaNotification"] = processOutputDeltaNotificationSchema()
 	schemas["ProcessOutputStream"] = processOutputStreamSchema()

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -10361,6 +10361,79 @@
       ],
       "type": "string"
     },
+    "PermissionProfileListParams": {
+      "properties": {
+        "cursor": {
+          "description": "Opaque pagination cursor returned by a previous call.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "cwd": {
+          "description": "Optional working directory to resolve project config layers.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "limit": {
+          "description": "Optional page size; defaults to the full result set.",
+          "format": "uint32",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "PermissionProfileListResponse": {
+      "properties": {
+        "data": {
+          "items": {
+            "$ref": "#/$defs/PermissionProfileSummary"
+          },
+          "type": "array"
+        },
+        "nextCursor": {
+          "description": "Opaque cursor to pass to the next call to continue after the last item. If None, there are no more items to return.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "data"
+      ],
+      "type": "object"
+    },
+    "PermissionProfileSummary": {
+      "properties": {
+        "allowed": {
+          "description": "Whether the effective requirements allow selecting this profile.",
+          "type": "boolean"
+        },
+        "description": {
+          "description": "Optional user-facing description for display in clients.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "id": {
+          "description": "Available permission profile identifier.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "allowed",
+        "id"
+      ],
+      "type": "object"
+    },
     "PermissionsApprovalRequestParams": {
       "additionalProperties": false,
       "properties": {

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 513 {
-		t.Fatalf("definition count = %d, want 513", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 516 {
+		t.Fatalf("definition count = %d, want 516", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 513 {
-		t.Fatalf("definition count = %d, want 513", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 516 {
+		t.Fatalf("definition count = %d, want 516", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 513 {
-		t.Fatalf("definition count = %d, want 513", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 516 {
+		t.Fatalf("definition count = %d, want 516", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -506,6 +506,45 @@ func MarshalTypeScript() ([]byte, error) {
 			schema["x-gollem-typescript-ignore-additional-properties"] = true
 			definition = schema
 		}
+		switch name {
+		case "PermissionProfileListParams":
+			definition = typeScriptDefinitionWithPropertySchemas(definition, Schema{
+				"cursor": nullableStringSchema(),
+				"cwd":    nullableStringSchema(),
+				"limit": Schema{"anyOf": []any{
+					Schema{"type": "integer"}, Schema{"type": "null"},
+				}},
+			})
+		case "PermissionProfileSummary":
+			definition = typeScriptDefinitionWithPropertySchemas(definition, Schema{
+				"description": nullableStringSchema(),
+			})
+		case "PermissionProfileListResponse":
+			definition = typeScriptDefinitionWithPropertySchemas(definition, Schema{
+				"nextCursor": nullableStringSchema(),
+			})
+		}
+		if name == "PermissionProfileSummary" || name == "PermissionProfileListResponse" {
+			// serde accepts omitted Option fields and emits them as null, while
+			// ts-rs exposes these two properties as required nullable values.
+			schema, _ := typeScriptSchema(definition)
+			required, _ := schema["required"].([]string)
+			required = append([]string(nil), required...)
+			if name == "PermissionProfileSummary" {
+				required = append(required, "description")
+			} else {
+				required = append(required, "nextCursor")
+			}
+			schema["required"] = required
+			definition = schema
+		}
+		if name == "PermissionProfileListParams" ||
+			name == "PermissionProfileSummary" ||
+			name == "PermissionProfileListResponse" {
+			schema, _ := typeScriptSchema(definition)
+			schema["x-gollem-typescript-ignore-additional-properties"] = true
+			definition = schema
+		}
 		if name == "HookRunSummary" {
 			// ts-rs maps each Rust i64 field to bigint, including nullable i64
 			// options. Keep these hints out of the public JSON Schema.

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -2643,6 +2643,23 @@ export type PatchChangeKind = {
 
 export type PermissionGrantScope = "turn" | "session";
 
+export type PermissionProfileListParams = {
+  "cursor"?: string | null;
+  "cwd"?: string | null;
+  "limit"?: number | null;
+};
+
+export type PermissionProfileListResponse = {
+  "data": Array<PermissionProfileSummary>;
+  "nextCursor": string | null;
+};
+
+export type PermissionProfileSummary = {
+  "allowed": boolean;
+  "description": string | null;
+  "id": string;
+};
+
 export type PermissionsApprovalRequestParams = {
   "base"?: string;
   "branch"?: string;

--- a/appserver/protocol/typescript/testdata/permission_profile_list_contract.ts
+++ b/appserver/protocol/typescript/testdata/permission_profile_list_contract.ts
@@ -1,0 +1,56 @@
+import type {
+  MethodParamsByName,
+  MethodResultsByName,
+  PermissionProfileListParams,
+  PermissionProfileListResponse,
+  PermissionProfileSummary,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2) ? true : false;
+type Expect<T extends true> = T;
+
+type Contracts = [
+  Expect<Equal<PermissionProfileListParams, {
+    cursor?: string | null;
+    cwd?: string | null;
+    limit?: number | null;
+  }>>,
+  Expect<Equal<PermissionProfileSummary, {
+    allowed: boolean;
+    description: string | null;
+    id: string;
+  }>>,
+  Expect<Equal<PermissionProfileListResponse, {
+    data: Array<PermissionProfileSummary>;
+    nextCursor: string | null;
+  }>>,
+  Expect<Equal<"permissionProfile/list" extends keyof MethodParamsByName ? true : false, false>>,
+  Expect<Equal<"permissionProfile/list" extends keyof MethodResultsByName ? true : false, false>>,
+];
+
+({}) satisfies PermissionProfileListParams;
+({ cursor: null, cwd: "", limit: 0 }) satisfies PermissionProfileListParams;
+({ cursor: " next ", cwd: " /workspace ", limit: 4294967295 }) satisfies PermissionProfileListParams;
+({ id: "", description: null, allowed: false }) satisfies PermissionProfileSummary;
+({ id: "profile", description: "", allowed: true }) satisfies PermissionProfileSummary;
+({ data: [], nextCursor: null }) satisfies PermissionProfileListResponse;
+({ data: [{ id: "profile", description: null, allowed: true }], nextCursor: "next" }) satisfies PermissionProfileListResponse;
+
+// @ts-expect-error limit is a number in pinned TypeScript, not bigint.
+({ limit: 1n }) satisfies PermissionProfileListParams;
+// @ts-expect-error cursor is nullable string data.
+({ cursor: 1 }) satisfies PermissionProfileListParams;
+// @ts-expect-error summary description is explicit nullable in TypeScript.
+({ id: "profile", allowed: true }) satisfies PermissionProfileSummary;
+// @ts-expect-error allowed is required.
+({ id: "profile", description: null }) satisfies PermissionProfileSummary;
+// @ts-expect-error response data is required.
+({ nextCursor: null }) satisfies PermissionProfileListResponse;
+// @ts-expect-error response nextCursor is explicit nullable in TypeScript.
+({ data: [] }) satisfies PermissionProfileListResponse;
+// @ts-expect-error summaries cannot be null.
+({ data: [null], nextCursor: null }) satisfies PermissionProfileListResponse;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/workspace_messages_contract_test.go
+++ b/appserver/protocol/workspace_messages_contract_test.go
@@ -209,8 +209,8 @@ func TestWorkspaceMessageContractsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/workspaceMessages/read = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 513 {
-		t.Fatalf("definition count = %d, want 513", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 516 {
+		t.Fatalf("definition count = %d, want 516", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 224/59/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary

- export exact standalone `PermissionProfileListParams`, `PermissionProfileSummary`, and `PermissionProfileListResponse` contracts from pinned public Codex commit `5c19155cbd93bfa099016e7487259f61669823ff`
- preserve serde omission/null canonicalization, opaque strings, uint32 boundaries, ordered duplicate-preserving arrays, strict required fields, unknown-field tolerance, duplicate-known rejection, and trailing-value rejection
- generate exact JSON Schema and framework-neutral TypeScript declarations, including ts-rs required-nullable `description` and `nextCursor`
- leave Gollem's broader live `permissionProfile/list` handler and all 224/59/5 method/item bindings unchanged

## Scope

This is a standalone data-contract slice. The existing live handler ignores public cursor/limit/cwd semantics and returns a broader profile catalog, so the exact params/result are deliberately not bound. These records do not grant permissions or prove profile enforcement.

Generated definitions move from 513 to 516. Method inventory and runtime bindings remain 224 methods, 59 method bindings, and 5 item bindings.

## Pinned source

Raw upstream SHA-256:

- params schema: `576d405f6c94cbde982a9f65c9301717043683b83ca35d564247907feb16b1b4`
- response schema (including embedded summary): `4a290b5b9d47c2fc671033e22754671161bc563027ba387e861bd935398f0def`
- params TypeScript: `cf28b4491d5288d3039c3e6b8eca84db14ed8c71a9efbda6f8145d8d34960921`
- summary TypeScript: `1202513133554ed4a96b916b5117ff2a0e5bbded9d326f44d39d622a418944c7`
- response TypeScript: `5ff6a99f0a0cc3956de6e980ad45d50c48e5319a9d421f11a85c7c96d3d92644`

Generated Gollem SHA-256:

- schema: `b1dd1453b3a04011752e367a0ee0fb5b739d78013ffa28baddcaec4d46ecebad`
- TypeScript: `972be6a39bebc14ddc13432127887c41e362e230fc053c9d36326e5a9faf74eb`

All three normalized definitions compare exactly to the pinned schemas after only document metadata, local-ref, and JSON numeric spelling normalization.

## Verification

- deliberate red: focused compilation failed only on the three absent contract types
- focused tests: 30 repetitions
- focused race: 10 repetitions
- every function in the new production file: 100% statement coverage
- all 59 non-Monty packages: normal, race, and coverage pass
- protocol coverage: 97.7%; overall non-Monty coverage: 77.5%
- strict TypeScript fixture compiles
- `golangci-lint run ./...`: 0 issues
- `go vet ./...`
- `go mod verify`; `go mod tidy` clean
- deterministic generation
- exact full-commit generated-artifact reversal to parent hashes
- configured pre-push hook passes with `hooks.skipMontyRace=true`
- parent/feature initialize + initialized + live permission-profile transcript: byte-identical, 39,583 bytes, SHA-256 `59305986ed0814dc09b96edb24af52fd23fd537c156357d2894c96c28e77247a`, empty stderr

The first full normal sweep hit the pre-existing three-second timeout in `TestServerRuntimeInterruptKillsOwnedCommand`. It reproduced on clean canonical `main`, while the feature branch passed 30/30 focused repetitions; the complete feature sweep then passed cleanly. No unrelated runtime code was changed.

Local Monty normal/race/coverage tests remain skipped by user policy; hosted CI is unchanged.