### PR TITLE
protocol: export collaboration capability contracts

### DIFF
--- a/appserver/protocol/README.md
+++ b/appserver/protocol/README.md
@@ -214,6 +214,24 @@ deferred loading, namespace dispatch, persistence, or execution. Generated
 TypeScript preserves the exact public function/namespace intersections without
 changing Gollem's existing 59 method bindings or five item bindings.
 
+## Exported Collaboration And Capability Contracts
+
+The schema exports exact standalone `Settings`, `ModeKind`, `MultiAgentMode`,
+`CollaborationModeMask`, `CollaborationMode`, `CapabilityRootLocation`, and
+`SelectedCapabilityRoot` definitions. Canonical output keeps plan/default mode
+values, explicit nullable settings and mask fields, strict built-in/custom
+multi-agent modes, environment-owned capability locations, and canonical
+`file:` path URIs. Decoding also accepts the public legacy mode aliases,
+legacy `none` multi-agent input, absolute POSIX/Windows paths, and unknown
+record fields while rejecting duplicate known fields, malformed unions,
+relative paths, non-file URIs, and trailing JSON values.
+
+These definitions describe configuration and selected roots only. They do not
+start collaboration sessions, change delegation policy, spawn subagents,
+resolve environments, expose files, grant capabilities or permissions, bind
+methods/items, persist selections, or add runtime authority. Existing live
+collaboration, thread, and capability behavior remains unchanged.
+
 ## Version 1 File-Change Item Contracts
 
 `FileUpdateChange`, `PatchChangeKind`, and `PatchApplyStatus` now use the public

--- a/appserver/protocol/account_credit_nudge_values_contract_test.go
+++ b/appserver/protocol/account_credit_nudge_values_contract_test.go
@@ -119,8 +119,8 @@ func TestAccountCreditNudgeValuesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/sendAddCreditsNudgeEmail = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/account_envelope_contract_test.go
+++ b/appserver/protocol/account_envelope_contract_test.go
@@ -268,8 +268,8 @@ func TestAccountEnvelopeContractsRemainStandaloneAndDeferred(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred %s", methodName, method, ok, surface)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 224/59/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/account_login_completed_notification_contract_test.go
+++ b/appserver/protocol/account_login_completed_notification_contract_test.go
@@ -88,8 +88,8 @@ func TestAccountLoginCompletedNotificationRemainsStandaloneAndDeferred(t *testin
 	if !found {
 		t.Fatal("account/login/completed method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/account_rate_limits_contract_test.go
+++ b/appserver/protocol/account_rate_limits_contract_test.go
@@ -484,8 +484,8 @@ func TestAccountRateLimitContractsRemainStandaloneAndDeferred(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred %s", methodName, method, ok, surface)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/account_token_usage_contract_test.go
+++ b/appserver/protocol/account_token_usage_contract_test.go
@@ -146,8 +146,8 @@ func TestAccountTokenUsageRecordsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/usage/read = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(defs); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_config_contract_test.go
+++ b/appserver/protocol/app_config_contract_test.go
@@ -109,8 +109,8 @@ func TestAppConfigRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppConfig unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_info_contract_test.go
+++ b/appserver/protocol/app_info_contract_test.go
@@ -131,8 +131,8 @@ func TestAppInfoRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_list_updated_notification_contract_test.go
+++ b/appserver/protocol/app_list_updated_notification_contract_test.go
@@ -105,8 +105,8 @@ func TestAppListUpdatedNotificationRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceServerNotification || method.State != MethodDeferredStub {
 		t.Fatalf("app/list/updated = %#v, %v; want deferred server notification", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_metadata_contract_test.go
+++ b/appserver/protocol/app_metadata_contract_test.go
@@ -107,8 +107,8 @@ func TestAppMetadataRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_metadata_leaf_contract_test.go
+++ b/appserver/protocol/app_metadata_leaf_contract_test.go
@@ -157,8 +157,8 @@ func TestAppMetadataLeavesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_summary_contract_test.go
+++ b/appserver/protocol/app_summary_contract_test.go
@@ -87,8 +87,8 @@ func TestAppSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppSummary unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_template_summary_contract_test.go
+++ b/appserver/protocol/app_template_summary_contract_test.go
@@ -107,8 +107,8 @@ func TestAppTemplateSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppTemplateSummary unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_template_unavailable_reason_contract_test.go
+++ b/appserver/protocol/app_template_unavailable_reason_contract_test.go
@@ -71,8 +71,8 @@ func TestAppTemplateUnavailableReasonRemainsStandalone(t *testing.T) {
 			t.Fatalf("AppTemplateUnavailableReason unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_tool_approval_contract_test.go
+++ b/appserver/protocol/app_tool_approval_contract_test.go
@@ -73,8 +73,8 @@ func TestAppToolApprovalRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppToolApproval unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/app_tools_config_contract_test.go
+++ b/appserver/protocol/app_tools_config_contract_test.go
@@ -140,8 +140,8 @@ func TestAppToolConfigsRemainStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/apply_patch_approval_params_contract_test.go
+++ b/appserver/protocol/apply_patch_approval_params_contract_test.go
@@ -139,8 +139,8 @@ func TestApplyPatchApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ApplyPatchApprovalParams unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(defs); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(defs); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/apps_config_contract_test.go
+++ b/appserver/protocol/apps_config_contract_test.go
@@ -185,8 +185,8 @@ func TestAppsConfigsRemainStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/apps_list_contract_test.go
+++ b/appserver/protocol/apps_list_contract_test.go
@@ -168,8 +168,8 @@ func TestAppsListContractsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/attestation_contract_test.go
+++ b/appserver/protocol/attestation_contract_test.go
@@ -133,8 +133,8 @@ func TestAttestationContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("attestation/generate = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
+++ b/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
@@ -179,8 +179,8 @@ func TestChatgptAuthTokensRefreshRemainsStandaloneAndDeferred(t *testing.T) {
 	if !found {
 		t.Fatal("refresh method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/collaboration_capability_contract_test.go
+++ b/appserver/protocol/collaboration_capability_contract_test.go
@@ -1,0 +1,397 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestCollaborationCapabilitySchemasAreExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	want := map[string]Schema{
+		"ModeKind": {
+			"description": "Initial collaboration mode to use when the TUI starts.",
+			"enum":        []any{"plan", "default"},
+			"type":        "string",
+		},
+		"MultiAgentMode": {
+			"description": "Controls the effective multi-agent delegation instructions for a turn. `custom` means the configured mode hint defines the policy instead of a built-in policy.",
+			"oneOf": []any{
+				Schema{"enum": []any{"explicitRequestOnly", "proactive"}, "type": "string"},
+				Schema{
+					"additionalProperties": false,
+					"properties":           Schema{"custom": Schema{"type": "string"}},
+					"required":             []string{"custom"},
+					"title":                "CustomMultiAgentMode",
+					"type":                 "object",
+				},
+			},
+		},
+		"Settings": {
+			"description": "Settings for a collaboration mode.",
+			"properties": Schema{
+				"developer_instructions": Schema{"type": []any{"string", "null"}},
+				"model":                  Schema{"type": "string"},
+				"reasoning_effort": nullableCollaborationSchema(
+					Schema{"$ref": "#/$defs/ReasoningEffort"},
+				),
+			},
+			"required": []string{"model"},
+			"type":     "object",
+		},
+		"CollaborationMode": {
+			"description": "Collaboration mode for a Codex session.",
+			"properties": Schema{
+				"mode":     Schema{"$ref": "#/$defs/ModeKind"},
+				"settings": Schema{"$ref": "#/$defs/Settings"},
+			},
+			"required": []string{"mode", "settings"},
+			"type":     "object",
+		},
+		"CollaborationModeMask": {
+			"description": "EXPERIMENTAL - collaboration mode preset metadata for clients.",
+			"properties": Schema{
+				"mode":  nullableCollaborationSchema(Schema{"$ref": "#/$defs/ModeKind"}),
+				"model": Schema{"type": []any{"string", "null"}},
+				"name":  Schema{"type": "string"},
+				"reasoning_effort": Schema{"anyOf": []any{
+					nullableCollaborationSchema(Schema{"$ref": "#/$defs/ReasoningEffort"}),
+					Schema{"type": "null"},
+				}},
+			},
+			"required": []string{"name"},
+			"type":     "object",
+		},
+		"CapabilityRootLocation": {
+			"description": "Location used to resolve a selected capability root.",
+			"oneOf": []any{Schema{
+				"description": "A path owned by an execution environment.",
+				"properties": Schema{
+					"environmentId": Schema{"type": "string"},
+					"path": Schema{
+						"description": "Absolute path for the root in the selected environment.",
+						"type":        "string",
+					},
+					"type": Schema{
+						"enum":  []any{"environment"},
+						"title": "EnvironmentCapabilityRootLocationType",
+						"type":  "string",
+					},
+				},
+				"required": []string{"environmentId", "path", "type"},
+				"title":    "EnvironmentCapabilityRootLocation",
+				"type":     "object",
+			}},
+		},
+		"SelectedCapabilityRoot": {
+			"description": "A user-selected root that can expose one or more runtime capabilities.",
+			"properties": Schema{
+				"id": Schema{
+					"description": "Stable identifier supplied by the capability selection platform.",
+					"type":        "string",
+				},
+				"location": Schema{
+					"allOf":       []any{Schema{"$ref": "#/$defs/CapabilityRootLocation"}},
+					"description": "Where the selected root can be resolved.",
+				},
+			},
+			"required": []string{"id", "location"},
+			"type":     "object",
+		},
+	}
+	for name, expected := range want {
+		if !reflect.DeepEqual(defs[name], expected) {
+			t.Errorf("%s schema = %#v, want %#v", name, defs[name], expected)
+		}
+	}
+}
+
+func TestCollaborationCapabilityWireCanonicalization(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+		value func() any
+	}{
+		{"mode plan", `"plan"`, `"plan"`, func() any { return new(ModeKind) }},
+		{"mode legacy code", `"code"`, `"default"`, func() any { return new(ModeKind) }},
+		{"mode legacy pair", `"pair_programming"`, `"default"`, func() any { return new(ModeKind) }},
+		{"mode legacy execute", `"execute"`, `"default"`, func() any { return new(ModeKind) }},
+		{"mode legacy custom", `"custom"`, `"default"`, func() any { return new(ModeKind) }},
+		{"multi-agent explicit", `"explicitRequestOnly"`, `"explicitRequestOnly"`, func() any { return new(MultiAgentMode) }},
+		{"multi-agent proactive", `"proactive"`, `"proactive"`, func() any { return new(MultiAgentMode) }},
+		{"multi-agent custom empty", `{"custom":""}`, `{"custom":""}`, func() any { return new(MultiAgentMode) }},
+		{"multi-agent legacy none", `"none"`, `{"custom":""}`, func() any { return new(MultiAgentMode) }},
+		{
+			"settings omitted options",
+			`{"model":""}`,
+			`{"model":"","reasoning_effort":null,"developer_instructions":null}`,
+			func() any { return new(Settings) },
+		},
+		{
+			"settings full and unknown",
+			`{"model":"gpt","reasoning_effort":"provider-effort","developer_instructions":"","ignored":true}`,
+			`{"model":"gpt","reasoning_effort":"provider-effort","developer_instructions":""}`,
+			func() any { return new(Settings) },
+		},
+		{
+			"collaboration mode",
+			`{"mode":"code","settings":{"model":"gpt"},"ignored":true}`,
+			`{"mode":"default","settings":{"model":"gpt","reasoning_effort":null,"developer_instructions":null}}`,
+			func() any { return new(CollaborationMode) },
+		},
+		{
+			"mask omitted options",
+			`{"name":""}`,
+			`{"name":"","mode":null,"model":null,"reasoning_effort":null}`,
+			func() any { return new(CollaborationModeMask) },
+		},
+		{
+			"mask full",
+			`{"name":"plan","mode":"plan","model":"","reasoning_effort":"high","ignored":true}`,
+			`{"name":"plan","mode":"plan","model":"","reasoning_effort":"high"}`,
+			func() any { return new(CollaborationModeMask) },
+		},
+		{
+			"foreign capability URI",
+			`{"type":"environment","environmentId":"executor","path":"file:///C:/plugins/demo"}`,
+			`{"type":"environment","environmentId":"executor","path":"file:///C:/plugins/demo"}`,
+			func() any { return new(CapabilityRootLocation) },
+		},
+		{
+			"legacy absolute capability path",
+			`{"type":"environment","environmentId":"","path":"/workspace/plugins/../demo","ignored":true}`,
+			`{"type":"environment","environmentId":"","path":"file:///workspace/demo"}`,
+			func() any { return new(CapabilityRootLocation) },
+		},
+		{
+			"selected capability root",
+			`{"id":"","location":{"type":"environment","environmentId":"remote","path":"/workspace"},"ignored":true}`,
+			`{"id":"","location":{"type":"environment","environmentId":"remote","path":"file:///workspace"}}`,
+			func() any { return new(SelectedCapabilityRoot) },
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			value := tc.value()
+			if err := json.Unmarshal([]byte(tc.input), value); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			encoded, err := json.Marshal(value)
+			if err != nil || string(encoded) != tc.want {
+				t.Fatalf("round trip = %s, %v; want %s", encoded, err, tc.want)
+			}
+		})
+	}
+}
+
+func TestCollaborationCapabilityRejectsMalformedWireValues(t *testing.T) {
+	tests := []struct {
+		name  string
+		value func() any
+		bad   []string
+	}{
+		{
+			"mode", func() any { return new(ModeKind) },
+			[]string{`null`, `""`, `"PLAN"`, `"pairProgramming"`, `0`, `{}`, `[]`, `"plan" {}`},
+		},
+		{
+			"multi-agent", func() any { return new(MultiAgentMode) },
+			[]string{`null`, `""`, `"unknown"`, `{"custom":null}`, `{"custom":0}`, `{"custom":"a","extra":true}`, `{"custom":"a","custom":"b"}`, `{}`, `[]`, `"proactive" {}`},
+		},
+		{
+			"settings", func() any { return new(Settings) },
+			[]string{`null`, `{}`, `{"model":null}`, `{"model":0}`, `{"model":"gpt","reasoning_effort":""}`, `{"model":"gpt","developer_instructions":0}`, `{"model":"a","model":"b"}`, `{"model":"gpt"} {}`},
+		},
+		{
+			"collaboration mode", func() any { return new(CollaborationMode) },
+			[]string{`null`, `{}`, `{"mode":"plan"}`, `{"settings":{"model":"gpt"}}`, `{"mode":null,"settings":{"model":"gpt"}}`, `{"mode":"plan","settings":null}`, `{"mode":"plan","settings":{"model":"gpt"},"mode":"default"}`, `{"mode":"plan","settings":{"model":"gpt"}} {}`},
+		},
+		{
+			"mask", func() any { return new(CollaborationModeMask) },
+			[]string{`null`, `{}`, `{"name":null}`, `{"name":0}`, `{"name":"x","mode":""}`, `{"name":"x","model":0}`, `{"name":"x","reasoning_effort":""}`, `{"name":"a","name":"b"}`, `{"name":"x"} {}`},
+		},
+		{
+			"capability location", func() any { return new(CapabilityRootLocation) },
+			[]string{`null`, `{}`, `{"type":"unknown","environmentId":"e","path":"/x"}`, `{"type":"environment","path":"/x"}`, `{"type":"environment","environmentId":"e"}`, `{"type":"environment","environmentId":null,"path":"/x"}`, `{"type":"environment","environmentId":"e","path":"relative"}`, `{"type":"environment","environmentId":"e","path":"https://example.com/x"}`, `{"type":"environment","environmentId":"e","path":"/x","type":"environment"}`, `{"type":"environment","environmentId":"e","path":"/x"} {}`},
+		},
+		{
+			"selected root", func() any { return new(SelectedCapabilityRoot) },
+			[]string{`null`, `{}`, `{"id":""}`, `{"location":{"type":"environment","environmentId":"e","path":"/x"}}`, `{"id":null,"location":{"type":"environment","environmentId":"e","path":"/x"}}`, `{"id":"","location":null}`, `{"id":"a","id":"b","location":{"type":"environment","environmentId":"e","path":"/x"}}`, `{"id":"","location":{"type":"environment","environmentId":"e","path":"relative"}}`, `{"id":"","location":{"type":"environment","environmentId":"e","path":"/x"}} {}`},
+		},
+	}
+	for _, tc := range tests {
+		for _, input := range tc.bad {
+			value := tc.value()
+			if err := json.Unmarshal([]byte(input), value); err == nil {
+				t.Errorf("%s accepted %s", tc.name, input)
+			}
+		}
+	}
+}
+
+func TestCollaborationCapabilityNilReceiversAndInvalidMarshal(t *testing.T) {
+	nilReceivers := []json.Unmarshaler{
+		(*ModeKind)(nil),
+		(*MultiAgentMode)(nil),
+		(*Settings)(nil),
+		(*CollaborationMode)(nil),
+		(*CollaborationModeMask)(nil),
+		(*CapabilityRootLocation)(nil),
+		(*SelectedCapabilityRoot)(nil),
+	}
+	for _, value := range nilReceivers {
+		if err := value.UnmarshalJSON([]byte(`{}`)); err == nil {
+			t.Errorf("%T nil receiver succeeded", value)
+		}
+	}
+
+	emptyEffort := ReasoningEffort("")
+	invalid := []any{
+		ModeKind("invalid"),
+		MultiAgentMode{},
+		Settings{Model: "gpt", ReasoningEffort: &emptyEffort},
+		CollaborationMode{Mode: ModeKind("invalid"), Settings: Settings{Model: "gpt"}},
+		CollaborationModeMask{Name: "mask", ReasoningEffort: &emptyEffort},
+		CapabilityRootLocation{},
+		SelectedCapabilityRoot{ID: "root"},
+	}
+	for _, value := range invalid {
+		if _, err := json.Marshal(value); err == nil {
+			t.Errorf("marshal %T succeeded", value)
+		}
+	}
+}
+
+func TestCapabilityRootPathCanonicalization(t *testing.T) {
+	opaque := opaqueCapabilityPathURI([]byte("/workspace/\x00/root"))
+	valid := []struct {
+		input string
+		want  string
+	}{
+		{"/", "file:///"},
+		{"/workspace/plugins/../root", "file:///workspace/root"},
+		{"/workspace/./root", "file:///workspace/root"},
+		{"/workspace/root/", "file:///workspace/root/"},
+		{`C:\plugins\..\root`, "file:///C:/root"},
+		{`C:\`, "file:///C:/"},
+		{`C:\..\root`, "file:///C:/root"},
+		{`\\server\share\plugins\..\root`, "file://server/share/root"},
+		{`\\server\share\..\root`, "file://server/share/root"},
+		{`\\server\share\`, "file://server/share/"},
+		{`\\.\COM1`, "file:///%00/bad/path/XABcAC4AXABDAE8ATQAxAA"},
+		{`\\bad host\share\x`, "file:///%00/bad/path/XABcAGIAYQBkACAAaABvAHMAdABcAHMAaABhAHIAZQBcAHgA"},
+		{"C:\\root\x00bad", "file:///%00/bad/path/QwA6AFwAcgBvAG8AdAAAAGIAYQBkAA"},
+		{"file://localhost/workspace", "file:///workspace"},
+		{"file://localhost", "file:///"},
+		{"file://SERVER/Share", "file://server/Share"},
+		{"file://server/share/../root", "file://server/root"},
+		{"file://server/share/..", "file://server/"},
+		{"file:///a//b", "file:///a//b"},
+		{"file:///tmp/a%2Fb", "file:///tmp/a%2Fb"},
+		{"file:///tmp/a/../root/", "file:///tmp/root/"},
+		{"file:///a/%2e%2e/root", "file:///root"},
+		{"file:///a/%2e", "file:///a/"},
+		{"file:///C:/..", "file:///C:/"},
+		{"file:relative", "file:///relative"},
+		{"file:", "file:///"},
+		{"/workspace/\x00/root", opaque},
+		{opaque, opaque},
+	}
+	for _, tc := range valid {
+		got, err := canonicalCapabilityRootPath(tc.input)
+		if err != nil || got != tc.want {
+			t.Errorf("canonicalCapabilityRootPath(%q) = %q, %v; want %q", tc.input, got, err, tc.want)
+		}
+	}
+
+	invalid := []string{
+		"",
+		"x",
+		"relative/path",
+		"https://example.com/root",
+		"file://user@server/root",
+		"file://server:99/root",
+		"file:///root?query=true",
+		"file:///root#fragment",
+		"file:///root%00bad",
+		"file:///%00/bad/path/not*base64",
+		"file:///%00/bad/path/YQ==",
+		`\\server`,
+		`\\\share`,
+	}
+	for _, input := range invalid {
+		if got, err := canonicalCapabilityRootPath(input); err == nil {
+			t.Errorf("canonicalCapabilityRootPath(%q) = %q without error", input, got)
+		}
+	}
+}
+
+func TestCollaborationCapabilityContractsRemainStandalone(t *testing.T) {
+	names := []string{
+		"CapabilityRootLocation", "CollaborationMode", "CollaborationModeMask",
+		"ModeKind", "MultiAgentMode", "SelectedCapabilityRoot", "Settings",
+	}
+	for _, binding := range WireTypeBindings() {
+		for _, name := range names {
+			if slices.Contains(binding.Params, name) || slices.Contains(binding.Result, name) {
+				t.Fatalf("%s unexpectedly bound to %s", name, binding.Method)
+			}
+		}
+	}
+	for _, binding := range ItemPayloadBindings() {
+		if slices.Contains(names, binding.Type) {
+			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
+	}
+	if got := len(Methods()); got != 224 {
+		t.Fatalf("methods = %d, want 224", got)
+	}
+	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))
+	}
+}
+
+func TestCollaborationCapabilityTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	source := string(generated)
+	for _, want := range []string{
+		`export type CapabilityRootLocation = {`,
+		`"type": "environment";`,
+		`"environmentId": string;`,
+		`"path": string;`,
+		`export type CollaborationMode = {`,
+		`"mode": ModeKind;`,
+		`"settings": Settings;`,
+		`export type CollaborationModeMask = {`,
+		`"mode": ModeKind | null;`,
+		`"model": string | null;`,
+		`"name": string;`,
+		`"reasoning_effort": ReasoningEffort | null | null;`,
+		`export type ModeKind = "plan" | "default";`,
+		`export type MultiAgentMode = { "custom": string } | "explicitRequestOnly" | "proactive";`,
+		`export type SelectedCapabilityRoot = {`,
+		`"id": string;`,
+		`"location": CapabilityRootLocation;`,
+		`export type Settings = {`,
+		`"developer_instructions": string | null;`,
+		`"model": string;`,
+		`"reasoning_effort": ReasoningEffort | null;`,
+	} {
+		if !strings.Contains(source, want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}
+
+func nullableCollaborationSchema(value Schema) Schema {
+	return Schema{"anyOf": []any{value, Schema{"type": "null"}}}
+}

--- a/appserver/protocol/collaboration_capability_types.go
+++ b/appserver/protocol/collaboration_capability_types.go
@@ -1,0 +1,640 @@
+package protocol
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+	"unicode/utf16"
+)
+
+type ModeKind string
+
+const (
+	ModeKindPlan    ModeKind = "plan"
+	ModeKindDefault ModeKind = "default"
+)
+
+// MultiAgentMode is standalone policy-description data. It does not enable
+// delegation or subagent execution.
+type MultiAgentMode struct{ raw json.RawMessage }
+
+// Settings is the exact public settings record used by a collaboration mode.
+// Optional serde inputs remain explicit nulls in canonical output.
+type Settings struct {
+	Model                 string           `json:"model"`
+	ReasoningEffort       *ReasoningEffort `json:"reasoning_effort"`
+	DeveloperInstructions *string          `json:"developer_instructions"`
+}
+
+// CollaborationMode is standalone session configuration data.
+type CollaborationMode struct {
+	Mode     ModeKind `json:"mode"`
+	Settings Settings `json:"settings"`
+}
+
+// CollaborationModeMask is the public app-server preset metadata record.
+// Its nested optional effort collapses to one nullable Go pointer on the wire.
+type CollaborationModeMask struct {
+	Name            string           `json:"name"`
+	Mode            *ModeKind        `json:"mode"`
+	Model           *string          `json:"model"`
+	ReasoningEffort *ReasoningEffort `json:"reasoning_effort"`
+}
+
+// CapabilityRootLocation describes an environment-owned path. It does not
+// resolve the environment or grant access to the path.
+type CapabilityRootLocation struct{ raw json.RawMessage }
+
+// SelectedCapabilityRoot is standalone capability-selection data.
+type SelectedCapabilityRoot struct {
+	ID       string                 `json:"id"`
+	Location CapabilityRootLocation `json:"location"`
+}
+
+func (m ModeKind) MarshalJSON() ([]byte, error) {
+	if m != ModeKindPlan && m != ModeKindDefault {
+		return nil, fmt.Errorf("unsupported collaboration mode kind %q", m)
+	}
+	return json.Marshal(string(m))
+}
+
+func (m *ModeKind) UnmarshalJSON(data []byte) error {
+	if m == nil {
+		return errors.New("decode collaboration mode kind into nil receiver")
+	}
+	var value string
+	if err := json.Unmarshal(data, &value); err != nil {
+		return fmt.Errorf("decode collaboration mode kind: %w", err)
+	}
+	switch value {
+	case "plan":
+		*m = ModeKindPlan
+	case "default", "code", "pair_programming", "execute", "custom":
+		*m = ModeKindDefault
+	default:
+		return fmt.Errorf("unsupported collaboration mode kind %q", value)
+	}
+	return nil
+}
+
+func (m MultiAgentMode) MarshalJSON() ([]byte, error) {
+	if len(m.raw) == 0 {
+		return nil, errors.New("multi-agent mode is empty")
+	}
+	return validateMultiAgentMode(m.raw)
+}
+
+func (m *MultiAgentMode) UnmarshalJSON(data []byte) error {
+	if m == nil {
+		return errors.New("decode multi-agent mode into nil receiver")
+	}
+	canonical, err := validateMultiAgentMode(data)
+	if err != nil {
+		return err
+	}
+	m.raw = canonical
+	return nil
+}
+
+func validateMultiAgentMode(data []byte) ([]byte, error) {
+	var simple string
+	if err := json.Unmarshal(data, &simple); err == nil {
+		switch simple {
+		case "explicitRequestOnly", "proactive":
+			return json.Marshal(simple)
+		case "none":
+			return []byte(`{"custom":""}`), nil
+		default:
+			return nil, fmt.Errorf("unsupported multi-agent mode %q", simple)
+		}
+	}
+
+	payload, err := decodeRustSerdeObject(data, "multi-agent mode", "custom")
+	if err != nil {
+		return nil, err
+	}
+	var allFields map[string]json.RawMessage
+	_ = json.Unmarshal(data, &allFields) // decodeRustSerdeObject already validated the object.
+	if len(allFields) != 1 {
+		return nil, errors.New("multi-agent mode custom variant requires only custom")
+	}
+	custom, err := decodeRequiredThreadItemValue[string](payload, "multi-agent mode", "custom")
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(struct {
+		Custom string `json:"custom"`
+	}{Custom: custom})
+}
+
+func (s *Settings) UnmarshalJSON(data []byte) error {
+	if s == nil {
+		return errors.New("decode collaboration settings into nil receiver")
+	}
+	const objectName = "collaboration settings"
+	payload, err := decodeRustSerdeObject(
+		data, objectName, "model", "reasoning_effort", "developer_instructions",
+	)
+	if err != nil {
+		return err
+	}
+	model, err := decodeRequiredThreadItemValue[string](payload, objectName, "model")
+	if err != nil {
+		return err
+	}
+	reasoningEffort, err := decodeOptionalCollaborationValue[ReasoningEffort](
+		payload, objectName, "reasoning_effort",
+	)
+	if err != nil {
+		return err
+	}
+	developerInstructions, err := decodeOptionalCollaborationValue[string](
+		payload, objectName, "developer_instructions",
+	)
+	if err != nil {
+		return err
+	}
+	*s = Settings{
+		Model: model, ReasoningEffort: reasoningEffort,
+		DeveloperInstructions: developerInstructions,
+	}
+	return nil
+}
+
+func (m *CollaborationMode) UnmarshalJSON(data []byte) error {
+	if m == nil {
+		return errors.New("decode collaboration mode into nil receiver")
+	}
+	const objectName = "collaboration mode"
+	payload, err := decodeRustSerdeObject(data, objectName, "mode", "settings")
+	if err != nil {
+		return err
+	}
+	mode, err := decodeRequiredThreadItemValue[ModeKind](payload, objectName, "mode")
+	if err != nil {
+		return err
+	}
+	settings, err := decodeRequiredThreadItemValue[Settings](payload, objectName, "settings")
+	if err != nil {
+		return err
+	}
+	*m = CollaborationMode{Mode: mode, Settings: settings}
+	return nil
+}
+
+func (m *CollaborationModeMask) UnmarshalJSON(data []byte) error {
+	if m == nil {
+		return errors.New("decode collaboration mode mask into nil receiver")
+	}
+	const objectName = "collaboration mode mask"
+	payload, err := decodeRustSerdeObject(
+		data, objectName, "name", "mode", "model", "reasoning_effort",
+	)
+	if err != nil {
+		return err
+	}
+	name, err := decodeRequiredThreadItemValue[string](payload, objectName, "name")
+	if err != nil {
+		return err
+	}
+	mode, err := decodeOptionalCollaborationValue[ModeKind](payload, objectName, "mode")
+	if err != nil {
+		return err
+	}
+	model, err := decodeOptionalCollaborationValue[string](payload, objectName, "model")
+	if err != nil {
+		return err
+	}
+	reasoningEffort, err := decodeOptionalCollaborationValue[ReasoningEffort](
+		payload, objectName, "reasoning_effort",
+	)
+	if err != nil {
+		return err
+	}
+	*m = CollaborationModeMask{
+		Name: name, Mode: mode, Model: model, ReasoningEffort: reasoningEffort,
+	}
+	return nil
+}
+
+func (l CapabilityRootLocation) MarshalJSON() ([]byte, error) {
+	if len(l.raw) == 0 {
+		return nil, errors.New("capability root location is empty")
+	}
+	return validateCapabilityRootLocation(l.raw)
+}
+
+func (l *CapabilityRootLocation) UnmarshalJSON(data []byte) error {
+	if l == nil {
+		return errors.New("decode capability root location into nil receiver")
+	}
+	canonical, err := validateCapabilityRootLocation(data)
+	if err != nil {
+		return err
+	}
+	l.raw = canonical
+	return nil
+}
+
+func validateCapabilityRootLocation(data []byte) ([]byte, error) {
+	const objectName = "capability root location"
+	payload, err := decodeRustSerdeObject(data, objectName, "type", "environmentId", "path")
+	if err != nil {
+		return nil, err
+	}
+	locationType, err := decodeRequiredThreadItemValue[string](payload, objectName, "type")
+	if err != nil {
+		return nil, err
+	}
+	if locationType != "environment" {
+		return nil, fmt.Errorf("unsupported capability root location type %q", locationType)
+	}
+	environmentID, err := decodeRequiredThreadItemValue[string](payload, objectName, "environmentId")
+	if err != nil {
+		return nil, err
+	}
+	rawPath, err := decodeRequiredThreadItemValue[string](payload, objectName, "path")
+	if err != nil {
+		return nil, err
+	}
+	canonicalPath, err := canonicalCapabilityRootPath(rawPath)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(struct {
+		Type          string `json:"type"`
+		EnvironmentID string `json:"environmentId"`
+		Path          string `json:"path"`
+	}{
+		Type: locationType, EnvironmentID: environmentID, Path: canonicalPath,
+	})
+}
+
+func (r *SelectedCapabilityRoot) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("decode selected capability root into nil receiver")
+	}
+	const objectName = "selected capability root"
+	payload, err := decodeRustSerdeObject(data, objectName, "id", "location")
+	if err != nil {
+		return err
+	}
+	id, err := decodeRequiredThreadItemValue[string](payload, objectName, "id")
+	if err != nil {
+		return err
+	}
+	location, err := decodeRequiredThreadItemValue[CapabilityRootLocation](
+		payload, objectName, "location",
+	)
+	if err != nil {
+		return err
+	}
+	*r = SelectedCapabilityRoot{ID: id, Location: location}
+	return nil
+}
+
+func decodeOptionalCollaborationValue[T any](
+	payload map[string]json.RawMessage,
+	objectName string,
+	fieldName string,
+) (*T, error) {
+	raw, ok := payload[fieldName]
+	if !ok || isJSONNull(raw) {
+		return nil, nil
+	}
+	var value T
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return nil, fmt.Errorf("decode %s %s: %w", objectName, fieldName, err)
+	}
+	return &value, nil
+}
+
+func canonicalCapabilityRootPath(value string) (string, error) {
+	if isWindowsDriveAbsolutePath(value) {
+		if strings.Contains(value, "\x00") {
+			return opaqueWindowsCapabilityPathURI(value), nil
+		}
+		segments := append(
+			[]string{value[:2]},
+			splitWindowsCapabilityPath(value[3:])...,
+		)
+		return capabilityFileURI(
+			"", normalizeNativeCapabilitySegments(segments, 1, true),
+		), nil
+	}
+	if strings.HasPrefix(value, `\\`) {
+		if isWindowsNamespacePath(value) || strings.Contains(value, "\x00") {
+			return opaqueWindowsCapabilityPathURI(value), nil
+		}
+		components := splitWindowsCapabilityPath(value[2:])
+		if len(components) < 2 || components[0] == "" || components[1] == "" {
+			return "", fmt.Errorf("capability root path %q is not a valid UNC path", value)
+		}
+		host, ok := canonicalCapabilityURIHost(components[0])
+		if !ok {
+			return opaqueWindowsCapabilityPathURI(value), nil
+		}
+		segments := normalizeNativeCapabilitySegments(
+			append([]string{components[1]}, components[2:]...), 1, false,
+		)
+		return capabilityFileURI(host, segments), nil
+	}
+	if parsed, err := url.Parse(value); err == nil && parsed.Scheme != "" {
+		if !strings.EqualFold(parsed.Scheme, "file") {
+			return "", fmt.Errorf("capability root path %q must use file scheme", value)
+		}
+		if parsed.User != nil || parsed.Port() != "" || parsed.RawQuery != "" || parsed.Fragment != "" {
+			return "", fmt.Errorf("capability root path %q contains unsupported URI metadata", value)
+		}
+		parsed.Scheme = "file"
+		if parsed.Opaque != "" {
+			parsed.Path = "/" + strings.TrimLeft(parsed.Opaque, "/")
+			parsed.Opaque = ""
+			parsed.RawPath = ""
+		}
+		if strings.EqualFold(parsed.Host, "localhost") {
+			parsed.Host = ""
+		} else {
+			parsed.Host = strings.ToLower(parsed.Host)
+		}
+		if parsed.Path == "" {
+			parsed.Path = "/"
+		}
+		if strings.Contains(parsed.Path, "\x00") &&
+			!validOpaqueCapabilityPathURI(parsed.String()) {
+			return "", fmt.Errorf("capability root path %q contains a null byte", value)
+		}
+		if strings.Contains(parsed.Path, "\x00") {
+			return parsed.String(), nil
+		}
+		escapedPath := parsed.EscapedPath()
+		anchorDepth := 0
+		if parsed.Host == "" && capabilityURIHasWindowsDrive(escapedPath) {
+			anchorDepth = 1
+		}
+		escapedPath = normalizeCapabilityURIEscapedPath(escapedPath, anchorDepth)
+		decodedPath, _ := url.PathUnescape(escapedPath)
+		parsed.Path = decodedPath
+		parsed.RawPath = escapedPath
+		return parsed.String(), nil
+	}
+
+	if strings.HasPrefix(value, "/") {
+		if strings.Contains(value, "\x00") {
+			return opaqueCapabilityPathURI([]byte(value)), nil
+		}
+		segments := normalizeNativeCapabilitySegments(strings.Split(value[1:], "/"), 0, false)
+		return capabilityFileURI("", segments), nil
+	}
+	return "", fmt.Errorf("capability root path %q is not absolute", value)
+}
+
+func splitWindowsCapabilityPath(value string) []string {
+	return strings.Split(strings.ReplaceAll(value, `\`, "/"), "/")
+}
+
+func normalizeNativeCapabilitySegments(
+	segments []string,
+	anchorDepth int,
+	forceAnchorTrailingSlash bool,
+) []string {
+	normalized := make([]string, 0, len(segments))
+	depth := 0
+	hasTrailingSeparator := false
+	for _, segment := range segments {
+		switch segment {
+		case "":
+			hasTrailingSeparator = true
+		case ".":
+			hasTrailingSeparator = false
+		case "..":
+			hasTrailingSeparator = false
+			if depth > anchorDepth {
+				normalized = normalized[:len(normalized)-1]
+				depth--
+			}
+		default:
+			normalized = append(normalized, segment)
+			depth++
+			hasTrailingSeparator = false
+		}
+	}
+	if hasTrailingSeparator || (forceAnchorTrailingSlash && depth == anchorDepth) {
+		normalized = append(normalized, "")
+	}
+	return normalized
+}
+
+func normalizeCapabilityURIEscapedPath(value string, anchorDepth int) string {
+	segments := strings.Split(value[1:], "/")
+	normalized := make([]string, 0, len(segments))
+	for index, segment := range segments {
+		last := index == len(segments)-1
+		switch capabilityURIDotSegment(segment) {
+		case 1:
+			if last {
+				normalized = append(normalized, "")
+			}
+		case 2:
+			if len(normalized) > anchorDepth {
+				normalized = normalized[:len(normalized)-1]
+			}
+			if last {
+				normalized = append(normalized, "")
+			}
+		default:
+			normalized = append(normalized, segment)
+		}
+	}
+	return "/" + strings.Join(normalized, "/")
+}
+
+func capabilityURIHasWindowsDrive(value string) bool {
+	first, _, _ := strings.Cut(value[1:], "/")
+	decoded, err := url.PathUnescape(first)
+	return err == nil && len(decoded) == 2 &&
+		((decoded[0] >= 'A' && decoded[0] <= 'Z') ||
+			(decoded[0] >= 'a' && decoded[0] <= 'z')) &&
+		decoded[1] == ':'
+}
+
+func capabilityURIDotSegment(segment string) int {
+	switch strings.ToLower(segment) {
+	case ".", "%2e":
+		return 1
+	case "..", ".%2e", "%2e.", "%2e%2e":
+		return 2
+	default:
+		return 0
+	}
+}
+
+func capabilityFileURI(host string, segments []string) string {
+	return (&url.URL{
+		Scheme: "file",
+		Host:   host,
+		Path:   "/" + strings.Join(segments, "/"),
+	}).String()
+}
+
+func canonicalCapabilityURIHost(host string) (string, bool) {
+	parsed, err := url.Parse("file://" + host + "/")
+	if err != nil || parsed.Host == "" || parsed.User != nil || parsed.Port() != "" {
+		return "", false
+	}
+	return strings.ToLower(parsed.Host), true
+}
+
+func isWindowsDriveAbsolutePath(value string) bool {
+	if len(value) < 3 {
+		return false
+	}
+	drive := value[0]
+	return ((drive >= 'A' && drive <= 'Z') || (drive >= 'a' && drive <= 'z')) &&
+		value[1] == ':' && (value[2] == '/' || value[2] == '\\')
+}
+
+func isWindowsNamespacePath(value string) bool {
+	return len(value) >= 4 &&
+		(value[0] == '/' || value[0] == '\\') &&
+		(value[1] == '/' || value[1] == '\\') &&
+		(value[2] == '.' || value[2] == '?') &&
+		(value[3] == '/' || value[3] == '\\')
+}
+
+func opaqueCapabilityPathURI(value []byte) string {
+	return "file:///%00/bad/path/" + base64.RawURLEncoding.EncodeToString(value)
+}
+
+func opaqueWindowsCapabilityPathURI(value string) string {
+	codeUnits := utf16.Encode([]rune(value))
+	bytes := make([]byte, 0, len(codeUnits)*2)
+	for _, codeUnit := range codeUnits {
+		bytes = append(bytes, byte(codeUnit), byte(codeUnit>>8))
+	}
+	return opaqueCapabilityPathURI(bytes)
+}
+
+func validOpaqueCapabilityPathURI(value string) bool {
+	const prefix = "file:///%00/bad/path/"
+	encoded, ok := strings.CutPrefix(value, prefix)
+	if !ok || encoded == "" || strings.Contains(encoded, "/") {
+		return false
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(encoded)
+	return err == nil && base64.RawURLEncoding.EncodeToString(decoded) == encoded
+}
+
+var (
+	_ json.Marshaler   = ModeKind("")
+	_ json.Unmarshaler = (*ModeKind)(nil)
+	_ json.Marshaler   = MultiAgentMode{}
+	_ json.Unmarshaler = (*MultiAgentMode)(nil)
+	_ json.Unmarshaler = (*Settings)(nil)
+	_ json.Unmarshaler = (*CollaborationMode)(nil)
+	_ json.Unmarshaler = (*CollaborationModeMask)(nil)
+	_ json.Marshaler   = CapabilityRootLocation{}
+	_ json.Unmarshaler = (*CapabilityRootLocation)(nil)
+	_ json.Unmarshaler = (*SelectedCapabilityRoot)(nil)
+)
+
+func collaborationCapabilitySchemas() map[string]Schema {
+	nullableRef := func(name string) Schema {
+		return Schema{"anyOf": []any{
+			Schema{"$ref": "#/$defs/" + name},
+			Schema{"type": "null"},
+		}}
+	}
+	return map[string]Schema{
+		"ModeKind": {
+			"description": "Initial collaboration mode to use when the TUI starts.",
+			"enum":        []any{"plan", "default"},
+			"type":        "string",
+		},
+		"MultiAgentMode": {
+			"description": "Controls the effective multi-agent delegation instructions for a turn. `custom` means the configured mode hint defines the policy instead of a built-in policy.",
+			"oneOf": []any{
+				Schema{"enum": []any{"explicitRequestOnly", "proactive"}, "type": "string"},
+				Schema{
+					"additionalProperties": false,
+					"properties":           Schema{"custom": Schema{"type": "string"}},
+					"required":             []string{"custom"},
+					"title":                "CustomMultiAgentMode",
+					"type":                 "object",
+				},
+			},
+		},
+		"Settings": {
+			"description": "Settings for a collaboration mode.",
+			"properties": Schema{
+				"developer_instructions": Schema{"type": []any{"string", "null"}},
+				"model":                  Schema{"type": "string"},
+				"reasoning_effort":       nullableRef("ReasoningEffort"),
+			},
+			"required": []string{"model"},
+			"type":     "object",
+		},
+		"CollaborationMode": {
+			"description": "Collaboration mode for a Codex session.",
+			"properties": Schema{
+				"mode":     Schema{"$ref": "#/$defs/ModeKind"},
+				"settings": Schema{"$ref": "#/$defs/Settings"},
+			},
+			"required": []string{"mode", "settings"},
+			"type":     "object",
+		},
+		"CollaborationModeMask": {
+			"description": "EXPERIMENTAL - collaboration mode preset metadata for clients.",
+			"properties": Schema{
+				"mode":  nullableRef("ModeKind"),
+				"model": Schema{"type": []any{"string", "null"}},
+				"name":  Schema{"type": "string"},
+				"reasoning_effort": Schema{"anyOf": []any{
+					nullableRef("ReasoningEffort"),
+					Schema{"type": "null"},
+				}},
+			},
+			"required": []string{"name"},
+			"type":     "object",
+		},
+		"CapabilityRootLocation": {
+			"description": "Location used to resolve a selected capability root.",
+			"oneOf": []any{Schema{
+				"description": "A path owned by an execution environment.",
+				"properties": Schema{
+					"environmentId": Schema{"type": "string"},
+					"path": Schema{
+						"description": "Absolute path for the root in the selected environment.",
+						"type":        "string",
+					},
+					"type": Schema{
+						"enum":  []any{"environment"},
+						"title": "EnvironmentCapabilityRootLocationType",
+						"type":  "string",
+					},
+				},
+				"required": []string{"environmentId", "path", "type"},
+				"title":    "EnvironmentCapabilityRootLocation",
+				"type":     "object",
+			}},
+		},
+		"SelectedCapabilityRoot": {
+			"description": "A user-selected root that can expose one or more runtime capabilities.",
+			"properties": Schema{
+				"id": Schema{
+					"description": "Stable identifier supplied by the capability selection platform.",
+					"type":        "string",
+				},
+				"location": Schema{
+					"allOf":       []any{Schema{"$ref": "#/$defs/CapabilityRootLocation"}},
+					"description": "Where the selected root can be resolved.",
+				},
+			},
+			"required": []string{"id", "location"},
+			"type":     "object",
+		},
+	}
+}

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/dynamic_tool_spec_contract_test.go
+++ b/appserver/protocol/dynamic_tool_spec_contract_test.go
@@ -318,8 +318,8 @@ func TestDynamicToolSpecContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/exec_command_approval_params_contract_test.go
+++ b/appserver/protocol/exec_command_approval_params_contract_test.go
@@ -137,8 +137,8 @@ func TestExecCommandApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ExecCommandApprovalParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(defs); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/experimental_feature_contract_test.go
+++ b/appserver/protocol/experimental_feature_contract_test.go
@@ -41,8 +41,8 @@ func TestExperimentalFeatureContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want implemented client request", methodName, method, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d/%d/%d, want 224/59/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,8 +217,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,8 +203,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -260,8 +260,8 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,8 +244,8 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -162,8 +162,8 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -175,8 +175,8 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_contract_test.go
+++ b/appserver/protocol/file_change_contract_test.go
@@ -108,8 +108,8 @@ func TestFileChangeRemainsStandalone(t *testing.T) {
 			t.Fatalf("FileChange unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/file_change_output_delta_notification_contract_test.go
+++ b/appserver/protocol/file_change_output_delta_notification_contract_test.go
@@ -100,8 +100,8 @@ func TestFileChangeOutputDeltaNotificationRemainsDeprecatedAndStandalone(t *test
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("item/fileChange/outputDelta = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -381,8 +381,8 @@ func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_action_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_action_contract_test.go
@@ -226,8 +226,8 @@ func TestGuardianApprovalReviewActionRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReviewAction unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
@@ -164,8 +164,8 @@ func TestGuardianApprovalReviewCompletedNotificationRemainsStandalone(t *testing
 			t.Fatalf("completed notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_contract_test.go
@@ -139,8 +139,8 @@ func TestGuardianApprovalReviewRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReview unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
@@ -175,8 +175,8 @@ func TestGuardianApprovalReviewStartedNotificationRemainsStandalone(t *testing.T
 			t.Fatalf("started notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/guardian_enum_foundation_contract_test.go
+++ b/appserver/protocol/guardian_enum_foundation_contract_test.go
@@ -89,8 +89,8 @@ func TestGuardianEnumFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_metadata_list_contract_test.go
+++ b/appserver/protocol/hook_metadata_list_contract_test.go
@@ -352,8 +352,8 @@ func TestHookMetadataListContractsStayStandalone(t *testing.T) {
 			t.Errorf("standalone definition %s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Errorf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Errorf("definition count = %d, want 527", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 {
 		t.Errorf("wire binding count = %d, want 59", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/hook_run_notification_contract_test.go
+++ b/appserver/protocol/hook_run_notification_contract_test.go
@@ -297,8 +297,8 @@ func TestHookRunNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("surface changed: %d methods, %d wire bindings, %d item bindings", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/hook_value_foundation_contract_test.go
+++ b/appserver/protocol/hook_value_foundation_contract_test.go
@@ -167,8 +167,8 @@ func TestHookValueFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 520 {
-		t.Fatalf("definition count = %d, want 520", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 527 {
+		t.Fatalf("definition count = %d, want 527", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/legacy_approval_response_contract_test.go
+++ b/appserver/protocol/legacy_approval_response_contract_test.go
@@ -98,8 +98,8 @@ func TestLegacyApprovalResponsesRemainStandaloneAndNominal(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_oauth_login_contract_test.go
+++ b/appserver/protocol/mcp_server_oauth_login_contract_test.go
@@ -228,8 +228,8 @@ func TestMcpServerOauthLoginContractsRemainStandaloneAndBlocked(t *testing.T) {
 	if !ok || notification.Surface != SurfaceServerNotification || notification.State != MethodBlocked {
 		t.Fatalf("mcpServer/oauthLogin/completed = %#v, %v; want blocked server notification", notification, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d/%d/%d, want 224/59/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_contract_test.go
+++ b/appserver/protocol/mcp_server_status_contract_test.go
@@ -277,8 +277,8 @@ func TestMcpServerStatusContractsRemainStandalone(t *testing.T) {
 	if !ok || method.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d/%d/%d, want 224/59/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_approval_context_contract_test.go
+++ b/appserver/protocol/network_approval_context_contract_test.go
@@ -84,8 +84,8 @@ func TestNetworkApprovalContextRemainsStandalone(t *testing.T) {
 			t.Fatalf("NetworkApprovalContext unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/parsed_command_contract_test.go
+++ b/appserver/protocol/parsed_command_contract_test.go
@@ -120,8 +120,8 @@ func TestParsedCommandRemainsStandalone(t *testing.T) {
 			t.Fatalf("ParsedCommand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/permission_profile_list_contract_test.go
+++ b/appserver/protocol/permission_profile_list_contract_test.go
@@ -255,8 +255,8 @@ func TestPermissionProfileListContractsRemainStandalone(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodImplemented {
 		t.Fatalf("permissionProfile/list = %#v, %v; want existing implemented client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d/%d/%d, want 224/59/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/process_contracts_contract_test.go
+++ b/appserver/protocol/process_contracts_contract_test.go
@@ -308,8 +308,8 @@ func TestProcessContractsRemainStandaloneFromLegacyRuntime(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want unchanged implemented notification", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 520 {
-		t.Fatalf("definition count = %d, want 520", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 527 {
+		t.Fatalf("definition count = %d, want 527", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 520 {
-		t.Fatalf("definition count = %d, want 520", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 527 {
+		t.Fatalf("definition count = %d, want 527", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 520 {
-		t.Fatalf("definition count = %d, want 520", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 527 {
+		t.Fatalf("definition count = %d, want 527", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 520 {
-		t.Fatalf("definition count = %d, want 520", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 527 {
+		t.Fatalf("definition count = %d, want 527", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 520 {
-		t.Fatalf("definition count = %d, want 520", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 527 {
+		t.Fatalf("definition count = %d, want 527", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/review_decision_contract_test.go
+++ b/appserver/protocol/review_decision_contract_test.go
@@ -136,8 +136,8 @@ func TestReviewDecisionRemainsStandalone(t *testing.T) {
 			t.Fatalf("ReviewDecision unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(defs); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -134,6 +134,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "CancelLoginAccountParams", Type: reflect.TypeFor[CancelLoginAccountParams]()},
 		{Name: "CancelLoginAccountResponse", Type: reflect.TypeFor[CancelLoginAccountResponse]()},
 		{Name: "CancelLoginAccountStatus", Type: reflect.TypeFor[CancelLoginAccountStatus]()},
+		{Name: "CapabilityRootLocation", Type: reflect.TypeFor[CapabilityRootLocation]()},
 		{Name: "ChatgptAuthTokensRefreshParams", Type: reflect.TypeFor[ChatgptAuthTokensRefreshParams]()},
 		{Name: "ChatgptAuthTokensRefreshReason", Type: reflect.TypeFor[ChatgptAuthTokensRefreshReason]()},
 		{Name: "ChatgptAuthTokensRefreshResponse", Type: reflect.TypeFor[ChatgptAuthTokensRefreshResponse]()},
@@ -143,6 +144,8 @@ func wireSchemaDefinitions() Schema {
 		{Name: "CollabAgentStatus", Type: reflect.TypeFor[CollabAgentStatus]()},
 		{Name: "CollabAgentTool", Type: reflect.TypeFor[CollabAgentTool]()},
 		{Name: "CollabAgentToolCallStatus", Type: reflect.TypeFor[CollabAgentToolCallStatus]()},
+		{Name: "CollaborationMode", Type: reflect.TypeFor[CollaborationMode]()},
+		{Name: "CollaborationModeMask", Type: reflect.TypeFor[CollaborationModeMask]()},
 		{Name: "CommandAction", Type: reflect.TypeFor[CommandAction]()},
 		{Name: "CommandExecOutputDeltaNotification", Type: reflect.TypeFor[CommandExecOutputDeltaNotification]()},
 		{Name: "CommandExecOutputStream", Type: reflect.TypeFor[CommandExecOutputStream]()},
@@ -324,6 +327,8 @@ func wireSchemaDefinitions() Schema {
 		{Name: "ModelVerification", Type: reflect.TypeFor[ModelVerification]()},
 		{Name: "ModelVerificationNotification", Type: reflect.TypeFor[ModelVerificationNotification]()},
 		{Name: "ModelsRequirements", Type: reflect.TypeFor[ModelsRequirements]()},
+		{Name: "ModeKind", Type: reflect.TypeFor[ModeKind]()},
+		{Name: "MultiAgentMode", Type: reflect.TypeFor[MultiAgentMode]()},
 		{Name: "NetworkDomainPermission", Type: reflect.TypeFor[NetworkDomainPermission]()},
 		{Name: "NetworkRequirements", Type: reflect.TypeFor[NetworkRequirements]()},
 		{Name: "NetworkUnixSocketPermission", Type: reflect.TypeFor[NetworkUnixSocketPermission]()},
@@ -460,11 +465,13 @@ func wireSchemaDefinitions() Schema {
 		{Name: "SandboxMode", Type: reflect.TypeFor[SandboxMode]()},
 		{Name: "SandboxPolicy", Type: reflect.TypeFor[SandboxPolicy]()},
 		{Name: "SandboxWorkspaceWrite", Type: reflect.TypeFor[SandboxWorkspaceWrite]()},
+		{Name: "SelectedCapabilityRoot", Type: reflect.TypeFor[SelectedCapabilityRoot]()},
 		{Name: "SendAddCreditsNudgeEmailParams", Type: reflect.TypeFor[SendAddCreditsNudgeEmailParams]()},
 		{Name: "SendAddCreditsNudgeEmailResponse", Type: reflect.TypeFor[SendAddCreditsNudgeEmailResponse]()},
 		{Name: "ServerRequestResolvedNotificationParams", Type: reflect.TypeFor[ServerRequestResolvedNotificationParams]()},
 		{Name: "ServerCapabilities", Type: reflect.TypeFor[ServerCapabilities]()},
 		{Name: "SessionSource", Type: reflect.TypeFor[SessionSource]()},
+		{Name: "Settings", Type: reflect.TypeFor[Settings]()},
 		{Name: "Surface", Type: reflect.TypeFor[Surface]()},
 		{Name: "SortDirection", Type: reflect.TypeFor[SortDirection]()},
 		{Name: "SubAgentActivityKind", Type: reflect.TypeFor[SubAgentActivityKind]()},
@@ -1061,6 +1068,9 @@ func wireSchemaDefinitions() Schema {
 		schemas[name] = schema
 	}
 	for name, schema := range dynamicToolSpecSchemas() {
+		schemas[name] = schema
+	}
+	for name, schema := range collaborationCapabilitySchemas() {
 		schemas[name] = schema
 	}
 	schemas["ProcessExitedNotification"] = processExitedNotificationSchema()

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -1489,6 +1489,37 @@
       ],
       "type": "string"
     },
+    "CapabilityRootLocation": {
+      "description": "Location used to resolve a selected capability root.",
+      "oneOf": [
+        {
+          "description": "A path owned by an execution environment.",
+          "properties": {
+            "environmentId": {
+              "type": "string"
+            },
+            "path": {
+              "description": "Absolute path for the root in the selected environment.",
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "environment"
+              ],
+              "title": "EnvironmentCapabilityRootLocationType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "environmentId",
+            "path",
+            "type"
+          ],
+          "title": "EnvironmentCapabilityRootLocation",
+          "type": "object"
+        }
+      ]
+    },
     "ChatgptAuthTokensRefreshParams": {
       "additionalProperties": false,
       "properties": {
@@ -1783,6 +1814,67 @@
         "failed"
       ],
       "type": "string"
+    },
+    "CollaborationMode": {
+      "description": "Collaboration mode for a Codex session.",
+      "properties": {
+        "mode": {
+          "$ref": "#/$defs/ModeKind"
+        },
+        "settings": {
+          "$ref": "#/$defs/Settings"
+        }
+      },
+      "required": [
+        "mode",
+        "settings"
+      ],
+      "type": "object"
+    },
+    "CollaborationModeMask": {
+      "description": "EXPERIMENTAL - collaboration mode preset metadata for clients.",
+      "properties": {
+        "mode": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ModeKind"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "model": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "reasoning_effort": {
+          "anyOf": [
+            {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ReasoningEffort"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
     },
     "CommandAction": {
       "oneOf": [
@@ -9452,6 +9544,14 @@
       },
       "type": "object"
     },
+    "ModeKind": {
+      "description": "Initial collaboration mode to use when the TUI starts.",
+      "enum": [
+        "plan",
+        "default"
+      ],
+      "type": "string"
+    },
     "Model": {
       "additionalProperties": false,
       "properties": {
@@ -9865,6 +9965,31 @@
         "newThread"
       ],
       "type": "object"
+    },
+    "MultiAgentMode": {
+      "description": "Controls the effective multi-agent delegation instructions for a turn. `custom` means the configured mode hint defines the policy instead of a built-in policy.",
+      "oneOf": [
+        {
+          "enum": [
+            "explicitRequestOnly",
+            "proactive"
+          ],
+          "type": "string"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "custom": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "custom"
+          ],
+          "title": "CustomMultiAgentMode",
+          "type": "object"
+        }
+      ]
     },
     "NetworkAccess": {
       "enum": [
@@ -12495,6 +12620,28 @@
       "type": "object",
       "x-gollem-typescript-ignore-additional-properties": true
     },
+    "SelectedCapabilityRoot": {
+      "description": "A user-selected root that can expose one or more runtime capabilities.",
+      "properties": {
+        "id": {
+          "description": "Stable identifier supplied by the capability selection platform.",
+          "type": "string"
+        },
+        "location": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/CapabilityRootLocation"
+            }
+          ],
+          "description": "Where the selected root can be resolved."
+        }
+      },
+      "required": [
+        "id",
+        "location"
+      ],
+      "type": "object"
+    },
     "SendAddCreditsNudgeEmailParams": {
       "properties": {
         "creditType": {
@@ -12629,6 +12776,34 @@
           "type": "object"
         }
       ]
+    },
+    "Settings": {
+      "description": "Settings for a collaboration mode.",
+      "properties": {
+        "developer_instructions": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "model": {
+          "type": "string"
+        },
+        "reasoning_effort": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ReasoningEffort"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "model"
+      ],
+      "type": "object"
     },
     "SkillMigration": {
       "additionalProperties": false,

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 520 {
-		t.Fatalf("definition count = %d, want 520", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 527 {
+		t.Fatalf("definition count = %d, want 527", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -237,8 +237,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -140,8 +140,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 520 {
-		t.Fatalf("definition count = %d, want 520", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 527 {
+		t.Fatalf("definition count = %d, want 527", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 520 {
-		t.Fatalf("definition count = %d, want 520", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 527 {
+		t.Fatalf("definition count = %d, want 527", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -110,8 +110,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/interrupt unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -233,8 +233,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/start unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,8 +156,8 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -560,6 +560,34 @@ func MarshalTypeScript() ([]byte, error) {
 				typeScriptRawTypeKeyword: `{ "type": "function" } & DynamicToolFunctionSpec | { "type": "namespace" } & DynamicToolNamespaceSpec`,
 			}
 		}
+		switch name {
+		case "CapabilityRootLocation":
+			definition = Schema{
+				typeScriptRawTypeKeyword: `{ "type": "environment"; "environmentId": string; "path": string; }`,
+			}
+		case "CollaborationMode":
+			definition = Schema{
+				typeScriptRawTypeKeyword: `{ "mode": ModeKind; "settings": Settings; }`,
+			}
+		case "CollaborationModeMask":
+			definition = Schema{
+				typeScriptRawTypeKeyword: `{ "name": string; "mode": ModeKind | null; "model": string | null; "reasoning_effort": ReasoningEffort | null | null; }`,
+			}
+		case "ModeKind":
+			definition = Schema{typeScriptRawTypeKeyword: `"plan" | "default"`}
+		case "MultiAgentMode":
+			definition = Schema{
+				typeScriptRawTypeKeyword: `{ "custom": string } | "explicitRequestOnly" | "proactive"`,
+			}
+		case "SelectedCapabilityRoot":
+			definition = Schema{
+				typeScriptRawTypeKeyword: `{ "id": string; "location": CapabilityRootLocation; }`,
+			}
+		case "Settings":
+			definition = Schema{
+				typeScriptRawTypeKeyword: `{ "model": string; "reasoning_effort": ReasoningEffort | null; "developer_instructions": string | null; }`,
+			}
+		}
 		if name == "HookRunSummary" {
 			// ts-rs maps each Rust i64 field to bigint, including nullable i64
 			// options. Keep these hints out of the public JSON Schema.

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -784,6 +784,8 @@ export type CancelLoginAccountResponse = {
 
 export type CancelLoginAccountStatus = "canceled" | "notFound";
 
+export type CapabilityRootLocation = { "type": "environment"; "environmentId": string; "path": string; };
+
 export type ChatgptAuthTokensRefreshParams = {
   "previousAccountId"?: string | null;
   "reason": ChatgptAuthTokensRefreshReason;
@@ -835,6 +837,10 @@ export type CollabAgentStatus = "pendingInit" | "running" | "interrupted" | "com
 export type CollabAgentTool = "spawnAgent" | "sendInput" | "resumeAgent" | "wait" | "closeAgent";
 
 export type CollabAgentToolCallStatus = "inProgress" | "completed" | "failed";
+
+export type CollaborationMode = { "mode": ModeKind; "settings": Settings; };
+
+export type CollaborationModeMask = { "name": string; "mode": ModeKind | null; "model": string | null; "reasoning_effort": ReasoningEffort | null | null; };
 
 export type CommandAction = {
   "command": string;
@@ -2481,6 +2487,8 @@ export type MigrationDetails = {
   "subagents": Array<SubagentMigration>;
 };
 
+export type ModeKind = "plan" | "default";
+
 export type Model = {
   "additionalSpeedTiers": Array<string>;
   "availabilityNux": ModelAvailabilityNux | null;
@@ -2567,6 +2575,8 @@ export type ModelVerificationNotification = {
 export type ModelsRequirements = {
   "newThread": NewThreadModelDefaults | null;
 };
+
+export type MultiAgentMode = { "custom": string } | "explicitRequestOnly" | "proactive";
 
 export type NetworkAccess = "restricted" | "enabled";
 
@@ -3047,6 +3057,8 @@ export type SandboxWorkspaceWrite = {
   "writable_roots": Array<string>;
 };
 
+export type SelectedCapabilityRoot = { "id": string; "location": CapabilityRootLocation; };
+
 export type SendAddCreditsNudgeEmailParams = {
   "creditType": AddCreditsNudgeCreditType;
 };
@@ -3079,6 +3091,8 @@ export type SessionSource = "cli" | "vscode" | "exec" | "appServer" | "unknown" 
 } | {
   "subAgent": SubAgentSource;
 };
+
+export type Settings = { "model": string; "reasoning_effort": ReasoningEffort | null; "developer_instructions": string | null; };
 
 export type SkillMigration = {
   "name": string;

--- a/appserver/protocol/typescript/testdata/collaboration_capability_contract.ts
+++ b/appserver/protocol/typescript/testdata/collaboration_capability_contract.ts
@@ -1,0 +1,118 @@
+import type {
+  CapabilityRootLocation,
+  CollaborationMode,
+  CollaborationModeMask,
+  ItemPayloadByKind,
+  MethodParamsByName,
+  MethodResultsByName,
+  ModeKind,
+  MultiAgentMode,
+  ReasoningEffort,
+  SelectedCapabilityRoot,
+  Settings,
+} from "../gollem_appserver_protocol";
+import {
+  itemPayloadBindings,
+  protocolMethods,
+  wireTypeBindings,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+type ExactMembers<Union, Expected> = Union extends unknown
+  ? Equal<Union, Expected> extends true
+    ? Union
+    : never
+  : never;
+
+type ExpectedSettings = {
+  model: string;
+  reasoning_effort: ReasoningEffort | null;
+  developer_instructions: string | null;
+};
+type ExpectedMode = {
+  mode: ModeKind;
+  settings: Settings;
+};
+type ExpectedMask = {
+  name: string;
+  mode: ModeKind | null;
+  model: string | null;
+  reasoning_effort: ReasoningEffort | null | null;
+};
+type ExpectedLocation = {
+  type: "environment";
+  environmentId: string;
+  path: string;
+};
+type ExpectedRoot = {
+  id: string;
+  location: CapabilityRootLocation;
+};
+type CollaborationCapabilityContracts =
+  | CapabilityRootLocation
+  | CollaborationMode
+  | CollaborationModeMask
+  | ModeKind
+  | MultiAgentMode
+  | SelectedCapabilityRoot
+  | Settings;
+
+type Contracts = [
+  Expect<Equal<ModeKind, "plan" | "default">>,
+  Expect<Equal<MultiAgentMode, { custom: string } | "explicitRequestOnly" | "proactive">>,
+  Expect<Equal<Settings, ExpectedSettings>>,
+  Expect<Equal<CollaborationMode, ExpectedMode>>,
+  Expect<Equal<CollaborationModeMask, ExpectedMask>>,
+  Expect<Equal<CapabilityRootLocation, ExpectedLocation>>,
+  Expect<Equal<SelectedCapabilityRoot, ExpectedRoot>>,
+  Expect<Equal<ExactMembers<MethodParamsByName[keyof MethodParamsByName], CollaborationCapabilityContracts>, never>>,
+  Expect<Equal<ExactMembers<MethodResultsByName[keyof MethodResultsByName], CollaborationCapabilityContracts>, never>>,
+  Expect<Equal<ExactMembers<ItemPayloadByKind[keyof ItemPayloadByKind], CollaborationCapabilityContracts>, never>>,
+  Expect<Equal<typeof protocolMethods["length"], 224>>,
+  Expect<Equal<typeof wireTypeBindings["length"], 59>>,
+  Expect<Equal<typeof itemPayloadBindings["length"], 5>>,
+];
+
+({
+  mode: "plan",
+  settings: {
+    model: "",
+    reasoning_effort: null,
+    developer_instructions: null,
+  },
+}) satisfies CollaborationMode;
+({
+  name: "",
+  mode: null,
+  model: null,
+  reasoning_effort: null,
+}) satisfies CollaborationModeMask;
+({
+  id: "",
+  location: {
+    type: "environment",
+    environmentId: "",
+    path: "file:///workspace",
+  },
+}) satisfies SelectedCapabilityRoot;
+({ custom: "" }) satisfies MultiAgentMode;
+
+// @ts-expect-error settings optional fields are canonically required nullable.
+({ model: "" }) satisfies Settings;
+// @ts-expect-error collaboration mode is closed to plan/default.
+"code" satisfies ModeKind;
+// @ts-expect-error legacy none is accepted only on serde input, not canonical TypeScript.
+"none" satisfies MultiAgentMode;
+// @ts-expect-error the custom payload is required and non-null.
+({ custom: null }) satisfies MultiAgentMode;
+// @ts-expect-error capability roots currently permit only environment locations.
+({ type: "local", environmentId: "", path: "/workspace" }) satisfies CapabilityRootLocation;
+// @ts-expect-error location is required.
+({ id: "" }) satisfies SelectedCapabilityRoot;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if got := len(WireTypeBindings()); got != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 59/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/workspace_messages_contract_test.go
+++ b/appserver/protocol/workspace_messages_contract_test.go
@@ -209,8 +209,8 @@ func TestWorkspaceMessageContractsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/workspaceMessages/read = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 520 {
-		t.Fatalf("definition count = %d, want 520", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 527 {
+		t.Fatalf("definition count = %d, want 527", got)
 	}
 	if len(Methods()) != 224 || len(WireTypeBindings()) != 59 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 224/59/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary

- export exact standalone `Settings`, `ModeKind`, `MultiAgentMode`, `CollaborationModeMask`, `CollaborationMode`, `CapabilityRootLocation`, and `SelectedCapabilityRoot` contracts from pinned public Codex `5c19155cbd93bfa099016e7487259f61669823ff`
- preserve serde aliases, optional/null canonicalization, strict tagged unions, and cross-platform `PathUri` normalization including foreign file URIs and opaque native-path fallbacks
- add exact JSON Schema and generated TypeScript declarations without changing the 224 method classifications, 59 method bindings, or 5 item bindings
- keep these records descriptive and standalone; no collaboration, delegation, environment resolution, filesystem, permission, persistence, or execution authority is added

## Verification

- focused normal repetition: 30 passes
- focused race repetition: 10 passes
- focused production-file statement coverage: 100%
- all 59 non-Monty packages: normal and race pass
- `golangci-lint run ./...`
- `go vet ./...`
- `go mod tidy` with no drift
- strict TypeScript compile
- deterministic generation twice: schema `e3043adad3552adeac6325f52bb137186abd3cb5c474f66facfaddaae64f464d`, TypeScript `b0f25f1938999b7daa782d6b20847703081cff735e5cf4d800670a2f5939f962`
- seven generated schemas are exact against pinned upstream after reference-root normalization
- structural reversal restores both parent generated artifacts byte-for-byte
- parent/feature app-server transcripts are byte-identical with empty stderr
- all five Slang real-Gollem stdio/Unix-socket/WebSocket workflows pass
- pre-push hook passed before commit and again on push

Local Monty normal/race/coverage runs were intentionally skipped per project instruction; hosted CI remains unchanged.