### PR TITLE
Add restart-safe app-server recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Restart-safe app-server retry and daemon ownership.** File-backed app-server
+  daemons now hold one process-lifetime store lock and reconcile queued or
+  running turns to an inspectable interrupted state after owner loss. The
+  generated `turn/retry` extension requires an idempotency key, atomically
+  creates or reuses one retry turn, preserves the recorded source prompt and
+  model selection, and bounds model-visible replay after the latest
+  compaction. Recovery never recreates pending approval authority or silently
+  treats prior tool side effects as resumed.
 - **Typed app-server catalog and run-lifecycle bindings.** Generated clients
   can now infer provider/model discovery, thread and turn start, turn
   interruption, thread/turn lifecycle notifications, and live text/reasoning

--- a/appserver/protocol/README.md
+++ b/appserver/protocol/README.md
@@ -293,11 +293,11 @@ result after process exit.
 Generated clients can discover providers and models, start and interrupt live
 runs, and consume the current streaming lifecycle without an untyped JSON
 escape hatch. `provider/list` and `model/list` bind the provider-aware catalog
-records; `thread/start`, `turn/start`, and `turn/interrupt` bind durable
-thread/turn results; and `thread/started`, `turn/started`, `turn/completed`,
-`item/agentMessage/delta`, and `item/reasoning/textDelta` bind the live
-notification records. The registry now contains 69 method bindings and five
-durable item bindings.
+records; `thread/start`, `turn/start`, `turn/retry`, and `turn/interrupt` bind
+durable thread/turn results; and `thread/started`, `turn/started`,
+`turn/completed`, `item/agentMessage/delta`, and
+`item/reasoning/textDelta` bind the live notification records. The registry
+now contains 70 method bindings and five durable item bindings.
 
 The live names are intentionally explicit: `ModelCatalog*`, `ThreadRun*`,
 `TurnRun*`, and `Runtime*`. Exact standalone public `ModelList*`,
@@ -513,6 +513,20 @@ response requires turn id. The current live handler instead accepts turn-id and
 prompt aliases, does not enforce the public active-turn precondition, persists
 a durable steer item, and returns richer status fields, so these definitions
 remain outside method bindings pending a separate compatibility migration.
+
+`TurnRunRetryParams` and `TurnRunRetryResult` define Gollem's restart-safe
+retry extension. Typed clients must persist a non-empty idempotency key before
+calling `turn/retry`; replaying the same source-turn/key pair returns the same
+durable retry turn without another model invocation. A key already bound to a
+different source fails closed. Retry requires a terminal source and creates a
+new turn whose `retryOfTurnId` and `retryIdempotencyKey` remain visible through
+durable thread reads; it does not claim same-turn execution resume, recreate
+pending approval authority, or silently treat prior tool side effects as
+resumed. A new model attempt can independently request the same mutation again,
+so clients must present that consequence before retrying a turn with incomplete
+tool work. On daemon startup, the process-lifetime store owner terminalizes
+stale queued or running turns with a stable owner-loss reason and one durable
+`runtimeRecovery` marker before accepting a transport.
 
 Exact standalone `TurnPlanStepStatus`, `TurnPlanStep`, and
 `TurnPlanUpdatedNotification` establish the fixed turn-level plan snapshot.

--- a/appserver/protocol/account_credit_nudge_values_contract_test.go
+++ b/appserver/protocol/account_credit_nudge_values_contract_test.go
@@ -119,14 +119,14 @@ func TestAccountCreditNudgeValuesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/sendAddCreditsNudgeEmail = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/account_envelope_contract_test.go
+++ b/appserver/protocol/account_envelope_contract_test.go
@@ -268,11 +268,11 @@ func TestAccountEnvelopeContractsRemainStandaloneAndDeferred(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred %s", methodName, method, ok, surface)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
-	if len(Methods()) != 224 || len(WireTypeBindings()) != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 224/69/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(Methods()) != 224 || len(WireTypeBindings()) != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 224/70/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/account_login_completed_notification_contract_test.go
+++ b/appserver/protocol/account_login_completed_notification_contract_test.go
@@ -88,14 +88,14 @@ func TestAccountLoginCompletedNotificationRemainsStandaloneAndDeferred(t *testin
 	if !found {
 		t.Fatal("account/login/completed method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/account_rate_limits_contract_test.go
+++ b/appserver/protocol/account_rate_limits_contract_test.go
@@ -484,14 +484,14 @@ func TestAccountRateLimitContractsRemainStandaloneAndDeferred(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred %s", methodName, method, ok, surface)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/account_token_usage_contract_test.go
+++ b/appserver/protocol/account_token_usage_contract_test.go
@@ -146,14 +146,14 @@ func TestAccountTokenUsageRecordsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/usage/read = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,14 +148,14 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(defs); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,14 +54,14 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_config_contract_test.go
+++ b/appserver/protocol/app_config_contract_test.go
@@ -109,14 +109,14 @@ func TestAppConfigRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppConfig unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_info_contract_test.go
+++ b/appserver/protocol/app_info_contract_test.go
@@ -131,14 +131,14 @@ func TestAppInfoRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_list_updated_notification_contract_test.go
+++ b/appserver/protocol/app_list_updated_notification_contract_test.go
@@ -105,14 +105,14 @@ func TestAppListUpdatedNotificationRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceServerNotification || method.State != MethodDeferredStub {
 		t.Fatalf("app/list/updated = %#v, %v; want deferred server notification", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_metadata_contract_test.go
+++ b/appserver/protocol/app_metadata_contract_test.go
@@ -107,14 +107,14 @@ func TestAppMetadataRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_metadata_leaf_contract_test.go
+++ b/appserver/protocol/app_metadata_leaf_contract_test.go
@@ -157,14 +157,14 @@ func TestAppMetadataLeavesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_summary_contract_test.go
+++ b/appserver/protocol/app_summary_contract_test.go
@@ -87,14 +87,14 @@ func TestAppSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppSummary unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_template_summary_contract_test.go
+++ b/appserver/protocol/app_template_summary_contract_test.go
@@ -107,14 +107,14 @@ func TestAppTemplateSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppTemplateSummary unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_template_unavailable_reason_contract_test.go
+++ b/appserver/protocol/app_template_unavailable_reason_contract_test.go
@@ -71,14 +71,14 @@ func TestAppTemplateUnavailableReasonRemainsStandalone(t *testing.T) {
 			t.Fatalf("AppTemplateUnavailableReason unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_tool_approval_contract_test.go
+++ b/appserver/protocol/app_tool_approval_contract_test.go
@@ -73,14 +73,14 @@ func TestAppToolApprovalRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppToolApproval unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_tools_config_contract_test.go
+++ b/appserver/protocol/app_tools_config_contract_test.go
@@ -140,14 +140,14 @@ func TestAppToolConfigsRemainStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/apply_patch_approval_params_contract_test.go
+++ b/appserver/protocol/apply_patch_approval_params_contract_test.go
@@ -139,14 +139,14 @@ func TestApplyPatchApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ApplyPatchApprovalParams unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(defs); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(defs); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/apps_config_contract_test.go
+++ b/appserver/protocol/apps_config_contract_test.go
@@ -185,14 +185,14 @@ func TestAppsConfigsRemainStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/apps_list_contract_test.go
+++ b/appserver/protocol/apps_list_contract_test.go
@@ -168,14 +168,14 @@ func TestAppsListContractsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/attestation_contract_test.go
+++ b/appserver/protocol/attestation_contract_test.go
@@ -133,14 +133,14 @@ func TestAttestationContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("attestation/generate = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,14 +74,14 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,14 +52,14 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/bindings.go
+++ b/appserver/protocol/bindings.go
@@ -84,6 +84,7 @@ var wireTypeBindings = []WireTypeBinding{
 	{Method: "turn/completed", Surface: SurfaceServerNotification, Params: []string{"RuntimeTurnNotification"}},
 	{Method: "turn/diff/updated", Surface: SurfaceServerNotification, Params: []string{"TurnDiffUpdatedNotification"}},
 	{Method: "turn/interrupt", Surface: SurfaceClientRequest, Params: []string{"TurnRunInterruptParams"}, Result: []string{"TurnRunInterruptResult"}},
+	{Method: "turn/retry", Surface: SurfaceGollemExtension, Params: []string{"TurnRunRetryParams"}, Result: []string{"TurnRunRetryResult"}},
 	{Method: "turn/start", Surface: SurfaceClientRequest, Params: []string{"TurnRunStartParams"}, Result: []string{"TurnRunStartResult"}},
 	{Method: "turn/started", Surface: SurfaceServerNotification, Params: []string{"RuntimeTurnNotification"}},
 }

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,14 +148,14 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
+++ b/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
@@ -179,14 +179,14 @@ func TestChatgptAuthTokensRefreshRemainsStandaloneAndDeferred(t *testing.T) {
 	if !found {
 		t.Fatal("refresh method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/collaboration_capability_contract_test.go
+++ b/appserver/protocol/collaboration_capability_contract_test.go
@@ -346,14 +346,14 @@ func TestCollaborationCapabilityContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,14 +102,14 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,14 +217,14 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,14 +146,14 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,14 +321,14 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,14 +67,14 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,14 +200,14 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,14 +228,14 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,11 +169,11 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,14 +332,14 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/dynamic_tool_spec_contract_test.go
+++ b/appserver/protocol/dynamic_tool_spec_contract_test.go
@@ -318,14 +318,14 @@ func TestDynamicToolSpecContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/exec_command_approval_params_contract_test.go
+++ b/appserver/protocol/exec_command_approval_params_contract_test.go
@@ -137,14 +137,14 @@ func TestExecCommandApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ExecCommandApprovalParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(defs); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/experimental_feature_contract_test.go
+++ b/appserver/protocol/experimental_feature_contract_test.go
@@ -41,11 +41,11 @@ func TestExperimentalFeatureContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want implemented client request", methodName, method, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
-	if len(Methods()) != 224 || len(WireTypeBindings()) != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("counts = %d/%d/%d, want 224/69/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(Methods()) != 224 || len(WireTypeBindings()) != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("counts = %d/%d/%d, want 224/70/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,14 +217,14 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,14 +203,14 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -260,14 +260,14 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,14 +244,14 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -162,14 +162,14 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -175,14 +175,14 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,14 +186,14 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,14 +84,14 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/file_change_contract_test.go
+++ b/appserver/protocol/file_change_contract_test.go
@@ -108,14 +108,14 @@ func TestFileChangeRemainsStandalone(t *testing.T) {
 			t.Fatalf("FileChange unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/file_change_output_delta_notification_contract_test.go
+++ b/appserver/protocol/file_change_output_delta_notification_contract_test.go
@@ -100,14 +100,14 @@ func TestFileChangeOutputDeltaNotificationRemainsDeprecatedAndStandalone(t *test
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("item/fileChange/outputDelta = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -381,14 +381,14 @@ func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/guardian_approval_review_action_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_action_contract_test.go
@@ -226,14 +226,14 @@ func TestGuardianApprovalReviewActionRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReviewAction unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
@@ -164,14 +164,14 @@ func TestGuardianApprovalReviewCompletedNotificationRemainsStandalone(t *testing
 			t.Fatalf("completed notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 	for _, method := range Methods() {
 		if (method.Method == "item/autoApprovalReview/started" ||

--- a/appserver/protocol/guardian_approval_review_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_contract_test.go
@@ -139,14 +139,14 @@ func TestGuardianApprovalReviewRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReview unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
@@ -175,14 +175,14 @@ func TestGuardianApprovalReviewStartedNotificationRemainsStandalone(t *testing.T
 			t.Fatalf("started notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 	for _, method := range Methods() {
 		if method.Method == "item/autoApprovalReview/started" && method.State != MethodBlocked {

--- a/appserver/protocol/guardian_enum_foundation_contract_test.go
+++ b/appserver/protocol/guardian_enum_foundation_contract_test.go
@@ -89,14 +89,14 @@ func TestGuardianEnumFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/hook_metadata_list_contract_test.go
+++ b/appserver/protocol/hook_metadata_list_contract_test.go
@@ -352,11 +352,11 @@ func TestHookMetadataListContractsStayStandalone(t *testing.T) {
 			t.Errorf("standalone definition %s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Errorf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Errorf("definition count = %d, want 551", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 {
-		t.Errorf("wire binding count = %d, want 69", got)
+	if got := len(WireTypeBindings()); got != 70 {
+		t.Errorf("wire binding count = %d, want 70", got)
 	}
 	if got := len(ItemPayloadBindings()); got != 5 {
 		t.Errorf("item binding count = %d, want 5", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,14 +102,14 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/hook_run_notification_contract_test.go
+++ b/appserver/protocol/hook_run_notification_contract_test.go
@@ -297,10 +297,10 @@ func TestHookRunNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
-	if len(Methods()) != 224 || len(WireTypeBindings()) != 69 || len(ItemPayloadBindings()) != 5 {
+	if len(Methods()) != 224 || len(WireTypeBindings()) != 70 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("surface changed: %d methods, %d wire bindings, %d item bindings", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 }

--- a/appserver/protocol/hook_value_foundation_contract_test.go
+++ b/appserver/protocol/hook_value_foundation_contract_test.go
@@ -167,14 +167,14 @@ func TestHookValueFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,11 +223,11 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,11 +159,11 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 549 {
-		t.Fatalf("definition count = %d, want 549", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 551 {
+		t.Fatalf("definition count = %d, want 551", len(JSONSchema()["$defs"].(Schema)))
 	}
-	if len(WireTypeBindings()) != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(WireTypeBindings()) != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 
 	generated, err := MarshalTypeScript()

--- a/appserver/protocol/legacy_approval_response_contract_test.go
+++ b/appserver/protocol/legacy_approval_response_contract_test.go
@@ -98,14 +98,14 @@ func TestLegacyApprovalResponsesRemainStandaloneAndNominal(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,14 +127,14 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,14 +276,14 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,14 +57,14 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,14 +70,14 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,14 +227,14 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,14 +74,14 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,14 +114,14 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,14 +130,14 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,14 +148,14 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,14 +102,14 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_oauth_login_contract_test.go
+++ b/appserver/protocol/mcp_server_oauth_login_contract_test.go
@@ -228,11 +228,11 @@ func TestMcpServerOauthLoginContractsRemainStandaloneAndBlocked(t *testing.T) {
 	if !ok || notification.Surface != SurfaceServerNotification || notification.State != MethodBlocked {
 		t.Fatalf("mcpServer/oauthLogin/completed = %#v, %v; want blocked server notification", notification, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
-	if len(Methods()) != 224 || len(WireTypeBindings()) != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("counts = %d/%d/%d, want 224/69/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(Methods()) != 224 || len(WireTypeBindings()) != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("counts = %d/%d/%d, want 224/70/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,14 +70,14 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,14 +116,14 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_status_contract_test.go
+++ b/appserver/protocol/mcp_server_status_contract_test.go
@@ -277,11 +277,11 @@ func TestMcpServerStatusContractsRemainStandalone(t *testing.T) {
 	if !ok || method.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
-	if len(Methods()) != 224 || len(WireTypeBindings()) != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("counts = %d/%d/%d, want 224/69/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(Methods()) != 224 || len(WireTypeBindings()) != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("counts = %d/%d/%d, want 224/70/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,14 +69,14 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,14 +125,14 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,14 +140,14 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,14 +134,14 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,14 +168,14 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,14 +184,14 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,14 +235,14 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,11 +201,11 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,14 +140,14 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,14 +159,14 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,11 +248,11 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/network_approval_context_contract_test.go
+++ b/appserver/protocol/network_approval_context_contract_test.go
@@ -84,14 +84,14 @@ func TestNetworkApprovalContextRemainsStandalone(t *testing.T) {
 			t.Fatalf("NetworkApprovalContext unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,14 +163,14 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/parsed_command_contract_test.go
+++ b/appserver/protocol/parsed_command_contract_test.go
@@ -120,14 +120,14 @@ func TestParsedCommandRemainsStandalone(t *testing.T) {
 			t.Fatalf("ParsedCommand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/permission_profile_list_contract_test.go
+++ b/appserver/protocol/permission_profile_list_contract_test.go
@@ -255,11 +255,11 @@ func TestPermissionProfileListContractsRemainStandalone(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodImplemented {
 		t.Fatalf("permissionProfile/list = %#v, %v; want existing implemented client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
-	if len(Methods()) != 224 || len(WireTypeBindings()) != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("counts = %d/%d/%d, want 224/69/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(Methods()) != 224 || len(WireTypeBindings()) != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("counts = %d/%d/%d, want 224/70/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,14 +127,14 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/process_contracts_contract_test.go
+++ b/appserver/protocol/process_contracts_contract_test.go
@@ -308,14 +308,14 @@ func TestProcessContractsRemainStandaloneFromLegacyRuntime(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want unchanged implemented notification", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,14 +258,14 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,11 +197,11 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 549 {
-		t.Fatalf("definition count = %d, want 549", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 551 {
+		t.Fatalf("definition count = %d, want 551", len(JSONSchema()["$defs"].(Schema)))
 	}
-	if len(WireTypeBindings()) != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(WireTypeBindings()) != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 	names := []string{
 		"ThreadStartedNotification", "ThreadStatusChangedNotification",

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,11 +204,11 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 549 {
-		t.Fatalf("definition count = %d, want 549", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 551 {
+		t.Fatalf("definition count = %d, want 551", len(JSONSchema()["$defs"].(Schema)))
 	}
-	if len(WireTypeBindings()) != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(WireTypeBindings()) != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 	for _, binding := range WireTypeBindings() {
 		if slices.Contains(binding.Params, "Thread") || slices.Contains(binding.Result, "Thread") {

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,11 +197,11 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 549 {
-		t.Fatalf("definition count = %d, want 549", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 551 {
+		t.Fatalf("definition count = %d, want 551", len(JSONSchema()["$defs"].(Schema)))
 	}
-	if len(bindings) != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", len(bindings), len(ItemPayloadBindings()))
+	if len(bindings) != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", len(bindings), len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,11 +146,11 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 549 {
-		t.Fatalf("definition count = %d, want 549", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 551 {
+		t.Fatalf("definition count = %d, want 551", len(JSONSchema()["$defs"].(Schema)))
 	}
-	if len(WireTypeBindings()) != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(WireTypeBindings()) != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 	for _, binding := range WireTypeBindings() {
 		if slices.Contains(binding.Params, "Turn") || slices.Contains(binding.Result, "Turn") {

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,11 +94,11 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 549 {
-		t.Fatalf("definition count = %d, want 549", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 551 {
+		t.Fatalf("definition count = %d, want 551", len(JSONSchema()["$defs"].(Schema)))
 	}
-	if len(WireTypeBindings()) != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(WireTypeBindings()) != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 
 	generated, err := MarshalTypeScript()

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,14 +159,14 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/review_decision_contract_test.go
+++ b/appserver/protocol/review_decision_contract_test.go
@@ -136,14 +136,14 @@ func TestReviewDecisionRemainsStandalone(t *testing.T) {
 			t.Fatalf("ReviewDecision unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(defs); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/runtime_client_types.go
+++ b/appserver/protocol/runtime_client_types.go
@@ -167,6 +167,24 @@ type TurnRunStartResult struct {
 	Turn   TurnRecord   `json:"turn"`
 }
 
+// TurnRunRetryParams is Gollem's exact idempotent retry request. Legacy
+// untyped clients may omit idempotencyKey at the handler boundary, but typed
+// clients must supply one so a lost response cannot duplicate model work.
+type TurnRunRetryParams struct {
+	TurnID         string         `json:"turnId"`
+	IdempotencyKey string         `json:"idempotencyKey"`
+	Prompt         string         `json:"prompt,omitempty"`
+	Metadata       map[string]any `json:"metadata,omitempty"`
+	RuntimeModelParams
+}
+
+type TurnRunRetryResult struct {
+	Turn           TurnRecord `json:"turn"`
+	SourceTurnID   string     `json:"sourceTurnId"`
+	IdempotencyKey string     `json:"idempotencyKey"`
+	Reused         bool       `json:"reused"`
+}
+
 type TurnRunInterruptParams struct {
 	ID       string `json:"id,omitempty"`
 	TurnID   string `json:"turnId,omitempty"`

--- a/appserver/protocol/runtime_recovery_contract_test.go
+++ b/appserver/protocol/runtime_recovery_contract_test.go
@@ -1,0 +1,109 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestTurnRunRetryContractIsGeneratedAndBound(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	params := defs["TurnRunRetryParams"].(Schema)
+	assertClosedObjectSchema(t, params, "turnId", "idempotencyKey")
+	assertRecoverySchemaKeys(t, params,
+		"turnId",
+		"idempotencyKey",
+		"prompt",
+		"metadata",
+		"providerId",
+		"provider",
+		"model",
+		"maxTokens",
+		"temperature",
+		"topP",
+		"thinkingBudget",
+		"adaptiveThinking",
+		"reasoningEffort",
+		"stopSequences",
+		"settings",
+		"input",
+	)
+	result := defs["TurnRunRetryResult"].(Schema)
+	assertClosedObjectSchema(t, result, "turn", "sourceTurnId", "idempotencyKey", "reused")
+	assertRecoverySchemaKeys(t, result,
+		"turn",
+		"sourceTurnId",
+		"idempotencyKey",
+		"reused",
+	)
+	turn := defs["TurnRecord"].(Schema)
+	turnProperties := turn["properties"].(Schema)
+	for _, key := range []string{"retryOfTurnId", "retryIdempotencyKey"} {
+		if _, ok := turnProperties[key]; !ok {
+			t.Fatalf("TurnRecord schema is missing %q: %#v", key, turnProperties)
+		}
+	}
+
+	var binding WireTypeBinding
+	for _, candidate := range WireTypeBindings() {
+		if candidate.Method == "turn/retry" {
+			binding = candidate
+			break
+		}
+	}
+	if binding.Method == "" {
+		t.Fatal("turn/retry binding is missing")
+	}
+	if !reflect.DeepEqual(binding.Params, []string{"TurnRunRetryParams"}) ||
+		!reflect.DeepEqual(binding.Result, []string{"TurnRunRetryResult"}) {
+		t.Fatalf("turn/retry binding = %#v", binding)
+	}
+
+	valid := TurnRunRetryParams{
+		TurnID:         "turn-1",
+		IdempotencyKey: "retry-1",
+		Prompt:         "try again",
+	}
+	encoded, err := json.Marshal(valid)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if string(encoded) != `{"turnId":"turn-1","idempotencyKey":"retry-1","prompt":"try again"}` {
+		t.Fatalf("encoded params = %s", encoded)
+	}
+
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	ts := string(generated)
+	for _, want := range []string{
+		`export type TurnRunRetryParams = {`,
+		`"idempotencyKey": string;`,
+		`"turnId": string;`,
+		`export type TurnRunRetryResult = {`,
+		`"reused": boolean;`,
+		`"sourceTurnId": string;`,
+		`"retryIdempotencyKey"?: string;`,
+		`"retryOfTurnId"?: string;`,
+		`"turn/retry": TurnRunRetryParams;`,
+	} {
+		if !strings.Contains(ts, want) {
+			t.Fatalf("generated TypeScript missing %q", want)
+		}
+	}
+}
+
+func assertRecoverySchemaKeys(t *testing.T, schema Schema, keys ...string) {
+	t.Helper()
+	properties := schema["properties"].(Schema)
+	if len(properties) != len(keys) {
+		t.Fatalf("schema properties = %#v, want %v", properties, keys)
+	}
+	for _, key := range keys {
+		if _, ok := properties[key]; !ok {
+			t.Fatalf("schema is missing property %q: %#v", key, properties)
+		}
+	}
+}

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -590,6 +590,8 @@ func wireSchemaDefinitions() Schema {
 		{Name: "TurnRecord", Type: reflect.TypeFor[TurnRecord]()},
 		{Name: "TurnRunInterruptParams", Type: reflect.TypeFor[TurnRunInterruptParams]()},
 		{Name: "TurnRunInterruptResult", Type: reflect.TypeFor[TurnRunInterruptResult]()},
+		{Name: "TurnRunRetryParams", Type: reflect.TypeFor[TurnRunRetryParams]()},
+		{Name: "TurnRunRetryResult", Type: reflect.TypeFor[TurnRunRetryResult]()},
 		{Name: "TurnRunStartParams", Type: reflect.TypeFor[TurnRunStartParams]()},
 		{Name: "TurnRunStartResult", Type: reflect.TypeFor[TurnRunStartResult]()},
 		{Name: "TurnStartParams", Type: reflect.TypeFor[TurnStartParams]()},

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -17800,6 +17800,12 @@
           ]
         },
         "result": {},
+        "retryIdempotencyKey": {
+          "type": "string"
+        },
+        "retryOfTurnId": {
+          "type": "string"
+        },
         "startedAt": {
           "format": "date-time",
           "type": "string"
@@ -17873,6 +17879,154 @@
       "required": [
         "ok",
         "turnId"
+      ],
+      "type": "object"
+    },
+    "TurnRunRetryParams": {
+      "additionalProperties": false,
+      "properties": {
+        "adaptiveThinking": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "input": {},
+        "maxTokens": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "metadata": {
+          "anyOf": [
+            {
+              "additionalProperties": {},
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "model": {
+          "type": "string"
+        },
+        "prompt": {
+          "type": "string"
+        },
+        "provider": {
+          "type": "string"
+        },
+        "providerId": {
+          "type": "string"
+        },
+        "reasoningEffort": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "settings": {
+          "anyOf": [
+            {
+              "additionalProperties": {},
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "stopSequences": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "temperature": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "thinkingBudget": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "topP": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "turnId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "turnId",
+        "idempotencyKey"
+      ],
+      "type": "object"
+    },
+    "TurnRunRetryResult": {
+      "additionalProperties": false,
+      "properties": {
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "reused": {
+          "type": "boolean"
+        },
+        "sourceTurnId": {
+          "type": "string"
+        },
+        "turn": {
+          "$ref": "#/$defs/TurnRecord"
+        }
+      },
+      "required": [
+        "turn",
+        "sourceTurnId",
+        "idempotencyKey",
+        "reused"
       ],
       "type": "object"
     },
@@ -20704,6 +20858,16 @@
       ],
       "result": [
         "TurnRunInterruptResult"
+      ]
+    },
+    {
+      "method": "turn/retry",
+      "surface": "gollem-extension",
+      "params": [
+        "TurnRunRetryParams"
+      ],
+      "result": [
+        "TurnRunRetryResult"
       ]
     },
     {

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,14 +128,14 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,14 +102,14 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,14 +102,14 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
 	if got := len(Methods()); got != 224 {
 		t.Fatalf("methods = %d, want 224", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,11 +387,11 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 549 {
-		t.Fatalf("definition count = %d, want 549", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 551 {
+		t.Fatalf("definition count = %d, want 551", len(JSONSchema()["$defs"].(Schema)))
 	}
-	if len(WireTypeBindings()) != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(WireTypeBindings()) != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 	for _, binding := range WireTypeBindings() {
 		if slices.Contains(binding.Params, "ThreadItem") || slices.Contains(binding.Result, "ThreadItem") {

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,11 +94,11 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,11 +273,11 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,11 +194,11 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -247,11 +247,11 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 	if !foundRuntimeStart {
 		t.Error("thread/start runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -150,11 +150,11 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 	if !foundRuntimeStart {
 		t.Error("thread/start runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,11 +311,11 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 549 {
-		t.Fatalf("definition count = %d, want 549", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 551 {
+		t.Fatalf("definition count = %d, want 551", len(JSONSchema()["$defs"].(Schema)))
 	}
-	if len(WireTypeBindings()) != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(WireTypeBindings()) != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 
 	generated, err := MarshalTypeScript()

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,11 +220,11 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 549 {
-		t.Fatalf("definition count = %d, want 549", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 551 {
+		t.Fatalf("definition count = %d, want 551", len(JSONSchema()["$defs"].(Schema)))
 	}
-	if len(WireTypeBindings()) != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(WireTypeBindings()) != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 
 	generated, err := MarshalTypeScript()

--- a/appserver/protocol/thread_types.go
+++ b/appserver/protocol/thread_types.go
@@ -145,19 +145,21 @@ type ThreadRecord struct {
 }
 
 type TurnRecord struct {
-	ID          string              `json:"id"`
-	ThreadID    string              `json:"threadId"`
-	Status      TurnLifecycleStatus `json:"status"`
-	Input       json.RawMessage     `json:"input,omitempty"`
-	Result      json.RawMessage     `json:"result,omitempty"`
-	Error       string              `json:"error,omitempty"`
-	Usage       map[string]any      `json:"usage,omitempty"`
-	Metadata    map[string]any      `json:"metadata,omitempty"`
-	CreatedAt   time.Time           `json:"createdAt"`
-	UpdatedAt   time.Time           `json:"updatedAt"`
-	StartedAt   time.Time           `json:"startedAt,omitempty"`
-	CompletedAt time.Time           `json:"completedAt,omitempty"`
-	Items       []TimelineItem      `json:"items,omitempty" jsonschema:"nonnullable=true"`
+	ID                  string              `json:"id"`
+	ThreadID            string              `json:"threadId"`
+	Status              TurnLifecycleStatus `json:"status"`
+	Input               json.RawMessage     `json:"input,omitempty"`
+	Result              json.RawMessage     `json:"result,omitempty"`
+	Error               string              `json:"error,omitempty"`
+	Usage               map[string]any      `json:"usage,omitempty"`
+	Metadata            map[string]any      `json:"metadata,omitempty"`
+	CreatedAt           time.Time           `json:"createdAt"`
+	UpdatedAt           time.Time           `json:"updatedAt"`
+	StartedAt           time.Time           `json:"startedAt,omitempty"`
+	CompletedAt         time.Time           `json:"completedAt,omitempty"`
+	RetryOfTurnID       string              `json:"retryOfTurnId,omitempty"`
+	RetryIdempotencyKey string              `json:"retryIdempotencyKey,omitempty"`
+	Items               []TimelineItem      `json:"items,omitempty" jsonschema:"nonnullable=true"`
 }
 
 // ThreadListResult adds Codex-compatible data/cursor fields while retaining

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -119,11 +119,11 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 	if !foundRuntimeBinding {
 		t.Error("turn/interrupt runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,11 +209,11 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -241,11 +241,11 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 	if !foundRuntimeBinding {
 		t.Error("turn/start runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,11 +156,11 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -4066,6 +4066,8 @@ export type TurnRecord = {
   "items"?: Array<TimelineItem>;
   "metadata"?: Record<string, unknown> | null;
   "result"?: unknown;
+  "retryIdempotencyKey"?: string;
+  "retryOfTurnId"?: string;
   "startedAt"?: string;
   "status": TurnLifecycleStatus;
   "threadId": string;
@@ -4083,6 +4085,32 @@ export type TurnRunInterruptResult = {
   "ok": boolean;
   "turn"?: TurnRecord | null;
   "turnId": string;
+};
+
+export type TurnRunRetryParams = {
+  "adaptiveThinking"?: boolean | null;
+  "idempotencyKey": string;
+  "input"?: unknown;
+  "maxTokens"?: number | null;
+  "metadata"?: Record<string, unknown> | null;
+  "model"?: string;
+  "prompt"?: string;
+  "provider"?: string;
+  "providerId"?: string;
+  "reasoningEffort"?: string | null;
+  "settings"?: Record<string, unknown> | null;
+  "stopSequences"?: Array<string> | null;
+  "temperature"?: number | null;
+  "thinkingBudget"?: number | null;
+  "topP"?: number | null;
+  "turnId": string;
+};
+
+export type TurnRunRetryResult = {
+  "idempotencyKey": string;
+  "reused": boolean;
+  "sourceTurnId": string;
+  "turn": TurnRecord;
 };
 
 export type TurnRunStartParams = {
@@ -4311,6 +4339,7 @@ export const wireTypeBindings = [
   { "method": "turn/completed", "surface": "server-notification", "params": ["RuntimeTurnNotification"] },
   { "method": "turn/diff/updated", "surface": "server-notification", "params": ["TurnDiffUpdatedNotification"] },
   { "method": "turn/interrupt", "surface": "client-request", "params": ["TurnRunInterruptParams"], "result": ["TurnRunInterruptResult"] },
+  { "method": "turn/retry", "surface": "gollem-extension", "params": ["TurnRunRetryParams"], "result": ["TurnRunRetryResult"] },
   { "method": "turn/start", "surface": "client-request", "params": ["TurnRunStartParams"], "result": ["TurnRunStartResult"] },
   { "method": "turn/started", "surface": "server-notification", "params": ["RuntimeTurnNotification"] },
 ] as const satisfies readonly WireTypeBinding[];
@@ -4383,6 +4412,7 @@ export interface MethodParamsByName {
   "turn/completed": RuntimeTurnNotification;
   "turn/diff/updated": TurnDiffUpdatedNotification;
   "turn/interrupt": TurnRunInterruptParams;
+  "turn/retry": TurnRunRetryParams;
   "turn/start": TurnRunStartParams;
   "turn/started": RuntimeTurnNotification;
 }
@@ -4430,6 +4460,7 @@ export interface MethodResultsByName {
   "thread/unarchive": ThreadUnarchiveResult;
   "thread/unsubscribe": ThreadUnsubscribeResponse;
   "turn/interrupt": TurnRunInterruptResult;
+  "turn/retry": TurnRunRetryResult;
   "turn/start": TurnRunStartResult;
 }
 

--- a/appserver/protocol/typescript/testdata/collaboration_capability_contract.ts
+++ b/appserver/protocol/typescript/testdata/collaboration_capability_contract.ts
@@ -74,7 +74,7 @@ type Contracts = [
   Expect<Equal<ExactMembers<MethodResultsByName[keyof MethodResultsByName], CollaborationCapabilityContracts>, never>>,
   Expect<Equal<ExactMembers<ItemPayloadByKind[keyof ItemPayloadByKind], CollaborationCapabilityContracts>, never>>,
   Expect<Equal<typeof protocolMethods["length"], 224>>,
-  Expect<Equal<typeof wireTypeBindings["length"], 69>>,
+  Expect<Equal<typeof wireTypeBindings["length"], 70>>,
   Expect<Equal<typeof itemPayloadBindings["length"], 5>>,
 ];
 

--- a/appserver/protocol/typescript/testdata/dynamic_tool_spec_contract.ts
+++ b/appserver/protocol/typescript/testdata/dynamic_tool_spec_contract.ts
@@ -58,7 +58,7 @@ type Contracts = [
   Expect<Equal<ExactMembers<MethodResultsByName[keyof MethodResultsByName], DynamicToolSpecContracts>, never>>,
   Expect<Equal<ExactMembers<ItemPayloadByKind[keyof ItemPayloadByKind], DynamicToolSpecContracts>, never>>,
   Expect<Equal<typeof protocolMethods["length"], 224>>,
-  Expect<Equal<typeof wireTypeBindings["length"], 69>>,
+  Expect<Equal<typeof wireTypeBindings["length"], 70>>,
   Expect<Equal<typeof itemPayloadBindings["length"], 5>>,
 ];
 

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,11 +163,11 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
-	if got := len(WireTypeBindings()); got != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 69/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 70/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/workspace_messages_contract_test.go
+++ b/appserver/protocol/workspace_messages_contract_test.go
@@ -209,11 +209,11 @@ func TestWorkspaceMessageContractsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/workspaceMessages/read = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 549 {
-		t.Fatalf("definition count = %d, want 549", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 551 {
+		t.Fatalf("definition count = %d, want 551", got)
 	}
-	if len(Methods()) != 224 || len(WireTypeBindings()) != 69 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 224/69/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(Methods()) != 224 || len(WireTypeBindings()) != 70 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 224/70/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/runtime.go
+++ b/appserver/runtime.go
@@ -15,11 +15,12 @@ import (
 )
 
 var (
-	ErrRuntimeNotConfigured = errors.New("appserver/runtime: model factory is not configured")
-	ErrRuntimeTurnActive    = errors.New("appserver/runtime: turn is already running")
-	ErrRuntimeTurnNotActive = errors.New("appserver/runtime: turn is not running")
-	ErrRuntimePromptEmpty   = errors.New("appserver/runtime: prompt is required")
-	ErrRuntimeShuttingDown  = errors.New("appserver/runtime: runtime is shutting down")
+	ErrRuntimeNotConfigured       = errors.New("appserver/runtime: model factory is not configured")
+	ErrRuntimeTurnActive          = errors.New("appserver/runtime: turn is already running")
+	ErrRuntimeTurnNotActive       = errors.New("appserver/runtime: turn is not running")
+	ErrRuntimePromptEmpty         = errors.New("appserver/runtime: prompt is required")
+	ErrRuntimeShuttingDown        = errors.New("appserver/runtime: runtime is shutting down")
+	ErrRuntimeRecoveryUnavailable = errors.New("appserver/runtime: store does not support restart recovery")
 )
 
 type RuntimeModelSelection struct {
@@ -103,6 +104,24 @@ type RuntimeInterruptResult struct {
 	OK     bool        `json:"ok"`
 	TurnID string      `json:"turnId"`
 	Turn   *store.Turn `json:"turn,omitempty"`
+}
+
+type RuntimeRetryRequest struct {
+	SourceTurnID   string
+	IdempotencyKey string
+	Prompt         string
+	Input          json.RawMessage
+	Metadata       map[string]any
+	Selection      RuntimeModelSelection
+	ModelSettings  core.ModelSettings
+	History        []core.ModelMessage
+}
+
+type RuntimeRetryResult struct {
+	Turn           *store.Turn
+	SourceTurnID   string
+	IdempotencyKey string
+	Reused         bool
 }
 
 type runtimeNotifier interface {
@@ -208,6 +227,104 @@ func (s *RuntimeService) Interrupt(ctx context.Context, st store.Store, turnID s
 	active.cancel()
 	turn, _ := st.GetTurn(ctx, turnID)
 	return &RuntimeInterruptResult{OK: true, TurnID: turnID, Turn: turn}, nil
+}
+
+// Retry starts at most one retry turn for an idempotency key. Replayed
+// requests return the durable turn without launching the model again.
+func (s *RuntimeService) Retry(ctx context.Context, st store.Store, notifier runtimeNotifier, req RuntimeRetryRequest) (*RuntimeRetryResult, error) {
+	if s == nil || s.modelFactory == nil || st == nil {
+		return nil, ErrRuntimeNotConfigured
+	}
+	req.Prompt = strings.TrimSpace(req.Prompt)
+	if req.Prompt == "" {
+		return nil, ErrRuntimePromptEmpty
+	}
+	s.startMu.Lock()
+	defer s.startMu.Unlock()
+	s.mu.Lock()
+	if s.shuttingDown {
+		s.mu.Unlock()
+		return nil, ErrRuntimeShuttingDown
+	}
+	s.mu.Unlock()
+
+	recoveryStore, ok := st.(store.RuntimeRecoveryStore)
+	if !ok {
+		return nil, ErrRuntimeRecoveryUnavailable
+	}
+	prepared, err := recoveryStore.PrepareTurnRetry(ctx, store.PrepareTurnRetryRequest{
+		SourceTurnID:   req.SourceTurnID,
+		IdempotencyKey: req.IdempotencyKey,
+		Input:          cloneRuntimeRaw(req.Input),
+		Metadata:       cloneRuntimeMap(req.Metadata),
+	})
+	if err != nil {
+		return nil, err
+	}
+	result := &RuntimeRetryResult{
+		Turn:           prepared.Turn,
+		SourceTurnID:   prepared.Source.ID,
+		IdempotencyKey: prepared.Turn.RetryIdempotencyKey,
+		Reused:         !prepared.Created,
+	}
+	if !prepared.Created {
+		return result, nil
+	}
+	if _, err := st.AppendItem(ctx, store.AppendItemRequest{
+		ThreadID: prepared.Turn.ThreadID,
+		TurnID:   prepared.Turn.ID,
+		Kind:     "message",
+		Status:   "completed",
+		Payload:  mustRuntimeJSON(runtimeMessagePayload{Role: "user", Text: req.Prompt, CreatedAt: time.Now().UTC()}),
+	}); err != nil {
+		s.failPreparedRetry(st, prepared.Turn, err)
+		return nil, err
+	}
+	started, err := st.StartTurn(ctx, prepared.Turn.ID)
+	if err != nil {
+		s.failPreparedRetry(st, prepared.Turn, err)
+		return nil, err
+	}
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	s.mu.Lock()
+	if _, exists := s.active[started.ID]; exists {
+		s.mu.Unlock()
+		cancel()
+		s.failPreparedRetry(st, started, ErrRuntimeTurnActive)
+		return nil, ErrRuntimeTurnActive
+	}
+	s.active[started.ID] = &activeRuntimeTurn{cancel: cancel}
+	s.wg.Add(1)
+	s.mu.Unlock()
+
+	publishTurnStarted(notifier, started)
+	result.Turn = started
+	startReq := RuntimeStartRequest{
+		ThreadID:      started.ThreadID,
+		Prompt:        req.Prompt,
+		Input:         cloneRuntimeRaw(started.Input),
+		Metadata:      cloneRuntimeMap(started.Metadata),
+		Selection:     req.Selection,
+		ModelSettings: req.ModelSettings,
+		History:       append([]core.ModelMessage(nil), req.History...),
+	}
+	go func() {
+		defer s.wg.Done()
+		s.run(runCtx, st, notifier, started, startReq)
+	}()
+	return result, nil
+}
+
+func (s *RuntimeService) failPreparedRetry(st store.Store, turn *store.Turn, cause error) {
+	if st == nil || turn == nil || cause == nil {
+		return
+	}
+	_, _ = st.CompleteTurn(context.Background(), store.CompleteTurnRequest{
+		ID:     turn.ID,
+		Status: store.TurnFailed,
+		Error:  cause.Error(),
+	})
 }
 
 func (s *RuntimeService) IsActive(turnID string) bool {

--- a/appserver/runtime_history.go
+++ b/appserver/runtime_history.go
@@ -10,7 +10,11 @@ import (
 	"github.com/fugue-labs/gollem/core"
 )
 
-const runtimeReplayIdentifierMaxBytes = 64
+const (
+	runtimeReplayIdentifierMaxBytes = 64
+	runtimeReplayMaxItems           = 512
+	runtimeReplayMaxPayloadBytes    = 4 << 20
+)
 
 type runtimeReplayToolRecord struct {
 	tool      string
@@ -24,6 +28,51 @@ type runtimeHistoryBuilder struct {
 	dynamicParents map[string]struct{}
 	callIDCounts   map[string]int
 	generatedIDs   int
+}
+
+func boundedRuntimeReplayItems(items []*store.Item) []*store.Item {
+	window := compactionWindowItems(items)
+	if len(window) == 0 {
+		return nil
+	}
+
+	firstTail := 0
+	usedItems := 0
+	usedBytes := 0
+	var compaction *store.Item
+	if window[0] != nil && window[0].Kind == threadCompactionItemKind {
+		firstTail = 1
+		if len(window[0].Payload) <= runtimeReplayMaxPayloadBytes {
+			compaction = window[0]
+			usedItems = 1
+			usedBytes = len(compaction.Payload)
+		}
+	}
+
+	start := len(window)
+	for i := len(window) - 1; i >= firstTail; i-- {
+		item := window[i]
+		payloadBytes := 0
+		if item != nil {
+			payloadBytes = len(item.Payload)
+		}
+		if usedItems+1 > runtimeReplayMaxItems ||
+			usedBytes+payloadBytes > runtimeReplayMaxPayloadBytes {
+			break
+		}
+		start = i
+		usedItems++
+		usedBytes += payloadBytes
+	}
+
+	out := make([]*store.Item, 0, usedItems)
+	if compaction != nil {
+		out = append(out, compaction)
+	}
+	if start < len(window) {
+		out = append(out, window[start:]...)
+	}
+	return out
 }
 
 func runtimeMessagesFromItems(items []*store.Item) []core.ModelMessage {

--- a/appserver/runtime_history_test.go
+++ b/appserver/runtime_history_test.go
@@ -3,6 +3,7 @@ package appserver
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -11,6 +12,66 @@ import (
 	"github.com/fugue-labs/gollem/appserver/store"
 	"github.com/fugue-labs/gollem/core"
 )
+
+func TestBoundedRuntimeReplayItemsKeepsLatestCompactionAndTail(t *testing.T) {
+	now := time.Now().UTC()
+	items := []*store.Item{
+		runtimeHistoryMessageItem("older", "user", "excluded before compaction", now),
+		{
+			ID:      "compaction",
+			Kind:    threadCompactionItemKind,
+			Payload: json.RawMessage(`{"type":"contextCompaction","summary":"bounded summary"}`),
+		},
+	}
+	for i := range runtimeReplayMaxItems + 20 {
+		items = append(items, runtimeHistoryMessageItem(
+			fmt.Sprintf("message-%03d", i),
+			"user",
+			"bounded replay",
+			now.Add(time.Duration(i+1)*time.Second),
+		))
+	}
+
+	got := boundedRuntimeReplayItems(items)
+	if len(got) != runtimeReplayMaxItems {
+		t.Fatalf("bounded replay item count = %d, want %d", len(got), runtimeReplayMaxItems)
+	}
+	if got[0].ID != "compaction" {
+		t.Fatalf("bounded replay first item = %#v, want latest compaction", got[0])
+	}
+	if got[len(got)-1].ID != fmt.Sprintf("message-%03d", runtimeReplayMaxItems+19) {
+		t.Fatalf("bounded replay last item = %#v", got[len(got)-1])
+	}
+	for _, item := range got {
+		if item.ID == "older" {
+			t.Fatal("bounded replay retained an item before the latest compaction")
+		}
+	}
+	payloadBytes := 0
+	for _, item := range got {
+		if item != nil {
+			payloadBytes += len(item.Payload)
+		}
+	}
+	if payloadBytes > runtimeReplayMaxPayloadBytes {
+		t.Fatalf("bounded replay payload bytes = %d, max %d", payloadBytes, runtimeReplayMaxPayloadBytes)
+	}
+}
+
+func TestBoundedRuntimeReplayItemsDropsOversizedCompaction(t *testing.T) {
+	now := time.Now().UTC()
+	compaction := &store.Item{
+		ID:      "oversized-compaction",
+		Kind:    threadCompactionItemKind,
+		Payload: json.RawMessage(strings.Repeat("x", runtimeReplayMaxPayloadBytes+1)),
+	}
+	tail := runtimeHistoryMessageItem("tail", "user", "bounded tail", now)
+
+	got := boundedRuntimeReplayItems([]*store.Item{compaction, tail})
+	if len(got) != 1 || got[0].ID != tail.ID {
+		t.Fatalf("bounded replay = %#v, want only tail", got)
+	}
+}
 
 func TestRuntimeMessagesFromItemsReconstructsMixedToolHistory(t *testing.T) {
 	now := time.Now().UTC()

--- a/appserver/runtime_params.go
+++ b/appserver/runtime_params.go
@@ -2,10 +2,12 @@ package appserver
 
 import (
 	"encoding/json"
+	"errors"
 	"strings"
 
 	"github.com/fugue-labs/gollem/appserver/protocol"
 	"github.com/fugue-labs/gollem/core"
+	"github.com/google/uuid"
 )
 
 type RuntimeModelParams = protocol.RuntimeModelParams
@@ -50,13 +52,25 @@ type turnSteerParams struct {
 }
 
 type turnRetryParams struct {
-	ID       string         `json:"id,omitempty"`
-	TurnID   string         `json:"turnId,omitempty"`
-	Prompt   string         `json:"prompt,omitempty"`
-	Message  string         `json:"message,omitempty"`
-	Text     string         `json:"text,omitempty"`
-	Metadata map[string]any `json:"metadata,omitempty"`
+	ID             string         `json:"id,omitempty"`
+	TurnID         string         `json:"turnId,omitempty"`
+	IdempotencyKey *string        `json:"idempotencyKey,omitempty"`
+	Prompt         string         `json:"prompt,omitempty"`
+	Message        string         `json:"message,omitempty"`
+	Text           string         `json:"text,omitempty"`
+	Metadata       map[string]any `json:"metadata,omitempty"`
 	RuntimeModelParams
+}
+
+func (p turnRetryParams) retryIdempotencyKey() (string, error) {
+	if p.IdempotencyKey == nil {
+		return uuid.NewString(), nil
+	}
+	key := strings.TrimSpace(*p.IdempotencyKey)
+	if key == "" || len(key) > 256 {
+		return "", errors.New("idempotencyKey must contain 1 to 256 bytes")
+	}
+	return key, nil
 }
 
 func runtimePromptFromStartParams(prompt, message, text string, input json.RawMessage) string {
@@ -69,6 +83,31 @@ func runtimeSelectionFromParams(providerID, provider, model string) RuntimeModel
 		Provider:   strings.TrimSpace(provider),
 		Model:      strings.TrimSpace(model),
 	}
+}
+
+func runtimeSelectionFromInput(input json.RawMessage) RuntimeModelSelection {
+	var stored runtimeTurnInput
+	if len(input) == 0 || json.Unmarshal(input, &stored) != nil {
+		return RuntimeModelSelection{}
+	}
+	return RuntimeModelSelection{
+		ProviderID: strings.TrimSpace(stored.ProviderID),
+		Provider:   strings.TrimSpace(stored.Provider),
+		Model:      strings.TrimSpace(stored.Model),
+	}
+}
+
+func mergeRuntimeSelection(primary, fallback RuntimeModelSelection) RuntimeModelSelection {
+	if primary.ProviderID == "" {
+		primary.ProviderID = fallback.ProviderID
+	}
+	if primary.Provider == "" {
+		primary.Provider = fallback.Provider
+	}
+	if primary.Model == "" {
+		primary.Model = fallback.Model
+	}
+	return primary
 }
 
 func runtimeSelectionWithThreadDefaults(selection RuntimeModelSelection, settings map[string]any) RuntimeModelSelection {

--- a/appserver/runtime_test.go
+++ b/appserver/runtime_test.go
@@ -624,6 +624,164 @@ func TestServerRuntimeTurnRetryBranchesBeforeSourceTurn(t *testing.T) {
 	assertRuntimeUserPrompt(t, calls[1].Messages[0], "original prompt")
 }
 
+func TestServerRuntimeTurnRetryIsIdempotentAcrossDuplicateRequests(t *testing.T) {
+	ctx := context.Background()
+	st := newRuntimeTestStore(t)
+	model := core.NewTestModel(core.TextResponse("first answer"), core.TextResponse("retry answer"))
+	server := readyServer(
+		WithStore(st),
+		WithRuntimeService(NewRuntimeService(WithRuntimeModel(model, RuntimeModelInfo{ProviderID: "test", Model: "test-model"}))),
+	)
+
+	startResp := server.HandleRequest(ctx, request("thread/start", map[string]any{"prompt": "original prompt"}))
+	if startResp.Error != nil {
+		t.Fatalf("thread/start error: %v", startResp.Error)
+	}
+	var started struct {
+		Turn *store.Turn `json:"turn"`
+	}
+	decodeResult(t, startResp, &started)
+	waitForNotificationSet(t, server, "turn/completed")
+
+	params := map[string]any{
+		"turnId":         started.Turn.ID,
+		"idempotencyKey": "desktop-retry-1",
+	}
+	firstResp := server.HandleRequest(ctx, request("turn/retry", params))
+	if firstResp.Error != nil {
+		t.Fatalf("first turn/retry error: %v", firstResp.Error)
+	}
+	var first protocol.TurnRunRetryResult
+	decodeResult(t, firstResp, &first)
+	if first.Reused || first.SourceTurnID != started.Turn.ID || first.Turn.ID == "" {
+		t.Fatalf("first retry = %#v", first)
+	}
+
+	duplicateResp := server.HandleRequest(ctx, request("turn/retry", params))
+	if duplicateResp.Error != nil {
+		t.Fatalf("duplicate turn/retry error: %v", duplicateResp.Error)
+	}
+	var duplicate protocol.TurnRunRetryResult
+	decodeResult(t, duplicateResp, &duplicate)
+	if !duplicate.Reused || duplicate.Turn.ID != first.Turn.ID ||
+		duplicate.IdempotencyKey != "desktop-retry-1" {
+		t.Fatalf("duplicate retry = %#v, first = %#v", duplicate, first)
+	}
+
+	waitForNotificationSet(t, server, "turn/completed")
+	if got := len(model.Calls()); got != 2 {
+		t.Fatalf("model calls = %d, want 2", got)
+	}
+	turns, err := st.ListTurns(ctx, store.TurnFilter{ThreadID: started.Turn.ThreadID})
+	if err != nil {
+		t.Fatalf("ListTurns: %v", err)
+	}
+	if len(turns) != 2 {
+		t.Fatalf("turns = %#v, want source plus one retry", turns)
+	}
+}
+
+func TestServerRuntimeTurnRetryCanBeCancelledAndRemainsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	st := newRuntimeTestStore(t)
+	thread, err := st.CreateThread(ctx, store.CreateThreadRequest{Title: "retry cancellation"})
+	if err != nil {
+		t.Fatalf("CreateThread: %v", err)
+	}
+	source, err := st.CreateTurn(ctx, store.CreateTurnRequest{
+		ThreadID: thread.ID,
+		Input:    json.RawMessage(`{"prompt":"retry me"}`),
+	})
+	if err != nil {
+		t.Fatalf("CreateTurn: %v", err)
+	}
+	if _, err := st.CompleteTurn(ctx, store.CompleteTurnRequest{
+		ID:     source.ID,
+		Status: store.TurnInterrupted,
+		Error:  store.RuntimeOwnerLostReason,
+	}); err != nil {
+		t.Fatalf("CompleteTurn: %v", err)
+	}
+	model := &blockingRuntimeModel{started: make(chan struct{})}
+	server := readyServer(
+		WithStore(st),
+		WithRuntimeService(NewRuntimeService(WithRuntimeModel(model, RuntimeModelInfo{ProviderID: "test", Model: "blocking"}))),
+	)
+
+	params := map[string]any{
+		"turnId":         source.ID,
+		"idempotencyKey": "cancelled-retry-1",
+	}
+	retryResp := server.HandleRequest(ctx, request("turn/retry", params))
+	if retryResp.Error != nil {
+		t.Fatalf("turn/retry error: %v", retryResp.Error)
+	}
+	var retried protocol.TurnRunRetryResult
+	decodeResult(t, retryResp, &retried)
+	waitForBlockingModel(t, model)
+
+	interruptResp := server.HandleRequest(ctx, request("turn/interrupt", map[string]any{"turnId": retried.Turn.ID}))
+	if interruptResp.Error != nil {
+		t.Fatalf("turn/interrupt error: %v", interruptResp.Error)
+	}
+	waitForNotificationSet(t, server, "turn/completed")
+	cancelled, err := st.GetTurn(ctx, retried.Turn.ID)
+	if err != nil {
+		t.Fatalf("GetTurn: %v", err)
+	}
+	if cancelled.Status != store.TurnInterrupted {
+		t.Fatalf("cancelled retry = %#v", cancelled)
+	}
+
+	duplicateResp := server.HandleRequest(ctx, request("turn/retry", params))
+	if duplicateResp.Error != nil {
+		t.Fatalf("duplicate turn/retry error: %v", duplicateResp.Error)
+	}
+	var duplicate protocol.TurnRunRetryResult
+	decodeResult(t, duplicateResp, &duplicate)
+	if !duplicate.Reused || duplicate.Turn.ID != retried.Turn.ID ||
+		duplicate.Turn.Status != protocol.TurnLifecycleInterrupted {
+		t.Fatalf("duplicate cancelled retry = %#v, first = %#v", duplicate, retried)
+	}
+}
+
+func TestServerRuntimeTurnRetryIsTypedUnavailableWithoutRecoveryStore(t *testing.T) {
+	ctx := context.Background()
+	sqlite := newRuntimeTestStore(t)
+	thread, err := sqlite.CreateThread(ctx, store.CreateThreadRequest{Title: "legacy store"})
+	if err != nil {
+		t.Fatalf("CreateThread: %v", err)
+	}
+	source, err := sqlite.CreateTurn(ctx, store.CreateTurnRequest{
+		ThreadID: thread.ID,
+		Input:    json.RawMessage(`{"prompt":"retry me"}`),
+	})
+	if err != nil {
+		t.Fatalf("CreateTurn: %v", err)
+	}
+	if _, err := sqlite.CompleteTurn(ctx, store.CompleteTurnRequest{ID: source.ID}); err != nil {
+		t.Fatalf("CompleteTurn: %v", err)
+	}
+	legacy := struct{ store.Store }{Store: sqlite}
+	server := readyServer(
+		WithStore(legacy),
+		WithRuntimeService(NewRuntimeService(WithRuntimeModel(
+			core.NewTestModel(core.TextResponse("must not run")),
+			RuntimeModelInfo{ProviderID: "test", Model: "test-model"},
+		))),
+	)
+
+	resp := server.HandleRequest(ctx, request("turn/retry", map[string]any{
+		"turnId":         source.ID,
+		"idempotencyKey": "legacy-store-retry",
+	}))
+	if resp.Error == nil || resp.Error.Code != protocol.CodeMethodUnavailable ||
+		resp.Error.Message != "method unavailable" ||
+		!strings.Contains(string(resp.Error.Data), "restart-safe retry") {
+		t.Fatalf("turn/retry unavailable error = %#v", resp.Error)
+	}
+}
+
 func TestServerRuntimeTurnInterruptCancelsActiveRun(t *testing.T) {
 	ctx := context.Background()
 	st := newRuntimeTestStore(t)

--- a/appserver/server.go
+++ b/appserver/server.go
@@ -1351,6 +1351,10 @@ func (s *Server) handleTurnRetry(ctx context.Context, raw json.RawMessage) (any,
 	if prompt == "" {
 		return nil, invalidParams("retry prompt is unavailable", nil)
 	}
+	idempotencyKey, err := params.retryIdempotencyKey()
+	if err != nil {
+		return nil, invalidParams(err.Error(), err)
+	}
 	beforeSeq, err := firstTurnItemSeq(ctx, st, source.ThreadID, source.ID)
 	if err != nil {
 		return nil, mapError("turn/retry", err)
@@ -1359,20 +1363,28 @@ func (s *Server) handleTurnRetry(ctx context.Context, raw json.RawMessage) (any,
 	if err != nil {
 		return nil, mapError("turn/retry", err)
 	}
-	turn, err := runtimeSvc.Start(ctx, st, s, RuntimeStartRequest{
-		ThreadID:      source.ThreadID,
-		Prompt:        prompt,
-		Input:         firstRaw(params.Input, source.Input),
-		Metadata:      params.Metadata,
-		Selection:     runtimeSelectionFromParams(params.ProviderID, params.Provider, params.Model),
-		ModelSettings: runtimeModelSettingsFromParams(params.RuntimeModelParams),
-		History:       history,
+	selection := runtimeSelectionFromParams(params.ProviderID, params.Provider, params.Model)
+	selection = mergeRuntimeSelection(selection, runtimeSelectionFromInput(source.Input))
+	retry, err := runtimeSvc.Retry(ctx, st, s, RuntimeRetryRequest{
+		SourceTurnID:   source.ID,
+		IdempotencyKey: idempotencyKey,
+		Prompt:         prompt,
+		Input:          firstRaw(params.Input, source.Input),
+		Metadata:       params.Metadata,
+		Selection:      selection,
+		ModelSettings:  runtimeModelSettingsFromParams(params.RuntimeModelParams),
+		History:        history,
 	})
 	if err != nil {
 		return nil, mapError("turn/retry", err)
 	}
 	s.markThreadLoadedID(source.ThreadID)
-	return map[string]any{"turn": turn.Turn, "sourceTurnId": source.ID}, nil
+	return protocol.TurnRunRetryResult{
+		Turn:           protocolTurnRecord(retry.Turn),
+		SourceTurnID:   retry.SourceTurnID,
+		IdempotencyKey: retry.IdempotencyKey,
+		Reused:         retry.Reused,
+	}, nil
 }
 
 func (s *Server) startTurnWithParams(ctx context.Context, method string, params turnStartParams) (any, *protocol.Error) {
@@ -1429,7 +1441,7 @@ func (s *Server) loadThreadHistory(ctx context.Context, st store.Store, threadID
 		}
 		filtered = append(filtered, item)
 	}
-	return runtimeMessagesFromItems(compactionWindowItems(filtered)), nil
+	return runtimeMessagesFromItems(boundedRuntimeReplayItems(filtered)), nil
 }
 
 func firstTurnItemSeq(ctx context.Context, st store.Store, threadID, turnID string) (int64, error) {
@@ -2230,6 +2242,8 @@ func mapError(method string, err error) *protocol.Error {
 		errors.Is(err, store.ErrTurnNotFound),
 		errors.Is(err, store.ErrItemNotFound),
 		errors.Is(err, store.ErrThreadDeleted),
+		errors.Is(err, store.ErrTurnNotTerminal),
+		errors.Is(err, store.ErrRetryIdempotencyConflict),
 		errors.Is(err, ErrMemoryRootRequired),
 		errors.Is(err, ErrMemoryRootUnsafe),
 		errors.Is(err, ErrRuntimePromptEmpty):
@@ -2240,6 +2254,8 @@ func mapError(method string, err error) *protocol.Error {
 		return rpcError(protocol.CodeInvalidRequest, "operation denied by approval policy", err)
 	case errors.Is(err, ErrRuntimeNotConfigured):
 		return protocol.MethodUnavailableErrorWithReason(method, "turn runtime model factory is not configured")
+	case errors.Is(err, ErrRuntimeRecoveryUnavailable):
+		return protocol.MethodUnavailableErrorWithReason(method, "configured store does not support restart-safe retry")
 	case errors.Is(err, ErrRuntimeShuttingDown):
 		return protocol.MethodUnavailableErrorWithReason(method, "turn runtime is shutting down")
 	default:

--- a/appserver/store/sqlite.go
+++ b/appserver/store/sqlite.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 const timeFormat = time.RFC3339Nano
 
 var _ Store = (*SQLiteStore)(nil)
+var _ RuntimeRecoveryStore = (*SQLiteStore)(nil)
 
 // SQLiteStore persists app-server state in SQLite.
 type SQLiteStore struct {
@@ -28,7 +30,7 @@ func NewSQLiteStore(dbPath string) (*SQLiteStore, error) {
 	if dbPath == "" {
 		return nil, errors.New("appserver/store: db path must not be empty")
 	}
-	db, err := sql.Open("sqlite", dbPath)
+	db, err := sql.Open("sqlite", sqliteDSN(dbPath))
 	if err != nil {
 		return nil, fmt.Errorf("open sqlite database: %w", err)
 	}
@@ -40,6 +42,17 @@ func NewSQLiteStore(dbPath string) (*SQLiteStore, error) {
 		return nil, err
 	}
 	return s, nil
+}
+
+func sqliteDSN(dbPath string) string {
+	if dbPath == ":memory:" {
+		return dbPath
+	}
+	separator := "?"
+	if strings.Contains(dbPath, "?") {
+		separator = "&"
+	}
+	return dbPath + separator + "_txlock=immediate"
 }
 
 // Close closes the database handle.
@@ -536,6 +549,173 @@ func (s *SQLiteStore) ListTurns(ctx context.Context, filter TurnFilter) ([]*Turn
 	return out, nil
 }
 
+// PrepareTurnRetry atomically creates or reuses one retry turn for an
+// idempotency key. The source must already be terminal.
+func (s *SQLiteStore) PrepareTurnRetry(ctx context.Context, req PrepareTurnRetryRequest) (*PrepareTurnRetryResult, error) {
+	ctx = normalizeContext(ctx)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	req.SourceTurnID = strings.TrimSpace(req.SourceTurnID)
+	req.IdempotencyKey = strings.TrimSpace(req.IdempotencyKey)
+	if req.SourceTurnID == "" {
+		return nil, ErrTurnNotFound
+	}
+	if req.IdempotencyKey == "" || len(req.IdempotencyKey) > 256 {
+		return nil, errors.New("appserver/store: retry idempotency key must contain 1 to 256 bytes")
+	}
+
+	var result *PrepareTurnRetryResult
+	if err := s.withTx(ctx, func(tx *sql.Tx) error {
+		source, err := loadTurnTx(ctx, tx, req.SourceTurnID)
+		if err != nil {
+			return err
+		}
+		if !terminalTurnStatus(source.Status) {
+			return ErrTurnNotTerminal
+		}
+		thread, err := loadThreadTx(ctx, tx, source.ThreadID)
+		if err != nil {
+			return err
+		}
+		if thread.Status == ThreadDeleted {
+			return ErrThreadDeleted
+		}
+
+		turns, err := loadAllTurnsTx(ctx, tx)
+		if err != nil {
+			return err
+		}
+		for _, candidate := range turns {
+			if candidate.RetryIdempotencyKey != req.IdempotencyKey {
+				continue
+			}
+			if candidate.RetryOfTurnID != source.ID {
+				return ErrRetryIdempotencyConflict
+			}
+			result = &PrepareTurnRetryResult{
+				Source:  cloneTurn(source),
+				Turn:    cloneTurn(candidate),
+				Created: false,
+			}
+			return nil
+		}
+
+		now := time.Now().UTC()
+		input := cloneRaw(req.Input)
+		if len(input) == 0 {
+			input = cloneRaw(source.Input)
+		}
+		retry := &Turn{
+			ID:                  newID("turn"),
+			ThreadID:            source.ThreadID,
+			Status:              TurnQueued,
+			Input:               input,
+			Metadata:            cloneMap(req.Metadata),
+			CreatedAt:           now,
+			UpdatedAt:           now,
+			RetryOfTurnID:       source.ID,
+			RetryIdempotencyKey: req.IdempotencyKey,
+		}
+		if err := saveTurnTx(ctx, tx, retry); err != nil {
+			return err
+		}
+		result = &PrepareTurnRetryResult{
+			Source:  cloneTurn(source),
+			Turn:    cloneTurn(retry),
+			Created: true,
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// RecoverOrphanedTurns terminalizes work whose in-memory execution owner did
+// not survive. It is idempotent: only queued/running turns are changed.
+func (s *SQLiteStore) RecoverOrphanedTurns(ctx context.Context, req RecoverOrphanedTurnsRequest) (*RecoverOrphanedTurnsResult, error) {
+	ctx = normalizeContext(ctx)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	recoveredAt := req.RecoveredAt.UTC()
+	if recoveredAt.IsZero() {
+		recoveredAt = time.Now().UTC()
+	}
+	reason := strings.TrimSpace(req.Reason)
+	if reason == "" {
+		reason = RuntimeOwnerLostReason
+	}
+	result := &RecoverOrphanedTurnsResult{}
+	if err := s.withTx(ctx, func(tx *sql.Tx) error {
+		turns, err := loadTurnsByStatusesTx(ctx, tx, TurnQueued, TurnRunning)
+		if err != nil {
+			return err
+		}
+		for _, turn := range turns {
+			previousStatus := turn.Status
+			items, err := loadItemsForTurnTx(ctx, tx, turn.ID)
+			if err != nil {
+				return err
+			}
+			var recoveredItemIDs []string
+			for _, item := range items {
+				if !orphanedItemStatus(item.Status) {
+					continue
+				}
+				item.Status = "failed"
+				item.Payload = recoveredItemPayload(item.Payload)
+				item.UpdatedAt = recoveredAt
+				if err := saveItemTx(ctx, tx, item); err != nil {
+					return err
+				}
+				recoveredItemIDs = append(recoveredItemIDs, item.ID)
+				result.Items = append(result.Items, cloneItem(item))
+			}
+
+			turn.Status = TurnInterrupted
+			turn.Error = reason
+			turn.CompletedAt = recoveredAt
+			turn.UpdatedAt = recoveredAt
+			if err := saveTurnTx(ctx, tx, turn); err != nil {
+				return err
+			}
+			result.Turns = append(result.Turns, cloneTurn(turn))
+
+			markerPayload, err := json.Marshal(map[string]any{
+				"turnId":           turn.ID,
+				"previousStatus":   previousStatus,
+				"status":           turn.Status,
+				"reason":           reason,
+				"recoveredItemIds": recoveredItemIDs,
+				"recoveredAt":      recoveredAt,
+			})
+			if err != nil {
+				return fmt.Errorf("marshal runtime recovery marker: %w", err)
+			}
+			marker := &Item{
+				ID:        newID("item"),
+				ThreadID:  turn.ThreadID,
+				TurnID:    turn.ID,
+				Kind:      "runtimeRecovery",
+				Status:    "completed",
+				Payload:   markerPayload,
+				CreatedAt: recoveredAt,
+				UpdatedAt: recoveredAt,
+			}
+			if err := saveItemTx(ctx, tx, marker); err != nil {
+				return err
+			}
+			result.Markers = append(result.Markers, cloneItem(marker))
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
 // RollbackThread implements Store.
 func (s *SQLiteStore) RollbackThread(ctx context.Context, req RollbackThreadRequest) (*RollbackThreadResult, error) {
 	ctx = normalizeContext(ctx)
@@ -844,6 +1024,96 @@ func loadTurnsForThreadTx(ctx context.Context, tx *sql.Tx, threadID string) ([]*
 		return nil, fmt.Errorf("iterate thread turns: %w", err)
 	}
 	return turns, nil
+}
+
+func loadAllTurnsTx(ctx context.Context, tx *sql.Tx) ([]*Turn, error) {
+	rows, err := tx.QueryContext(ctx, `SELECT payload FROM app_turns ORDER BY created_at ASC, id ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("load turns: %w", err)
+	}
+	defer rows.Close()
+	var turns []*Turn
+	for rows.Next() {
+		turn, err := scanTurn(rows)
+		if err != nil {
+			return nil, err
+		}
+		turns = append(turns, turn)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate turns: %w", err)
+	}
+	return turns, nil
+}
+
+func loadTurnsByStatusesTx(ctx context.Context, tx *sql.Tx, statuses ...TurnStatus) ([]*Turn, error) {
+	turns, err := loadAllTurnsTx(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+	var out []*Turn
+	for _, turn := range turns {
+		for _, status := range statuses {
+			if turn.Status == status {
+				out = append(out, turn)
+				break
+			}
+		}
+	}
+	return out, nil
+}
+
+func loadItemsForTurnTx(ctx context.Context, tx *sql.Tx, turnID string) ([]*Item, error) {
+	rows, err := tx.QueryContext(ctx, `SELECT payload FROM app_items WHERE turn_id = ? ORDER BY seq ASC`, turnID)
+	if err != nil {
+		return nil, fmt.Errorf("load turn items: %w", err)
+	}
+	defer rows.Close()
+	var items []*Item
+	for rows.Next() {
+		item, err := scanItem(rows)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate turn items: %w", err)
+	}
+	return items, nil
+}
+
+func terminalTurnStatus(status TurnStatus) bool {
+	switch status {
+	case TurnCompleted, TurnFailed, TurnInterrupted:
+		return true
+	default:
+		return false
+	}
+}
+
+func orphanedItemStatus(status string) bool {
+	switch status {
+	case "inProgress", "in_progress", "pending", "queued", "running", "started":
+		return true
+	default:
+		return false
+	}
+}
+
+func recoveredItemPayload(payload json.RawMessage) json.RawMessage {
+	var object map[string]any
+	if len(payload) == 0 || json.Unmarshal(payload, &object) != nil || object == nil {
+		return cloneRaw(payload)
+	}
+	if status, ok := object["status"].(string); ok && orphanedItemStatus(status) {
+		object["status"] = "failed"
+	}
+	encoded, err := json.Marshal(object)
+	if err != nil {
+		return cloneRaw(payload)
+	}
+	return encoded
 }
 
 func loadLastTurnsTx(ctx context.Context, tx *sql.Tx, threadID string, limit int) ([]*Turn, error) {

--- a/appserver/store/sqlite_test.go
+++ b/appserver/store/sqlite_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestSQLiteStoreThreadLifecyclePersists(t *testing.T) {
@@ -107,6 +108,268 @@ func TestSQLiteStoreClosedOperationsReturnErrStoreClosed(t *testing.T) {
 	}
 	if _, err := s.ListThreads(ctx, ThreadFilter{}); !errors.Is(err, ErrStoreClosed) {
 		t.Fatalf("ListThreads after close error = %v, want ErrStoreClosed", err)
+	}
+}
+
+func TestSQLiteStoreRecoverOrphanedRuntimeStateIsAtomicAndIdempotent(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "appserver.db")
+	s := newTestSQLiteStore(t, path)
+
+	thread, err := s.CreateThread(ctx, CreateThreadRequest{Title: "Recovery"})
+	if err != nil {
+		t.Fatalf("CreateThread: %v", err)
+	}
+	queued, err := s.CreateTurn(ctx, CreateTurnRequest{
+		ThreadID: thread.ID,
+		Input:    json.RawMessage(`{"prompt":"queued"}`),
+	})
+	if err != nil {
+		t.Fatalf("CreateTurn queued: %v", err)
+	}
+	running, err := s.CreateTurn(ctx, CreateTurnRequest{
+		ThreadID: thread.ID,
+		Input:    json.RawMessage(`{"prompt":"running"}`),
+	})
+	if err != nil {
+		t.Fatalf("CreateTurn running: %v", err)
+	}
+	running, err = s.StartTurn(ctx, running.ID)
+	if err != nil {
+		t.Fatalf("StartTurn: %v", err)
+	}
+	completed, err := s.CreateTurn(ctx, CreateTurnRequest{
+		ThreadID: thread.ID,
+		Input:    json.RawMessage(`{"prompt":"completed"}`),
+	})
+	if err != nil {
+		t.Fatalf("CreateTurn completed: %v", err)
+	}
+	if _, err := s.CompleteTurn(ctx, CompleteTurnRequest{
+		ID:     completed.ID,
+		Status: TurnCompleted,
+		Result: json.RawMessage(`{"text":"done"}`),
+	}); err != nil {
+		t.Fatalf("CompleteTurn: %v", err)
+	}
+	inProgress, err := s.AppendItem(ctx, AppendItemRequest{
+		ThreadID: running.ThreadID,
+		TurnID:   running.ID,
+		Kind:     "commandExecution",
+		Status:   "inProgress",
+		Payload:  json.RawMessage(`{"type":"commandExecution","id":"command","status":"inProgress"}`),
+	})
+	if err != nil {
+		t.Fatalf("AppendItem in progress: %v", err)
+	}
+	malformed, err := s.AppendItem(ctx, AppendItemRequest{
+		ThreadID: running.ThreadID,
+		TurnID:   running.ID,
+		Kind:     "mcpToolCall",
+		Status:   "running",
+		Payload:  json.RawMessage(`"not-an-object"`),
+	})
+	if err != nil {
+		t.Fatalf("AppendItem malformed: %v", err)
+	}
+	stable, err := s.AppendItem(ctx, AppendItemRequest{
+		ThreadID: running.ThreadID,
+		TurnID:   running.ID,
+		Kind:     "message",
+		Status:   "completed",
+		Payload:  json.RawMessage(`{"role":"user","text":"keep"}`),
+	})
+	if err != nil {
+		t.Fatalf("AppendItem stable: %v", err)
+	}
+
+	recoveredAt := time.Date(2026, 7, 29, 11, 30, 0, 0, time.UTC)
+	result, err := s.RecoverOrphanedTurns(ctx, RecoverOrphanedTurnsRequest{
+		RecoveredAt: recoveredAt,
+		Reason:      RuntimeOwnerLostReason,
+	})
+	if err != nil {
+		t.Fatalf("RecoverOrphanedTurns: %v", err)
+	}
+	if len(result.Turns) != 2 || len(result.Items) != 2 || len(result.Markers) != 2 {
+		t.Fatalf("recovery result = %#v", result)
+	}
+	for _, turnID := range []string{queued.ID, running.ID} {
+		turn, err := s.GetTurn(ctx, turnID)
+		if err != nil {
+			t.Fatalf("GetTurn %s: %v", turnID, err)
+		}
+		if turn.Status != TurnInterrupted || turn.Error != RuntimeOwnerLostReason {
+			t.Fatalf("recovered turn = %#v", turn)
+		}
+		if !turn.CompletedAt.Equal(recoveredAt) || !turn.UpdatedAt.Equal(recoveredAt) {
+			t.Fatalf("recovered turn timestamps = %#v", turn)
+		}
+	}
+	gotCompleted, err := s.GetTurn(ctx, completed.ID)
+	if err != nil {
+		t.Fatalf("GetTurn completed: %v", err)
+	}
+	if gotCompleted.Status != TurnCompleted || string(gotCompleted.Result) != `{"text":"done"}` {
+		t.Fatalf("completed turn changed = %#v", gotCompleted)
+	}
+	gotInProgress, err := s.GetItem(ctx, inProgress.ID)
+	if err != nil {
+		t.Fatalf("GetItem in progress: %v", err)
+	}
+	if gotInProgress.Status != "failed" {
+		t.Fatalf("recovered item status = %q", gotInProgress.Status)
+	}
+	var recoveredPayload map[string]any
+	if err := json.Unmarshal(gotInProgress.Payload, &recoveredPayload); err != nil {
+		t.Fatalf("decode recovered payload: %v", err)
+	}
+	if recoveredPayload["status"] != "failed" {
+		t.Fatalf("recovered payload = %#v", recoveredPayload)
+	}
+	gotMalformed, err := s.GetItem(ctx, malformed.ID)
+	if err != nil {
+		t.Fatalf("GetItem malformed: %v", err)
+	}
+	if gotMalformed.Status != "failed" || string(gotMalformed.Payload) != `"not-an-object"` {
+		t.Fatalf("recovered malformed item = %#v", gotMalformed)
+	}
+	gotStable, err := s.GetItem(ctx, stable.ID)
+	if err != nil {
+		t.Fatalf("GetItem stable: %v", err)
+	}
+	if gotStable.Status != "completed" || string(gotStable.Payload) != `{"role":"user","text":"keep"}` {
+		t.Fatalf("stable item changed = %#v", gotStable)
+	}
+
+	again, err := s.RecoverOrphanedTurns(ctx, RecoverOrphanedTurnsRequest{
+		RecoveredAt: recoveredAt.Add(time.Minute),
+		Reason:      RuntimeOwnerLostReason,
+	})
+	if err != nil {
+		t.Fatalf("RecoverOrphanedTurns again: %v", err)
+	}
+	if len(again.Turns) != 0 || len(again.Items) != 0 || len(again.Markers) != 0 {
+		t.Fatalf("second recovery result = %#v", again)
+	}
+
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	s = newTestSQLiteStore(t, path)
+	persisted, err := s.GetTurn(ctx, running.ID)
+	if err != nil {
+		t.Fatalf("GetTurn after reopen: %v", err)
+	}
+	if persisted.Status != TurnInterrupted || persisted.Error != RuntimeOwnerLostReason {
+		t.Fatalf("persisted recovered turn = %#v", persisted)
+	}
+}
+
+func TestSQLiteStorePrepareTurnRetryIsAtomicAcrossHandlesAndDurable(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "appserver.db")
+	first := newTestSQLiteStore(t, path)
+
+	thread, err := first.CreateThread(ctx, CreateThreadRequest{Title: "Retry"})
+	if err != nil {
+		t.Fatalf("CreateThread: %v", err)
+	}
+	source, err := first.CreateTurn(ctx, CreateTurnRequest{
+		ThreadID: thread.ID,
+		Input:    json.RawMessage(`{"prompt":"source"}`),
+	})
+	if err != nil {
+		t.Fatalf("CreateTurn source: %v", err)
+	}
+	if _, err := first.CompleteTurn(ctx, CompleteTurnRequest{ID: source.ID, Status: TurnCompleted}); err != nil {
+		t.Fatalf("CompleteTurn source: %v", err)
+	}
+	active, err := first.CreateTurn(ctx, CreateTurnRequest{ThreadID: thread.ID})
+	if err != nil {
+		t.Fatalf("CreateTurn active: %v", err)
+	}
+	if _, err := first.PrepareTurnRetry(ctx, PrepareTurnRetryRequest{
+		SourceTurnID:   active.ID,
+		IdempotencyKey: "active-source",
+	}); !errors.Is(err, ErrTurnNotTerminal) {
+		t.Fatalf("PrepareTurnRetry active source error = %v, want ErrTurnNotTerminal", err)
+	}
+
+	second := newTestSQLiteStore(t, path)
+	request := PrepareTurnRetryRequest{
+		SourceTurnID:   source.ID,
+		IdempotencyKey: "desktop-retry-1",
+		Metadata:       map[string]any{"origin": "desktop"},
+	}
+	start := make(chan struct{})
+	results := make(chan *PrepareTurnRetryResult, 2)
+	errs := make(chan error, 2)
+	for _, st := range []*SQLiteStore{first, second} {
+		go func(st *SQLiteStore) {
+			<-start
+			result, err := st.PrepareTurnRetry(ctx, request)
+			results <- result
+			errs <- err
+		}(st)
+	}
+	close(start)
+
+	var got []*PrepareTurnRetryResult
+	created := 0
+	for range 2 {
+		if err := <-errs; err != nil {
+			t.Fatalf("concurrent PrepareTurnRetry: %v", err)
+		}
+		result := <-results
+		if result == nil || result.Turn == nil {
+			t.Fatalf("concurrent result = %#v", result)
+		}
+		got = append(got, result)
+		if result.Created {
+			created++
+		}
+	}
+	if created != 1 || got[0].Turn.ID != got[1].Turn.ID {
+		t.Fatalf("concurrent retry results = %#v", got)
+	}
+	retryID := got[0].Turn.ID
+	if got[0].Turn.RetryOfTurnID != source.ID ||
+		got[0].Turn.RetryIdempotencyKey != request.IdempotencyKey {
+		t.Fatalf("retry lineage = %#v", got[0].Turn)
+	}
+
+	if err := first.Close(); err != nil {
+		t.Fatalf("close first: %v", err)
+	}
+	if err := second.Close(); err != nil {
+		t.Fatalf("close second: %v", err)
+	}
+	reopened := newTestSQLiteStore(t, path)
+	reused, err := reopened.PrepareTurnRetry(ctx, request)
+	if err != nil {
+		t.Fatalf("PrepareTurnRetry after reopen: %v", err)
+	}
+	if reused.Created || reused.Turn.ID != retryID {
+		t.Fatalf("reused retry = %#v, want %s", reused, retryID)
+	}
+
+	otherSource, err := reopened.CreateTurn(ctx, CreateTurnRequest{ThreadID: thread.ID})
+	if err != nil {
+		t.Fatalf("CreateTurn other source: %v", err)
+	}
+	if _, err := reopened.CompleteTurn(ctx, CompleteTurnRequest{
+		ID:     otherSource.ID,
+		Status: TurnFailed,
+		Error:  "expected",
+	}); err != nil {
+		t.Fatalf("CompleteTurn other source: %v", err)
+	}
+	if _, err := reopened.PrepareTurnRetry(ctx, PrepareTurnRetryRequest{
+		SourceTurnID:   otherSource.ID,
+		IdempotencyKey: request.IdempotencyKey,
+	}); !errors.Is(err, ErrRetryIdempotencyConflict) {
+		t.Fatalf("PrepareTurnRetry conflicting source error = %v, want ErrRetryIdempotencyConflict", err)
 	}
 }
 

--- a/appserver/store/types.go
+++ b/appserver/store/types.go
@@ -26,12 +26,16 @@ const (
 )
 
 var (
-	ErrThreadNotFound = errors.New("appserver/store: thread not found")
-	ErrTurnNotFound   = errors.New("appserver/store: turn not found")
-	ErrItemNotFound   = errors.New("appserver/store: item not found")
-	ErrThreadDeleted  = errors.New("appserver/store: thread is deleted")
-	ErrStoreClosed    = errors.New("appserver/store: store is closed")
+	ErrThreadNotFound           = errors.New("appserver/store: thread not found")
+	ErrTurnNotFound             = errors.New("appserver/store: turn not found")
+	ErrItemNotFound             = errors.New("appserver/store: item not found")
+	ErrThreadDeleted            = errors.New("appserver/store: thread is deleted")
+	ErrStoreClosed              = errors.New("appserver/store: store is closed")
+	ErrTurnNotTerminal          = errors.New("appserver/store: turn is not terminal")
+	ErrRetryIdempotencyConflict = errors.New("appserver/store: retry idempotency key is already bound to another turn")
 )
+
+const RuntimeOwnerLostReason = "appserver/runtime: execution owner exited before terminal state"
 
 // Thread is a durable conversation container.
 type Thread struct {
@@ -50,18 +54,20 @@ type Thread struct {
 
 // Turn is one model run attempt within a thread.
 type Turn struct {
-	ID          string          `json:"id"`
-	ThreadID    string          `json:"threadId"`
-	Status      TurnStatus      `json:"status"`
-	Input       json.RawMessage `json:"input,omitempty"`
-	Result      json.RawMessage `json:"result,omitempty"`
-	Error       string          `json:"error,omitempty"`
-	Usage       map[string]any  `json:"usage,omitempty"`
-	Metadata    map[string]any  `json:"metadata,omitempty"`
-	CreatedAt   time.Time       `json:"createdAt"`
-	UpdatedAt   time.Time       `json:"updatedAt"`
-	StartedAt   time.Time       `json:"startedAt,omitempty"`
-	CompletedAt time.Time       `json:"completedAt,omitempty"`
+	ID                  string          `json:"id"`
+	ThreadID            string          `json:"threadId"`
+	Status              TurnStatus      `json:"status"`
+	Input               json.RawMessage `json:"input,omitempty"`
+	Result              json.RawMessage `json:"result,omitempty"`
+	Error               string          `json:"error,omitempty"`
+	Usage               map[string]any  `json:"usage,omitempty"`
+	Metadata            map[string]any  `json:"metadata,omitempty"`
+	CreatedAt           time.Time       `json:"createdAt"`
+	UpdatedAt           time.Time       `json:"updatedAt"`
+	StartedAt           time.Time       `json:"startedAt,omitempty"`
+	CompletedAt         time.Time       `json:"completedAt,omitempty"`
+	RetryOfTurnID       string          `json:"retryOfTurnId,omitempty"`
+	RetryIdempotencyKey string          `json:"retryIdempotencyKey,omitempty"`
 }
 
 // Item is an ordered timeline entry for messages, reasoning, tools, commands,
@@ -126,6 +132,30 @@ type TurnFilter struct {
 	Limit    int
 }
 
+type PrepareTurnRetryRequest struct {
+	SourceTurnID   string
+	IdempotencyKey string
+	Input          json.RawMessage
+	Metadata       map[string]any
+}
+
+type PrepareTurnRetryResult struct {
+	Source  *Turn
+	Turn    *Turn
+	Created bool
+}
+
+type RecoverOrphanedTurnsRequest struct {
+	RecoveredAt time.Time
+	Reason      string
+}
+
+type RecoverOrphanedTurnsResult struct {
+	Turns   []*Turn
+	Items   []*Item
+	Markers []*Item
+}
+
 type RollbackThreadRequest struct {
 	ID       string
 	NumTurns int
@@ -183,4 +213,11 @@ type Store interface {
 	UpdateItem(context.Context, UpdateItemRequest) (*Item, error)
 	GetItem(context.Context, string) (*Item, error)
 	ListItems(context.Context, ItemFilter) ([]*Item, error)
+}
+
+// RuntimeRecoveryStore is the optional persistence capability required for
+// restart reconciliation and exactly-once retry creation.
+type RuntimeRecoveryStore interface {
+	PrepareTurnRetry(context.Context, PrepareTurnRetryRequest) (*PrepareTurnRetryResult, error)
+	RecoverOrphanedTurns(context.Context, RecoverOrphanedTurnsRequest) (*RecoverOrphanedTurnsResult, error)
 }

--- a/appserver/thread_protocol.go
+++ b/appserver/thread_protocol.go
@@ -281,18 +281,20 @@ func protocolTurnRecord(turn *store.Turn) protocol.TurnRecord {
 		return protocol.TurnRecord{}
 	}
 	return protocol.TurnRecord{
-		ID:          turn.ID,
-		ThreadID:    turn.ThreadID,
-		Status:      protocol.TurnLifecycleStatus(turn.Status),
-		Input:       append(json.RawMessage(nil), turn.Input...),
-		Result:      append(json.RawMessage(nil), turn.Result...),
-		Error:       turn.Error,
-		Usage:       cloneSettings(turn.Usage),
-		Metadata:    cloneSettings(turn.Metadata),
-		CreatedAt:   turn.CreatedAt,
-		UpdatedAt:   turn.UpdatedAt,
-		StartedAt:   turn.StartedAt,
-		CompletedAt: turn.CompletedAt,
+		ID:                  turn.ID,
+		ThreadID:            turn.ThreadID,
+		Status:              protocol.TurnLifecycleStatus(turn.Status),
+		Input:               append(json.RawMessage(nil), turn.Input...),
+		Result:              append(json.RawMessage(nil), turn.Result...),
+		Error:               turn.Error,
+		Usage:               cloneSettings(turn.Usage),
+		Metadata:            cloneSettings(turn.Metadata),
+		CreatedAt:           turn.CreatedAt,
+		UpdatedAt:           turn.UpdatedAt,
+		StartedAt:           turn.StartedAt,
+		CompletedAt:         turn.CompletedAt,
+		RetryOfTurnID:       turn.RetryOfTurnID,
+		RetryIdempotencyKey: turn.RetryIdempotencyKey,
 	}
 }
 

--- a/cmd/gollem/app_server.go
+++ b/cmd/gollem/app_server.go
@@ -369,6 +369,18 @@ func shutdownCLIAppServerRuntime(runtimeSvc *appserver.RuntimeService) {
 }
 
 func serveCLIAppServerTransports(ctx context.Context, flags appServerFlags) error {
+	if !flags.stdio && flags.socketPath == "" && flags.websocketAddr == "" {
+		return errors.New("no app-server transports enabled")
+	}
+	storeLock, err := acquireAppServerStoreLock(flags)
+	if err != nil {
+		return err
+	}
+	defer storeLock.Close()
+	if err := recoverCLIAppServerState(flags); err != nil {
+		return fmt.Errorf("recover app-server state: %w", err)
+	}
+
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	errCh := make(chan error, 3)
@@ -400,12 +412,35 @@ func serveCLIAppServerTransports(ctx context.Context, flags appServerFlags) erro
 	if started == 0 {
 		return errors.New("no app-server transports enabled")
 	}
-	err := <-errCh
+	err = <-errCh
 	cancel()
 	if errors.Is(err, errAppServerDaemonStopped) {
 		return nil
 	}
 	return err
+}
+
+func recoverCLIAppServerState(flags appServerFlags) error {
+	workDir, err := filepath.Abs(flags.workDir)
+	if err != nil {
+		return fmt.Errorf("resolve workdir: %w", err)
+	}
+	storePath, err := resolveAppServerStorePath(workDir, flags.storePath)
+	if err != nil {
+		return err
+	}
+	if storePath == ":memory:" {
+		return nil
+	}
+
+	st, err := store.NewSQLiteStore(storePath)
+	if err != nil {
+		return err
+	}
+	_, recoverErr := st.RecoverOrphanedTurns(context.Background(), store.RecoverOrphanedTurnsRequest{
+		Reason: store.RuntimeOwnerLostReason,
+	})
+	return errors.Join(recoverErr, st.Close())
 }
 
 func appServerTransportName(flags appServerFlags) string {
@@ -650,7 +685,9 @@ func resolveAppServerStorePath(workDir, configured string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("resolve store path: %w", err)
 	}
-	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+	// The store path is an explicit CLI configuration value. It is normalized
+	// above so the daemon and its owner lock use one canonical location.
+	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil { // #nosec G703
 		return "", fmt.Errorf("create store directory: %w", err)
 	}
 	return abs, nil

--- a/cmd/gollem/app_server_lock.go
+++ b/cmd/gollem/app_server_lock.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+var errAppServerStoreOwned = errors.New("app-server store is already owned by another daemon")
+
+type appServerStoreLock struct {
+	file *os.File
+}
+
+func acquireAppServerStoreLock(flags appServerFlags) (*appServerStoreLock, error) {
+	workDir, err := filepath.Abs(flags.workDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve workdir: %w", err)
+	}
+	storePath, err := resolveAppServerStorePath(workDir, flags.storePath)
+	if err != nil {
+		return nil, err
+	}
+	if storePath == ":memory:" {
+		return &appServerStoreLock{}, nil
+	}
+
+	lockPath := storePath + ".owner.lock"
+	// lockPath is derived from the canonical store path resolved above.
+	file, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600) // #nosec G703
+	if err != nil {
+		return nil, fmt.Errorf("open app-server store lock: %w", err)
+	}
+	if err := tryLockAppServerStoreFile(file); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	if err := file.Truncate(0); err != nil {
+		_ = unlockAppServerStoreFile(file)
+		_ = file.Close()
+		return nil, fmt.Errorf("truncate app-server store lock: %w", err)
+	}
+	if _, err := file.Seek(0, 0); err != nil {
+		_ = unlockAppServerStoreFile(file)
+		_ = file.Close()
+		return nil, fmt.Errorf("seek app-server store lock: %w", err)
+	}
+	if _, err := fmt.Fprintf(file, "%d\n", os.Getpid()); err != nil {
+		_ = unlockAppServerStoreFile(file)
+		_ = file.Close()
+		return nil, fmt.Errorf("write app-server store owner: %w", err)
+	}
+	return &appServerStoreLock{file: file}, nil
+}
+
+func (l *appServerStoreLock) Close() error {
+	if l == nil || l.file == nil {
+		return nil
+	}
+	file := l.file
+	l.file = nil
+	return errors.Join(unlockAppServerStoreFile(file), file.Close())
+}

--- a/cmd/gollem/app_server_lock_unix.go
+++ b/cmd/gollem/app_server_lock_unix.go
@@ -1,0 +1,46 @@
+//go:build aix || android || darwin || dragonfly || freebsd || illumos || ios || linux || netbsd || openbsd || solaris || zos
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func tryLockAppServerStoreFile(file *os.File) error {
+	fd, err := appServerStoreFileDescriptor(file)
+	if err != nil {
+		return err
+	}
+	err = unix.Flock(fd, unix.LOCK_EX|unix.LOCK_NB)
+	if errors.Is(err, unix.EWOULDBLOCK) || errors.Is(err, unix.EAGAIN) {
+		return errAppServerStoreOwned
+	}
+	if err != nil {
+		return fmt.Errorf("lock app-server store: %w", err)
+	}
+	return nil
+}
+
+func unlockAppServerStoreFile(file *os.File) error {
+	fd, err := appServerStoreFileDescriptor(file)
+	if err != nil {
+		return err
+	}
+	if err := unix.Flock(fd, unix.LOCK_UN); err != nil {
+		return fmt.Errorf("unlock app-server store: %w", err)
+	}
+	return nil
+}
+
+func appServerStoreFileDescriptor(file *os.File) (int, error) {
+	fd := file.Fd()
+	maxInt := int(^uint(0) >> 1)
+	if fd > uintptr(maxInt) {
+		return 0, fmt.Errorf("app-server store file descriptor %d exceeds int range", fd)
+	}
+	return int(fd), nil // #nosec G115 -- fd is range-checked above.
+}

--- a/cmd/gollem/app_server_lock_unsupported.go
+++ b/cmd/gollem/app_server_lock_unsupported.go
@@ -1,0 +1,17 @@
+//go:build !aix && !android && !darwin && !dragonfly && !freebsd && !illumos && !ios && !linux && !netbsd && !openbsd && !solaris && !windows && !zos
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+)
+
+func tryLockAppServerStoreFile(*os.File) error {
+	return fmt.Errorf("app-server store ownership is unavailable on %s", runtime.GOOS)
+}
+
+func unlockAppServerStoreFile(*os.File) error {
+	return nil
+}

--- a/cmd/gollem/app_server_lock_windows.go
+++ b/cmd/gollem/app_server_lock_windows.go
@@ -1,0 +1,38 @@
+//go:build windows
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func tryLockAppServerStoreFile(file *os.File) error {
+	var overlapped windows.Overlapped
+	err := windows.LockFileEx(
+		windows.Handle(file.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+		0,
+		1,
+		0,
+		&overlapped,
+	)
+	if errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+		return errAppServerStoreOwned
+	}
+	if err != nil {
+		return fmt.Errorf("lock app-server store: %w", err)
+	}
+	return nil
+}
+
+func unlockAppServerStoreFile(file *os.File) error {
+	var overlapped windows.Overlapped
+	if err := windows.UnlockFileEx(windows.Handle(file.Fd()), 0, 1, 0, &overlapped); err != nil {
+		return fmt.Errorf("unlock app-server store: %w", err)
+	}
+	return nil
+}

--- a/cmd/gollem/app_server_test.go
+++ b/cmd/gollem/app_server_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"os"
@@ -77,6 +78,422 @@ func TestParseAppServerFlags(t *testing.T) {
 	}
 	if _, err := parseAppServerFlags([]string{"--websocket", "127.0.0.1:0", "--websocket-path", "rpc"}); err == nil || !strings.Contains(err.Error(), "must start with /") {
 		t.Fatalf("invalid websocket path error = %v", err)
+	}
+}
+
+func TestRecoverCLIAppServerStateTerminalizesStaleRuntimeBeforeServing(t *testing.T) {
+	ctx := context.Background()
+	workDir := t.TempDir()
+	storePath := filepath.Join(workDir, "app.db")
+	st, err := store.NewSQLiteStore(storePath)
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	thread, err := st.CreateThread(ctx, store.CreateThreadRequest{Title: "recovery"})
+	if err != nil {
+		t.Fatalf("CreateThread: %v", err)
+	}
+	turn, err := st.CreateTurn(ctx, store.CreateTurnRequest{ThreadID: thread.ID})
+	if err != nil {
+		t.Fatalf("CreateTurn: %v", err)
+	}
+	if _, err := st.StartTurn(ctx, turn.ID); err != nil {
+		t.Fatalf("StartTurn: %v", err)
+	}
+	activeItem, err := st.AppendItem(ctx, store.AppendItemRequest{
+		ThreadID: thread.ID,
+		TurnID:   turn.ID,
+		Kind:     "commandExecution",
+		Status:   "inProgress",
+		Payload:  json.RawMessage(`{"status":"inProgress","command":"sleep"}`),
+	})
+	if err != nil {
+		t.Fatalf("AppendItem: %v", err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if err := recoverCLIAppServerState(appServerFlags{
+		workDir:   workDir,
+		storePath: storePath,
+	}); err != nil {
+		t.Fatalf("recoverCLIAppServerState: %v", err)
+	}
+
+	reopened, err := store.NewSQLiteStore(storePath)
+	if err != nil {
+		t.Fatalf("reopen NewSQLiteStore: %v", err)
+	}
+	defer reopened.Close()
+	recoveredTurn, err := reopened.GetTurn(ctx, turn.ID)
+	if err != nil {
+		t.Fatalf("GetTurn: %v", err)
+	}
+	if recoveredTurn.Status != store.TurnInterrupted || recoveredTurn.Error != store.RuntimeOwnerLostReason {
+		t.Fatalf("recovered turn = %#v", recoveredTurn)
+	}
+	recoveredItem, err := reopened.GetItem(ctx, activeItem.ID)
+	if err != nil {
+		t.Fatalf("GetItem: %v", err)
+	}
+	if recoveredItem.Status != "failed" || !strings.Contains(string(recoveredItem.Payload), `"status":"failed"`) {
+		t.Fatalf("recovered item = %#v", recoveredItem)
+	}
+	items, err := reopened.ListItems(ctx, store.ItemFilter{ThreadID: thread.ID, TurnID: turn.ID})
+	if err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+	recoveryMarkers := 0
+	for _, item := range items {
+		if item.Kind == "runtimeRecovery" {
+			recoveryMarkers++
+		}
+	}
+	if recoveryMarkers != 1 {
+		t.Fatalf("runtime recovery markers = %d, want 1", recoveryMarkers)
+	}
+}
+
+func TestCLIAppServerRecoversAfterHardKillAndRetriesExactlyOnce(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("hard process kill semantics differ on Windows")
+	}
+	workDir := t.TempDir()
+	storePath := filepath.Join(workDir, "app.db")
+
+	first := startHardKillCLIProcess(t, workDir, storePath, "30s")
+	first.initialize(t)
+	assertHardKillCLIStoreRejectsContender(t, workDir, storePath)
+	startResp := first.request(t, "start", "thread/start", map[string]any{
+		"prompt": "survive a hard kill",
+	})
+	if startResp.Error != nil {
+		first.kill(t)
+		t.Fatalf("thread/start error: %v", startResp.Error)
+	}
+	var started protocol.ThreadRunStartResult
+	if err := json.Unmarshal(startResp.Result, &started); err != nil {
+		first.kill(t)
+		t.Fatalf("decode thread/start result: %v", err)
+	}
+	if started.Turn.ID == "" || started.Turn.Status != protocol.TurnLifecycleRunning {
+		first.kill(t)
+		t.Fatalf("started turn = %#v", started.Turn)
+	}
+	first.kill(t)
+
+	second := startHardKillCLIProcess(t, workDir, storePath, "0s")
+	defer second.killIfRunning()
+	second.initialize(t)
+	recovered := second.readThread(t, started.Thread.ID)
+	if len(recovered.Turns) != 1 {
+		t.Fatalf("recovered turns = %#v", recovered.Turns)
+	}
+	recoveredTurn := recovered.Turns[0]
+	if recoveredTurn.ID != started.Turn.ID ||
+		recoveredTurn.Status != protocol.TurnLifecycleInterrupted ||
+		recoveredTurn.Error != store.RuntimeOwnerLostReason {
+		t.Fatalf("recovered turn = %#v", recoveredTurn)
+	}
+	recoveryMarkers := 0
+	for _, item := range recovered.Items {
+		if item.Kind == "runtimeRecovery" && item.TurnID == started.Turn.ID {
+			recoveryMarkers++
+		}
+	}
+	if recoveryMarkers != 1 {
+		t.Fatalf("runtime recovery markers = %d, items = %#v", recoveryMarkers, recovered.Items)
+	}
+
+	retryParams := map[string]any{
+		"turnId":         started.Turn.ID,
+		"idempotencyKey": "hard-kill-retry-1",
+	}
+	retryResp := second.request(t, "retry", "turn/retry", retryParams)
+	if retryResp.Error != nil {
+		t.Fatalf("turn/retry error: %v", retryResp.Error)
+	}
+	var retried protocol.TurnRunRetryResult
+	if err := json.Unmarshal(retryResp.Result, &retried); err != nil {
+		t.Fatalf("decode turn/retry result: %v", err)
+	}
+	if retried.Reused || retried.SourceTurnID != started.Turn.ID || retried.Turn.ID == "" {
+		t.Fatalf("first retry = %#v", retried)
+	}
+	completed := second.waitForTurnStatus(t, started.Thread.ID, retried.Turn.ID, protocol.TurnLifecycleCompleted)
+	if completed.Error != "" {
+		t.Fatalf("completed retry = %#v", completed)
+	}
+
+	duplicateResp := second.request(t, "retry-duplicate", "turn/retry", retryParams)
+	if duplicateResp.Error != nil {
+		t.Fatalf("duplicate turn/retry error: %v", duplicateResp.Error)
+	}
+	var duplicate protocol.TurnRunRetryResult
+	if err := json.Unmarshal(duplicateResp.Result, &duplicate); err != nil {
+		t.Fatalf("decode duplicate turn/retry result: %v", err)
+	}
+	if !duplicate.Reused || duplicate.Turn.ID != retried.Turn.ID ||
+		duplicate.IdempotencyKey != "hard-kill-retry-1" {
+		t.Fatalf("duplicate retry = %#v, first = %#v", duplicate, retried)
+	}
+	final := second.readThread(t, started.Thread.ID)
+	if len(final.Turns) != 2 {
+		t.Fatalf("final turns = %#v, want interrupted source plus one retry", final.Turns)
+	}
+	if final.Turns[1].RetryOfTurnID != started.Turn.ID ||
+		final.Turns[1].RetryIdempotencyKey != "hard-kill-retry-1" {
+		t.Fatalf("durable retry lineage = %#v", final.Turns[1])
+	}
+	second.close(t)
+}
+
+func assertHardKillCLIStoreRejectsContender(t *testing.T, workDir, storePath string) {
+	t.Helper()
+	cmd := exec.CommandContext(t.Context(), os.Args[0], "-test.run=^TestCLIAppServerHardKillHelper$")
+	cmd.Env = append(os.Environ(),
+		"GOLLEM_HARD_KILL_HELPER=1",
+		"GOLLEM_HARD_KILL_WORKDIR="+workDir,
+		"GOLLEM_HARD_KILL_STORE="+storePath,
+		"GOLLEM_TEST_MODEL_DELAY=0s",
+	)
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("contending app-server unexpectedly acquired the live store: %s", output)
+	}
+	if !strings.Contains(string(output), errAppServerStoreOwned.Error()) {
+		t.Fatalf("contending app-server error = %v output=%s", err, output)
+	}
+}
+
+func TestCLIAppServerHardKillHelper(t *testing.T) {
+	if os.Getenv("GOLLEM_HARD_KILL_HELPER") != "1" {
+		t.Skip("subprocess helper")
+	}
+	err := serveCLIAppServerTransports(context.Background(), appServerFlags{
+		workDir:        os.Getenv("GOLLEM_HARD_KILL_WORKDIR"),
+		storePath:      os.Getenv("GOLLEM_HARD_KILL_STORE"),
+		provider:       "test",
+		stdio:          true,
+		allowMutations: true,
+	})
+	if err != nil {
+		t.Fatalf("serveCLIAppServerTransports: %v", err)
+	}
+}
+
+type hardKillCLIProcess struct {
+	cmd     *exec.Cmd
+	stdin   io.WriteCloser
+	lines   <-chan string
+	scanErr <-chan error
+	stderr  *bytes.Buffer
+	running bool
+	nextID  int
+}
+
+func startHardKillCLIProcess(t *testing.T, workDir, storePath, delay string) *hardKillCLIProcess {
+	t.Helper()
+	stderr := &bytes.Buffer{}
+	cmd := exec.CommandContext(t.Context(), os.Args[0], "-test.run=^TestCLIAppServerHardKillHelper$")
+	cmd.Env = append(os.Environ(),
+		"GOLLEM_HARD_KILL_HELPER=1",
+		"GOLLEM_HARD_KILL_WORKDIR="+workDir,
+		"GOLLEM_HARD_KILL_STORE="+storePath,
+		"GOLLEM_TEST_MODEL_DELAY="+delay,
+	)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatalf("hard-kill helper stdin: %v", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("hard-kill helper stdout: %v", err)
+	}
+	cmd.Stderr = stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start hard-kill helper: %v", err)
+	}
+	lines := make(chan string, 256)
+	scanErr := make(chan error, 1)
+	go func() {
+		scanner := bufio.NewScanner(stdout)
+		for scanner.Scan() {
+			lines <- scanner.Text()
+		}
+		scanErr <- scanner.Err()
+		close(lines)
+	}()
+	return &hardKillCLIProcess{
+		cmd:     cmd,
+		stdin:   stdin,
+		lines:   lines,
+		scanErr: scanErr,
+		stderr:  stderr,
+		running: true,
+	}
+}
+
+func (p *hardKillCLIProcess) initialize(t *testing.T) {
+	t.Helper()
+	resp := p.request(t, "init", "initialize", map[string]any{
+		"clientInfo": map[string]any{"name": "hard-kill-test", "version": "1.0.0"},
+	})
+	if resp.Error != nil {
+		t.Fatalf("initialize error: %v", resp.Error)
+	}
+	p.notify(t, "initialized", nil)
+}
+
+func (p *hardKillCLIProcess) request(t *testing.T, id, method string, params any) protocol.Response {
+	t.Helper()
+	line, err := json.Marshal(map[string]any{
+		"id":     id,
+		"method": method,
+		"params": params,
+	})
+	if err != nil {
+		t.Fatalf("marshal %s request: %v", method, err)
+	}
+	writeCLIInputLine(t, p.stdin, string(line))
+	return p.waitResponse(t, id)
+}
+
+func (p *hardKillCLIProcess) notify(t *testing.T, method string, params any) {
+	t.Helper()
+	line, err := json.Marshal(map[string]any{
+		"method": method,
+		"params": params,
+	})
+	if err != nil {
+		t.Fatalf("marshal %s notification: %v", method, err)
+	}
+	writeCLIInputLine(t, p.stdin, string(line))
+}
+
+func (p *hardKillCLIProcess) waitResponse(t *testing.T, id string) protocol.Response {
+	t.Helper()
+	timer := time.NewTimer(10 * time.Second)
+	defer timer.Stop()
+	for {
+		select {
+		case line, ok := <-p.lines:
+			if !ok {
+				var scanErr error
+				select {
+				case scanErr = <-p.scanErr:
+				default:
+				}
+				t.Fatalf("hard-kill helper output closed waiting for %q: scan=%v stderr=%s", id, scanErr, p.stderr)
+			}
+			var envelope struct {
+				ID json.RawMessage `json:"id"`
+			}
+			if err := json.Unmarshal([]byte(line), &envelope); err != nil || len(envelope.ID) == 0 {
+				continue
+			}
+			var resp protocol.Response
+			if err := json.Unmarshal([]byte(line), &resp); err != nil {
+				t.Fatalf("decode hard-kill helper response %s: %v", line, err)
+			}
+			if got, _ := resp.ID.Value().(string); got == id {
+				return resp
+			}
+		case <-timer.C:
+			t.Fatalf("timed out waiting for response %q: stderr=%s", id, p.stderr)
+		}
+	}
+}
+
+func (p *hardKillCLIProcess) readThread(t *testing.T, threadID string) protocol.ThreadReadResult {
+	t.Helper()
+	p.nextID++
+	resp := p.request(t, fmt.Sprintf("read-%d", p.nextID), "thread/read", map[string]any{
+		"threadId":     threadID,
+		"includeTurns": true,
+		"includeItems": true,
+	})
+	if resp.Error != nil {
+		t.Fatalf("thread/read error: %v", resp.Error)
+	}
+	var read protocol.ThreadReadResult
+	if err := json.Unmarshal(resp.Result, &read); err != nil {
+		t.Fatalf("decode thread/read result: %v", err)
+	}
+	return read
+}
+
+func (p *hardKillCLIProcess) waitForTurnStatus(
+	t *testing.T,
+	threadID string,
+	turnID string,
+	status protocol.TurnLifecycleStatus,
+) protocol.TurnRecord {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		read := p.readThread(t, threadID)
+		for _, turn := range read.Turns {
+			if turn.ID == turnID && turn.Status == status {
+				return turn
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("turn %s did not reach %s", turnID, status)
+	return protocol.TurnRecord{}
+}
+
+func (p *hardKillCLIProcess) kill(t *testing.T) {
+	t.Helper()
+	if !p.running {
+		return
+	}
+	if err := p.cmd.Process.Kill(); err != nil {
+		t.Fatalf("kill hard-kill helper: %v", err)
+	}
+	_ = p.stdin.Close()
+	if err := p.cmd.Wait(); err == nil {
+		t.Fatal("hard-kill helper exited successfully after Process.Kill")
+	}
+	p.running = false
+}
+
+func (p *hardKillCLIProcess) killIfRunning() {
+	if p == nil || !p.running {
+		return
+	}
+	_ = p.cmd.Process.Kill()
+	_ = p.stdin.Close()
+	_ = p.cmd.Wait()
+	p.running = false
+}
+
+func (p *hardKillCLIProcess) close(t *testing.T) {
+	t.Helper()
+	if !p.running {
+		return
+	}
+	if err := p.stdin.Close(); err != nil {
+		t.Fatalf("close hard-kill helper stdin: %v", err)
+	}
+	waitCh := make(chan error, 1)
+	go func() {
+		waitCh <- p.cmd.Wait()
+	}()
+	select {
+	case err := <-waitCh:
+		if err != nil {
+			t.Fatalf("hard-kill helper shutdown: %v stderr=%s", err, p.stderr)
+		}
+		p.running = false
+	case <-time.After(10 * time.Second):
+		_ = p.cmd.Process.Kill()
+		_ = p.stdin.Close()
+		<-waitCh
+		p.running = false
+		t.Fatal("timed out shutting down hard-kill helper")
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.40.0
 	go.temporal.io/sdk v1.40.0
 	golang.org/x/oauth2 v0.35.0
+	golang.org/x/sys v0.40.0
 	modernc.org/sqlite v1.46.1
 )
 
@@ -104,7 +105,6 @@ require (
 	golang.org/x/mod v0.30.0 // indirect
 	golang.org/x/net v0.48.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
-	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/text v0.32.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
 	golang.org/x/tools v0.39.0 // indirect


### PR DESCRIPTION
## Summary

- acquire one process-lifetime owner lock per file-backed app-server store and reconcile stale queued/running turns before serving transports
- add an atomic, idempotent `turn/retry` extension with durable source/key lineage, typed unavailable behavior, and strict bounded history replay
- prove owner contention, hard-kill recovery, cancellation, duplicate requests, persistence, generation, and cross-handle SQLite races

## Safety boundary

Recovery terminalizes work whose in-memory owner was lost. It does not claim same-turn resume or recreate pending approval authority. A new retry can independently request a prior mutation again, so clients must present that consequence when incomplete tool work is present.

## Verification

- `go test ./appserver/... ./cmd/gollem`
- repository-wide `go test -race -coverprofile=...` excluding only `ext/monty` per local hook policy
- hard-kill recovery/retry test, 10 consecutive runs
- focused retry/cancellation/replay tests, 10 consecutive runs
- `go vet ./...`
- `golangci-lint run ./...` (0 issues)
- `tsc --project appserver/protocol/typescript/tsconfig.json`
- deterministic schema/TypeScript regeneration (byte-identical SHA-256)
- Linux `cmd/gollem` cross-compile and isolated Windows owner-lock compile

The repository pre-push gate independently passed lint, the non-Monty race suite, vet, and module tidy checks.