### PR TITLE
provider/openai: secret-safe latency instrumentation for ChatGPT paths (#242)

### DIFF
--- a/examples/openai-latency/README.md
+++ b/examples/openai-latency/README.md
@@ -1,0 +1,80 @@
+# openai-latency
+
+A reproducible harness for investigating latency in ChatGPT OAuth-backed OpenAI
+requests ([issue #242](https://github.com/fugue-labs/gollem/issues/242)).
+
+It loads ChatGPT subscription credentials, builds one provider per transport
+(`http` `Request`, `http` `RequestStream`, `websocket`), runs a fixed prompt
+across a growing conversation history, and prints a **secret-safe per-request
+phase-breakdown table**.
+
+## What it measures
+
+For every physical provider request the harness prints, measured from request
+start:
+
+| column | meaning |
+| ------ | ------- |
+| `refresh` | OAuth token-refresh duration (distinguishes refresh I/O from the request itself) |
+| `ttfb` | time to response headers (HTTP) or websocket dial+handshake |
+| `first_event` | time to first SSE/websocket event |
+| `first_token` | time to first text/tool delta |
+| `terminal` | time to the terminal response event |
+| `total` | wall-clock for the whole provider call |
+| `ws_reused` | whether the websocket connection was reused |
+| `prev_reused` | whether `previous_response_id` continuation was used |
+| `cache` | prompt-cache-key fingerprint (continuity check, not the key) |
+| `status` / `err` | HTTP status + sanitized error classification |
+
+Together these let you separate refresh time from request upload, backend
+queueing/reasoning (`first_event − ttfb`), streaming (`terminal − first_token`),
+and retry gaps (separate rows).
+
+## Credentials & safety
+
+No access/refresh/ID tokens, account IDs, authorization URLs, callback queries,
+device codes, or raw provider error bodies are ever printed — only sizes,
+timings, sanitized error markers, and a non-reversible cache-key fingerprint.
+
+Log in once to populate `~/.golem/auth.json` with a ChatGPT Plus/Pro/Team
+account, then run:
+
+```bash
+OPENAI_MODEL=gpt-5.3-codex go run ./examples/openai-latency
+```
+
+### Environment
+
+| variable | default | notes |
+| -------- | ------- | ----- |
+| `OPENAI_MODEL` | `gpt-5.3-codex` | model to request |
+| `OPENAI_AUTH_PATH` | `~/.golem/auth.json` | path to chatgpt auth file |
+| `OPENAI_TRANSPORTS` | `http,stream,websocket` | comma list of transports |
+| `OPENAI_HISTORY_TURNS` | `1,5,15` | comma list of history sizes |
+
+## Comparing against official Codex
+
+This harness produces Gollem-side before/after evidence across transports and
+history sizes. The comparison against **official Codex 0.144.6** (the version
+bundled by `openai/codex-security`) is intentionally run separately because it
+requires that binary; collect its per-request timings the same way (same account,
+model, prompt, reasoning effort, and history sizes) and diff the phase
+breakdowns. The questions this is designed to answer (from the issue):
+
+- Is the difference total completion time, time to first token, or both?
+- Is Gollem refreshing OAuth tokens more often than intended?
+- Is HTTP full-context upload/reprocessing the dominant difference as history grows?
+- Are retries or `Retry-After` sleeps hidden inside the observed latency?
+- Is provider recreation defeating prompt-cache continuity?
+
+## Follow-ups (explicitly tracked separately)
+
+This investigation deliberately does **not** change any transport default. Per
+the issue, the following are tracked as follow-up work pending this evidence:
+
+- Canonical ChatGPT account-claim parsing (`https://api.openai.com/auth` object,
+  including `chatgpt_account_id`, plan type, FedRAMP routing) for OAuth parity.
+- Refresh/recovery parity (JSON refresh grants, serialized refreshes, guarded
+  credential reload, 401 recovery via reload → refresh → retry).
+- Any proposed default change (e.g. websocket-by-default for ChatGPT) — to be
+  evaluated only with the evidence this harness produces.

--- a/examples/openai-latency/main.go
+++ b/examples/openai-latency/main.go
@@ -1,0 +1,230 @@
+// Example openai-latency is a reproducible harness for investigating latency in
+// ChatGPT OAuth-backed OpenAI requests (issue #242).
+//
+// It loads ChatGPT subscription credentials (auth/openai), builds one provider
+// per transport with WithChatGPTAuth + WithTokenRefresher(RefreshIfNeeded) +
+// WithRequestObserver, runs a fixed prompt across a growing conversation
+// history, and prints a secret-safe per-request phase-breakdown table.
+//
+// Usage:
+//
+//	# Log in once to populate ~/.golem/auth.json (chatgpt subscription path):
+//	#   (use your own ChatGPT Plus/Pro/Team account)
+//
+//	OPENAI_MODEL=gpt-5.3-codex go run ./examples/openai-latency
+//
+// Environment:
+//
+//	OPENAI_MODEL            model to request (default gpt-5.3-codex)
+//	OPENAI_AUTH_PATH        path to auth.json (default ~/.golem/auth.json)
+//	OPENAI_TRANSPORTS       comma list: http,websocket,stream (default http,stream,websocket)
+//	OPENAI_HISTORY_TURNS    comma list of history sizes (default 1,5,15)
+//
+// No access/refresh/ID tokens, account IDs, authorization URLs, or raw provider
+// error bodies are ever printed — only sizes, timings, and sanitized markers.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/fugue-labs/gollem/auth/openai"
+	"github.com/fugue-labs/gollem/core"
+	oai "github.com/fugue-labs/gollem/provider/openai"
+)
+
+const defaultModel = "gpt-5.3-codex"
+
+func main() {
+	authPath := envOr("OPENAI_AUTH_PATH", "")
+	model := envOr("OPENAI_MODEL", defaultModel)
+	transports := splitCSV(envOr("OPENAI_TRANSPORTS", "http,stream,websocket"))
+	turns := parseIntCSV(envOr("OPENAI_HISTORY_TURNS", "1,5,15"))
+	flag.Parse()
+
+	creds, err := loadCredentials(authPath)
+	if err != nil {
+		log.Fatalf("loading ChatGPT credentials: %v\n(log in first, or set OPENAI_AUTH_PATH)", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
+
+	fmt.Printf("# ChatGPT OAuth latency investigation — model=%s account_claim=%s\n\n", model, redacted(creds.AccountID))
+	fmt.Println("# Phases are measured from request start. No credentials are printed.")
+	fmt.Println("# transport | turns | refresh | ttfb | first_event | first_token | terminal | total | ws_reused | prev_reused | cache | status | err")
+	fmt.Println("# --------- | ----- | ------- | ---- | ----------- | ----------- | -------- | ----- | --------- | ----------- | ----- | ------ | ---")
+
+	for _, transport := range transports {
+		for _, n := range turns {
+			if err := runOnce(ctx, creds, model, transport, n); err != nil {
+				fmt.Printf("# %s turns=%d ERROR: %v\n", transport, n, err)
+			}
+		}
+	}
+}
+
+func runOnce(ctx context.Context, creds *openai.Credentials, model, transport string, historyTurns int) error {
+	var (
+		mu    sync.Mutex
+		trace oai.RequestTrace
+	)
+	obs := func(t oai.RequestTrace) {
+		mu.Lock()
+		trace = t
+		mu.Unlock()
+	}
+
+	// tokenRefresher mirrors how a downstream ChatGPT-auth consumer wires the
+	// OAuth credential lifecycle into the provider: refresh if near expiry, then
+	// persist the rotated credentials atomically.
+	tokenRefresher := func() (string, error) {
+		refreshed, err := openai.RefreshIfNeeded(creds)
+		if err != nil {
+			return "", err
+		}
+		if refreshed != creds {
+			creds = refreshed
+		}
+		return creds.AccessToken, nil
+	}
+
+	opts := []oai.Option{
+		oai.WithChatGPTAuth(creds.AccessToken, creds.AccountID),
+		oai.WithModel(model),
+		oai.WithTokenRefresher(tokenRefresher),
+		oai.WithRequestObserver(obs),
+	}
+	if transport == "websocket" {
+		opts = append(opts, oai.WithTransport("websocket"))
+	}
+
+	provider := oai.New(opts...)
+	defer provider.Close()
+
+	msgs := buildHistory(historyTurns)
+
+	switch transport {
+	case "http", "websocket":
+		resp, err := provider.Request(ctx, msgs, nil, nil)
+		if err != nil {
+			return err
+		}
+		_ = resp
+	case "stream":
+		stream, err := provider.RequestStream(ctx, msgs, nil, nil)
+		if err != nil {
+			return err
+		}
+		for {
+			if _, err := stream.Next(); err != nil {
+				break
+			}
+		}
+		_ = stream.Close()
+	default:
+		return fmt.Errorf("unknown transport %q", transport)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	fmt.Printf("%-9s | %5d | %7s | %4s | %11s | %11s | %8s | %5s | %9t | %11t | %5s | %6d | %s\n",
+		transport, historyTurns,
+		trace.TokenRefreshDuration.Round(time.Millisecond),
+		trace.TimeToHeaders.Round(time.Millisecond),
+		trace.TimeToFirstEvent.Round(time.Millisecond),
+		trace.TimeToFirstToken.Round(time.Millisecond),
+		trace.TimeToTerminal.Round(time.Millisecond),
+		trace.TotalDuration.Round(time.Millisecond),
+		trace.WebSocketConnectionReused,
+		trace.PreviousResponseIDReused,
+		trace.PromptCacheKeyFingerprint,
+		trace.HTTPStatus,
+		trace.ErrorClassification,
+	)
+	return nil
+}
+
+// buildHistory constructs a synthetic append-only conversation of the given
+// number of turns. Each turn is a user prompt plus an assistant reply so the
+// history grows deterministically.
+func buildHistory(turns int) []core.ModelMessage {
+	var msgs []core.ModelMessage
+	for i := range turns {
+		msgs = append(msgs, core.ModelRequest{
+			Parts: []core.ModelRequestPart{
+				core.UserPromptPart{Content: fmt.Sprintf("Turn %d: briefly summarize what you did so far.", i+1)},
+			},
+		})
+		msgs = append(msgs, core.ModelResponse{
+			Parts: []core.ModelResponsePart{
+				core.TextPart{Content: fmt.Sprintf("On turn %d I restated the goal and checked prior context.", i+1)},
+			},
+		})
+	}
+	msgs = append(msgs, core.ModelRequest{
+		Parts: []core.ModelRequestPart{
+			core.UserPromptPart{Content: "Reply with the single word: done"},
+		},
+	})
+	return msgs
+}
+
+func loadCredentials(path string) (*openai.Credentials, error) {
+	if path != "" {
+		return openai.LoadCredentialsFrom(path)
+	}
+	return openai.LoadCredentials()
+}
+
+func envOr(key, def string) string {
+	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
+		return v
+	}
+	return def
+}
+
+func splitCSV(s string) []string {
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func parseIntCSV(s string) []int {
+	parts := splitCSV(s)
+	out := make([]int, 0, len(parts))
+	for _, p := range parts {
+		var n int
+		_, _ = fmt.Sscanf(p, "%d", &n)
+		if n > 0 {
+			out = append(out, n)
+		}
+	}
+	if len(out) == 0 {
+		return []int{1}
+	}
+	return out
+}
+
+// redacted confirms an account was loaded without exposing it: prints the first
+// two and last two characters with a mask in between.
+func redacted(accountID string) string {
+	if accountID == "" {
+		return "<none>"
+	}
+	if len(accountID) <= 4 {
+		return "****"
+	}
+	return accountID[:2] + "…" + accountID[len(accountID)-2:]
+}

--- a/examples/openai-latency/main.go
+++ b/examples/openai-latency/main.go
@@ -26,8 +26,10 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"strings"
@@ -61,69 +63,131 @@ func main() {
 	fmt.Println("# transport | turns | refresh | ttfb | first_event | first_token | terminal | total | ws_reused | prev_reused | cache | status | err")
 	fmt.Println("# --------- | ----- | ------- | ---- | ----------- | ----------- | -------- | ----- | --------- | ----------- | ----- | ------ | ---")
 
+	// credsHolder carries the live OAuth credentials across every run so that a
+	// token rotation performed by one transport's refresher persists to the next
+	// run (and the next transport). Without this each run would start from the
+	// original credentials and re-pay refresh latency (or fail on a rotated
+	// refresh token).
+	credsHolder := &credentialHolder{creds: creds}
+
 	for _, transport := range transports {
+		// Build ONE provider per transport and reuse it across all history
+		// sizes. This is essential to the experiment: only a reused provider
+		// keeps its prompt-cache key, websocket connection, and continuation
+		// state, so ws_reused / prev_reused / cache-continuity are measurable.
+		mp, err := buildProvider(model, transport, credsHolder)
+		if err != nil {
+			fmt.Printf("# %s ERROR building provider: %v\n", transport, err)
+			continue
+		}
 		for _, n := range turns {
-			if err := runOnce(ctx, creds, model, transport, n); err != nil {
+			if err := runOnce(ctx, mp, transport, n); err != nil {
 				fmt.Printf("# %s turns=%d ERROR: %v\n", transport, n, err)
 			}
 		}
+		_ = mp.provider.Close()
 	}
 }
 
-func runOnce(ctx context.Context, creds *openai.Credentials, model, transport string, historyTurns int) error {
-	var (
-		mu    sync.Mutex
-		trace oai.RequestTrace
-	)
-	obs := func(t oai.RequestTrace) {
-		mu.Lock()
-		trace = t
-		mu.Unlock()
-	}
+// credentialHolder is a tiny concurrency-safe holder for the live OAuth
+// credentials shared across all transport runs.
+type credentialHolder struct {
+	mu    sync.Mutex
+	creds *openai.Credentials
+}
+
+func (h *credentialHolder) get() *openai.Credentials {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.creds
+}
+
+func (h *credentialHolder) set(c *openai.Credentials) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.creds = c
+}
+
+// measuredProvider pairs a provider with a slot capturing its most recent trace
+// so runOnce can print a row per request without a package global.
+type measuredProvider struct {
+	provider *oai.Provider
+	mu       sync.Mutex
+	trace    oai.RequestTrace
+	hasTrace bool
+}
+
+func (m *measuredProvider) record(t oai.RequestTrace) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.trace = t
+	m.hasTrace = true
+}
+
+func (m *measuredProvider) last() (oai.RequestTrace, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.trace, m.hasTrace
+}
+
+func buildProvider(model, transport string, h *credentialHolder) (*measuredProvider, error) {
+	creds := h.get()
+	mp := &measuredProvider{}
 
 	// tokenRefresher mirrors how a downstream ChatGPT-auth consumer wires the
 	// OAuth credential lifecycle into the provider: refresh if near expiry, then
-	// persist the rotated credentials atomically.
+	// persist the rotated credentials back into the shared holder so every
+	// subsequent run (any transport) sees them.
 	tokenRefresher := func() (string, error) {
-		refreshed, err := openai.RefreshIfNeeded(creds)
+		current := h.get()
+		refreshed, err := openai.RefreshIfNeeded(current)
 		if err != nil {
 			return "", err
 		}
-		if refreshed != creds {
-			creds = refreshed
+		if refreshed != current {
+			h.set(refreshed)
 		}
-		return creds.AccessToken, nil
+		return refreshed.AccessToken, nil
 	}
 
 	opts := []oai.Option{
 		oai.WithChatGPTAuth(creds.AccessToken, creds.AccountID),
 		oai.WithModel(model),
 		oai.WithTokenRefresher(tokenRefresher),
-		oai.WithRequestObserver(obs),
+		oai.WithRequestObserver(mp.record),
 	}
 	if transport == "websocket" {
 		opts = append(opts, oai.WithTransport("websocket"))
 	}
 
-	provider := oai.New(opts...)
-	defer provider.Close()
+	mp.provider = oai.New(opts...)
+	return mp, nil
+}
 
+func runOnce(ctx context.Context, mp *measuredProvider, transport string, historyTurns int) error {
 	msgs := buildHistory(historyTurns)
 
+	var runErr error
 	switch transport {
 	case "http", "websocket":
-		resp, err := provider.Request(ctx, msgs, nil, nil)
+		resp, err := mp.provider.Request(ctx, msgs, nil, nil)
 		if err != nil {
-			return err
+			runErr = err
 		}
 		_ = resp
 	case "stream":
-		stream, err := provider.RequestStream(ctx, msgs, nil, nil)
+		stream, err := mp.provider.RequestStream(ctx, msgs, nil, nil)
 		if err != nil {
-			return err
+			runErr = err
+			break
 		}
+		// io.EOF is the normal terminal sentinel; any other error is a real
+		// transport/provider failure and must be surfaced, not swallowed.
 		for {
 			if _, err := stream.Next(); err != nil {
+				if !errors.Is(err, io.EOF) {
+					runErr = err
+				}
 				break
 			}
 		}
@@ -132,8 +196,7 @@ func runOnce(ctx context.Context, creds *openai.Credentials, model, transport st
 		return fmt.Errorf("unknown transport %q", transport)
 	}
 
-	mu.Lock()
-	defer mu.Unlock()
+	trace, _ := mp.last()
 	fmt.Printf("%-9s | %5d | %7s | %4s | %11s | %11s | %8s | %5s | %9t | %11t | %5s | %6d | %s\n",
 		transport, historyTurns,
 		trace.TokenRefreshDuration.Round(time.Millisecond),
@@ -148,7 +211,7 @@ func runOnce(ctx context.Context, creds *openai.Credentials, model, transport st
 		trace.HTTPStatus,
 		trace.ErrorClassification,
 	)
-	return nil
+	return runErr
 }
 
 // buildHistory constructs a synthetic append-only conversation of the given

--- a/examples/openai-latency/main_test.go
+++ b/examples/openai-latency/main_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/fugue-labs/gollem/auth/openai"
+	oai "github.com/fugue-labs/gollem/provider/openai"
+)
+
+func TestSplitCSV(t *testing.T) {
+	got := splitCSV("a, b ,c,")
+	want := []string{"a", "b", "c"}
+	if len(got) != len(want) {
+		t.Fatalf("splitCSV = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("splitCSV[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestParseIntCSV(t *testing.T) {
+	tests := []struct {
+		in   string
+		want []int
+	}{
+		{"1,5,15", []int{1, 5, 15}},
+		{" 3 , ,7", []int{3, 7}},
+		{"", []int{1}},     // empty -> default single run
+		{"0,-1", []int{1}}, // all non-positive -> default
+	}
+	for _, tc := range tests {
+		got := parseIntCSV(tc.in)
+		if len(got) != len(tc.want) {
+			t.Errorf("parseIntCSV(%q) = %v, want %v", tc.in, got, tc.want)
+			continue
+		}
+		for i := range tc.want {
+			if got[i] != tc.want[i] {
+				t.Errorf("parseIntCSV(%q)[%d] = %d, want %d", tc.in, i, got[i], tc.want[i])
+			}
+		}
+	}
+}
+
+func TestEnvOrDefault(t *testing.T) {
+	t.Setenv("OPENAI_LATENCY_TEST_VAR", "set-value")
+	if got := envOr("OPENAI_LATENCY_TEST_VAR", "def"); got != "set-value" {
+		t.Errorf("envOr set var = %q, want set-value", got)
+	}
+	if got := envOr("OPENAI_LATENCY_UNSET_VAR", "def"); got != "def" {
+		t.Errorf("envOr unset var = %q, want def", got)
+	}
+	t.Setenv("OPENAI_LATENCY_BLANK", "   ")
+	if got := envOr("OPENAI_LATENCY_BLANK", "def"); got != "def" {
+		t.Errorf("envOr blank var = %q, want def", got)
+	}
+}
+
+func TestRedacted(t *testing.T) {
+	if got := redacted(""); got != "<none>" {
+		t.Errorf("redacted('') = %q, want <none>", got)
+	}
+	if got := redacted("ab"); got != "****" {
+		t.Errorf("redacted short = %q, want ****", got)
+	}
+	// Longer account ids keep first 2 and last 2 chars with a separator.
+	if got := redacted("abcdef"); got != "ab…ef" {
+		t.Errorf("redacted('abcdef') = %q, want ab…ef", got)
+	}
+}
+
+func TestBuildHistoryGrowsWithTurns(t *testing.T) {
+	for _, turns := range []int{1, 5, 15} {
+		msgs := buildHistory(turns)
+		// Each turn contributes a request + response, plus a final request.
+		if len(msgs) != turns*2+1 {
+			t.Errorf("turns=%d: got %d messages, want %d", turns, len(msgs), turns*2+1)
+		}
+	}
+	if msgs := buildHistory(0); len(msgs) != 1 {
+		t.Errorf("turns=0: got %d messages, want 1", len(msgs))
+	}
+}
+
+func TestCredentialHolder(t *testing.T) {
+	initial := &openai.Credentials{AccessToken: "a", ExpiresAt: time.Now().Add(time.Hour)}
+	h := &credentialHolder{creds: initial}
+	if h.get() != initial {
+		t.Fatal("get should return the initial creds")
+	}
+	rotated := &openai.Credentials{AccessToken: "b", ExpiresAt: time.Now().Add(2 * time.Hour)}
+	h.set(rotated)
+	if h.get() != rotated {
+		t.Fatal("get should return the rotated creds after set")
+	}
+}
+
+func TestMeasuredProviderRecordAndLast(t *testing.T) {
+	mp := &measuredProvider{}
+	if _, ok := mp.last(); ok {
+		t.Fatal("fresh measuredProvider should have no trace")
+	}
+	tr := oai.RequestTrace{Transport: "http", Model: "gpt-5"}
+	mp.record(tr)
+	got, ok := mp.last()
+	if !ok {
+		t.Fatal("last should report a trace after record")
+	}
+	if got.Transport != "http" || got.Model != "gpt-5" {
+		t.Errorf("last() = %+v, want the recorded trace", got)
+	}
+}

--- a/examples/openai-latency/main_test.go
+++ b/examples/openai-latency/main_test.go
@@ -1,6 +1,14 @@
 package main
 
 import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -112,4 +120,136 @@ func TestMeasuredProviderRecordAndLast(t *testing.T) {
 	if got.Transport != "http" || got.Model != "gpt-5" {
 		t.Errorf("last() = %+v, want the recorded trace", got)
 	}
+}
+
+func TestLoadCredentialsFromPath(t *testing.T) {
+	// Writing a credentials file and loading via the path exercises both
+	// branches of loadCredentials without touching the real home dir.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "auth.json")
+	creds := &openai.Credentials{
+		AccessToken:  "at",
+		RefreshToken: "rt",
+		AccountID:    "acct",
+		ExpiresAt:    time.Now().Add(time.Hour),
+	}
+	data, _ := json.Marshal(creds)
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got, err := loadCredentials(path)
+	if err != nil {
+		t.Fatalf("loadCredentials: %v", err)
+	}
+	if got.AccountID != "acct" {
+		t.Errorf("AccountID = %q, want acct", got.AccountID)
+	}
+}
+
+func TestLoadCredentialsMissingPathErrors(t *testing.T) {
+	if _, err := loadCredentials(filepath.Join(t.TempDir(), "nope.json")); err == nil {
+		t.Fatal("expected error loading missing file")
+	}
+}
+
+// TestBuildProviderWiresObserverAndRefresher verifies buildProvider constructs a
+// provider whose observer and token refresher are wired and functional, without
+// needing a live account. The refresher is exercised against non-expiring
+// (no-op refresh) credentials.
+func TestBuildProviderWiresObserverAndRefresher(t *testing.T) {
+	h := &credentialHolder{creds: &openai.Credentials{
+		AccessToken:  "tok",
+		RefreshToken: "rt",
+		AccountID:    "acct",
+		// Far future expiry so RefreshIfNeeded is a no-op (returns same creds).
+		ExpiresAt: time.Now().Add(24 * time.Hour),
+	}}
+	mp, err := buildProvider("gpt-5", "http", h)
+	if err != nil {
+		t.Fatalf("buildProvider: %v", err)
+	}
+	if mp.provider == nil {
+		t.Fatal("provider should be non-nil")
+	}
+	// The observer records into mp; drive a trace through it.
+	mp.record(oai.RequestTrace{Transport: "http"})
+	if _, ok := mp.last(); !ok {
+		t.Fatal("observer not wired into measuredProvider")
+	}
+}
+
+// TestRunOnceHTTPAndStreamErrors drives runOnce against a local fake ChatGPT
+// backend for both the http and stream transports, and verifies a non-EOF
+// stream error is propagated (not swallowed). This covers the request-driving
+// switch and stream-error handling without real credentials.
+func TestRunOnceHTTPAndStreamErrors(t *testing.T) {
+	sse := "data: {\"type\":\"response.output_text.delta\",\"delta\":\"ok\"}\n\n" +
+		"data: {\"type\":\"response.completed\",\"response\":{\"id\":\"r\",\"model\":\"gpt-5\",\"output\":[],\"usage\":{\"input_tokens\":3,\"output_tokens\":1}}}\n\n" +
+		"data: [DONE]\n\n"
+
+	// successServer serves the happy-path SSE for the "http" transport.
+	successServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, sse)
+	}))
+	defer successServer.Close()
+
+	mp := newTestMeasuredProvider(t, successServer.URL+"/chatgpt.com")
+
+	// HTTP transport success.
+	if err := runOnce(context.Background(), mp, "http", 1); err != nil {
+		t.Fatalf("runOnce http: %v", err)
+	}
+	if tr, ok := mp.last(); !ok || tr.TotalDuration <= 0 {
+		t.Error("expected a recorded trace after a successful http run")
+	}
+
+	// Stream transport success.
+	if err := runOnce(context.Background(), mp, "stream", 1); err != nil {
+		t.Fatalf("runOnce stream: %v", err)
+	}
+
+	// Now point at a server that returns a 429 so RequestStream setup fails and
+	// runOnce surfaces the error rather than treating it as completion.
+	errServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":{"type":"rate_limit","message":"slow down"}}`, http.StatusTooManyRequests)
+	}))
+	defer errServer.Close()
+	mpErr := newTestMeasuredProvider(t, errServer.URL+"/chatgpt.com")
+	if err := runOnce(context.Background(), mpErr, "stream", 1); err == nil {
+		t.Fatal("runOnce stream should propagate the setup error, not swallow it")
+	}
+
+	// Unknown transport returns an error.
+	if err := runOnce(context.Background(), mp, "carrier-pigeon", 1); err == nil ||
+		!strings.Contains(err.Error(), "carrier-pigeon") {
+		t.Fatalf("runOnce unknown transport err = %v, want a carrier-pigeon error", err)
+	}
+}
+
+func TestRunOnceRequestErrorPropagated(t *testing.T) {
+	// "http" transport against a 500 should surface the error.
+	errServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":{"type":"server_error","message":"boom"}}`, http.StatusInternalServerError)
+	}))
+	defer errServer.Close()
+	mp := newTestMeasuredProvider(t, errServer.URL+"/chatgpt.com")
+	if err := runOnce(context.Background(), mp, "http", 1); err == nil {
+		t.Fatal("runOnce http should propagate the request error")
+	}
+}
+
+// newTestMeasuredProvider builds a measuredProvider pointed at a fake ChatGPT
+// backend URL. Constructing the struct first (then the provider) avoids the
+// "cannot use mp.record while mp is being assigned" ordering problem.
+func newTestMeasuredProvider(t *testing.T, baseURL string) *measuredProvider {
+	t.Helper()
+	mp := &measuredProvider{}
+	mp.provider = oai.New(
+		oai.WithChatGPTAuth("tok", "acct"),
+		oai.WithBaseURL(baseURL),
+		oai.WithModel("gpt-5"),
+		oai.WithRequestObserver(mp.record),
+	)
+	return mp
 }

--- a/provider/openai/doc.go
+++ b/provider/openai/doc.go
@@ -41,4 +41,21 @@
 //	model := openai.NewLiteLLM("http://localhost:4000",
 //	    openai.WithModel("claude-3-sonnet"),
 //	)
+//
+// # Latency Instrumentation
+//
+// WithRequestObserver installs a callback that receives one secret-safe
+// RequestTrace per physical provider request, covering the HTTP and WebSocket
+// transports. The trace measures token refresh, request upload, time to
+// headers/first-event/first-token/terminal, sanitized error classification,
+// Retry-After, and continuation/cache-continuity signals.
+//
+// It is intended for diagnosing latency (for example comparing ChatGPT
+// OAuth-backed requests across transports). It deliberately carries no
+// credentials, request content, or raw provider error bodies — only sizes,
+// timings, and sanitized markers.
+//
+// Set OPENAI_REQUEST_TRACE=1 to install the default stderr observer when no
+// explicit observer is configured. When unset, the provider incurs no
+// instrumentation overhead.
 package openai

--- a/provider/openai/instrumentation.go
+++ b/provider/openai/instrumentation.go
@@ -1,0 +1,373 @@
+package openai
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/fugue-labs/gollem/core"
+)
+
+// RequestTrace is the secret-safe per-request latency record delivered to a
+// RequestObserver. It measures timing phases and sizes only; it never carries
+// access/refresh/ID tokens, account IDs, authorization URLs, callback queries,
+// device codes, request content, or raw provider error bodies.
+//
+// All durations are measured from StartedAt. Fields are zero when the
+// corresponding phase did not occur (for example TimeToFirstToken is zero for a
+// non-streaming request that the caller never drained incrementally).
+type RequestTrace struct {
+	// Transport is "http" or "websocket".
+	Transport string
+	// Model is the model the provider was configured to request.
+	Model string
+	// StartedAt is when the physical provider request began (before token
+	// refresh, header construction, and the network round-trip).
+	StartedAt time.Time
+	// TotalDuration spans StartedAt through response finalization (or the
+	// returned error). It therefore includes any refresh, upload, backend
+	// queueing/reasoning, streaming, and retry/backoff time spent inside this
+	// single provider call. Retry gaps between separate provider calls appear
+	// as separate RequestTrace records.
+	TotalDuration time.Duration
+
+	// RequestBytes is the marshaled request body size in bytes. Input content
+	// is not included.
+	RequestBytes int
+	// InputItems is the count of top-level input items sent to the provider.
+	InputItems int
+
+	// TokenRefreshInvoked reports whether the configured TokenRefresher was
+	// called for this request.
+	TokenRefreshInvoked bool
+	// TokenRefreshDuration is how long the refresher took. A non-trivial value
+	// combined with TokenRefreshInvoked indicates network I/O occurred; a value
+	// near zero typically indicates the refresh was elided because the token
+	// was still valid.
+	TokenRefreshDuration time.Duration
+
+	// TimeToHeaders is the time from StartedAt until response headers arrived
+	// (HTTP) or the WebSocket dial+handshake completed. Zero if the request
+	// failed before headers.
+	TimeToHeaders time.Duration
+	// TimeToFirstEvent is the time until the first SSE/WebSocket event was
+	// observed. Zero if no event arrived.
+	TimeToFirstEvent time.Duration
+	// TimeToFirstToken is the time until the first text or tool delta was
+	// produced. Zero if it never occurred (for example a request that errored
+	// before any content).
+	TimeToFirstToken time.Duration
+	// TimeToTerminal is the time until the terminal response event. Zero if the
+	// request failed before a terminal event.
+	TimeToTerminal time.Duration
+
+	// HTTPStatus is the HTTP status code (HTTP transport) or the inferred
+	// websocket error status. Zero when unknown.
+	HTTPStatus int
+	// ErrorClassification is the sanitized provider error marker (for example
+	// "rate_limited", "previous_response_not_found") produced by
+	// classifyProviderError, or "" on success. It never contains raw provider
+	// bodies.
+	ErrorClassification string
+	// RetryAfter is the Retry-After duration parsed from a 429 response, if any.
+	RetryAfter time.Duration
+	// ErrorClass is a coarse typed-error category ("", "http", "identity",
+	// "transport", "context") on failure. It never contains err.Error().
+	ErrorClass string
+
+	// WebSocketConnectionReused reports whether an existing WebSocket
+	// connection was reused rather than dialing a new one. HTTP transport sets
+	// this to false.
+	WebSocketConnectionReused bool
+	// PreviousResponseIDReused reports whether the request was sent as a
+	// continuation on top of a previous response id (Responses API).
+	PreviousResponseIDReused bool
+	// PromptCacheKeyActive reports whether a prompt cache key was applied to
+	// the request.
+	PromptCacheKeyActive bool
+	// PromptCacheKeyFingerprint is a short, non-reversible fingerprint
+	// (sha256 prefix) of the prompt cache key in use, or "" if none. It lets a
+	// downstream aggregator verify cross-request and cross-instance cache
+	// continuity without ever exposing the key itself.
+	PromptCacheKeyFingerprint string
+}
+
+// RequestObserver receives one RequestTrace per physical provider request. It
+// is invoked from the request goroutine; nil means no instrumentation (fully
+// no-op, zero overhead). The implementation must be safe to call from the
+// provider's request goroutine.
+type RequestObserver func(trace RequestTrace)
+
+// WithRequestObserver installs a callback that receives a secret-safe
+// per-request latency trace. The trace covers token refresh, request upload,
+// time to headers/first-event/first-token/terminal, sanitized error
+// classification, and continuation/cache-continuity signals — but never
+// credentials, request content, or raw provider error bodies.
+//
+// It fires for both the HTTP and WebSocket transports. When unset, the
+// provider incurs no instrumentation overhead.
+func WithRequestObserver(obs RequestObserver) Option {
+	return func(p *Provider) {
+		p.requestObserver = obs
+	}
+}
+
+// DefaultStderrRequestObserver returns a RequestObserver that prints a tagged,
+// human-readable summary of each trace to os.Stderr.
+func DefaultStderrRequestObserver() RequestObserver {
+	return func(t RequestTrace) {
+		fmt.Fprintln(os.Stderr, formatRequestTrace(t))
+	}
+}
+
+// formatRequestTrace renders a single trace as a compact, grep-friendly line
+// block. Exported via DefaultStderrRequestObserver; kept here for testability.
+func formatRequestTrace(t RequestTrace) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "[gollem-openai-trace] transport=%s model=%s started=%s",
+		t.Transport, t.Model, t.StartedAt.Format(time.RFC3339Nano))
+	if t.RequestBytes > 0 || t.InputItems > 0 {
+		fmt.Fprintf(&b, " req_bytes=%d input_items=%d", t.RequestBytes, t.InputItems)
+	}
+	fmt.Fprintf(&b, " total=%s", t.TotalDuration)
+	if t.TokenRefreshInvoked {
+		fmt.Fprintf(&b, " refresh=%s", t.TokenRefreshDuration)
+	}
+	if t.TimeToHeaders > 0 {
+		fmt.Fprintf(&b, " ttfb=%s", t.TimeToHeaders)
+	}
+	if t.TimeToFirstEvent > 0 {
+		fmt.Fprintf(&b, " first_event=%s", t.TimeToFirstEvent)
+	}
+	if t.TimeToFirstToken > 0 {
+		fmt.Fprintf(&b, " first_token=%s", t.TimeToFirstToken)
+	}
+	if t.TimeToTerminal > 0 {
+		fmt.Fprintf(&b, " terminal=%s", t.TimeToTerminal)
+	}
+	if t.HTTPStatus != 0 {
+		fmt.Fprintf(&b, " status=%d", t.HTTPStatus)
+	}
+	if t.ErrorClassification != "" {
+		fmt.Fprintf(&b, " err=%s", t.ErrorClassification)
+	}
+	if t.RetryAfter > 0 {
+		fmt.Fprintf(&b, " retry_after=%s", t.RetryAfter)
+	}
+	if t.ErrorClass != "" {
+		fmt.Fprintf(&b, " err_class=%s", t.ErrorClass)
+	}
+	if t.WebSocketConnectionReused {
+		fmt.Fprintf(&b, " ws_reused=true")
+	}
+	if t.PreviousResponseIDReused {
+		fmt.Fprintf(&b, " prev_response_reused=true")
+	}
+	if t.PromptCacheKeyActive {
+		fmt.Fprintf(&b, " cache_key=%s", t.PromptCacheKeyFingerprint)
+	}
+	return b.String()
+}
+
+// requestInstrumentation accumulates timing for a single physical provider
+// request. A nil pointer is a no-op everywhere it is consulted, so unobserved
+// requests incur zero allocation and zero clock reads on the hot path.
+//
+// It is per-request (created at the top of Request/RequestStream) rather than
+// a shared provider field, so concurrent requests do not race on it.
+type requestInstrumentation struct {
+	obs      RequestObserver
+	trace    RequestTrace
+	start    time.Time
+	tokenSt  time.Time
+	finished bool
+
+	headersRecorded    bool
+	firstEventRecorded bool
+	firstTokenRecorded bool
+	terminalRecorded   bool
+}
+
+// newRequestInstrumentation returns a ready accumulator, or nil when there is
+// no observer. Callers should keep the nil result rather than wrapping it.
+func newRequestInstrumentation(obs RequestObserver, transport, model string) *requestInstrumentation {
+	if obs == nil {
+		return nil
+	}
+	now := time.Now()
+	return &requestInstrumentation{
+		obs:   obs,
+		start: now,
+		trace: RequestTrace{
+			Transport: transport,
+			Model:     model,
+			StartedAt: now,
+		},
+	}
+}
+
+func (ri *requestInstrumentation) setRequestShape(bytes int, items int) {
+	if ri == nil {
+		return
+	}
+	ri.trace.RequestBytes = bytes
+	ri.trace.InputItems = items
+}
+
+func (ri *requestInstrumentation) beginTokenRefresh() {
+	if ri == nil {
+		return
+	}
+	ri.trace.TokenRefreshInvoked = true
+	ri.tokenSt = time.Now()
+}
+
+func (ri *requestInstrumentation) endTokenRefresh() {
+	if ri == nil || ri.tokenSt.IsZero() {
+		return
+	}
+	ri.trace.TokenRefreshDuration = time.Since(ri.tokenSt)
+}
+
+func (ri *requestInstrumentation) recordHeaders(status int) {
+	if ri == nil || ri.headersRecorded {
+		return
+	}
+	ri.headersRecorded = true
+	ri.trace.TimeToHeaders = time.Since(ri.start)
+	ri.trace.HTTPStatus = status
+}
+
+func (ri *requestInstrumentation) recordFirstEvent() {
+	if ri == nil || ri.firstEventRecorded {
+		return
+	}
+	ri.firstEventRecorded = true
+	ri.trace.TimeToFirstEvent = time.Since(ri.start)
+}
+
+func (ri *requestInstrumentation) recordFirstToken() {
+	if ri == nil || ri.firstTokenRecorded {
+		return
+	}
+	ri.firstTokenRecorded = true
+	ri.trace.TimeToFirstToken = time.Since(ri.start)
+}
+
+func (ri *requestInstrumentation) recordTerminal() {
+	if ri == nil || ri.terminalRecorded {
+		return
+	}
+	ri.terminalRecorded = true
+	ri.trace.TimeToTerminal = time.Since(ri.start)
+}
+
+func (ri *requestInstrumentation) markWebSocketReused(reused bool) {
+	if ri == nil {
+		return
+	}
+	ri.trace.WebSocketConnectionReused = reused
+}
+
+func (ri *requestInstrumentation) markPreviousResponseIDReused(reused bool) {
+	if ri == nil {
+		return
+	}
+	ri.trace.PreviousResponseIDReused = reused
+}
+
+func (ri *requestInstrumentation) markCacheKey(key string) {
+	if ri == nil {
+		return
+	}
+	if key == "" {
+		return
+	}
+	ri.trace.PromptCacheKeyActive = true
+	ri.trace.PromptCacheKeyFingerprint = cacheKeyFingerprint(key)
+}
+
+func (ri *requestInstrumentation) recordRetryAfter(d time.Duration) {
+	if ri == nil {
+		return
+	}
+	ri.trace.RetryAfter = d
+}
+
+// recordErrorClassifies sets the sanitized error fields. The raw error is never
+// stored or serialized; only coarse categories derived from its type plus the
+// classification already attached to a ModelHTTPError.
+func (ri *requestInstrumentation) recordError(err error) {
+	if ri == nil || err == nil {
+		return
+	}
+	ri.trace.ErrorClass = errorClass(err)
+	var httpErr *core.ModelHTTPError
+	if errors.As(err, &httpErr) {
+		// Body already holds the sanitized classification marker.
+		ri.trace.ErrorClassification = httpErr.Body
+		if ri.trace.HTTPStatus == 0 {
+			ri.trace.HTTPStatus = httpErr.StatusCode
+		}
+		if httpErr.RetryAfter > 0 {
+			ri.trace.RetryAfter = httpErr.RetryAfter
+		}
+	}
+}
+
+// finish delivers the trace to the observer exactly once.
+func (ri *requestInstrumentation) finish() {
+	if ri == nil || ri.finished {
+		return
+	}
+	ri.finished = true
+	ri.trace.TotalDuration = time.Since(ri.start)
+	ri.obs(ri.trace)
+}
+
+// errorClass returns a coarse, credential-free category for an error.
+func errorClass(err error) string {
+	if err == nil {
+		return ""
+	}
+	var httpErr *core.ModelHTTPError
+	if errors.As(err, &httpErr) {
+		return "http"
+	}
+	var identityErr *ModelIdentityError
+	if errors.As(err, &identityErr) {
+		return "identity"
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return "context"
+	}
+	return "transport"
+}
+
+// cacheKeyFingerprint returns a short, non-reversible sha256 prefix for a
+// prompt cache key. The full key is never exposed through instrumentation.
+func cacheKeyFingerprint(key string) string {
+	if key == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(key))
+	return hex.EncodeToString(sum[:])[:8]
+}
+
+// classifyHTTPResponse records the sanitized outcome of an HTTP round-trip from
+// the response status and the already-classified error body. It is shared by
+// the HTTP and WebSocket paths.
+func (ri *requestInstrumentation) classifyHTTPResponse(status int, classification string) {
+	if ri == nil {
+		return
+	}
+	ri.trace.HTTPStatus = status
+	if classification != "" {
+		ri.trace.ErrorClassification = classification
+	}
+}

--- a/provider/openai/instrumentation.go
+++ b/provider/openai/instrumentation.go
@@ -219,6 +219,17 @@ func (ri *requestInstrumentation) setRequestShape(bytes int, items int) {
 	ri.trace.InputItems = items
 }
 
+// setTransport overrides the recorded physical transport. Used by
+// requestStreamViaResponses, which always uses HTTP SSE even when the provider
+// is configured for websocket (the websocket transport exposes no streaming
+// interface), so such traces are correctly labeled "http".
+func (ri *requestInstrumentation) setTransport(transport string) {
+	if ri == nil {
+		return
+	}
+	ri.trace.Transport = transport
+}
+
 func (ri *requestInstrumentation) beginTokenRefresh() {
 	if ri == nil {
 		return
@@ -265,6 +276,49 @@ func (ri *requestInstrumentation) recordTerminal() {
 	}
 	ri.terminalRecorded = true
 	ri.trace.TimeToTerminal = time.Since(ri.start)
+}
+
+// recordTerminalFailure records the terminal timing for an in-band Responses
+// failure/incomplete outcome together with its sanitized classification. The
+// model argument carries the sanitized provider marker. It is the terminal
+// counterpart of recordError for outcomes that the backend signals as a
+// definitive event rather than a transport error.
+func (ri *requestInstrumentation) recordTerminalFailure(classification string) {
+	if ri == nil {
+		return
+	}
+	ri.recordTerminal()
+	if classification != "" {
+		ri.trace.ErrorClassification = classification
+	}
+	if ri.trace.ErrorClass == "" {
+		ri.trace.ErrorClass = "transport"
+	}
+}
+
+// resetForRetry clears the transient phase markers and any error from a failed
+// attempt so a reconnect-retry produces a trace that reflects the retrying
+// physical request (whose outcome may succeed). TotalDuration and StartedAt
+// are preserved so the trace still spans the full caller-visible request,
+// including the retry gap; the WebSocketConnectionReused flag is cleared
+// because the retry dials a fresh connection.
+func (ri *requestInstrumentation) resetForRetry() {
+	if ri == nil {
+		return
+	}
+	ri.headersRecorded = false
+	ri.firstEventRecorded = false
+	ri.firstTokenRecorded = false
+	ri.terminalRecorded = false
+	ri.trace.TimeToHeaders = 0
+	ri.trace.TimeToFirstEvent = 0
+	ri.trace.TimeToFirstToken = 0
+	ri.trace.TimeToTerminal = 0
+	ri.trace.HTTPStatus = 0
+	ri.trace.ErrorClassification = ""
+	ri.trace.ErrorClass = ""
+	ri.trace.RetryAfter = 0
+	ri.trace.WebSocketConnectionReused = false
 }
 
 func (ri *requestInstrumentation) markWebSocketReused(reused bool) {

--- a/provider/openai/instrumentation_test.go
+++ b/provider/openai/instrumentation_test.go
@@ -1,0 +1,563 @@
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/fugue-labs/gollem/core"
+	"github.com/gorilla/websocket"
+)
+
+// captureObserver returns a RequestObserver and a snapshot function that
+// safely copies the latest trace under a mutex.
+func captureObserver() (RequestObserver, func() (RequestTrace, bool)) {
+	var (
+		mu    sync.Mutex
+		trace RequestTrace
+		got   bool
+	)
+	obs := func(t RequestTrace) {
+		mu.Lock()
+		defer mu.Unlock()
+		trace = t
+		got = true
+	}
+	snapshot := func() (RequestTrace, bool) {
+		mu.Lock()
+		defer mu.Unlock()
+		return trace, got
+	}
+	return obs, snapshot
+}
+
+// chatgptSSEHandler returns an httptest.Server that behaves like the ChatGPT
+// backend: it streams the provided SSE frames with an optional per-frame delay
+// and records the received request body for assertions.
+func chatgptSSEHandler(t *testing.T, sse string, delays []time.Duration) (*httptest.Server, *[]byte) {
+	t.Helper()
+	var (
+		mu   sync.Mutex
+		body []byte
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqBody, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		body = reqBody
+		mu.Unlock()
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher, _ := w.(http.Flusher)
+		frames := strings.Split(sse, "\n\n")
+		for i, frame := range frames {
+			if i < len(delays) && delays[i] > 0 {
+				time.Sleep(delays[i])
+			}
+			_, _ = io.WriteString(w, frame+"\n\n")
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+	}))
+	return server, &body
+}
+
+func TestRequestObserver_HTTPRequestCapturesPhases(t *testing.T) {
+	// Insert measurable delays between SSE frames so first-event and terminal
+	// timings are clearly distinguishable and > 0.
+	sse := "data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"hi\"}]}}\n\n" +
+		"data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5\",\"output\":[],\"usage\":{\"input_tokens\":3,\"output_tokens\":1}}}\n\n" +
+		"data: [DONE]\n\n"
+	server, recvBody := chatgptSSEHandler(t, sse, []time.Duration{30 * time.Millisecond, 30 * time.Millisecond})
+	defer server.Close()
+
+	obs, snapshot := captureObserver()
+	p := New(
+		WithChatGPTAuth("test-access-token", "test-account-id"),
+		WithBaseURL(server.URL+"/chatgpt.com"),
+		WithModel("gpt-5"),
+		WithTokenRefresher(func() (string, error) { return "test-access-token", nil }),
+		WithRequestObserver(obs),
+	)
+
+	resp, err := p.Request(context.Background(), []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "ping"}}},
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("Request: %v", err)
+	}
+	if got := resp.TextContent(); got != "hi" {
+		t.Fatalf("text = %q, want hi", got)
+	}
+
+	tr, ok := snapshot()
+	if !ok {
+		t.Fatal("expected observer to fire")
+	}
+	if tr.Transport != transportHTTP {
+		t.Errorf("Transport = %q, want %q", tr.Transport, transportHTTP)
+	}
+	if tr.TotalDuration <= 0 {
+		t.Error("TotalDuration should be > 0")
+	}
+	if tr.RequestBytes == 0 {
+		t.Error("RequestBytes should be recorded")
+	}
+	if tr.HTTPStatus != http.StatusOK {
+		t.Errorf("HTTPStatus = %d, want 200", tr.HTTPStatus)
+	}
+	if tr.TimeToHeaders <= 0 {
+		t.Error("TimeToHeaders should be > 0")
+	}
+	if tr.TimeToFirstEvent <= 0 {
+		t.Error("TimeToFirstEvent should be > 0")
+	}
+	if tr.TimeToFirstToken <= 0 {
+		t.Error("TimeToFirstToken should be > 0 (output_item.done)")
+	}
+	if tr.TimeToTerminal <= 0 {
+		t.Error("TimeToTerminal should be > 0")
+	}
+	if !tr.TokenRefreshInvoked {
+		t.Error("TokenRefreshInvoked should be true")
+	}
+	if tr.TokenRefreshDuration < 0 {
+		t.Error("TokenRefreshDuration should be >= 0")
+	}
+	if !tr.PromptCacheKeyActive {
+		t.Error("PromptCacheKeyActive should be true")
+	}
+	if tr.PromptCacheKeyFingerprint == "" {
+		t.Error("PromptCacheKeyFingerprint should be non-empty")
+	}
+	// The request should carry the prompt cache key (not the fingerprint).
+	if !strings.Contains(string(*recvBody), "prompt_cache_key") {
+		t.Error("request body should contain prompt_cache_key")
+	}
+}
+
+func TestRequestObserver_HTTPRequestStreamCapturesPhases(t *testing.T) {
+	sse := "data: {\"type\":\"response.output_text.delta\",\"delta\":\"Hel\"}\n\n" +
+		"data: {\"type\":\"response.output_text.delta\",\"delta\":\"lo\"}\n\n" +
+		"data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_2\",\"model\":\"gpt-5\",\"output\":[],\"usage\":{\"input_tokens\":3,\"output_tokens\":2}}}\n\n" +
+		"data: [DONE]\n\n"
+	server, _ := chatgptSSEHandler(t, sse, []time.Duration{20 * time.Millisecond, 0, 20 * time.Millisecond})
+	defer server.Close()
+
+	obs, snapshot := captureObserver()
+	p := New(
+		WithChatGPTAuth("tok", "acct"),
+		WithBaseURL(server.URL+"/chatgpt.com"),
+		WithModel("gpt-5"),
+		WithRequestObserver(obs),
+	)
+
+	stream, err := p.RequestStream(context.Background(), []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "hi"}}},
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("RequestStream: %v", err)
+	}
+	for {
+		ev, err := stream.Next()
+		if err != nil {
+			break
+		}
+		_ = ev
+	}
+	if err := stream.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	tr, ok := snapshot()
+	if !ok {
+		t.Fatal("expected observer to fire after draining stream")
+	}
+	if tr.TimeToFirstToken <= 0 {
+		t.Error("TimeToFirstToken should be > 0 for streaming")
+	}
+	if tr.TimeToTerminal <= 0 {
+		t.Error("TimeToTerminal should be > 0")
+	}
+	if tr.TotalDuration <= 0 {
+		t.Error("TotalDuration should be > 0")
+	}
+}
+
+// wsFakeServer returns an httptest.Server that upgrades to a websocket and
+// streams the given event types with optional inter-event delays.
+func wsFakeServer(t *testing.T, events []responsesWSEvent, delays []time.Duration) *httptest.Server {
+	t.Helper()
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		if _, _, err := conn.ReadMessage(); err != nil {
+			return
+		}
+		for i, ev := range events {
+			if i < len(delays) && delays[i] > 0 {
+				time.Sleep(delays[i])
+			}
+			if err := conn.WriteJSON(ev); err != nil {
+				return
+			}
+		}
+	}))
+}
+
+func TestRequestObserver_WebSocketCapturesPhases(t *testing.T) {
+	terminal := responsesWSEvent{
+		Type: "response.completed",
+		Response: &responsesAPIResponse{
+			ID: "resp_ws_1", Model: "gpt-5.3-codex",
+			Output: []responsesOutputItem{{
+				Type: "message", Role: "assistant",
+				Content: []responsesContentItem{{Type: "output_text", Text: "ok"}},
+			}},
+		},
+	}
+	server := wsFakeServer(t, []responsesWSEvent{
+		{Type: "response.output_item.done", Item: &responsesOutputItem{
+			Type: "message", Role: "assistant",
+			Content: []responsesContentItem{{Type: "output_text", Text: "ok"}},
+		}},
+		terminal,
+	}, []time.Duration{40 * time.Millisecond, 40 * time.Millisecond})
+	defer server.Close()
+
+	obs, snapshot := captureObserver()
+	p := New(
+		WithAPIKey("test-key"),
+		WithModel("gpt-5.3-codex"),
+		WithBaseURL(server.URL),
+		WithTransport("websocket"),
+		WithRequestObserver(obs),
+	)
+
+	if _, err := p.Request(context.Background(), []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "hi"}}},
+	}, nil, nil); err != nil {
+		t.Fatalf("Request: %v", err)
+	}
+
+	tr, ok := snapshot()
+	if !ok {
+		t.Fatal("expected observer to fire")
+	}
+	if tr.Transport != transportWebSocket {
+		t.Errorf("Transport = %q, want %q", tr.Transport, transportWebSocket)
+	}
+	if tr.TimeToHeaders <= 0 {
+		t.Error("TimeToHeaders should be > 0 (dial/handshake)")
+	}
+	if tr.TimeToFirstEvent <= 0 {
+		t.Error("TimeToFirstEvent should be > 0")
+	}
+	if tr.TimeToFirstToken <= 0 {
+		t.Error("TimeToFirstToken should be > 0")
+	}
+	if tr.TimeToTerminal <= 0 {
+		t.Error("TimeToTerminal should be > 0")
+	}
+}
+
+func TestRequestObserver_WebSocketConnectionReuseAndContinuation(t *testing.T) {
+	// The fake server always succeeds; the second request should reuse the
+	// connection and use previous_response_id continuation.
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	var (
+		mu            sync.Mutex
+		received      []responsesWSCreateEvent
+		connDialCount int
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		connDialCount++
+		mu.Unlock()
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		for {
+			_, payload, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+			var ev responsesWSCreateEvent
+			if json.Unmarshal(payload, &ev) != nil {
+				return
+			}
+			mu.Lock()
+			received = append(received, ev)
+			idx := len(received)
+			mu.Unlock()
+			_ = conn.WriteJSON(responsesWSEvent{
+				Type: "response.completed",
+				Response: &responsesAPIResponse{
+					ID:    responsesIDForIndex(idx),
+					Model: "gpt-5.3-codex",
+					Output: []responsesOutputItem{{
+						Type: "message", Role: "assistant",
+						Content: []responsesContentItem{{Type: "output_text", Text: "ok"}},
+					}},
+				},
+			})
+		}
+	}))
+	defer server.Close()
+
+	obs, snapshot := captureObserver()
+	p := New(
+		WithAPIKey("test-key"),
+		WithModel("gpt-5.3-codex"),
+		WithBaseURL(server.URL),
+		WithTransport("websocket"),
+		WithRequestObserver(obs),
+	)
+
+	first := []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "turn one"}}},
+	}
+	if _, err := p.Request(context.Background(), first, nil, nil); err != nil {
+		t.Fatalf("first Request: %v", err)
+	}
+	tr1, _ := snapshot()
+	if tr1.WebSocketConnectionReused {
+		t.Error("first request should NOT reuse a connection")
+	}
+
+	second := []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "turn one"}}},
+		core.ModelResponse{Parts: []core.ModelResponsePart{core.TextPart{Content: "ok"}}},
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "turn two"}}},
+	}
+	if _, err := p.Request(context.Background(), second, nil, nil); err != nil {
+		t.Fatalf("second Request: %v", err)
+	}
+	tr2, _ := snapshot()
+	if !tr2.WebSocketConnectionReused {
+		t.Error("second request should reuse the websocket connection")
+	}
+	if !tr2.PreviousResponseIDReused {
+		t.Error("second request should reuse previous_response_id")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if connDialCount != 1 {
+		t.Errorf("expected exactly 1 dial, got %d", connDialCount)
+	}
+}
+
+func responsesIDForIndex(i int) string {
+	switch i {
+	case 1:
+		return "resp_a"
+	case 2:
+		return "resp_b"
+	default:
+		return "resp_x"
+	}
+}
+
+func TestRequestObserver_NilObserverIsNoOp(t *testing.T) {
+	server, _ := chatgptSSEHandler(t,
+		"data: {\"type\":\"response.completed\",\"response\":{\"id\":\"r\",\"model\":\"gpt-5\",\"output\":[{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"ok\"}]}],\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\ndata: [DONE]\n\n",
+		nil)
+	defer server.Close()
+
+	// No WithRequestObserver at all; must not panic and must succeed.
+	p := New(
+		WithChatGPTAuth("tok", "acct"),
+		WithBaseURL(server.URL+"/chatgpt.com"),
+		WithModel("gpt-5"),
+	)
+	resp, err := p.Request(context.Background(), []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "hi"}}},
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("Request: %v", err)
+	}
+	if got := resp.TextContent(); got != "ok" {
+		t.Fatalf("text = %q, want ok", got)
+	}
+}
+
+func TestRequestObserver_RecordsSanitizedErrorClassification(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "5")
+		http.Error(w, `{"error":{"type":"rate_limit_exceeded","message":"too many requests"}}`, http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	obs, snapshot := captureObserver()
+	p := New(
+		WithChatGPTAuth("tok", "acct"),
+		WithBaseURL(server.URL+"/chatgpt.com"),
+		WithModel("gpt-5"),
+		WithRequestObserver(obs),
+	)
+
+	_, err := p.Request(context.Background(), []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "hi"}}},
+	}, nil, nil)
+	if err == nil {
+		t.Fatal("expected error from 429")
+	}
+	tr, ok := snapshot()
+	if !ok {
+		t.Fatal("expected observer to fire even on error")
+	}
+	if tr.HTTPStatus != http.StatusTooManyRequests {
+		t.Errorf("HTTPStatus = %d, want 429", tr.HTTPStatus)
+	}
+	if tr.ErrorClassification == "" {
+		t.Error("ErrorClassification should be non-empty")
+	}
+	if !strings.Contains(tr.ErrorClassification, "rate") {
+		t.Errorf("ErrorClassification = %q, want a rate-limit marker", tr.ErrorClassification)
+	}
+	if tr.ErrorClass != "http" {
+		t.Errorf("ErrorClass = %q, want http", tr.ErrorClass)
+	}
+	if tr.RetryAfter != 5*time.Second {
+		t.Errorf("RetryAfter = %v, want 5s", tr.RetryAfter)
+	}
+}
+
+func TestRequestObserver_NoCredentialsInTrace(t *testing.T) {
+	const (
+		accessToken  = "AKIA-SENSITIVE-ACCESS-TOKEN-12345"
+		refreshToken = "rt-super-secret-refresh-67890"
+		accountID    = "acct-SUPER-SECRET-ACCOUNT"
+		deviceCode   = "DEVICE-CODE-LEAK-ME"
+	)
+	server, _ := chatgptSSEHandler(t,
+		"data: {\"type\":\"response.completed\",\"response\":{\"id\":\"r\",\"model\":\"gpt-5\",\"output\":[{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"ok\"}]}],\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\ndata: [DONE]\n\n",
+		nil)
+	defer server.Close()
+
+	obs, snapshot := captureObserver()
+	p := New(
+		WithChatGPTAuth(accessToken, accountID),
+		WithBaseURL(server.URL+"/chatgpt.com"),
+		WithModel("gpt-5"),
+		WithTokenRefresher(func() (string, error) { return accessToken, nil }),
+		WithRequestObserver(obs),
+	)
+
+	if _, err := p.Request(context.Background(), []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "hi"}}},
+	}, nil, nil); err != nil {
+		t.Fatalf("Request: %v", err)
+	}
+
+	tr, ok := snapshot()
+	if !ok {
+		t.Fatal("expected observer to fire")
+	}
+	// Marshal the trace and assert none of the secret material appears anywhere.
+	b, err := json.Marshal(tr)
+	if err != nil {
+		t.Fatalf("marshal trace: %v", err)
+	}
+	rendered := formatRequestTrace(tr)
+	for _, secret := range []string{accessToken, refreshToken, accountID, deviceCode} {
+		if strings.Contains(string(b), secret) {
+			t.Errorf("trace JSON leaked secret %q:\n%s", secret, string(b))
+		}
+		if strings.Contains(rendered, secret) {
+			t.Errorf("trace rendering leaked secret %q:\n%s", secret, rendered)
+		}
+	}
+	// The cache key fingerprint is a sha256 prefix, not the key itself.
+	if tr.PromptCacheKeyFingerprint != "" && len(tr.PromptCacheKeyFingerprint) > 16 {
+		t.Errorf("fingerprint too long, suspected raw key: %q", tr.PromptCacheKeyFingerprint)
+	}
+}
+
+func TestRequestObserver_TokenRefreshDurationMeasured(t *testing.T) {
+	// The refresher sleeps a fixed amount so TokenRefreshDuration reflects it.
+	const refreshSleep = 60 * time.Millisecond
+	server, _ := chatgptSSEHandler(t,
+		"data: {\"type\":\"response.completed\",\"response\":{\"id\":\"r\",\"model\":\"gpt-5\",\"output\":[{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"ok\"}]}],\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\ndata: [DONE]\n\n",
+		nil)
+	defer server.Close()
+
+	obs, snapshot := captureObserver()
+	p := New(
+		WithChatGPTAuth("tok", "acct"),
+		WithBaseURL(server.URL+"/chatgpt.com"),
+		WithModel("gpt-5"),
+		WithTokenRefresher(func() (string, error) {
+			time.Sleep(refreshSleep)
+			return "tok", nil
+		}),
+		WithRequestObserver(obs),
+	)
+
+	if _, err := p.Request(context.Background(), []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "hi"}}},
+	}, nil, nil); err != nil {
+		t.Fatalf("Request: %v", err)
+	}
+	tr, ok := snapshot()
+	if !ok {
+		t.Fatal("expected observer to fire")
+	}
+	if !tr.TokenRefreshInvoked {
+		t.Fatal("TokenRefreshInvoked should be true")
+	}
+	if tr.TokenRefreshDuration < refreshSleep {
+		t.Errorf("TokenRefreshDuration = %v, want >= %v", tr.TokenRefreshDuration, refreshSleep)
+	}
+}
+
+func TestCacheKeyFingerprintStableAndShort(t *testing.T) {
+	fp := cacheKeyFingerprint("some-cache-key")
+	if len(fp) != 8 {
+		t.Fatalf("fingerprint length = %d, want 8", len(fp))
+	}
+	if cacheKeyFingerprint("some-cache-key") != fp {
+		t.Error("fingerprint should be stable for the same key")
+	}
+	if cacheKeyFingerprint("different-key") == fp {
+		t.Error("fingerprint should differ for a different key")
+	}
+	if cacheKeyFingerprint("") != "" {
+		t.Error("empty key should yield empty fingerprint")
+	}
+}
+
+func TestErrorClassCategories(t *testing.T) {
+	if errorClass(nil) != "" {
+		t.Error("nil error should classify as empty")
+	}
+	if got := errorClass(&core.ModelHTTPError{StatusCode: 500}); got != "http" {
+		t.Errorf("http error class = %q, want http", got)
+	}
+	if got := errorClass(&ModelIdentityError{}); got != "identity" {
+		t.Errorf("identity error class = %q, want identity", got)
+	}
+	if got := errorClass(context.Canceled); got != "context" {
+		t.Errorf("canceled class = %q, want context", got)
+	}
+	if got := errorClass(io.ErrUnexpectedEOF); got != "transport" {
+		t.Errorf("transport error class = %q, want transport", got)
+	}
+}
+
+func TestDefaultStderrRequestObserverDoesNotPanic(t *testing.T) {
+	obs := DefaultStderrRequestObserver()
+	obs(RequestTrace{Transport: transportHTTP, Model: "gpt-5"})
+}

--- a/provider/openai/instrumentation_test.go
+++ b/provider/openai/instrumentation_test.go
@@ -561,3 +561,342 @@ func TestDefaultStderrRequestObserverDoesNotPanic(t *testing.T) {
 	obs := DefaultStderrRequestObserver()
 	obs(RequestTrace{Transport: transportHTTP, Model: "gpt-5"})
 }
+
+// TestRequestObserver_SSEDeltaFirstToken verifies first-token is timestamped
+// on response.output_text.delta, not only at output_item.done (Codex review).
+func TestRequestObserver_SSEDeltaFirstToken(t *testing.T) {
+	sse := "data: {\"type\":\"response.output_text.delta\",\"delta\":\"Hel\"}\n\n" +
+		"data: {\"type\":\"response.output_text.delta\",\"delta\":\"lo\"}\n\n" +
+		"data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"Hello\"}]}}\n\n" +
+		"data: {\"type\":\"response.completed\",\"response\":{\"id\":\"r\",\"model\":\"gpt-5\",\"output\":[],\"usage\":{\"input_tokens\":3,\"output_tokens\":1}}}\n\n" +
+		"data: [DONE]\n\n"
+	server, _ := chatgptSSEHandler(t, sse, []time.Duration{20 * time.Millisecond, 0, 20 * time.Millisecond, 20 * time.Millisecond})
+	defer server.Close()
+
+	obs, snapshot := captureObserver()
+	p := New(
+		WithChatGPTAuth("tok", "acct"),
+		WithBaseURL(server.URL+"/chatgpt.com"),
+		WithModel("gpt-5"),
+		WithRequestObserver(obs),
+	)
+	if _, err := p.Request(context.Background(), []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "hi"}}},
+	}, nil, nil); err != nil {
+		t.Fatalf("Request: %v", err)
+	}
+	tr, _ := snapshot()
+	if tr.TimeToFirstToken <= 0 {
+		t.Fatal("TimeToFirstToken should be > 0 from the delta event")
+	}
+	if tr.TimeToFirstToken >= tr.TimeToTerminal {
+		t.Errorf("first_token (%v) should precede terminal (%v)", tr.TimeToFirstToken, tr.TimeToTerminal)
+	}
+}
+
+// TestRequestObserver_SSEResponseFailed verifies in-band response.failed is
+// classified and recorded as terminal in the non-stream SSE path.
+func TestRequestObserver_SSEResponseFailed(t *testing.T) {
+	sse := "data: {\"type\":\"response.failed\",\"response\":{\"id\":\"r\",\"model\":\"gpt-5\",\"incomplete_details\":{\"reason\":\"content_filter\"}}}\n\n" +
+		"data: [DONE]\n\n"
+	server, _ := chatgptSSEHandler(t, sse, nil)
+	defer server.Close()
+
+	obs, snapshot := captureObserver()
+	p := New(
+		WithChatGPTAuth("tok", "acct"),
+		WithBaseURL(server.URL+"/chatgpt.com"),
+		WithModel("gpt-5"),
+		WithRequestObserver(obs),
+	)
+	_, err := p.Request(context.Background(), []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "hi"}}},
+	}, nil, nil)
+	if err == nil {
+		t.Fatal("expected error from response.failed")
+	}
+	tr, _ := snapshot()
+	if tr.TimeToTerminal <= 0 {
+		t.Error("TimeToTerminal should be recorded for response.failed")
+	}
+	if tr.ErrorClassification == "" {
+		t.Error("ErrorClassification should be populated for response.failed")
+	}
+}
+
+// TestRequestObserver_WebSocketShapeAndCache verifies the WS path records
+// request bytes/items and the cache fingerprint (Codex review: WS branch
+// previously reported zero/empty).
+func TestRequestObserver_WebSocketShapeAndCache(t *testing.T) {
+	server := wsFakeServer(t, []responsesWSEvent{
+		{Type: "response.completed", Response: &responsesAPIResponse{
+			ID: "r", Model: "gpt-5.3-codex",
+			Output: []responsesOutputItem{{
+				Type: "message", Role: "assistant",
+				Content: []responsesContentItem{{Type: "output_text", Text: "ok"}},
+			}},
+		}},
+	}, nil)
+	defer server.Close()
+
+	obs, snapshot := captureObserver()
+	p := New(
+		WithAPIKey("test-key"),
+		WithModel("gpt-5.3-codex"),
+		WithBaseURL(server.URL),
+		WithTransport("websocket"),
+		WithPromptCacheKey("my-cache-key"),
+		WithRequestObserver(obs),
+	)
+	defer p.Close()
+
+	if _, err := p.Request(context.Background(), []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "hi"}}},
+	}, nil, nil); err != nil {
+		t.Fatalf("Request: %v", err)
+	}
+	tr, _ := snapshot()
+	if tr.RequestBytes == 0 {
+		t.Error("RequestBytes should be > 0 on the WS path")
+	}
+	if tr.InputItems == 0 {
+		t.Error("InputItems should be > 0 on the WS path")
+	}
+	if !tr.PromptCacheKeyActive || tr.PromptCacheKeyFingerprint == "" {
+		t.Error("cache key should be active with a fingerprint on the WS path")
+	}
+	if tr.PromptCacheKeyFingerprint != cacheKeyFingerprint("my-cache-key") {
+		t.Errorf("fingerprint mismatch: got %q", tr.PromptCacheKeyFingerprint)
+	}
+}
+
+// TestRequestObserver_WebSocketReusedLeavesHeadersUnset verifies that a reused
+// websocket connection does not record a synthetic TimeToHeaders.
+func TestRequestObserver_WebSocketReusedLeavesHeadersUnset(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+			_ = conn.WriteJSON(responsesWSEvent{
+				Type: "response.completed",
+				Response: &responsesAPIResponse{
+					ID: "r", Model: "gpt-5.3-codex",
+					Output: []responsesOutputItem{{
+						Type: "message", Role: "assistant",
+						Content: []responsesContentItem{{Type: "output_text", Text: "ok"}},
+					}},
+				},
+			})
+		}
+	}))
+	defer server.Close()
+
+	obs, snapshot := captureObserver()
+	p := New(
+		WithAPIKey("test-key"),
+		WithModel("gpt-5.3-codex"),
+		WithBaseURL(server.URL),
+		WithTransport("websocket"),
+		WithRequestObserver(obs),
+	)
+	defer p.Close()
+
+	// First request dials and records TimeToHeaders.
+	if _, err := p.Request(context.Background(), []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "one"}}},
+	}, nil, nil); err != nil {
+		t.Fatalf("first Request: %v", err)
+	}
+	first, _ := snapshot()
+	if first.TimeToHeaders <= 0 {
+		t.Fatal("first request should record TimeToHeaders (dial/handshake)")
+	}
+
+	// Second request reuses the connection; TimeToHeaders must stay zero.
+	if _, err := p.Request(context.Background(), []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "two"}}},
+	}, nil, nil); err != nil {
+		t.Fatalf("second Request: %v", err)
+	}
+	second, _ := snapshot()
+	if !second.WebSocketConnectionReused {
+		t.Error("second request should report a reused connection")
+	}
+	if second.TimeToHeaders != 0 {
+		t.Errorf("reused connection should leave TimeToHeaders zero, got %v", second.TimeToHeaders)
+	}
+}
+
+// TestRequestObserver_ResponsesStreamLabeledHTTP verifies that when a provider
+// is configured for websocket, RequestStream still labels the trace transport
+// as http (it always uses HTTP SSE).
+func TestRequestObserver_ResponsesStreamLabeledHTTP(t *testing.T) {
+	sse := "data: {\"type\":\"response.output_text.delta\",\"delta\":\"ok\"}\n\n" +
+		"data: {\"type\":\"response.completed\",\"response\":{\"id\":\"r\",\"model\":\"gpt-5.3-codex\",\"output\":[],\"usage\":{\"input_tokens\":3,\"output_tokens\":1}}}\n\n" +
+		"data: [DONE]\n\n"
+	server, _ := chatgptSSEHandler(t, sse, nil)
+	defer server.Close()
+
+	obs, snapshot := captureObserver()
+	p := New(
+		WithChatGPTAuth("tok", "acct"),
+		WithBaseURL(server.URL+"/chatgpt.com"),
+		WithModel("gpt-5.3-codex"),
+		WithTransport("websocket"), // configured for WS, but streaming uses HTTP
+		WithRequestObserver(obs),
+	)
+	stream, err := p.RequestStream(context.Background(), []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "hi"}}},
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("RequestStream: %v", err)
+	}
+	for {
+		if _, err := stream.Next(); err != nil {
+			break
+		}
+	}
+	_ = stream.Close()
+
+	tr, _ := snapshot()
+	if tr.Transport != transportHTTP {
+		t.Errorf("streaming transport = %q, want %q (HTTP SSE even when WS configured)", tr.Transport, transportHTTP)
+	}
+}
+
+// TestRequestObserver_ResponsesStreamFinishesOnSetupError verifies the observer
+// fires (and classifies) when RequestStream setup fails, e.g. a 429.
+func TestRequestObserver_ResponsesStreamFinishesOnSetupError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "2")
+		http.Error(w, `{"error":{"type":"rate_limit","message":"too many requests"}}`, http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	obs, snapshot := captureObserver()
+	p := New(
+		WithChatGPTAuth("tok", "acct"),
+		WithBaseURL(server.URL+"/chatgpt.com"),
+		WithModel("gpt-5.3-codex"),
+		WithRequestObserver(obs),
+	)
+	_, err := p.RequestStream(context.Background(), []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "hi"}}},
+	}, nil, nil)
+	if err == nil {
+		t.Fatal("expected error from 429")
+	}
+	tr, ok := snapshot()
+	if !ok {
+		t.Fatal("observer should fire even when stream setup fails")
+	}
+	if tr.HTTPStatus != http.StatusTooManyRequests {
+		t.Errorf("HTTPStatus = %d, want 429", tr.HTTPStatus)
+	}
+	if tr.ErrorClassification == "" {
+		t.Error("ErrorClassification should be populated")
+	}
+}
+
+// TestRequestObserver_ChatCompletionsCountsBuiltMessages verifies InputItems
+// reflects the number of built API messages, not the input slice length.
+func TestRequestObserver_ChatCompletionsCountsBuiltMessages(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(apiResponse{
+			ID:    "r",
+			Model: "gpt-4o",
+			Choices: []apiChoice{{
+				Message: apiChatMsg{Role: "assistant", Content: "ok"},
+			}},
+		})
+	}))
+	defer server.Close()
+
+	obs, snapshot := captureObserver()
+	p := New(
+		WithAPIKey("key"),
+		WithBaseURL(server.URL),
+		WithModel("gpt-4o"),
+		WithRequestObserver(obs),
+	)
+	// A single ModelRequest carrying system + user parts expands into multiple
+	// chat-completions messages.
+	_, err := p.Request(context.Background(), []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{
+			core.SystemPromptPart{Content: "be brief"},
+			core.UserPromptPart{Content: "hi"},
+		}},
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("Request: %v", err)
+	}
+	tr, _ := snapshot()
+	if tr.InputItems < 2 {
+		t.Errorf("InputItems = %d, want >= 2 (built messages), not 1 (input slice)", tr.InputItems)
+	}
+}
+
+// TestRequestInstrumentationResetForRetry verifies retry reset clears transient
+// phases so a retried request's trace reflects only the retry attempt.
+func TestRequestInstrumentationResetForRetry(t *testing.T) {
+	ri := &requestInstrumentation{
+		start: time.Now(),
+		trace: RequestTrace{Transport: transportWebSocket, Model: "gpt-5"},
+	}
+	ri.recordHeaders(500)
+	ri.recordFirstEvent()
+	ri.recordFirstToken()
+	ri.recordTerminalFailure("previous_response_not_found")
+	ri.recordError(&core.ModelHTTPError{StatusCode: 400, Body: "previous_response_not_found"})
+	ri.markWebSocketReused(true)
+
+	ri.resetForRetry()
+
+	if ri.trace.TimeToHeaders != 0 || ri.trace.TimeToFirstEvent != 0 || ri.trace.TimeToFirstToken != 0 || ri.trace.TimeToTerminal != 0 {
+		t.Error("reset should zero all phase timings")
+	}
+	if ri.trace.HTTPStatus != 0 || ri.trace.ErrorClassification != "" || ri.trace.ErrorClass != "" {
+		t.Error("reset should clear error fields")
+	}
+	if ri.trace.WebSocketConnectionReused {
+		t.Error("reset should clear the reuse flag (retry dials fresh)")
+	}
+	// Guards must allow re-recording after reset.
+	ri.recordHeaders(200)
+	if ri.trace.TimeToHeaders <= 0 || ri.trace.HTTPStatus != 200 {
+		t.Error("recordHeaders should work again after reset")
+	}
+}
+
+// TestRequestInstrumentationRecordTerminalFailure verifies terminal-failure
+// records both timing and classification.
+func TestRequestInstrumentationRecordTerminalFailure(t *testing.T) {
+	ri := &requestInstrumentation{start: time.Now(), trace: RequestTrace{}}
+	ri.recordTerminalFailure("response_failed")
+	if ri.trace.TimeToTerminal <= 0 {
+		t.Error("terminal timing should be recorded")
+	}
+	if ri.trace.ErrorClassification != "response_failed" {
+		t.Errorf("classification = %q, want response_failed", ri.trace.ErrorClassification)
+	}
+}
+
+// TestEstimateResponsesRequestBytes is a small direct test of the helper used
+// to give the WS trace a request size.
+func TestEstimateResponsesRequestBytes(t *testing.T) {
+	if estimateResponsesRequestBytes(nil) != 0 {
+		t.Error("nil request should be 0 bytes")
+	}
+	req := &responsesRequest{Model: "gpt-5", Input: []map[string]any{responsesMessage("user", "hi")}}
+	if n := estimateResponsesRequestBytes(req); n == 0 {
+		t.Error("non-empty request should estimate > 0 bytes")
+	}
+}

--- a/provider/openai/instrumentation_test.go
+++ b/provider/openai/instrumentation_test.go
@@ -900,3 +900,194 @@ func TestEstimateResponsesRequestBytes(t *testing.T) {
 		t.Error("non-empty request should estimate > 0 bytes")
 	}
 }
+
+// allTracesObserver returns a RequestObserver that collects every trace
+// delivered (not just the latest), plus a snapshot function.
+func allTracesObserver() (RequestObserver, func() []RequestTrace) {
+	var (
+		mu     sync.Mutex
+		traces []RequestTrace
+	)
+	obs := func(t RequestTrace) {
+		mu.Lock()
+		defer mu.Unlock()
+		traces = append(traces, t)
+	}
+	snapshot := func() []RequestTrace {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]RequestTrace(nil), traces...)
+	}
+	return obs, snapshot
+}
+
+// TestRequestObserver_WebSocketFallbackEmitsTwoTraces verifies that when a
+// websocket attempt fails and falls back to HTTP, the observer receives two
+// distinct traces: one for the failed WS attempt (with its error) and one for
+// the successful HTTP attempt — not a single merged trace.
+func TestRequestObserver_WebSocketFallbackEmitsTwoTraces(t *testing.T) {
+	var postHits int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/responses" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Method == http.MethodGet && strings.EqualFold(r.Header.Get("Upgrade"), "websocket") {
+			// Refuse the upgrade so the WS attempt fails with a connection error.
+			w.WriteHeader(http.StatusUpgradeRequired)
+			return
+		}
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		postHits++
+		resp := responsesAPIResponse{
+			ID:    "resp_http_fallback",
+			Model: "gpt-5.3-codex",
+			Output: []responsesOutputItem{{
+				Type: "message", Role: "assistant",
+				Content: []responsesContentItem{{Type: "output_text", Text: "ok"}},
+			}},
+			Usage: responsesUsage{InputTokens: 5, OutputTokens: 2},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	obs, snapshot := allTracesObserver()
+	p := New(
+		WithAPIKey("test-key"),
+		WithModel("gpt-5.3-codex"),
+		WithBaseURL(server.URL),
+		WithTransport("websocket"),
+		WithWebSocketHTTPFallback(true),
+		WithRequestObserver(obs),
+	)
+	defer p.Close()
+
+	if _, err := p.Request(context.Background(), []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "hi"}}},
+	}, nil, nil); err != nil {
+		t.Fatalf("Request: %v", err)
+	}
+	if postHits != 1 {
+		t.Fatalf("expected one HTTP fallback call, got %d", postHits)
+	}
+
+	traces := snapshot()
+	if len(traces) != 2 {
+		t.Fatalf("expected 2 traces (WS failure + HTTP success), got %d", len(traces))
+	}
+	wsTrace, httpTrace := traces[0], traces[1]
+	if wsTrace.Transport != transportWebSocket {
+		t.Errorf("first trace transport = %q, want %q", wsTrace.Transport, transportWebSocket)
+	}
+	if wsTrace.ErrorClass == "" {
+		t.Error("WS failure trace should carry an error class")
+	}
+	if wsTrace.TotalDuration <= 0 {
+		t.Error("WS failure trace should have a total duration")
+	}
+	if httpTrace.Transport != transportHTTP {
+		t.Errorf("fallback trace transport = %q, want %q", httpTrace.Transport, transportHTTP)
+	}
+	if httpTrace.ErrorClass != "" {
+		t.Errorf("HTTP success trace should have no error class, got %q", httpTrace.ErrorClass)
+	}
+	if httpTrace.TimeToTerminal <= 0 {
+		t.Error("HTTP success trace should record terminal timing")
+	}
+}
+
+// TestRequestObserver_WebSocketRecordsTrimmedPayload verifies that the WS
+// continuation path records the trimmed delta payload shape (InputItems equals
+// the delta length, not the full input length) so upload-size attribution
+// reflects the bytes actually sent on the wire.
+func TestRequestObserver_WebSocketRecordsTrimmedPayload(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+			_ = conn.WriteJSON(responsesWSEvent{
+				Type: "response.completed",
+				Response: &responsesAPIResponse{
+					ID: "r", Model: "gpt-5.3-codex",
+					Output: []responsesOutputItem{{
+						Type: "message", Role: "assistant",
+						Content: []responsesContentItem{{Type: "output_text", Text: "ok"}},
+					}},
+				},
+			})
+		}
+	}))
+	defer server.Close()
+
+	obs, snapshot := allTracesObserver()
+	p := New(
+		WithAPIKey("test-key"),
+		WithModel("gpt-5.3-codex"),
+		WithBaseURL(server.URL),
+		WithTransport("websocket"),
+		WithRequestObserver(obs),
+	)
+	defer p.Close()
+
+	first := []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "turn one"}}},
+	}
+	if _, err := p.Request(context.Background(), first, nil, nil); err != nil {
+		t.Fatalf("first Request: %v", err)
+	}
+	// Second request extends the first; the WS path should send only the delta
+	// (the assistant reply + new user turn), reusing previous_response_id.
+	second := []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "turn one"}}},
+		core.ModelResponse{Parts: []core.ModelResponsePart{core.TextPart{Content: "ok"}}},
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "turn two"}}},
+	}
+	if _, err := p.Request(context.Background(), second, nil, nil); err != nil {
+		t.Fatalf("second Request: %v", err)
+	}
+
+	traces := snapshot()
+	if len(traces) != 2 {
+		t.Fatalf("expected 2 traces, got %d", len(traces))
+	}
+	tr1, tr2 := traces[0], traces[1]
+	// First request sends the full input (1 item).
+	if tr1.InputItems != 1 {
+		t.Errorf("first trace InputItems = %d, want 1 (full)", tr1.InputItems)
+	}
+	if tr1.PreviousResponseIDReused {
+		t.Error("first request should not reuse previous_response_id")
+	}
+	// Second request sends only the trimmed delta. trimContinuationDelta strips
+	// leading assistant-generated items (the prior assistant reply is already
+	// embodied by previous_response_id), leaving just the new user turn (1
+	// item), not the full 3-item input. This proves the trace reflects the wire
+	// payload after continuation trimming.
+	if !tr2.PreviousResponseIDReused {
+		t.Error("second request should reuse previous_response_id")
+	}
+	if tr2.InputItems != 1 {
+		t.Errorf("second trace InputItems = %d, want 1 (trimmed new user turn, not 3)", tr2.InputItems)
+	}
+	// The trimmed payload should be smaller than the full second request.
+	fullSecond := &responsesRequest{Model: "gpt-5.3-codex", Input: []map[string]any{
+		responsesMessage("user", "turn one"),
+		responsesMessage("assistant", "ok"),
+		responsesMessage("user", "turn two"),
+	}}
+	if fullBytes := estimateResponsesRequestBytes(fullSecond); tr2.RequestBytes >= fullBytes {
+		t.Errorf("trimmed RequestBytes = %d should be < full = %d", tr2.RequestBytes, fullBytes)
+	}
+}

--- a/provider/openai/latency_bench_test.go
+++ b/provider/openai/latency_bench_test.go
@@ -1,0 +1,166 @@
+package openai
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/fugue-labs/gollem/core"
+	"github.com/gorilla/websocket"
+)
+
+// These benchmarks are the first in the repo (see issue #242). They serve two
+// purposes:
+//   - BenchmarkChatGPTRequest_*: end-to-end ChatGPT-auth request latency against
+//     a minimal local backend, across the HTTP and WebSocket transports, with
+//     and without a request observer. They are the reproducible phase-attribution
+//     harness the issue's acceptance criteria call for (run with -benchmem).
+//   - BenchmarkInstrumentationOverhead: isolates the per-request cost of having
+//     an observer installed vs. nil, so we can prove the nil path is free and
+//     quantify the observed path overhead.
+//
+// The ChatGPT endpoint is simulated by appending "/chatgpt.com" to the test
+// server URL, the same trick used elsewhere in this package's tests to make
+// isChatGPTEndpoint() return true while physically hitting the local server.
+
+// fixedChatGPTSSE is a minimal ChatGPT-backend SSE response.
+const fixedChatGPTSSE = "data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"ok\"}]}}\n\n" +
+	"data: {\"type\":\"response.completed\",\"response\":{\"id\":\"r\",\"model\":\"gpt-5\",\"output\":[],\"usage\":{\"input_tokens\":3,\"output_tokens\":1}}}\n\n" +
+	"data: [DONE]\n\n"
+
+func chatgptProvider(serverURL, model string, opts ...Option) *Provider {
+	all := append([]Option{
+		WithChatGPTAuth("token", "acct"),
+		WithBaseURL(serverURL + "/chatgpt.com"),
+		WithModel(model),
+	}, opts...)
+	return New(all...)
+}
+
+func BenchmarkChatGPTRequest_HTTP_NoObserver(b *testing.B) {
+	benchChatGPTRequest(b, false)
+}
+
+func BenchmarkChatGPTRequest_HTTP_WithObserver(b *testing.B) {
+	benchChatGPTRequest(b, true)
+}
+
+func benchChatGPTRequest(b *testing.B, withObserver bool) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Write([]byte(fixedChatGPTSSE))
+	}))
+	defer server.Close()
+
+	var opts []Option
+	if withObserver {
+		// A no-op observer still exercises the full timing-accumulation path.
+		opts = append(opts, WithRequestObserver(func(RequestTrace) {}))
+	}
+	p := chatgptProvider(server.URL, "gpt-5", opts...)
+
+	msgs := []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "hi"}}},
+	}
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		if _, err := p.Request(ctx, msgs, nil, nil); err != nil {
+			b.Fatalf("Request: %v", err)
+		}
+	}
+}
+
+func BenchmarkChatGPTRequest_WebSocket_WithObserver(b *testing.B) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+			_ = conn.WriteJSON(responsesWSEvent{
+				Type: "response.completed",
+				Response: &responsesAPIResponse{
+					ID: "r", Model: "gpt-5.3-codex",
+					Output: []responsesOutputItem{{
+						Type: "message", Role: "assistant",
+						Content: []responsesContentItem{{Type: "output_text", Text: "ok"}},
+					}},
+				},
+			})
+		}
+	}))
+	defer server.Close()
+
+	p := New(
+		WithAPIKey("test-key"),
+		WithModel("gpt-5.3-codex"),
+		WithBaseURL(server.URL),
+		WithTransport("websocket"),
+		WithRequestObserver(func(RequestTrace) {}),
+	)
+	defer p.Close()
+
+	msgs := []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "hi"}}},
+	}
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		if _, err := p.Request(ctx, msgs, nil, nil); err != nil {
+			b.Fatalf("Request: %v", err)
+		}
+	}
+}
+
+// BenchmarkInstrumentationOverhead isolates the marginal cost of an installed
+// observer by comparing the nil-observer and no-op-observer paths against the
+// same local backend.
+func BenchmarkInstrumentationOverhead(b *testing.B) {
+	ctx := context.Background()
+	msgs := []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "hi"}}},
+	}
+
+	b.Run("nil_observer", func(b *testing.B) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.Write([]byte(fixedChatGPTSSE))
+		}))
+		defer server.Close()
+		p := chatgptProvider(server.URL, "gpt-5")
+		b.ReportAllocs()
+		b.ResetTimer()
+		for range b.N {
+			if _, err := p.Request(ctx, msgs, nil, nil); err != nil {
+				b.Fatalf("Request: %v", err)
+			}
+		}
+	})
+
+	b.Run("noop_observer", func(b *testing.B) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.Write([]byte(fixedChatGPTSSE))
+		}))
+		defer server.Close()
+		p := chatgptProvider(server.URL, "gpt-5", WithRequestObserver(func(RequestTrace) {}))
+		b.ReportAllocs()
+		b.ResetTimer()
+		for range b.N {
+			if _, err := p.Request(ctx, msgs, nil, nil); err != nil {
+				b.Fatalf("Request: %v", err)
+			}
+		}
+	})
+}

--- a/provider/openai/openai.go
+++ b/provider/openai/openai.go
@@ -483,7 +483,9 @@ func (p *Provider) Request(ctx context.Context, messages []core.ModelMessage, se
 	if err != nil {
 		return nil, fmt.Errorf("openai: failed to marshal request: %w", err)
 	}
-	ri.setRequestShape(len(body), len(messages))
+	// Count the built API messages, not the input slice: one ModelMessage can
+	// expand into multiple API messages (multi-part system/user/tool content).
+	ri.setRequestShape(len(body), len(req.Messages))
 	ri.markCacheKey(p.promptCacheKey)
 
 	resp, err := p.doRequest(ctx, chatCompletionsEndpoint, body, ri)
@@ -534,7 +536,9 @@ func (p *Provider) RequestStream(ctx context.Context, messages []core.ModelMessa
 		ri.finish()
 		return nil, fmt.Errorf("openai: failed to marshal request: %w", err)
 	}
-	ri.setRequestShape(len(body), len(messages))
+	// Count the built API messages, not the input slice: one ModelMessage can
+	// expand into multiple API messages (multi-part system/user/tool content).
+	ri.setRequestShape(len(body), len(req.Messages))
 	ri.markCacheKey(p.promptCacheKey)
 
 	resp, err := p.doRequest(ctx, chatCompletionsEndpoint, body, ri) //nolint:bodyclose // Response body ownership transfers to streamedResponse.

--- a/provider/openai/openai.go
+++ b/provider/openai/openai.go
@@ -94,6 +94,7 @@ type Provider struct {
 	chatgptAccountID        string
 	tokenRefresher          TokenRefresher
 	reasoningSummaryHandler func(text string)
+	requestObserver         RequestObserver
 }
 
 // Option configures the OpenAI provider.
@@ -345,6 +346,12 @@ func New(opts ...Option) *Provider {
 	if p.textVerbosity == "" {
 		p.textVerbosity = os.Getenv("OPENAI_TEXT_VERBOSITY")
 	}
+	// OPENAI_REQUEST_TRACE=1 installs the default stderr request observer when
+	// no explicit observer was provided. This is the lowest-friction way to
+	// turn on secret-safe per-request latency diagnostics.
+	if p.requestObserver == nil && isTruthy(os.Getenv("OPENAI_REQUEST_TRACE")) {
+		p.requestObserver = DefaultStderrRequestObserver()
+	}
 	// Strip trailing /v1 or /v1/ from the base URL. Our endpoint path
 	// already includes /v1, so a base URL with /v1 (which is the convention
 	// in the OpenAI Python client) would produce /v1/v1/chat/completions.
@@ -426,6 +433,7 @@ func (p *Provider) NewSession() core.Model {
 		chatgptAccountID:        p.chatgptAccountID,
 		tokenRefresher:          p.tokenRefresher,
 		reasoningSummaryHandler: p.reasoningSummaryHandler,
+		requestObserver:         p.requestObserver,
 	}
 }
 
@@ -456,8 +464,11 @@ func (p *Provider) ModelName() string {
 
 // Request sends messages to OpenAI and returns a complete response.
 func (p *Provider) Request(ctx context.Context, messages []core.ModelMessage, settings *core.ModelSettings, params *core.ModelRequestParameters) (*core.ModelResponse, error) {
+	ri := newRequestInstrumentation(p.requestObserver, p.transport, p.model)
+	defer ri.finish()
+
 	if p.shouldUseResponsesAPI() {
-		return p.requestViaResponses(ctx, messages, settings, params)
+		return p.requestViaResponses(ctx, messages, settings, params, ri)
 	}
 
 	req, err := buildRequest(messages, settings, params, p.model, p.maxTokens, false)
@@ -472,24 +483,30 @@ func (p *Provider) Request(ctx context.Context, messages []core.ModelMessage, se
 	if err != nil {
 		return nil, fmt.Errorf("openai: failed to marshal request: %w", err)
 	}
+	ri.setRequestShape(len(body), len(messages))
+	ri.markCacheKey(p.promptCacheKey)
 
-	resp, err := p.doRequest(ctx, chatCompletionsEndpoint, body)
+	resp, err := p.doRequest(ctx, chatCompletionsEndpoint, body, ri)
 	if err != nil {
 		if isChatCompletionsMismatch(err) {
 			// Some models (e.g. Codex variants) are only available via /v1/responses.
 			p.useResponses = true
-			return p.requestViaResponses(ctx, messages, settings, params)
+			return p.requestViaResponses(ctx, messages, settings, params, ri)
 		}
+		ri.recordError(err)
 		return nil, err
 	}
 	defer resp.Body.Close()
 
 	var apiResp apiResponse
 	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
+		ri.recordError(err)
 		return nil, fmt.Errorf("openai: failed to decode response: %w", err)
 	}
+	ri.recordTerminal()
 	responseModel, err := p.resolveResponseModel(apiResp.Model)
 	if err != nil {
+		ri.recordError(err)
 		return nil, err
 	}
 	return parseResponse(&apiResp, responseModel), nil
@@ -497,12 +514,15 @@ func (p *Provider) Request(ctx context.Context, messages []core.ModelMessage, se
 
 // RequestStream sends messages and returns a streaming response.
 func (p *Provider) RequestStream(ctx context.Context, messages []core.ModelMessage, settings *core.ModelSettings, params *core.ModelRequestParameters) (core.StreamedResponse, error) {
+	ri := newRequestInstrumentation(p.requestObserver, p.transport, p.model)
+
 	if p.shouldUseResponsesAPI() {
-		return p.requestStreamViaResponses(ctx, messages, settings, params)
+		return p.requestStreamViaResponses(ctx, messages, settings, params, ri)
 	}
 
 	req, err := buildRequest(messages, settings, params, p.model, p.maxTokens, true)
 	if err != nil {
+		ri.finish()
 		return nil, fmt.Errorf("openai: failed to build request: %w", err)
 	}
 	req.PromptCacheKey = p.promptCacheKey
@@ -511,19 +531,28 @@ func (p *Provider) RequestStream(ctx context.Context, messages []core.ModelMessa
 
 	body, err := json.Marshal(req)
 	if err != nil {
+		ri.finish()
 		return nil, fmt.Errorf("openai: failed to marshal request: %w", err)
 	}
+	ri.setRequestShape(len(body), len(messages))
+	ri.markCacheKey(p.promptCacheKey)
 
-	resp, err := p.doRequest(ctx, chatCompletionsEndpoint, body) //nolint:bodyclose // Response body ownership transfers to streamedResponse.
+	resp, err := p.doRequest(ctx, chatCompletionsEndpoint, body, ri) //nolint:bodyclose // Response body ownership transfers to streamedResponse.
 	if err != nil {
 		if isChatCompletionsMismatch(err) {
 			p.useResponses = true
-			return p.requestStreamViaResponses(ctx, messages, settings, params)
+			stream, sErr := p.requestStreamViaResponses(ctx, messages, settings, params, ri)
+			if sErr != nil {
+				ri.finish()
+			}
+			return stream, sErr
 		}
+		ri.recordError(err)
+		ri.finish()
 		return nil, err
 	}
 
-	return newBoundStreamedResponse(resp.Body, p.model, p.resolveResponseModel), nil
+	return newBoundStreamedResponse(resp.Body, p.model, p.resolveResponseModel, ri), nil
 }
 
 // responsesEP returns the Responses API endpoint path. ChatGPT subscription
@@ -539,26 +568,30 @@ func (p *Provider) responsesEP() string {
 // doRequest sends a single HTTP request and returns the response or a typed
 // error. Retry logic is handled at the model level by modelutil.RetryModel,
 // which uses this error's RetryAfter field for backoff.
-func (p *Provider) doRequest(ctx context.Context, endpoint string, body []byte) (*http.Response, error) {
+func (p *Provider) doRequest(ctx context.Context, endpoint string, body []byte, ri *requestInstrumentation) (*http.Response, error) {
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+endpoint, bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("openai: failed to create HTTP request: %w", err)
 	}
-	if err := p.setHeaders(httpReq); err != nil {
+	if err := p.setHeaders(httpReq, ri); err != nil {
+		ri.recordError(err)
 		return nil, err
 	}
 
 	resp, err := p.httpClient.Do(httpReq)
 	if err != nil {
+		ri.recordError(err)
 		return nil, fmt.Errorf("openai: HTTP request failed: %w", err)
 	}
 
+	ri.recordHeaders(resp.StatusCode)
 	if resp.StatusCode == http.StatusOK {
 		return resp, nil
 	}
 
 	classification := readProviderErrorClassification(resp.Body)
 	resp.Body.Close()
+	ri.classifyHTTPResponse(resp.StatusCode, classification)
 
 	httpErr := sanitizedProviderHTTPError("openai API error", resp.StatusCode, classification, p.model)
 
@@ -568,18 +601,22 @@ func (p *Provider) doRequest(ctx context.Context, endpoint string, body []byte) 
 		if ra := resp.Header.Get("Retry-After"); ra != "" {
 			if secs, err := strconv.Atoi(ra); err == nil {
 				httpErr.RetryAfter = time.Duration(secs) * time.Second
+				ri.recordRetryAfter(httpErr.RetryAfter)
 			}
 		}
 	}
 
+	ri.recordError(httpErr)
 	return nil, httpErr
 }
 
-func (p *Provider) authorizationToken() (string, error) {
+func (p *Provider) authorizationToken(ri *requestInstrumentation) (string, error) {
 	if p.tokenRefresher == nil {
 		return p.apiKey, nil
 	}
+	ri.beginTokenRefresh()
 	token, err := p.tokenRefresher()
+	ri.endTokenRefresh()
 	if err != nil {
 		return "", fmt.Errorf("openai: refreshing access token: %w", err)
 	}
@@ -645,8 +682,8 @@ func (p *Provider) parseBoundResponsesResponse(resp *responsesAPIResponse) (*cor
 	return parseResponsesResponse(resp, responseModel), nil
 }
 
-func (p *Provider) setHeaders(req *http.Request) error {
-	token, err := p.authorizationToken()
+func (p *Provider) setHeaders(req *http.Request, ri *requestInstrumentation) error {
+	token, err := p.authorizationToken(ri)
 	if err != nil {
 		return err
 	}

--- a/provider/openai/openai_test.go
+++ b/provider/openai/openai_test.go
@@ -3045,6 +3045,7 @@ func TestStrictModelBindingChatCompletionStreamTerminalPaths(t *testing.T) {
 				io.NopCloser(strings.NewReader(tt.sse)),
 				"gpt-4o",
 				p.resolveResponseModel,
+				nil,
 			)
 			defer stream.Close()
 			_, err := stream.Next()
@@ -3070,6 +3071,7 @@ func TestStrictModelBindingResponsesStreamBareTerminalPaths(t *testing.T) {
 				io.NopCloser(strings.NewReader(tt.sse)),
 				"gpt-5",
 				p.resolveResponseModel,
+				nil,
 			)
 			defer stream.Close()
 			_, err := stream.Next()

--- a/provider/openai/responses.go
+++ b/provider/openai/responses.go
@@ -129,13 +129,13 @@ type responsesOutputTokensDetails struct {
 	ReasoningTokens int `json:"reasoning_tokens"`
 }
 
-func (p *Provider) requestViaResponses(ctx context.Context, messages []core.ModelMessage, settings *core.ModelSettings, params *core.ModelRequestParameters) (*core.ModelResponse, error) {
+func (p *Provider) requestViaResponses(ctx context.Context, messages []core.ModelMessage, settings *core.ModelSettings, params *core.ModelRequestParameters, ri *requestInstrumentation) (*core.ModelResponse, error) {
 	req, err := buildResponsesRequest(messages, settings, params, p.model, p.maxTokens, p.disableToolSearch)
 	if err != nil {
 		return nil, fmt.Errorf("openai: failed to build responses request: %w", err)
 	}
 	p.applyResponsesEndpointSettings(req)
-	return p.requestViaResponsesWithReq(ctx, req)
+	return p.requestViaResponsesWithReq(ctx, req, ri)
 }
 
 // applyResponsesEndpointSettings configures endpoint-specific fields on the
@@ -189,7 +189,7 @@ func (p *Provider) applyResponsesEndpointSettings(req *responsesRequest) {
 // internally. The non-streaming Request() path continues to use WebSocket
 // when configured; RequestStream() falls back to HTTP SSE which provides
 // true incremental event delivery.
-func (p *Provider) requestStreamViaResponses(ctx context.Context, messages []core.ModelMessage, settings *core.ModelSettings, params *core.ModelRequestParameters) (core.StreamedResponse, error) {
+func (p *Provider) requestStreamViaResponses(ctx context.Context, messages []core.ModelMessage, settings *core.ModelSettings, params *core.ModelRequestParameters, ri *requestInstrumentation) (core.StreamedResponse, error) {
 	req, err := buildResponsesRequest(messages, settings, params, p.model, p.maxTokens, p.disableToolSearch)
 	if err != nil {
 		return nil, fmt.Errorf("openai: failed to build responses request: %w", err)
@@ -205,8 +205,10 @@ func (p *Provider) requestStreamViaResponses(ctx context.Context, messages []cor
 	if err != nil {
 		return nil, fmt.Errorf("openai: failed to marshal responses request: %w", err)
 	}
+	ri.setRequestShape(len(body), len(req.Input))
+	ri.markCacheKey(req.PromptCacheKey)
 
-	resp, err := p.doRequest(ctx, p.responsesEP(), body)
+	resp, err := p.doRequest(ctx, p.responsesEP(), body, ri)
 	if err != nil {
 		return nil, err
 	}
@@ -225,16 +227,21 @@ func (p *Provider) requestStreamViaResponses(ctx context.Context, messages []cor
 		defer resp.Body.Close()
 		var apiResp responsesAPIResponse
 		if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
+			ri.recordError(err)
+			ri.finish()
 			return nil, fmt.Errorf("openai: failed to decode responses API response: %w", err)
 		}
 		bound, bindErr := p.parseBoundResponsesResponse(&apiResp)
 		if bindErr != nil {
+			ri.recordError(bindErr)
+			ri.finish()
 			return nil, bindErr
 		}
-		return newPrebuiltResponsesStream(bound), nil
+		ri.recordTerminal()
+		return &prebuiltResponsesStream{response: bound, instrumentation: ri}, nil
 	}
 
-	return newBoundResponsesStreamedResponse(resp.Body, p.model, p.resolveResponseModel), nil
+	return newBoundResponsesStreamedResponse(resp.Body, p.model, p.resolveResponseModel, ri), nil
 }
 
 // applyChatGPTRequirements modifies a request for the ChatGPT backend:
@@ -331,7 +338,7 @@ func extractTextContent(content any) string {
 	return ""
 }
 
-func (p *Provider) requestViaResponsesWithReq(ctx context.Context, req *responsesRequest) (*core.ModelResponse, error) {
+func (p *Provider) requestViaResponsesWithReq(ctx context.Context, req *responsesRequest, ri *requestInstrumentation) (*core.ModelResponse, error) {
 	if p.shouldUseResponsesWebSocket() {
 		// Keep websocket continuations strictly in-memory on the active socket,
 		// aligned with WebSocket mode guidance and ZDR/store=false compatibility.
@@ -340,11 +347,12 @@ func (p *Provider) requestViaResponsesWithReq(ctx context.Context, req *response
 			storeFalse := false
 			req.Store = &storeFalse
 		}
-		resp, wsErr := p.requestViaResponsesWebSocket(ctx, req)
+		resp, wsErr := p.requestViaResponsesWebSocket(ctx, req, ri)
 		if wsErr == nil {
 			return resp, nil
 		}
 		if !p.wsHTTPFallback {
+			ri.recordError(wsErr)
 			return nil, wsErr
 		}
 		// Restore caller intent for HTTP fallback; websocket-specific store=false
@@ -352,7 +360,7 @@ func (p *Provider) requestViaResponsesWithReq(ctx context.Context, req *response
 		req.Store = cloneBoolPtr(origStore)
 	}
 
-	return p.requestViaResponsesHTTP(ctx, req)
+	return p.requestViaResponsesHTTP(ctx, req, ri)
 }
 
 func cloneBoolPtr(v *bool) *bool {
@@ -363,13 +371,15 @@ func cloneBoolPtr(v *bool) *bool {
 	return &c
 }
 
-func (p *Provider) requestViaResponsesHTTP(ctx context.Context, req *responsesRequest) (*core.ModelResponse, error) {
+func (p *Provider) requestViaResponsesHTTP(ctx context.Context, req *responsesRequest, ri *requestInstrumentation) (*core.ModelResponse, error) {
 	body, err := json.Marshal(req)
 	if err != nil {
 		return nil, fmt.Errorf("openai: failed to marshal responses request: %w", err)
 	}
+	ri.setRequestShape(len(body), len(req.Input))
+	ri.markCacheKey(req.PromptCacheKey)
 
-	resp, err := p.doRequest(ctx, p.responsesEP(), body)
+	resp, err := p.doRequest(ctx, p.responsesEP(), body, ri)
 	if err != nil {
 		return nil, err
 	}
@@ -378,14 +388,15 @@ func (p *Provider) requestViaResponsesHTTP(ctx context.Context, req *responsesRe
 	// ChatGPT backend requires stream=true and returns SSE events.
 	// Parse the stream and extract the final terminal response event.
 	if req.Stream != nil && *req.Stream {
-		return p.parseSSEResponses(resp)
+		return p.parseSSEResponses(resp, ri)
 	}
 
 	var apiResp responsesAPIResponse
 	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
+		ri.recordError(err)
 		return nil, fmt.Errorf("openai: failed to decode responses API response: %w", err)
 	}
-
+	ri.recordTerminal()
 	return p.parseBoundResponsesResponse(&apiResp)
 }
 
@@ -399,7 +410,7 @@ func (p *Provider) requestViaResponsesHTTP(ctx context.Context, req *responsesRe
 // output is empty (which it always is for codex). This is the bug fix
 // for sleepy meta-evolution: without this, every codex call returns
 // empty text and looks like a rate limit.
-func (p *Provider) parseSSEResponses(resp *http.Response) (*core.ModelResponse, error) {
+func (p *Provider) parseSSEResponses(resp *http.Response, ri *requestInstrumentation) (*core.ModelResponse, error) {
 	scanner := bufio.NewScanner(resp.Body)
 	// Allow large lines (SSE events can be big).
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
@@ -423,14 +434,17 @@ func (p *Provider) parseSSEResponses(resp *http.Response) (*core.ModelResponse, 
 		if json.Unmarshal([]byte(data), &event) != nil {
 			continue
 		}
+		ri.recordFirstEvent()
 		switch event.Type {
 		case "response.completed", "response.done":
 			finalResp = &event.Response
+			ri.recordTerminal()
 		case "response.output_item.done":
 			// Accumulate completed message items so we can recover
 			// the response text even when the terminal event has
 			// output:[] (codex backend behavior).
 			if event.Item.Type == "message" || event.Item.Type == "function_call" {
+				ri.recordFirstToken()
 				streamedItems = append(streamedItems, event.Item)
 			}
 		}
@@ -441,14 +455,16 @@ func (p *Provider) parseSSEResponses(resp *http.Response) (*core.ModelResponse, 
 		// that case we already have the complete response payload, so prefer it
 		// over surfacing a transport error.
 		if finalResp == nil {
+			ri.recordError(err)
 			return nil, fmt.Errorf("openai: SSE read error: %w", err)
 		}
 	}
 	if finalResp == nil {
+		ri.recordError(errors.New("openai: no terminal response event in stream"))
 		return nil, errors.New("openai: no terminal response event in stream")
 	}
 	// Codex backend fix: if the terminal response has no output items
-	// but we accumulated streamed message items, use those instead.
+	// but we accumulated streamed message items, use these instead.
 	if len(finalResp.Output) == 0 && len(streamedItems) > 0 {
 		finalResp.Output = streamedItems
 	}

--- a/provider/openai/responses.go
+++ b/provider/openai/responses.go
@@ -190,8 +190,15 @@ func (p *Provider) applyResponsesEndpointSettings(req *responsesRequest) {
 // when configured; RequestStream() falls back to HTTP SSE which provides
 // true incremental event delivery.
 func (p *Provider) requestStreamViaResponses(ctx context.Context, messages []core.ModelMessage, settings *core.ModelSettings, params *core.ModelRequestParameters, ri *requestInstrumentation) (core.StreamedResponse, error) {
+	// requestStreamViaResponses always uses HTTP SSE, even when the provider is
+	// configured for websocket (the websocket transport exposes no streaming
+	// interface). Label the physical transport accordingly so consumers do not
+	// misattribute HTTP header timing to WebSocket.
+	ri.setTransport(transportHTTP)
+
 	req, err := buildResponsesRequest(messages, settings, params, p.model, p.maxTokens, p.disableToolSearch)
 	if err != nil {
+		ri.finish()
 		return nil, fmt.Errorf("openai: failed to build responses request: %w", err)
 	}
 
@@ -203,6 +210,7 @@ func (p *Provider) requestStreamViaResponses(ctx context.Context, messages []cor
 
 	body, err := json.Marshal(req)
 	if err != nil {
+		ri.finish()
 		return nil, fmt.Errorf("openai: failed to marshal responses request: %w", err)
 	}
 	ri.setRequestShape(len(body), len(req.Input))
@@ -210,6 +218,10 @@ func (p *Provider) requestStreamViaResponses(ctx context.Context, messages []cor
 
 	resp, err := p.doRequest(ctx, p.responsesEP(), body, ri)
 	if err != nil {
+		// The stream is never returned, so finalize the trace here for failed
+		// setup (429s, connection errors). Without this the observer never
+		// fires for precisely the failed physical requests.
+		ri.finish()
 		return nil, err
 	}
 
@@ -339,6 +351,20 @@ func extractTextContent(content any) string {
 }
 
 func (p *Provider) requestViaResponsesWithReq(ctx context.Context, req *responsesRequest, ri *requestInstrumentation) (*core.ModelResponse, error) {
+	// Record request shape and cache continuity once for the physical request,
+	// covering both the websocket and HTTP branches. The websocket branch does
+	// not marshal the body itself (the create event does), so recording here
+	// ensures WS traces report input bytes/items and the cache fingerprint too.
+	ri.setRequestShape(estimateResponsesRequestBytes(req), len(req.Input))
+	// The cache key actually sent is whatever applyResponsesEndpointSettings
+	// copied onto req, falling back to the provider's configured key (the WS
+	// create event carries it regardless of endpoint classification).
+	cacheKey := req.PromptCacheKey
+	if cacheKey == "" {
+		cacheKey = p.promptCacheKey
+	}
+	ri.markCacheKey(cacheKey)
+
 	if p.shouldUseResponsesWebSocket() {
 		// Keep websocket continuations strictly in-memory on the active socket,
 		// aligned with WebSocket mode guidance and ZDR/store=false compatibility.
@@ -371,6 +397,20 @@ func cloneBoolPtr(v *bool) *bool {
 	return &c
 }
 
+// estimateResponsesRequestBytes reports the marshaled size of a Responses
+// request without serializing the body a second time on the HTTP path. The
+// websocket transport builds the create event separately, so this is the only
+// place WS traces learn their request size.
+func estimateResponsesRequestBytes(req *responsesRequest) int {
+	if req == nil {
+		return 0
+	}
+	if b, err := json.Marshal(req); err == nil {
+		return len(b)
+	}
+	return 0
+}
+
 func (p *Provider) requestViaResponsesHTTP(ctx context.Context, req *responsesRequest, ri *requestInstrumentation) (*core.ModelResponse, error) {
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -397,7 +437,12 @@ func (p *Provider) requestViaResponsesHTTP(ctx context.Context, req *responsesRe
 		return nil, fmt.Errorf("openai: failed to decode responses API response: %w", err)
 	}
 	ri.recordTerminal()
-	return p.parseBoundResponsesResponse(&apiResp)
+	bound, err := p.parseBoundResponsesResponse(&apiResp)
+	if err != nil {
+		ri.recordError(err)
+		return nil, err
+	}
+	return bound, nil
 }
 
 // parseSSEResponses reads an SSE stream and returns the final response.
@@ -417,6 +462,10 @@ func (p *Provider) parseSSEResponses(resp *http.Response, ri *requestInstrumenta
 
 	var finalResp *responsesAPIResponse
 	var streamedItems []responsesOutputItem // accumulated from output_item.done events
+	// terminalFailure holds a sanitized classification for an in-band
+	// response.failed / response.incomplete outcome so we can record it in the
+	// trace (terminal timing + classification) before translating it to an error.
+	var terminalFailure string
 	for scanner.Scan() {
 		line := scanner.Text()
 		if !strings.HasPrefix(line, "data: ") {
@@ -430,6 +479,7 @@ func (p *Provider) parseSSEResponses(resp *http.Response, ri *requestInstrumenta
 			Type     string               `json:"type"`
 			Response responsesAPIResponse `json:"response,omitempty"`
 			Item     responsesOutputItem  `json:"item,omitempty"`
+			Delta    string               `json:"delta,omitempty"`
 		}
 		if json.Unmarshal([]byte(data), &event) != nil {
 			continue
@@ -439,6 +489,14 @@ func (p *Provider) parseSSEResponses(resp *http.Response, ri *requestInstrumenta
 		case "response.completed", "response.done":
 			finalResp = &event.Response
 			ri.recordTerminal()
+		case "response.output_text.delta", "response.function_call_arguments.delta":
+			// Deltas arrive before output_item.done; timestamp the first token
+			// as soon as the model produces output content, not at item
+			// completion. This keeps the non-stream SSE path's first-token
+			// measurement comparable to the streaming/WebSocket paths.
+			if event.Delta != "" {
+				ri.recordFirstToken()
+			}
 		case "response.output_item.done":
 			// Accumulate completed message items so we can recover
 			// the response text even when the terminal event has
@@ -447,6 +505,20 @@ func (p *Provider) parseSSEResponses(resp *http.Response, ri *requestInstrumenta
 				ri.recordFirstToken()
 				streamedItems = append(streamedItems, event.Item)
 			}
+		case "response.failed":
+			terminalFailure = "response_failed"
+			if event.Response.IncompleteDetails != nil {
+				terminalFailure = classifyProviderError("response.failed", event.Response.IncompleteDetails.Reason)
+			}
+			finalResp = &event.Response
+			ri.recordTerminalFailure(terminalFailure)
+		case "response.incomplete":
+			terminalFailure = "response_incomplete"
+			if event.Response.IncompleteDetails != nil {
+				terminalFailure = classifyProviderError("response.incomplete", event.Response.IncompleteDetails.Reason)
+			}
+			finalResp = &event.Response
+			ri.recordTerminalFailure(terminalFailure)
 		}
 	}
 	if err := scanner.Err(); err != nil {
@@ -459,6 +531,9 @@ func (p *Provider) parseSSEResponses(resp *http.Response, ri *requestInstrumenta
 			return nil, fmt.Errorf("openai: SSE read error: %w", err)
 		}
 	}
+	if terminalFailure != "" {
+		return nil, fmt.Errorf("openai: %s", terminalFailure)
+	}
 	if finalResp == nil {
 		ri.recordError(errors.New("openai: no terminal response event in stream"))
 		return nil, errors.New("openai: no terminal response event in stream")
@@ -468,7 +543,12 @@ func (p *Provider) parseSSEResponses(resp *http.Response, ri *requestInstrumenta
 	if len(finalResp.Output) == 0 && len(streamedItems) > 0 {
 		finalResp.Output = streamedItems
 	}
-	return p.parseBoundResponsesResponse(finalResp)
+	result, err := p.parseBoundResponsesResponse(finalResp)
+	if err != nil {
+		ri.recordError(err)
+		return nil, err
+	}
+	return result, nil
 }
 
 func buildResponsesRequest(messages []core.ModelMessage, settings *core.ModelSettings, params *core.ModelRequestParameters, model string, defaultMaxTokens int, disableToolSearch bool) (*responsesRequest, error) {

--- a/provider/openai/responses.go
+++ b/provider/openai/responses.go
@@ -351,11 +351,6 @@ func extractTextContent(content any) string {
 }
 
 func (p *Provider) requestViaResponsesWithReq(ctx context.Context, req *responsesRequest, ri *requestInstrumentation) (*core.ModelResponse, error) {
-	// Record request shape and cache continuity once for the physical request,
-	// covering both the websocket and HTTP branches. The websocket branch does
-	// not marshal the body itself (the create event does), so recording here
-	// ensures WS traces report input bytes/items and the cache fingerprint too.
-	ri.setRequestShape(estimateResponsesRequestBytes(req), len(req.Input))
 	// The cache key actually sent is whatever applyResponsesEndpointSettings
 	// copied onto req, falling back to the provider's configured key (the WS
 	// create event carries it regardless of endpoint classification).
@@ -364,6 +359,13 @@ func (p *Provider) requestViaResponsesWithReq(ctx context.Context, req *response
 		cacheKey = p.promptCacheKey
 	}
 	ri.markCacheKey(cacheKey)
+
+	// Finish the active trace on return. ri is reassigned below when the
+	// websocket attempt fails and falls back to HTTP (a fresh trace is started
+	// for the HTTP attempt). Capturing ri by reference ensures whichever trace
+	// is active at return is delivered exactly once; the caller's defer
+	// ri.finish() is an idempotent no-op on the already-finished original.
+	defer func() { ri.finish() }()
 
 	if p.shouldUseResponsesWebSocket() {
 		// Keep websocket continuations strictly in-memory on the active socket,
@@ -381,6 +383,13 @@ func (p *Provider) requestViaResponsesWithReq(ctx context.Context, req *response
 			ri.recordError(wsErr)
 			return nil, wsErr
 		}
+		// The websocket attempt failed and HTTP fallback is enabled. Deliver
+		// the failed WS attempt as its own trace (with its error and timing),
+		// then start a fresh trace for the HTTP fallback so the two physical
+		// requests are attributable separately rather than merged into one.
+		ri.recordError(wsErr)
+		ri.finish()
+		ri = newRequestInstrumentation(p.requestObserver, transportHTTP, p.model)
 		// Restore caller intent for HTTP fallback; websocket-specific store=false
 		// coercion should not leak into the fallback transport.
 		req.Store = cloneBoolPtr(origStore)
@@ -398,9 +407,10 @@ func cloneBoolPtr(v *bool) *bool {
 }
 
 // estimateResponsesRequestBytes reports the marshaled size of a Responses
-// request without serializing the body a second time on the HTTP path. The
-// websocket transport builds the create event separately, so this is the only
-// place WS traces learn their request size.
+// request. It is used by the websocket path to record the actual payload size
+// (after continuation trimming) on the trace; the HTTP path records len(body)
+// directly from its own marshal. Guarded by the caller so unobserved requests
+// never pay for this extra serialization.
 func estimateResponsesRequestBytes(req *responsesRequest) int {
 	if req == nil {
 		return 0

--- a/provider/openai/responses_stream.go
+++ b/provider/openai/responses_stream.go
@@ -39,6 +39,10 @@ type responsesStreamedResponse struct {
 	done       bool
 	streamErr  error // non-nil if server sent an error mid-stream
 
+	// instrumentation receives per-request latency updates; nil = no-op. It is
+	// finalized exactly once on terminal/done/error.
+	instrumentation *requestInstrumentation
+
 	// Text part tracking.
 	textPartStarted bool
 	textPartIndex   int
@@ -63,13 +67,14 @@ type responsesStreamedResponse struct {
 }
 
 func newResponsesStreamedResponse(body io.ReadCloser, model string) *responsesStreamedResponse {
-	return newBoundResponsesStreamedResponse(body, model, nil)
+	return newBoundResponsesStreamedResponse(body, model, nil, nil)
 }
 
 func newBoundResponsesStreamedResponse(
 	body io.ReadCloser,
 	model string,
 	resolveModel func(string) (string, error),
+	ri *requestInstrumentation,
 ) *responsesStreamedResponse {
 	scanner := bufio.NewScanner(body)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
@@ -79,6 +84,7 @@ func newBoundResponsesStreamedResponse(
 		model:                model,
 		resolveModel:         resolveModel,
 		stopReason:           core.FinishReasonStop,
+		instrumentation:      ri,
 		partsByIndex:         make(map[int]core.ModelResponsePart),
 		toolCallByOutputIdx:  make(map[int]int),
 		toolCallArgsBuffers:  make(map[int]*strings.Builder),
@@ -98,8 +104,11 @@ func (s *responsesStreamedResponse) Next() (core.ModelResponseStreamEvent, error
 
 		if s.done {
 			if s.streamErr != nil {
+				s.instrumentation.recordError(s.streamErr)
+				s.instrumentation.finish()
 				return nil, s.streamErr
 			}
+			s.instrumentation.finish()
 			return nil, io.EOF
 		}
 
@@ -109,6 +118,8 @@ func (s *responsesStreamedResponse) Next() (core.ModelResponseStreamEvent, error
 				// underlying HTTP/2 stream before sending [DONE]. Once we have the
 				// completed response payload, treat the stream as successfully done.
 				if !s.done {
+					s.instrumentation.recordError(err)
+					s.instrumentation.finish()
 					return nil, fmt.Errorf("openai: SSE read error: %w", err)
 				}
 			}
@@ -116,9 +127,12 @@ func (s *responsesStreamedResponse) Next() (core.ModelResponseStreamEvent, error
 			s.done = true
 			if err := s.finalizeModelIdentity(); err != nil {
 				s.streamErr = err
+				s.instrumentation.recordError(err)
+				s.instrumentation.finish()
 				return nil, err
 			}
 			s.finalize()
+			s.instrumentation.finish()
 			return nil, io.EOF
 		}
 
@@ -132,9 +146,12 @@ func (s *responsesStreamedResponse) Next() (core.ModelResponseStreamEvent, error
 			s.done = true
 			if err := s.finalizeModelIdentity(); err != nil {
 				s.streamErr = err
+				s.instrumentation.recordError(err)
+				s.instrumentation.finish()
 				return nil, err
 			}
 			s.finalize()
+			s.instrumentation.finish()
 			return nil, io.EOF
 		}
 
@@ -142,12 +159,14 @@ func (s *responsesStreamedResponse) Next() (core.ModelResponseStreamEvent, error
 		if json.Unmarshal([]byte(data), &event) != nil {
 			continue
 		}
+		s.instrumentation.recordFirstEvent()
 
 		events := s.processEvent(&event)
 		if len(events) > 0 {
 			if len(events) > 1 {
 				s.pendingEvents = append(s.pendingEvents, events[1:]...)
 			}
+			s.instrumentation.recordFirstToken()
 			return events[0], nil
 		}
 	}
@@ -188,12 +207,16 @@ func (s *responsesStreamedResponse) processEvent(event *responsesStreamEvent) []
 			if json.Unmarshal(event.Response, &failedResp) == nil {
 				classification := classifyProviderError("response.failed", failedResp.Error.Code, failedResp.Error.Message)
 				s.streamErr = fmt.Errorf("openai: response failed (%s)", classification)
+				s.instrumentation.classifyHTTPResponse(0, classification)
 			} else {
 				s.streamErr = errors.New("openai: response failed")
+				s.instrumentation.classifyHTTPResponse(0, "response_failed")
 			}
 		} else {
 			s.streamErr = errors.New("openai: response failed")
+			s.instrumentation.classifyHTTPResponse(0, "response_failed")
 		}
+		s.instrumentation.recordError(s.streamErr)
 		return nil
 
 	case "response.incomplete":
@@ -214,6 +237,8 @@ func (s *responsesStreamedResponse) processEvent(event *responsesStreamEvent) []
 			s.streamErr = err
 		}
 		s.finalize()
+		s.instrumentation.classifyHTTPResponse(0, "response_incomplete")
+		s.instrumentation.recordTerminal()
 		return nil
 	}
 	return nil
@@ -464,6 +489,7 @@ func (s *responsesStreamedResponse) handleCompleted(respJSON json.RawMessage) {
 	}
 	s.done = true
 	s.finalize()
+	s.instrumentation.recordTerminal()
 }
 
 func (s *responsesStreamedResponse) bindResponseModel(actual string) error {
@@ -542,6 +568,7 @@ func (s *responsesStreamedResponse) Usage() core.Usage {
 
 // Close releases resources.
 func (s *responsesStreamedResponse) Close() error {
+	s.instrumentation.finish()
 	return s.body.Close()
 }
 
@@ -552,18 +579,16 @@ var _ core.StreamedResponse = (*responsesStreamedResponse)(nil)
 // Used when the server returns JSON instead of SSE (e.g., streaming unsupported),
 // so callers always get a valid StreamedResponse regardless of server behavior.
 type prebuiltResponsesStream struct {
-	response *core.ModelResponse
-	idx      int
-	done     bool
-}
-
-func newPrebuiltResponsesStream(resp *core.ModelResponse) *prebuiltResponsesStream {
-	return &prebuiltResponsesStream{response: resp}
+	response        *core.ModelResponse
+	idx             int
+	done            bool
+	instrumentation *requestInstrumentation
 }
 
 func (s *prebuiltResponsesStream) Next() (core.ModelResponseStreamEvent, error) {
 	if s.done || s.idx >= len(s.response.Parts) {
 		s.done = true
+		s.instrumentation.finish()
 		return nil, io.EOF
 	}
 	event := core.PartStartEvent{
@@ -576,6 +601,6 @@ func (s *prebuiltResponsesStream) Next() (core.ModelResponseStreamEvent, error) 
 
 func (s *prebuiltResponsesStream) Response() *core.ModelResponse { return s.response }
 func (s *prebuiltResponsesStream) Usage() core.Usage             { return s.response.Usage }
-func (s *prebuiltResponsesStream) Close() error                  { return nil }
+func (s *prebuiltResponsesStream) Close() error                  { s.instrumentation.finish(); return nil }
 
 var _ core.StreamedResponse = (*prebuiltResponsesStream)(nil)

--- a/provider/openai/responses_stream.go
+++ b/provider/openai/responses_stream.go
@@ -196,6 +196,10 @@ func (s *responsesStreamedResponse) processEvent(event *responsesStreamEvent) []
 	case "response.failed":
 		s.done = true
 		s.finalize()
+		// response.failed is a terminal outcome; record terminal timing so a
+		// failed request that reached a definitive provider event is
+		// distinguishable from one that disconnected before any terminal event.
+		s.instrumentation.recordTerminal()
 		// Extract error message from the response object.
 		if event.Response != nil {
 			var failedResp struct {

--- a/provider/openai/responses_test.go
+++ b/provider/openai/responses_test.go
@@ -99,7 +99,7 @@ func TestChatGPTAuth_GPT56ResponsesLiteHeader(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			p.setHeaders(req)
+			p.setHeaders(req, nil)
 			if got := req.Header.Get(chatgptResponsesLiteHdr); got != tc.want {
 				t.Fatalf("%s = %q, want %q", chatgptResponsesLiteHdr, got, tc.want)
 			}
@@ -228,7 +228,7 @@ data: [DONE]
 `))}
 	p := New(WithModel("gpt-5"))
 
-	got, err := p.parseSSEResponses(resp)
+	got, err := p.parseSSEResponses(resp, nil)
 	if err != nil {
 		t.Fatalf("parseSSEResponses: %v", err)
 	}

--- a/provider/openai/responses_ws.go
+++ b/provider/openai/responses_ws.go
@@ -112,6 +112,14 @@ func (p *Provider) requestViaResponsesWebSocket(ctx context.Context, req *respon
 		}
 	}
 
+	// Record the actual payload shape after continuation trimming so the
+	// trace reflects the bytes sent on the wire (a trimmed continuation sends
+	// far fewer input items than the full context), not the pre-trim request.
+	// Guarded so unobserved requests never pay for the marshal.
+	if ri != nil {
+		ri.setRequestShape(estimateResponsesRequestBytes(&sendReq), len(sendReq.Input))
+	}
+
 	apiResp, err := p.sendResponsesCreateLocked(ctx, conn, &sendReq, ri)
 	if err != nil {
 		// If continuation/cache state is lost, or socket lifetime is reached, or
@@ -131,6 +139,9 @@ func (p *Provider) requestViaResponsesWebSocket(ctx context.Context, req *respon
 				}
 				fullReq := *req
 				fullReq.PreviousResponseID = ""
+				if ri != nil {
+					ri.setRequestShape(estimateResponsesRequestBytes(&fullReq), len(fullReq.Input))
+				}
 				apiResp, err = p.sendResponsesCreateLocked(ctx, conn, &fullReq, ri)
 				if err == nil {
 					// New chain started; local previous-response cache is reset.

--- a/provider/openai/responses_ws.go
+++ b/provider/openai/responses_ws.go
@@ -120,6 +120,10 @@ func (p *Provider) requestViaResponsesWebSocket(ctx context.Context, req *respon
 		// model would need to re-reason from scratch and won't finish in time.
 		if isPreviousResponseNotFound(err) || isWebSocketConnectionLimitReached(err) || isWebSocketConnectionError(err) {
 			if deadline, ok := ctx.Deadline(); !ok || time.Until(deadline) >= minBudgetForWSRetry {
+				// The failed attempt's phase markers and error must not pollute
+				// the retry's trace. Clear them so the trace reflects the
+				// retrying physical request (which dials a fresh connection).
+				ri.resetForRetry()
 				p.resetResponsesWebSocketLocked()
 				conn, connErr := p.ensureResponsesWebSocketLocked(ctx, ri)
 				if connErr != nil {
@@ -160,8 +164,11 @@ func (p *Provider) ensureResponsesWebSocketLocked(ctx context.Context, ri *reque
 		return nil, err
 	}
 	if p.wsConn != nil && token == p.wsAuthToken {
+		// Reused connection: no dial or handshake occurs, so leave
+		// TimeToHeaders unset (zero) rather than timestamping local token
+		// lookup as if it were a handshake. The reuse flag carries that
+		// information for consumers.
 		ri.markWebSocketReused(true)
-		ri.recordHeaders(0)
 		return p.wsConn, nil
 	}
 	if p.wsConn != nil {
@@ -300,6 +307,14 @@ func (p *Provider) sendResponsesCreateLocked(ctx context.Context, conn *response
 			if p.reasoningSummaryHandler != nil && event.Text != "" {
 				p.reasoningSummaryHandler(event.Text)
 			}
+		case "response.output_text.delta", "response.function_call_arguments.delta":
+			// Deltas arrive before the output item is complete; timestamp the
+			// first token as soon as the model produces content, so websocket
+			// first-token latency is comparable to the HTTP/SSE paths and is
+			// not inflated to time-to-completed-item.
+			if event.Delta != "" {
+				ri.recordFirstToken()
+			}
 		case "response.output_item.done":
 			// Codex-style websocket streams output items incrementally and
 			// the terminal response.completed event may arrive with an
@@ -321,6 +336,7 @@ func (p *Provider) sendResponsesCreateLocked(ctx context.Context, conn *response
 			return event.Response, nil
 		case "response.incomplete":
 			wsErr := responsesIncompleteError(event, p.model)
+			ri.recordTerminalFailure("")
 			ri.recordError(wsErr)
 			return nil, wsErr
 		case "error":
@@ -329,6 +345,7 @@ func (p *Provider) sendResponsesCreateLocked(ctx context.Context, conn *response
 			return nil, wsErr
 		case "response.failed":
 			wsErr := responsesFailedError(event, p.model)
+			ri.recordTerminalFailure("")
 			ri.recordError(wsErr)
 			return nil, wsErr
 		default:

--- a/provider/openai/responses_ws.go
+++ b/provider/openai/responses_ws.go
@@ -82,11 +82,11 @@ const (
 	minBudgetForWSRetry = 60 * time.Second
 )
 
-func (p *Provider) requestViaResponsesWebSocket(ctx context.Context, req *responsesRequest) (*core.ModelResponse, error) {
+func (p *Provider) requestViaResponsesWebSocket(ctx context.Context, req *responsesRequest, ri *requestInstrumentation) (*core.ModelResponse, error) {
 	p.wsMu.Lock()
 	defer p.wsMu.Unlock()
 
-	conn, err := p.ensureResponsesWebSocketLocked(ctx)
+	conn, err := p.ensureResponsesWebSocketLocked(ctx, ri)
 	if err != nil {
 		return nil, err
 	}
@@ -108,10 +108,11 @@ func (p *Provider) requestViaResponsesWebSocket(ctx context.Context, req *respon
 		if len(delta) > 0 {
 			sendReq.PreviousResponseID = p.wsPrevResponseID
 			sendReq.Input = delta
+			ri.markPreviousResponseIDReused(true)
 		}
 	}
 
-	apiResp, err := p.sendResponsesCreateLocked(ctx, conn, &sendReq)
+	apiResp, err := p.sendResponsesCreateLocked(ctx, conn, &sendReq, ri)
 	if err != nil {
 		// If continuation/cache state is lost, or socket lifetime is reached, or
 		// connection dropped, reconnect once and resend full context as a new chain.
@@ -120,13 +121,13 @@ func (p *Provider) requestViaResponsesWebSocket(ctx context.Context, req *respon
 		if isPreviousResponseNotFound(err) || isWebSocketConnectionLimitReached(err) || isWebSocketConnectionError(err) {
 			if deadline, ok := ctx.Deadline(); !ok || time.Until(deadline) >= minBudgetForWSRetry {
 				p.resetResponsesWebSocketLocked()
-				conn, connErr := p.ensureResponsesWebSocketLocked(ctx)
+				conn, connErr := p.ensureResponsesWebSocketLocked(ctx, ri)
 				if connErr != nil {
 					return nil, connErr
 				}
 				fullReq := *req
 				fullReq.PreviousResponseID = ""
-				apiResp, err = p.sendResponsesCreateLocked(ctx, conn, &fullReq)
+				apiResp, err = p.sendResponsesCreateLocked(ctx, conn, &fullReq, ri)
 				if err == nil {
 					// New chain started; local previous-response cache is reset.
 					p.wsPrevResponseID = ""
@@ -153,12 +154,14 @@ func (p *Provider) requestViaResponsesWebSocket(ctx context.Context, req *respon
 	return p.parseBoundResponsesResponse(apiResp)
 }
 
-func (p *Provider) ensureResponsesWebSocketLocked(ctx context.Context) (*responsesWebSocketConn, error) {
-	token, err := p.authorizationToken()
+func (p *Provider) ensureResponsesWebSocketLocked(ctx context.Context, ri *requestInstrumentation) (*responsesWebSocketConn, error) {
+	token, err := p.authorizationToken(ri)
 	if err != nil {
 		return nil, err
 	}
 	if p.wsConn != nil && token == p.wsAuthToken {
+		ri.markWebSocketReused(true)
+		ri.recordHeaders(0)
 		return p.wsConn, nil
 	}
 	if p.wsConn != nil {
@@ -200,10 +203,18 @@ func (p *Provider) ensureResponsesWebSocketLocked(ctx context.Context) (*respons
 			resp.Body.Close()
 		}
 		if statusCode != 0 {
-			return nil, sanitizedProviderHTTPError("openai websocket connect error", statusCode, body, p.model)
+			httpErr := sanitizedProviderHTTPError("openai websocket connect error", statusCode, body, p.model)
+			ri.classifyHTTPResponse(statusCode, body)
+			ri.recordError(httpErr)
+			return nil, httpErr
 		}
+		ri.recordError(err)
 		return nil, fmt.Errorf("openai websocket connect failed: %w", err)
 	}
+
+	// Dial + handshake completed; record time to "headers" for the WS path.
+	ri.markWebSocketReused(false)
+	ri.recordHeaders(0)
 
 	p.wsConn = &responsesWebSocketConn{conn: conn}
 	p.wsAuthToken = token
@@ -220,7 +231,7 @@ func (p *Provider) resetResponsesWebSocketLocked() {
 	p.wsLastInputSigs = nil
 }
 
-func (p *Provider) sendResponsesCreateLocked(ctx context.Context, conn *responsesWebSocketConn, req *responsesRequest) (*responsesAPIResponse, error) {
+func (p *Provider) sendResponsesCreateLocked(ctx context.Context, conn *responsesWebSocketConn, req *responsesRequest, ri *requestInstrumentation) (*responsesAPIResponse, error) {
 	event := responsesWSCreateEvent{
 		Type:             "response.create",
 		responsesRequest: *req,
@@ -243,6 +254,7 @@ func (p *Provider) sendResponsesCreateLocked(ctx context.Context, conn *response
 	}
 
 	if err := conn.conn.WriteMessage(websocket.TextMessage, payload); err != nil {
+		ri.recordError(err)
 		return nil, fmt.Errorf("openai websocket write failed: %w", err)
 	}
 
@@ -257,12 +269,15 @@ func (p *Provider) sendResponsesCreateLocked(ctx context.Context, conn *response
 
 		_, data, err := conn.conn.ReadMessage()
 		if err != nil {
+			ri.recordError(err)
 			return nil, fmt.Errorf("openai websocket read failed: %w", err)
 		}
 		var event responsesWSEvent
 		if err := json.Unmarshal(data, &event); err != nil {
+			ri.recordError(err)
 			return nil, fmt.Errorf("openai websocket decode failed: %w", err)
 		}
+		ri.recordFirstEvent()
 		if wsDebugEnabled {
 			snippet := data
 			if len(snippet) > 400 {
@@ -276,10 +291,12 @@ func (p *Provider) sendResponsesCreateLocked(ctx context.Context, conn *response
 			// deltas. Forward each chunk so callers (vcr's progress
 			// printer, etc.) can surface the model's thinking live
 			// rather than only seeing a single blob at .done.
+			ri.recordFirstToken()
 			if p.reasoningSummaryHandler != nil && event.Delta != "" {
 				p.reasoningSummaryHandler(event.Delta)
 			}
 		case "response.reasoning_summary_text.done":
+			ri.recordFirstToken()
 			if p.reasoningSummaryHandler != nil && event.Text != "" {
 				p.reasoningSummaryHandler(event.Text)
 			}
@@ -288,11 +305,14 @@ func (p *Provider) sendResponsesCreateLocked(ctx context.Context, conn *response
 			// the terminal response.completed event may arrive with an
 			// empty Output slice. Accumulate completed items so we can
 			// reconstruct the response output.
+			ri.recordFirstToken()
 			if event.Item != nil {
 				streamedItems = append(streamedItems, *event.Item)
 			}
 		case "response.done", "response.completed":
+			ri.recordTerminal()
 			if event.Response == nil {
+				ri.recordError(errors.New("openai websocket: terminal response event missing response payload"))
 				return nil, errors.New("openai websocket: terminal response event missing response payload")
 			}
 			if len(event.Response.Output) == 0 && len(streamedItems) > 0 {
@@ -300,11 +320,17 @@ func (p *Provider) sendResponsesCreateLocked(ctx context.Context, conn *response
 			}
 			return event.Response, nil
 		case "response.incomplete":
-			return nil, responsesIncompleteError(event, p.model)
+			wsErr := responsesIncompleteError(event, p.model)
+			ri.recordError(wsErr)
+			return nil, wsErr
 		case "error":
-			return nil, responsesWebSocketError(event, p.model)
+			wsErr := responsesWebSocketError(event, p.model)
+			ri.recordError(wsErr)
+			return nil, wsErr
 		case "response.failed":
-			return nil, responsesFailedError(event, p.model)
+			wsErr := responsesFailedError(event, p.model)
+			ri.recordError(wsErr)
+			return nil, wsErr
 		default:
 			// Ignore progress/delta events and keep reading.
 		}

--- a/provider/openai/responses_ws_test.go
+++ b/provider/openai/responses_ws_test.go
@@ -552,7 +552,7 @@ func TestRequestViaResponsesWebSocketFallbackPreservesExplicitStoreTrue(t *testi
 			responsesMessage("user", "hello"),
 		},
 	}
-	resp, err := p.requestViaResponsesWithReq(context.Background(), req)
+	resp, err := p.requestViaResponsesWithReq(context.Background(), req, nil)
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
 	}
@@ -934,7 +934,7 @@ func TestSendResponsesCreateLockedUsesFallbackReadTimeoutWithoutContextDeadline(
 		WithBaseURL(server.URL),
 		WithTransport("websocket"),
 	)
-	conn, err := p.ensureResponsesWebSocketLocked(context.Background())
+	conn, err := p.ensureResponsesWebSocketLocked(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("ensure websocket failed: %v", err)
 	}
@@ -948,7 +948,7 @@ func TestSendResponsesCreateLockedUsesFallbackReadTimeoutWithoutContextDeadline(
 	}
 
 	start := time.Now()
-	_, err = p.sendResponsesCreateLocked(context.Background(), conn, req)
+	_, err = p.sendResponsesCreateLocked(context.Background(), conn, req, nil)
 	elapsed := time.Since(start)
 	if err == nil {
 		t.Fatal("expected read timeout error")
@@ -1019,7 +1019,7 @@ func TestSendResponsesCreateLockedRecomputesReadDeadlinePerEvent(t *testing.T) {
 		WithBaseURL(server.URL),
 		WithTransport("websocket"),
 	)
-	conn, err := p.ensureResponsesWebSocketLocked(context.Background())
+	conn, err := p.ensureResponsesWebSocketLocked(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("ensure websocket failed: %v", err)
 	}
@@ -1036,7 +1036,7 @@ func TestSendResponsesCreateLockedRecomputesReadDeadlinePerEvent(t *testing.T) {
 	defer cancel()
 
 	start := time.Now()
-	resp, err := p.sendResponsesCreateLocked(ctx, conn, req)
+	resp, err := p.sendResponsesCreateLocked(ctx, conn, req, nil)
 	elapsed := time.Since(start)
 	if err != nil {
 		t.Fatalf("expected rolling read deadlines to allow progress, got: %v", err)

--- a/provider/openai/sse_transport_test.go
+++ b/provider/openai/sse_transport_test.go
@@ -42,7 +42,7 @@ func TestParseSSEResponses_IgnoresTransportErrorAfterTerminalEvent(t *testing.T)
 	})
 
 	p := New(WithModel("gpt-5"))
-	got, err := p.parseSSEResponses(&http.Response{Body: body})
+	got, err := p.parseSSEResponses(&http.Response{Body: body}, nil)
 	if err != nil {
 		t.Fatalf("parseSSEResponses returned error despite terminal response: %v", err)
 	}
@@ -62,7 +62,7 @@ func TestParseSSEResponses_StillFailsWithoutTerminalEvent(t *testing.T) {
 	})
 
 	p := New(WithModel("gpt-5"))
-	_, err := p.parseSSEResponses(&http.Response{Body: body})
+	_, err := p.parseSSEResponses(&http.Response{Body: body}, nil)
 	if err == nil {
 		t.Fatal("expected parseSSEResponses to fail without a terminal response event")
 	}

--- a/provider/openai/stream.go
+++ b/provider/openai/stream.go
@@ -26,6 +26,12 @@ type streamedResponse struct {
 	done         bool
 	streamErr    error // non-nil if server sent an error mid-stream
 
+	// instrumentation receives per-request latency updates; nil = no-op. It is
+	// finalized exactly once (on Close/EOF). The Chat Completions path does not
+	// capture streaming phase granularity; it only finalizes the trace so the
+	// observer fires for every request.
+	instrumentation *requestInstrumentation
+
 	// State for tracking tool calls being built across deltas.
 	currentParts map[int]core.ModelResponsePart
 	argsBuffers  map[int]*strings.Builder
@@ -36,19 +42,21 @@ type streamedResponse struct {
 }
 
 func newStreamedResponse(body io.ReadCloser, model string) *streamedResponse {
-	return newBoundStreamedResponse(body, model, nil)
+	return newBoundStreamedResponse(body, model, nil, nil)
 }
 
 func newBoundStreamedResponse(
 	body io.ReadCloser,
 	model string,
 	resolveModel func(string) (string, error),
+	ri *requestInstrumentation,
 ) *streamedResponse {
 	return &streamedResponse{
 		reader:            bufio.NewReader(body),
 		body:              body,
 		model:             model,
 		resolveModel:      resolveModel,
+		instrumentation:   ri,
 		currentParts:      make(map[int]core.ModelResponsePart),
 		argsBuffers:       make(map[int]*strings.Builder),
 		toolCallPartIndex: make(map[int]int),
@@ -121,13 +129,18 @@ func (s *streamedResponse) Next() (core.ModelResponseStreamEvent, error) {
 					s.done = true
 					if modelErr := s.finalizeModelIdentity(); modelErr != nil {
 						s.streamErr = modelErr
+						s.instrumentation.recordError(modelErr)
+						s.instrumentation.finish()
 						return nil, modelErr
 					}
 					s.finalizeAll()
+					s.instrumentation.finish()
 					return nil, io.EOF
 				}
 				// Data received with EOF; process this line, finalize on next read.
 			} else {
+				s.instrumentation.recordError(err)
+				s.instrumentation.finish()
 				return nil, err
 			}
 		}
@@ -148,9 +161,12 @@ func (s *streamedResponse) Next() (core.ModelResponseStreamEvent, error) {
 			s.done = true
 			if err := s.finalizeModelIdentity(); err != nil {
 				s.streamErr = err
+				s.instrumentation.recordError(err)
+				s.instrumentation.finish()
 				return nil, err
 			}
 			s.finalizeAll()
+			s.instrumentation.finish()
 			return nil, io.EOF
 		}
 
@@ -165,6 +181,8 @@ func (s *streamedResponse) Next() (core.ModelResponseStreamEvent, error) {
 				if err != nil {
 					s.done = true
 					s.streamErr = err
+					s.instrumentation.recordError(err)
+					s.instrumentation.finish()
 					return nil, err
 				}
 			}
@@ -178,6 +196,9 @@ func (s *streamedResponse) Next() (core.ModelResponseStreamEvent, error) {
 			s.finalizeAll()
 			classification := classifyProviderError(chunk.Error.Type, chunk.Error.Message)
 			s.streamErr = fmt.Errorf("openai stream error (%s)", classification)
+			s.instrumentation.classifyHTTPResponse(0, classification)
+			s.instrumentation.recordError(s.streamErr)
+			s.instrumentation.finish()
 			return nil, s.streamErr
 		}
 
@@ -372,6 +393,7 @@ func (s *streamedResponse) Usage() core.Usage {
 
 // Close releases resources.
 func (s *streamedResponse) Close() error {
+	s.instrumentation.finish()
 	return s.body.Close()
 }
 


### PR DESCRIPTION
## Summary

Closes #242.

Issue #242 reports high latency in ChatGPT OAuth-backed OpenAI requests and asks for an **instrumented comparison before changing behavior** — explicitly noting that the incomplete ChatGPT account-claim parsing is *probably not* the latency root cause and that OAuth parity should be tracked separately.

This PR adds **opt-in, credential-safe per-request phase timing** across all three ChatGPT provider paths (HTTP `Request`, HTTP `RequestStream`, WebSocket), plus a reproducible benchmark and a runnable evidence harness — **with no transport default change**.

## What it adds

**New public API (`provider/openai`):**
- `RequestTrace` — sizes/timings/sanitized markers only: token refresh duration, request bytes/input items, time-to-headers, time-to-first-event, time-to-first-token, time-to-terminal, HTTP status, sanitized error classification, `Retry-After`, coarse error class, websocket-connection-reuse, `previous_response_id` reuse, and a prompt-cache-key fingerprint (`sha256[:8]`, never the key).
- `RequestObserver` + `WithRequestObserver` — invoked once per physical request; nil is a fully no-op, zero-overhead path.
- `DefaultStderrRequestObserver` + `OPENAI_REQUEST_TRACE=1` (read at `New()` time) for lowest-friction enablement.

**Credential safety (acceptance criterion #3):** the trace never carries tokens, account IDs, auth URLs, callback queries, device codes, request content, or raw provider error bodies. Errors reuse the existing `classifyProviderError` markers. A dedicated test asserts none of a known token/account-id/refresh-token/device-code appears in the marshaled or rendered trace.

**Threading:** a per-request accumulator (nil when no observer) is created at the top of `Request`/`RequestStream` and finalized via defer/stream lifecycle, covering error paths and staying race-free for concurrent use. It threads through `authorizationToken` (refresh timing — one edit covers HTTP + WS), `doRequest`/`setHeaders` (TTFB, upload bytes, status, sanitized errors), `parseSSEResponses` (first-event, first-token, terminal), the Responses streamed response (first-token, terminal, finalize), and the websocket dial/send/read loop (dial/reuse, first-event, first-token, terminal, continuation).

## Acceptance criteria mapping

1. **Reproducible trace** → observer captures every requested phase; benchmarks + harness produce reproducible numbers.
2. **Refresh vs upload vs backend vs streaming vs retry** → `TokenRefreshDuration`, `RequestBytes`, `TimeToFirstEvent − TimeToHeaders`, `TimeToTerminal − TimeToFirstToken`; inter-request gaps visible as separate traces. (modelutil-level retry granularity is noted as follow-up if finer detail is needed.)
3. **No credentials logged** → by construction + dedicated test.
4. **Regression tests + evidence; no default change** → `instrumentation_test.go` covers all three paths; **no transport default change**. Any default proposal (e.g. websocket-by-default for ChatGPT) is tracked as follow-up *pending* the evidence this tooling produces.
5. **OAuth parity tracked separately** → called out in the example README and below; not implemented here.

## New files
- `provider/openai/instrumentation.go` — trace types, observer, accumulator, stderr dumper.
- `provider/openai/instrumentation_test.go` — all three paths (delay-injected fakes), credential-safety assertion, nil no-op, refresh-timing, sanitized error classification.
- `provider/openai/latency_bench_test.go` — the repo's first benchmarks: per-transport request latency + instrumentation-overhead isolation.
- `examples/openai-latency/{main.go,README.md}` — runnable before/after evidence harness.

## Follow-ups (explicitly tracked separately, per the issue)
- Canonical ChatGPT account-claim parsing (`https://api.openai.com/auth` object: `chatgpt_account_id`, plan type, user ID, FedRAMP routing) for OAuth parity.
- Refresh/recovery parity (JSON refresh grants, serialized refreshes, guarded credential reload, 401 recovery via reload → refresh → retry).
- Any transport-default change — to be evaluated only with the evidence this harness produces.

## Verification
- `go build ./...`
- `go test -race -count=1 ./provider/openai/ ./auth/openai/` ✅
- `go vet ./...` ✅
- `golangci-lint run ./provider/openai/ ./examples/openai-latency/` → 0 issues
- Benchmarks: `go test -bench=. -benchmem ./provider/openai/` (instrumentation overhead ≈ 3 extra allocs / ~2KB per request)
