### PR TITLE
ci: stabilize golangci analysis baseline

### DIFF
--- a/core/agent_test.go
+++ b/core/agent_test.go
@@ -1063,6 +1063,7 @@ func TestRunStream_IncludesToolsetTools(t *testing.T) {
 	params := calls[0].Parameters
 	if params == nil {
 		t.Fatal("expected parameters")
+		return
 	}
 	found := false
 	for _, td := range params.FunctionTools {
@@ -1163,6 +1164,7 @@ func TestRunStream_AppliesToolChoice(t *testing.T) {
 	settings := calls[0].Settings
 	if settings == nil {
 		t.Fatal("expected settings to be non-nil")
+		return
 	}
 	if settings.ToolChoice == nil {
 		t.Error("expected tool choice to be set in RunStream settings")

--- a/core/iter_test.go
+++ b/core/iter_test.go
@@ -25,6 +25,7 @@ func TestIterBasicText(t *testing.T) {
 	}
 	if resp == nil {
 		t.Fatal("expected non-nil response")
+		return
 	}
 	if resp.TextContent() != "Hello" {
 		t.Errorf("expected 'Hello', got %q", resp.TextContent())

--- a/core/snapshot_test.go
+++ b/core/snapshot_test.go
@@ -163,6 +163,7 @@ func TestSnapshotPreservesRunContextMessagesWhenRichGetterIsUsed(t *testing.T) {
 	snap := Snapshot(rc)
 	if snap == nil {
 		t.Fatal("Snapshot() returned nil")
+		return
 	}
 	if snap.Retries != 3 {
 		t.Fatalf("rich state fields were not preserved: %+v", snap)

--- a/core/trace_test.go
+++ b/core/trace_test.go
@@ -79,6 +79,7 @@ func TestTrace_WithToolCalls(t *testing.T) {
 	trace := result.Trace
 	if trace == nil {
 		t.Fatal("expected non-nil trace")
+		return
 	}
 
 	hasToolCall := false

--- a/ext/memory/store_test.go
+++ b/ext/memory/store_test.go
@@ -25,6 +25,7 @@ func TestMemoryStore_PutGet(t *testing.T) {
 	}
 	if doc == nil {
 		t.Fatal("expected document, got nil")
+		return
 	}
 	if doc.Key != "user1" {
 		t.Errorf("expected key 'user1', got %q", doc.Key)
@@ -194,6 +195,7 @@ func TestMemoryStore_NamespaceIsolation(t *testing.T) {
 	doc1, _ := store.Get(ctx, ns1, "key1")
 	if doc1 == nil {
 		t.Fatal("expected document in ns1")
+		return
 	}
 	if doc1.Value["scope"] != "users" {
 		t.Errorf("expected 'users', got %v", doc1.Value["scope"])
@@ -203,6 +205,7 @@ func TestMemoryStore_NamespaceIsolation(t *testing.T) {
 	doc2, _ := store.Get(ctx, ns2, "key1")
 	if doc2 == nil {
 		t.Fatal("expected document in ns2")
+		return
 	}
 	if doc2.Value["scope"] != "settings" {
 		t.Errorf("expected 'settings', got %v", doc2.Value["scope"])
@@ -536,6 +539,7 @@ func TestSQLiteStore_Persistence(t *testing.T) {
 	}
 	if doc == nil {
 		t.Fatal("expected document to survive close and reopen")
+		return
 	}
 	if doc.Value["data"] != "survives restart" {
 		t.Errorf("expected 'survives restart', got %v", doc.Value["data"])

--- a/ext/temporal/callbacks_test.go
+++ b/ext/temporal/callbacks_test.go
@@ -50,6 +50,7 @@ func TestTemporalAgent_BuildCallbackRunContext_PreservesRunStateSnapshot(t *test
 	snap := rc.RunStateSnapshot()
 	if snap == nil {
 		t.Fatal("expected callback run context snapshot")
+		return
 	}
 	if snap.Prompt != "inspect snapshot" {
 		t.Fatalf("unexpected prompt %q", snap.Prompt)

--- a/ext/temporal/query_signal_test.go
+++ b/ext/temporal/query_signal_test.go
@@ -120,6 +120,7 @@ func TestTemporalAgent_RunWorkflow_QueryStatusWhileWaitingOnDeferred(t *testing.
 	}
 	if trace == nil {
 		t.Fatal("expected workflow status trace")
+		return
 	}
 	var hasReq, hasResp, hasToolCall, hasToolResult, hasDeferredRequested, hasWaitStarted bool
 	for _, step := range trace.Steps {

--- a/ext/temporal/tools_test.go
+++ b/ext/temporal/tools_test.go
@@ -133,6 +133,7 @@ func TestTemporalizeTool_RunStateSnapshotParity(t *testing.T) {
 			snap := rc.RunStateSnapshot()
 			if snap == nil {
 				t.Fatal("expected run state snapshot in temporal tool context")
+				return "", nil
 			}
 			if snap.Prompt != "snapshot prompt" {
 				t.Fatalf("unexpected prompt %q", snap.Prompt)

--- a/ext/temporal/workflow_test.go
+++ b/ext/temporal/workflow_test.go
@@ -459,6 +459,7 @@ func TestTemporalAgent_RunWorkflow_TraceCostAndExporterParity(t *testing.T) {
 	exported := exporter.Last()
 	if exported == nil {
 		t.Fatal("expected exported trace")
+		return
 	}
 	if exported.RunID != result.RunID {
 		t.Fatalf("expected exported trace run ID %q, got %q", result.RunID, exported.RunID)

--- a/provider/vertexai/vertexai.go
+++ b/provider/vertexai/vertexai.go
@@ -162,7 +162,7 @@ func (p *Provider) getToken(ctx context.Context) (string, error) {
 // createTokenSource creates an OAuth2 token source based on configuration.
 func (p *Provider) createTokenSource(ctx context.Context) (oauth2.TokenSource, error) {
 	if p.credentialsJSON != nil {
-		creds, err := google.CredentialsFromJSON(ctx, p.credentialsJSON, cloudScope) //nolint:staticcheck // deprecated but still functional
+		creds, err := google.CredentialsFromJSON(ctx, p.credentialsJSON, cloudScope) //nolint:staticcheck,nolintlint // credentials are explicitly configured by the process owner
 		if err != nil {
 			return nil, err
 		}
@@ -173,7 +173,7 @@ func (p *Provider) createTokenSource(ctx context.Context) (oauth2.TokenSource, e
 		if err != nil {
 			return nil, fmt.Errorf("failed to read credentials file: %w", err)
 		}
-		creds, err := google.CredentialsFromJSON(ctx, data, cloudScope) //nolint:staticcheck // deprecated but still functional
+		creds, err := google.CredentialsFromJSON(ctx, data, cloudScope) //nolint:staticcheck,nolintlint // credentials are explicitly configured by the process owner
 		if err != nil {
 			return nil, err
 		}

--- a/provider/vertexai_anthropic/vertexai_anthropic.go
+++ b/provider/vertexai_anthropic/vertexai_anthropic.go
@@ -263,7 +263,7 @@ func (p *Provider) getToken(ctx context.Context) (string, error) {
 // createTokenSource creates an OAuth2 token source based on configuration.
 func (p *Provider) createTokenSource(ctx context.Context) (oauth2.TokenSource, error) {
 	if p.credentialsJSON != nil {
-		creds, err := google.CredentialsFromJSON(ctx, p.credentialsJSON, cloudScope) //nolint:staticcheck // deprecated but still functional
+		creds, err := google.CredentialsFromJSON(ctx, p.credentialsJSON, cloudScope) //nolint:staticcheck,nolintlint // credentials are explicitly configured by the process owner
 		if err != nil {
 			return nil, err
 		}
@@ -274,7 +274,7 @@ func (p *Provider) createTokenSource(ctx context.Context) (oauth2.TokenSource, e
 		if err != nil {
 			return nil, fmt.Errorf("failed to read credentials file: %w", err)
 		}
-		creds, err := google.CredentialsFromJSON(ctx, data, cloudScope) //nolint:staticcheck // deprecated but still functional
+		creds, err := google.CredentialsFromJSON(ctx, data, cloudScope) //nolint:staticcheck,nolintlint // credentials are explicitly configured by the process owner
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary
- make nil-guard control flow explicit for staticcheck across core, memory, and Temporal tests
- tolerate cache-dependent deprecation analysis while retaining the documented owner-configured Vertex credential path
- keep the change mechanical and independent of thread rollback behavior

## Verification
- `golangci-lint run` (v2.10.1): 0 issues
- focused changed-package tests and vet: passed
- pre-push full non-Monty race suite, vet, and tidy verification: passed
- Monty race tests intentionally skipped by `hooks.skipMontyRace=true`