### PR TITLE
feat(mcp): migrate to MCP spec 2026-07-28 (hard cut)

### DIFF
--- a/cmd/gollem-mcp-server/main.go
+++ b/cmd/gollem-mcp-server/main.go
@@ -38,7 +38,6 @@ type rpcError struct {
 	Message string `json:"message"`
 }
 
-type initializeResult = mcp.InitializeResult
 type toolsListResult struct {
 	Tools []mcp.Tool `json:"tools"`
 }
@@ -314,19 +313,14 @@ func normalizeID(raw *json.RawMessage) any {
 func createModel(provider, modelName string, rc *mcp.RequestContext) (core.Model, error) {
 	switch provider {
 	case "mcp":
-		if rc == nil || rc.ClientCapabilities().Sampling == nil {
-			return nil, fmt.Errorf("provider %q requires an MCP client with sampling support", provider)
-		}
-		var opts []mcp.MCPModelOption
-		if modelName != "" {
-			opts = append(opts,
-				mcp.WithMCPModelName(modelName),
-				mcp.WithMCPModelPreferences(mcp.ModelPreferences{
-					Hints: []mcp.ModelHint{{Name: modelName}},
-				}),
-			)
-		}
-		return mcp.NewMCPModel(rc, opts...), nil
+		// The 2026-07-28 MCP protocol replaces server-initiated sampling with
+		// Multi Round-Trip Requests (MRTR). Borrowing the connected client's
+		// model now requires a handler to return an *mcp.InputRequiredResult
+		// built via rc.NeedInput and mcp.BuildSamplingInputRequest, then parse
+		// the client's answer with mcp.ParseCreateMessageResult on retry.
+		// TODO(mcp-2026): wire the run_agent tool to MRTR sampling so provider
+		// "mcp" borrows the client's model again.
+		return nil, fmt.Errorf("provider %q requires MRTR sampling wiring (not yet implemented for this server)", provider)
 	case "openai":
 		var opts []openai.Option
 		if modelName != "" {

--- a/cmd/gollem-mcp-server/main_test.go
+++ b/cmd/gollem-mcp-server/main_test.go
@@ -10,9 +10,25 @@ import (
 	"testing"
 )
 
-// sendRequest formats a JSON-RPC request line.
+// sendRequest formats a JSON-RPC request line. Every request carries the
+// stateless _meta envelope required by the 2026-07-28 protocol.
 func sendRequest(t *testing.T, id interface{}, method string, params interface{}) string {
 	t.Helper()
+	if params == nil {
+		params = map[string]interface{}{}
+	}
+	if pm, ok := params.(map[string]interface{}); ok {
+		if _, exists := pm["_meta"]; !exists {
+			pm["_meta"] = map[string]interface{}{
+				"io.modelcontextprotocol/protocolVersion":    protocolVersion,
+				"io.modelcontextprotocol/clientCapabilities": map[string]interface{}{},
+				"io.modelcontextprotocol/clientInfo": map[string]interface{}{
+					"name":    "test-client",
+					"version": "1.0.0",
+				},
+			}
+		}
+	}
 	req := map[string]interface{}{
 		"jsonrpc": "2.0",
 		"method":  method,
@@ -63,18 +79,10 @@ func runServer(t *testing.T, lines ...string) []string {
 	return results
 }
 
-func TestInitializeHandshake(t *testing.T) {
-	initReq := sendRequest(t, 1, "initialize", map[string]interface{}{
-		"protocolVersion": protocolVersion,
-		"capabilities":    map[string]interface{}{},
-		"clientInfo": map[string]interface{}{
-			"name":    "test-client",
-			"version": "1.0.0",
-		},
-	})
-	notifReq := sendRequest(t, nil, "notifications/initialized", nil)
+func TestDiscover(t *testing.T) {
+	discoverReq := sendRequest(t, 1, "server/discover", nil)
 
-	lines := runServer(t, initReq, notifReq)
+	lines := runServer(t, discoverReq)
 	if len(lines) != 1 {
 		t.Fatalf("expected 1 response line, got %d: %v", len(lines), lines)
 	}
@@ -84,24 +92,32 @@ func TestInitializeHandshake(t *testing.T) {
 		t.Fatalf("unexpected error: %v", resp.Error)
 	}
 
-	// Parse the result.
 	resultJSON, err := json.Marshal(resp.Result)
 	if err != nil {
 		t.Fatalf("marshal result: %v", err)
 	}
 
-	var initResult initializeResult
-	if err := json.Unmarshal(resultJSON, &initResult); err != nil {
-		t.Fatalf("unmarshal init result: %v", err)
+	var discResult struct {
+		SupportedVersions []string `json:"supportedVersions"`
+		ServerInfo        struct {
+			Name    string `json:"name"`
+			Version string `json:"version"`
+		} `json:"serverInfo"`
+		Capabilities struct {
+			Tools interface{} `json:"tools"`
+		} `json:"capabilities"`
+	}
+	if err := json.Unmarshal(resultJSON, &discResult); err != nil {
+		t.Fatalf("unmarshal discover result: %v", err)
 	}
 
-	if initResult.ProtocolVersion != protocolVersion {
-		t.Errorf("protocol version = %q, want %q", initResult.ProtocolVersion, protocolVersion)
+	if len(discResult.SupportedVersions) != 1 || discResult.SupportedVersions[0] != protocolVersion {
+		t.Errorf("protocol versions = %+v, want [%s]", discResult.SupportedVersions, protocolVersion)
 	}
-	if initResult.ServerInfo.Name != "gollem-mcp-server" {
-		t.Errorf("server name = %q, want %q", initResult.ServerInfo.Name, "gollem-mcp-server")
+	if discResult.ServerInfo.Name != "gollem-mcp-server" {
+		t.Errorf("server name = %q, want %q", discResult.ServerInfo.Name, "gollem-mcp-server")
 	}
-	if initResult.Capabilities.Tools == nil {
+	if discResult.Capabilities.Tools == nil {
 		t.Error("expected tools capability to be set")
 	}
 }
@@ -423,22 +439,16 @@ func TestUnknownMethod(t *testing.T) {
 }
 
 func TestMultipleRequests(t *testing.T) {
-	initReq := sendRequest(t, 1, "initialize", map[string]interface{}{
-		"protocolVersion": protocolVersion,
-		"capabilities":    map[string]interface{}{},
-		"clientInfo":      map[string]interface{}{"name": "test", "version": "1.0.0"},
-	})
-	notifReq := sendRequest(t, nil, "notifications/initialized", nil)
+	discoverReq := sendRequest(t, 1, "server/discover", nil)
 	listReq := sendRequest(t, 2, "tools/list", nil)
 	provReq := sendRequest(t, 3, "tools/call", map[string]interface{}{
 		"name":      "list_providers",
 		"arguments": map[string]interface{}{},
 	})
 
-	lines := runServer(t, initReq, notifReq, listReq, provReq)
+	lines := runServer(t, discoverReq, listReq, provReq)
 
-	// Should get 3 responses: initialize, tools/list, tools/call.
-	// notifications/initialized has no id so no response.
+	// Should get 3 responses: server/discover, tools/list, tools/call.
 	if len(lines) != 3 {
 		t.Fatalf("expected 3 responses, got %d: %v", len(lines), lines)
 	}

--- a/ext/mcp/client.go
+++ b/ext/mcp/client.go
@@ -59,7 +59,9 @@ func WithStdioEnv(env map[string]string) StdioClientOption {
 	}
 }
 
-// NewStdioClient spawns an MCP server process and connects via stdio.
+// NewStdioClient spawns an MCP server process and connects via stdio. The
+// 2026-07-28 protocol is stateless: no initialize handshake is performed.
+// Clients MAY call Discover to learn server identity and capabilities.
 func NewStdioClient(ctx context.Context, command string, args ...string) (*Client, error) {
 	return NewStdioClientWithOptions(ctx, command, WithStdioArgs(args...))
 }
@@ -116,11 +118,6 @@ func NewStdioClientWithConfig(ctx context.Context, command string, config Client
 
 	go c.readLoop()
 
-	if err := c.initialize(ctx); err != nil {
-		c.Close()
-		return nil, fmt.Errorf("mcp: initialization failed: %w", err)
-	}
-
 	return c, nil
 }
 
@@ -129,11 +126,9 @@ func NewStdioClientWithOptions(ctx context.Context, command string, opts ...Stdi
 	return NewStdioClientWithConfig(ctx, command, ClientConfig{}, opts...)
 }
 
-func (c *Client) initialize(ctx context.Context) error {
-	return initializeClient(ctx, c.clientState, c.call, c.notify)
-}
-
-// call sends a JSON-RPC request and waits for a response.
+// call sends a JSON-RPC request and waits for a response. params is expected to
+// be a json.RawMessage already carrying the stateless _meta envelope (built via
+// mergeRequestMeta by the shared roundTrip driver).
 func (c *Client) call(ctx context.Context, method string, params any) (json.RawMessage, error) {
 	id, ch, err := c.prepareCall()
 	if err != nil {
@@ -144,7 +139,16 @@ func (c *Client) call(ctx context.Context, method string, params any) (json.RawM
 		JSONRPC: "2.0",
 		ID:      id,
 		Method:  method,
-		Params:  params,
+	}
+	if raw, ok := params.(json.RawMessage); ok && len(raw) > 0 {
+		req.Params = raw
+	} else if params != nil {
+		data, mErr := json.Marshal(params)
+		if mErr != nil {
+			c.removePending(id)
+			return nil, mErr
+		}
+		req.Params = data
 	}
 
 	data, err := json.Marshal(req)
@@ -167,29 +171,48 @@ func (c *Client) call(ctx context.Context, method string, params any) (json.RawM
 // notify sends a JSON-RPC notification (no response expected).
 func (c *Client) notify(_ context.Context, method string, params any) error {
 	req := struct {
-		JSONRPC string `json:"jsonrpc"`
-		Method  string `json:"method"`
-		Params  any    `json:"params,omitempty"`
+		JSONRPC string          `json:"jsonrpc"`
+		Method  string          `json:"method"`
+		Params  json.RawMessage `json:"params,omitempty"`
 	}{
 		JSONRPC: "2.0",
 		Method:  method,
-		Params:  params,
+	}
+	if raw, ok := params.(json.RawMessage); ok {
+		req.Params = raw
+	} else if params != nil {
+		data, err := json.Marshal(params)
+		if err != nil {
+			return err
+		}
+		req.Params = data
 	}
 
+	return c.writeJSON(mustRawJSON(marshalRequest(req)))
+}
+
+func marshalRequest(req any) []byte {
 	data, err := json.Marshal(req)
 	if err != nil {
-		return err
+		return nil
 	}
-
-	return c.writeJSON(data)
+	return data
 }
 
 func (c *Client) respond(_ context.Context, id any, result any, rpcErr *jsonRPCError) error {
 	resp := jsonRPCResponse{
 		JSONRPC: "2.0",
 		ID:      id,
-		Result:  result,
 		Error:   rpcErr,
+	}
+	if raw, ok := result.(json.RawMessage); ok {
+		resp.Result = raw
+	} else if result != nil {
+		data, err := json.Marshal(result)
+		if err != nil {
+			return err
+		}
+		resp.Result = data
 	}
 	data, err := json.Marshal(resp)
 	if err != nil {
@@ -222,44 +245,97 @@ func (c *Client) readLoop() {
 	}
 }
 
-// ListTools discovers available tools from the MCP server.
-func (c *Client) ListTools(ctx context.Context) ([]Tool, error) {
-	return listTools(ctx, c.call)
+// Discover calls server/discover and caches the server's identity, capabilities,
+// and instructions on the client state. It is optional; clients MAY call it
+// before any other request to select a protocol version up front.
+func (c *Client) Discover(ctx context.Context) (*DiscoverResult, error) {
+	return discover(ctx, c.call, c.clientState)
 }
 
-// CallTool invokes a tool on the MCP server.
+// ListTools discovers available tools from the MCP server.
+func (c *Client) ListTools(ctx context.Context) ([]Tool, error) {
+	return listTools(ctx, c.call, c.clientState)
+}
+
+// CallTool invokes a tool on the MCP server. tools/call is MRTR-eligible: if the
+// server returns input_required, the client fulfills the input requests and
+// retries automatically.
 func (c *Client) CallTool(ctx context.Context, name string, args map[string]any) (*ToolResult, error) {
-	return callTool(ctx, c.call, name, args)
+	return callTool(ctx, c.call, c.clientState, name, args)
 }
 
 // ListResources lists resources exposed by the MCP server.
 func (c *Client) ListResources(ctx context.Context) ([]Resource, error) {
-	return listResources(ctx, c.call)
+	return listResources(ctx, c.call, c.clientState)
 }
 
-// ReadResource reads a resource from the MCP server.
+// ReadResource reads a resource from the MCP server. resources/read is
+// MRTR-eligible.
 func (c *Client) ReadResource(ctx context.Context, uri string) (*ReadResourceResult, error) {
-	return readResource(ctx, c.call, uri)
+	return readResource(ctx, c.call, c.clientState, uri)
 }
 
 // ListResourceTemplates lists URI templates exposed by the MCP server.
 func (c *Client) ListResourceTemplates(ctx context.Context) ([]ResourceTemplate, error) {
-	return listResourceTemplates(ctx, c.call)
+	return listResourceTemplates(ctx, c.call, c.clientState)
 }
 
 // ListPrompts lists prompts exposed by the MCP server.
 func (c *Client) ListPrompts(ctx context.Context) ([]Prompt, error) {
-	return listPrompts(ctx, c.call)
+	return listPrompts(ctx, c.call, c.clientState)
 }
 
-// GetPrompt resolves a prompt from the MCP server.
+// GetPrompt resolves a prompt from the MCP server. prompts/get is MRTR-eligible.
 func (c *Client) GetPrompt(ctx context.Context, name string, args map[string]string) (*PromptResult, error) {
-	return getPrompt(ctx, c.call, name, args)
+	return getPrompt(ctx, c.call, c.clientState, name, args)
 }
 
-// NotifyRootsListChanged emits notifications/roots/list_changed to the server.
-func (c *Client) NotifyRootsListChanged(ctx context.Context) error {
-	return notifyRootsListChanged(ctx, c.notify)
+// Listen opens a subscriptions/listen stream over the shared stdio channel. It
+// registers handler for every server notification, sends subscriptions/listen
+// (the server replies with notifications/subscriptions/acknowledged and then
+// fans out notifications on the same channel), and blocks until ctx is
+// cancelled. On cancellation it unregisters the handler and sends
+// notifications/cancelled referencing the listen request id so the server
+// gracefully closes the subscription. Notifications are also delivered to any
+// handlers registered via OnNotification.
+func (c *Client) Listen(ctx context.Context, filter SubscriptionFilter, handler func(Notification)) error {
+	unregister := c.OnNotification("", handler)
+
+	params := SubscribeParams{Notifications: filter}
+	paramsRaw, err := mergeRequestMeta(params, c.requestMeta())
+	if err != nil {
+		unregister()
+		return fmt.Errorf("mcp: failed to build subscriptions/listen params: %w", err)
+	}
+	id := c.nextID.Add(1)
+	req := jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      id,
+		Method:  "subscriptions/listen",
+		Params:  paramsRaw,
+	}
+	data, err := json.Marshal(req)
+	if err != nil {
+		unregister()
+		return err
+	}
+	c.writeMu.Lock()
+	_, werr := fmt.Fprintf(c.stdin, "%s\n", data)
+	c.writeMu.Unlock()
+	if werr != nil {
+		unregister()
+		return fmt.Errorf("mcp: failed to send subscriptions/listen: %w", werr)
+	}
+
+	<-ctx.Done()
+	unregister()
+
+	// Cooperatively cancel the subscription so the server can close it and
+	// reclaim the hub entry.
+	idJSON, _ := json.Marshal(id)
+	cancelParams := map[string]any{"requestId": json.RawMessage(idJSON)}
+	_ = c.notify(context.Background(), "notifications/cancelled", cancelParams)
+	return ctx.Err()
 }
 
 // Close shuts down the MCP server process and releases resources.

--- a/ext/mcp/client_test.go
+++ b/ext/mcp/client_test.go
@@ -39,14 +39,15 @@ func TestJSONRPCRequestSerialization(t *testing.T) {
 }
 
 func TestJSONRPCRequestWithParams(t *testing.T) {
+	params, _ := json.Marshal(map[string]any{
+		"name":      "get_weather",
+		"arguments": map[string]any{"city": "NYC"},
+	})
 	req := jsonRPCRequest{
 		JSONRPC: "2.0",
 		ID:      2,
 		Method:  "tools/call",
-		Params: map[string]any{
-			"name":      "get_weather",
-			"arguments": map[string]any{"city": "NYC"},
-		},
+		Params:  params,
 	}
 
 	data, err := json.Marshal(req)
@@ -57,11 +58,11 @@ func TestJSONRPCRequestWithParams(t *testing.T) {
 	var parsed map[string]any
 	json.Unmarshal(data, &parsed)
 
-	params := parsed["params"].(map[string]any)
-	if params["name"] != "get_weather" {
-		t.Errorf("expected name get_weather, got %v", params["name"])
+	paramsMap := parsed["params"].(map[string]any)
+	if paramsMap["name"] != "get_weather" {
+		t.Errorf("expected name get_weather, got %v", paramsMap["name"])
 	}
-	args := params["arguments"].(map[string]any)
+	args := paramsMap["arguments"].(map[string]any)
 	if args["city"] != "NYC" {
 		t.Errorf("expected city NYC, got %v", args["city"])
 	}

--- a/ext/mcp/http.go
+++ b/ext/mcp/http.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -15,9 +14,12 @@ import (
 	"github.com/fugue-labs/gollem/core"
 )
 
-// HTTPClient communicates with an MCP server over the streamable HTTP transport.
-// It supports direct JSON responses, SSE responses to POST requests, and an
-// optional background SSE stream for notifications and asynchronous responses.
+// HTTPClient communicates with an MCP server over the streamable HTTP
+// transport. The 2026-07-28 protocol is stateless: there is no session id, no
+// initialize handshake, and no SSE resumability. POST carries a single
+// JSON-RPC request (with the stateless _meta envelope) and returns the result
+// inline as application/json. The one long-lived stream is subscriptions/listen,
+// delivered as a POST whose response is text/event-stream (see Listen).
 type HTTPClient struct {
 	*clientState
 
@@ -25,15 +27,12 @@ type HTTPClient struct {
 	httpClient *http.Client
 	headers    map[string]string
 
-	streamMu        sync.Mutex
-	cancelStream    context.CancelFunc
-	streamConnected bool
-	sessionID       string
-
 	closeOnce sync.Once
 }
 
 // NewHTTPClient connects to an MCP server over the streamable HTTP transport.
+// No initialize handshake is performed; clients MAY call Discover to learn the
+// server's identity and capabilities.
 func NewHTTPClient(ctx context.Context, url string, opts ...HTTPClientOption) (*HTTPClient, error) {
 	return NewHTTPClientWithConfig(ctx, url, ClientConfig{}, opts...)
 }
@@ -54,17 +53,7 @@ func NewHTTPClientWithConfig(ctx context.Context, url string, config ClientConfi
 		headers:     cloneStringMap(cfg.headers),
 	}
 
-	if err := c.initialize(ctx); err != nil {
-		c.Close()
-		return nil, fmt.Errorf("mcp: initialization failed: %w", err)
-	}
-
-	c.ensureNotificationStream()
 	return c, nil
-}
-
-func (c *HTTPClient) initialize(ctx context.Context) error {
-	return initializeClient(ctx, c.clientState, c.call, c.notify)
 }
 
 func (c *HTTPClient) call(ctx context.Context, method string, params any) (json.RawMessage, error) {
@@ -77,7 +66,16 @@ func (c *HTTPClient) call(ctx context.Context, method string, params any) (json.
 		JSONRPC: "2.0",
 		ID:      id,
 		Method:  method,
-		Params:  params,
+	}
+	if raw, ok := params.(json.RawMessage); ok && len(raw) > 0 {
+		req.Params = raw
+	} else if params != nil {
+		data, mErr := json.Marshal(params)
+		if mErr != nil {
+			c.removePending(id)
+			return nil, mErr
+		}
+		req.Params = data
 	}
 
 	data, err := json.Marshal(req)
@@ -93,25 +91,25 @@ func (c *HTTPClient) call(ctx context.Context, method string, params any) (json.
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("Accept", "application/json, text/event-stream")
+	httpReq.Header.Set("Mcp-Method", method)
+	if name := mcpNameForRequest(method, req.Params); name != "" {
+		httpReq.Header.Set("Mcp-Name", name)
+	}
 	applyHeaders(httpReq, c.headers)
 	applyProtocolVersionHeader(httpReq, c.ProtocolVersion())
-	if sessionID := c.getSessionID(); sessionID != "" {
-		httpReq.Header.Set("Mcp-Session-Id", sessionID)
-	}
 
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
 		c.removePending(id)
 		return nil, fmt.Errorf("mcp: failed to send request: %w", err)
 	}
-	c.captureSessionID(resp)
 	defer func() {
 		if resp.Body != nil {
 			resp.Body.Close()
 		}
 	}()
 
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
+	if resp.StatusCode != http.StatusOK {
 		c.removePending(id)
 		respBody, _ := io.ReadAll(resp.Body)
 		if len(respBody) > 0 {
@@ -124,7 +122,6 @@ func (c *HTTPClient) call(ctx context.Context, method string, params any) (json.
 	switch {
 	case strings.Contains(contentType, "text/event-stream"):
 		stream := resp.Body
-		resp.Body = nil
 		go func(callID int64, stream io.ReadCloser) {
 			_ = readEventStream(stream, c.handleEvent)
 			c.failPendingCall(callID)
@@ -145,62 +142,25 @@ func (c *HTTPClient) call(ctx context.Context, method string, params any) (json.
 		}
 	default:
 		_, _ = io.Copy(io.Discard, resp.Body)
-		if resp.StatusCode == http.StatusAccepted {
-			c.ensureNotificationStream()
-			if !c.waitForStream(ctx, streamConnectWait) {
-				c.removePending(id)
-				return nil, errors.New("mcp: HTTP request accepted but no event stream is connected")
-			}
-		}
 	}
 
 	return c.awaitResponse(ctx, id, ch)
-}
-
-func (c *HTTPClient) notify(ctx context.Context, method string, params any) error {
-	req := struct {
-		JSONRPC string `json:"jsonrpc"`
-		Method  string `json:"method"`
-		Params  any    `json:"params,omitempty"`
-	}{
-		JSONRPC: "2.0",
-		Method:  method,
-		Params:  params,
-	}
-
-	data, err := json.Marshal(req)
-	if err != nil {
-		return err
-	}
-
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint, bytes.NewReader(data))
-	if err != nil {
-		return err
-	}
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Accept", "application/json, text/event-stream")
-	applyHeaders(httpReq, c.headers)
-	applyProtocolVersionHeader(httpReq, c.ProtocolVersion())
-	if sessionID := c.getSessionID(); sessionID != "" {
-		httpReq.Header.Set("Mcp-Session-Id", sessionID)
-	}
-
-	resp, err := c.httpClient.Do(httpReq)
-	if err != nil {
-		return fmt.Errorf("mcp: failed to send notification: %w", err)
-	}
-	c.captureSessionID(resp)
-	_, _ = io.Copy(io.Discard, resp.Body)
-	resp.Body.Close()
-	return nil
 }
 
 func (c *HTTPClient) respond(ctx context.Context, id any, result any, rpcErr *jsonRPCError) error {
 	resp := jsonRPCResponse{
 		JSONRPC: "2.0",
 		ID:      id,
-		Result:  result,
 		Error:   rpcErr,
+	}
+	if raw, ok := result.(json.RawMessage); ok {
+		resp.Result = raw
+	} else if result != nil {
+		data, err := json.Marshal(result)
+		if err != nil {
+			return err
+		}
+		resp.Result = data
 	}
 	data, err := json.Marshal(resp)
 	if err != nil {
@@ -212,123 +172,16 @@ func (c *HTTPClient) respond(ctx context.Context, id any, result any, rpcErr *js
 		return err
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Accept", "application/json, text/event-stream")
 	applyHeaders(httpReq, c.headers)
 	applyProtocolVersionHeader(httpReq, c.ProtocolVersion())
-	if sessionID := c.getSessionID(); sessionID != "" {
-		httpReq.Header.Set("Mcp-Session-Id", sessionID)
-	}
 
 	httpResp, err := c.httpClient.Do(httpReq)
 	if err != nil {
 		return fmt.Errorf("mcp: failed to send response: %w", err)
 	}
-	c.captureSessionID(httpResp)
 	_, _ = io.Copy(io.Discard, httpResp.Body)
 	httpResp.Body.Close()
 	return nil
-}
-
-// ListTools discovers available tools from the MCP server.
-func (c *HTTPClient) ListTools(ctx context.Context) ([]Tool, error) {
-	return listTools(ctx, c.call)
-}
-
-// CallTool invokes a tool on the MCP server.
-func (c *HTTPClient) CallTool(ctx context.Context, name string, args map[string]any) (*ToolResult, error) {
-	return callTool(ctx, c.call, name, args)
-}
-
-// ListResources lists resources exposed by the MCP server.
-func (c *HTTPClient) ListResources(ctx context.Context) ([]Resource, error) {
-	return listResources(ctx, c.call)
-}
-
-// ReadResource reads a resource from the MCP server.
-func (c *HTTPClient) ReadResource(ctx context.Context, uri string) (*ReadResourceResult, error) {
-	return readResource(ctx, c.call, uri)
-}
-
-// ListResourceTemplates lists URI templates exposed by the MCP server.
-func (c *HTTPClient) ListResourceTemplates(ctx context.Context) ([]ResourceTemplate, error) {
-	return listResourceTemplates(ctx, c.call)
-}
-
-// ListPrompts lists prompts exposed by the MCP server.
-func (c *HTTPClient) ListPrompts(ctx context.Context) ([]Prompt, error) {
-	return listPrompts(ctx, c.call)
-}
-
-// GetPrompt resolves a prompt from the MCP server.
-func (c *HTTPClient) GetPrompt(ctx context.Context, name string, args map[string]string) (*PromptResult, error) {
-	return getPrompt(ctx, c.call, name, args)
-}
-
-// NotifyRootsListChanged emits notifications/roots/list_changed to the server.
-func (c *HTTPClient) NotifyRootsListChanged(ctx context.Context) error {
-	return notifyRootsListChanged(ctx, c.notify)
-}
-
-// Tools converts MCP tools into core.Tool instances that call back to the
-// remote MCP server.
-func (c *HTTPClient) Tools(ctx context.Context) ([]core.Tool, error) {
-	return toolsForSource(ctx, c)
-}
-
-func (c *HTTPClient) ensureNotificationStream() {
-	c.streamMu.Lock()
-	if c.cancelStream != nil {
-		c.streamMu.Unlock()
-		return
-	}
-	streamCtx, cancel := context.WithCancel(context.Background())
-	c.cancelStream = cancel
-	c.streamMu.Unlock()
-
-	go c.readNotificationStream(streamCtx)
-}
-
-func (c *HTTPClient) readNotificationStream(ctx context.Context) {
-	defer func() {
-		c.streamMu.Lock()
-		c.streamConnected = false
-		c.cancelStream = nil
-		c.streamMu.Unlock()
-	}()
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.endpoint, nil)
-	if err != nil {
-		return
-	}
-	req.Header.Set("Accept", "text/event-stream")
-	applyHeaders(req, c.headers)
-	applyProtocolVersionHeader(req, c.ProtocolVersion())
-	if sessionID := c.getSessionID(); sessionID != "" {
-		req.Header.Set("Mcp-Session-Id", sessionID)
-	}
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return
-	}
-	c.captureSessionID(resp)
-	if resp.StatusCode != http.StatusOK || !strings.Contains(resp.Header.Get("Content-Type"), "text/event-stream") {
-		_, _ = io.Copy(io.Discard, resp.Body)
-		resp.Body.Close()
-		return
-	}
-
-	c.streamMu.Lock()
-	c.streamConnected = true
-	c.streamMu.Unlock()
-
-	if err := readEventStream(resp.Body, c.handleEvent); err != nil && ctx.Err() == nil {
-		c.failPending()
-		return
-	}
-	if ctx.Err() == nil {
-		c.failPending()
-	}
 }
 
 func (c *HTTPClient) handleEvent(_ string, data string) {
@@ -339,92 +192,259 @@ func (c *HTTPClient) handleEvent(_ string, data string) {
 	c.dispatchMessage(&msg, c.respond)
 }
 
-func (c *HTTPClient) captureSessionID(resp *http.Response) {
-	if resp == nil {
-		return
+// mcpNameForRequest extracts the Mcp-Name header value for a request: the tool
+// name for tools/call, the prompt name for prompts/get, and the resource uri
+// for resources/read. Empty for methods without a name.
+func mcpNameForRequest(method string, params json.RawMessage) string {
+	if len(params) == 0 {
+		return ""
 	}
-	sessionID := resp.Header.Get("Mcp-Session-Id")
-	if sessionID == "" {
-		return
+	var probe struct {
+		Name string `json:"name"`
+		URI  string `json:"uri"`
 	}
-	c.streamMu.Lock()
-	c.sessionID = sessionID
-	c.streamMu.Unlock()
+	if err := json.Unmarshal(params, &probe); err != nil {
+		return ""
+	}
+	switch method {
+	case "tools/call", "prompts/get":
+		return probe.Name
+	case "resources/read":
+		return probe.URI
+	default:
+		return ""
+	}
 }
 
-func (c *HTTPClient) getSessionID() string {
-	c.streamMu.Lock()
-	defer c.streamMu.Unlock()
-	return c.sessionID
+// Discover calls server/discover and caches the server's identity, capabilities,
+// and instructions on the client state.
+func (c *HTTPClient) Discover(ctx context.Context) (*DiscoverResult, error) {
+	return discover(ctx, c.call, c.clientState)
 }
 
-func (c *HTTPClient) isStreamConnected() bool {
-	c.streamMu.Lock()
-	defer c.streamMu.Unlock()
-	return c.streamConnected
+// ListTools discovers available tools from the MCP server.
+func (c *HTTPClient) ListTools(ctx context.Context) ([]Tool, error) {
+	return listTools(ctx, c.call, c.clientState)
 }
 
-// streamConnectWait bounds how long a call whose response was
-// deferred to the notification stream (HTTP 202) waits for that
-// stream to connect. The wait returns the moment the stream is up,
-// so a generous bound only delays the failure path. The previous
-// 250ms bound lost the cold-start race deterministically: a client's
-// first tools/call could be accepted by the server before the
-// client's notification GET finished connecting, surfacing as
-// "request accepted but no event stream is connected" on otherwise
-// healthy local servers (and as a load-dependent flake in CI).
-const streamConnectWait = 5 * time.Second
+// CallTool invokes a tool on the MCP server. tools/call is MRTR-eligible.
+func (c *HTTPClient) CallTool(ctx context.Context, name string, args map[string]any) (*ToolResult, error) {
+	return callTool(ctx, c.call, c.clientState, name, args)
+}
 
-func (c *HTTPClient) waitForStream(ctx context.Context, timeout time.Duration) bool {
-	if c.isStreamConnected() {
-		return true
+// ListResources lists resources exposed by the MCP server.
+func (c *HTTPClient) ListResources(ctx context.Context) ([]Resource, error) {
+	return listResources(ctx, c.call, c.clientState)
+}
+
+// ReadResource reads a resource from the MCP server. resources/read is MRTR-eligible.
+func (c *HTTPClient) ReadResource(ctx context.Context, uri string) (*ReadResourceResult, error) {
+	return readResource(ctx, c.call, c.clientState, uri)
+}
+
+// ListResourceTemplates lists URI templates exposed by the MCP server.
+func (c *HTTPClient) ListResourceTemplates(ctx context.Context) ([]ResourceTemplate, error) {
+	return listResourceTemplates(ctx, c.call, c.clientState)
+}
+
+// ListPrompts lists prompts exposed by the MCP server.
+func (c *HTTPClient) ListPrompts(ctx context.Context) ([]Prompt, error) {
+	return listPrompts(ctx, c.call, c.clientState)
+}
+
+// GetPrompt resolves a prompt from the MCP server. prompts/get is MRTR-eligible.
+func (c *HTTPClient) GetPrompt(ctx context.Context, name string, args map[string]string) (*PromptResult, error) {
+	return getPrompt(ctx, c.call, c.clientState, name, args)
+}
+
+// Tools converts MCP tools into core.Tool instances that call back to the
+// remote MCP server.
+func (c *HTTPClient) Tools(ctx context.Context) ([]core.Tool, error) {
+	return toolsForSource(ctx, c)
+}
+
+// OnNotification registers a handler for server notifications delivered over
+// the subscriptions/listen stream. The HTTP client dispatches notifications
+// received via Listen to these handlers in addition to the per-call handler
+// passed to Listen. It is inherited from clientState.OnNotification.
+
+// Listen opens a subscriptions/listen stream to the server. It POSTs the
+// request with the stateless _meta envelope, reads the text/event-stream
+// response, and dispatches each notification (including the
+// notifications/subscriptions/acknowledged first message) to handler and to any
+// handlers registered via OnNotification. Listen blocks until the stream closes
+// (server graceful closure or transport drop) or ctx is cancelled. Cancelling
+// ctx closes the HTTP request, which the server treats as a client disconnect.
+func (c *HTTPClient) Listen(ctx context.Context, filter SubscriptionFilter, handler func(Notification)) error {
+	params := SubscribeParams{Notifications: filter}
+	paramsRaw, err := mergeRequestMeta(params, c.requestMeta())
+	if err != nil {
+		return fmt.Errorf("mcp: failed to build subscriptions/listen params: %w", err)
 	}
 
-	timer := time.NewTimer(timeout)
-	defer timer.Stop()
-	ticker := time.NewTicker(10 * time.Millisecond)
-	defer ticker.Stop()
+	id := c.nextID.Add(1)
+	req := jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      id,
+		Method:  "subscriptions/listen",
+		Params:  paramsRaw,
+	}
+	data, err := json.Marshal(req)
+	if err != nil {
+		return err
+	}
 
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint, bytes.NewReader(data))
+	if err != nil {
+		return fmt.Errorf("mcp: failed to create subscriptions/listen request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "text/event-stream, application/json")
+	httpReq.Header.Set("Mcp-Method", "subscriptions/listen")
+	applyHeaders(httpReq, c.headers)
+	applyProtocolVersionHeader(httpReq, c.ProtocolVersion())
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("mcp: subscriptions/listen request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		if len(bytes.TrimSpace(body)) > 0 {
+			return fmt.Errorf("mcp: subscriptions/listen returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		}
+		return fmt.Errorf("mcp: subscriptions/listen returned status %d", resp.StatusCode)
+	}
+
+	return readEventStream(resp.Body, func(eventType, data string) {
+		var msg jsonRPCMessage
+		if err := json.Unmarshal([]byte(data), &msg); err != nil {
+			return
+		}
+		if msg.Method != "" {
+			note := Notification{Method: msg.Method, Params: append(json.RawMessage(nil), msg.Params...)}
+			if handler != nil {
+				handler(note)
+			}
+			c.dispatchNotification(note)
+			return
+		}
+		// A message with an id and no method is the graceful-closure response
+		// to the original subscriptions/listen request; the stream is ending.
+	})
+}
+
+// GetTask retrieves the current state of a task by id.
+func (c *HTTPClient) GetTask(ctx context.Context, taskID string) (*Task, error) {
+	return getTask(ctx, c.call, c.clientState, taskID)
+}
+
+// UpdateTask submits input responses for a task awaiting input (status
+// input_required). Unknown or already-satisfied keys are ignored by the server.
+func (c *HTTPClient) UpdateTask(ctx context.Context, taskID string, responses InputResponses) error {
+	return updateTask(ctx, c.call, c.clientState, taskID, responses)
+}
+
+// CancelTask requests cooperative cancellation of a task. The task may still
+// reach a non-cancelled terminal state depending on application progress.
+func (c *HTTPClient) CancelTask(ctx context.Context, taskID string) error {
+	return cancelTask(ctx, c.call, c.clientState, taskID)
+}
+
+// CallToolAwait invokes a tool and, if the server returns a task, polls
+// tasks/get honoring pollIntervalMs until the task reaches a terminal state.
+// On completed it unmarshals the task's Result into a ToolResult and returns
+// it. On failed/cancelled it returns an error. On input_required it returns an
+// *InputRequiredTaskError carrying the task so the caller can UpdateTask and
+// retry. poll, if non-nil, is invoked for every observed non-terminal task
+// state (useful for progress reporting). The client must have advertised the
+// tasks extension (see WithTasksExtension) before using this method.
+func (c *HTTPClient) CallToolAwait(ctx context.Context, name string, args map[string]any, poll func(*Task)) (*ToolResult, error) {
+	raw, err := callToolRaw(ctx, c.call, c.clientState, name, args)
+	if err != nil {
+		return nil, fmt.Errorf("mcp: tools/call failed: %w", err)
+	}
+	rt := readResultType(raw)
+	if rt == ResultTypeComplete {
+		var toolResult ToolResult
+		if err := json.Unmarshal(raw, &toolResult); err != nil {
+			return nil, fmt.Errorf("mcp: failed to parse tool result: %w", err)
+		}
+		return &toolResult, nil
+	}
+	if rt != ResultTypeTask {
+		return nil, fmt.Errorf("mcp: unexpected resultType %q for tools/call", rt)
+	}
+	var ctr CreateTaskResult
+	if err := json.Unmarshal(raw, &ctr); err != nil {
+		return nil, fmt.Errorf("mcp: failed to parse task result: %w", err)
+	}
+	task := ctr.Task
 	for {
-		if c.isStreamConnected() {
-			return true
+		if poll != nil {
+			poll(&task)
 		}
+		switch task.Status {
+		case TaskStatusCompleted:
+			var toolResult ToolResult
+			if len(task.Result) > 0 {
+				if err := json.Unmarshal(task.Result, &toolResult); err != nil {
+					return nil, fmt.Errorf("mcp: failed to parse completed task result: %w", err)
+				}
+			}
+			return &toolResult, nil
+		case TaskStatusFailed:
+			if task.Error != nil {
+				return nil, task.Error
+			}
+			return nil, fmt.Errorf("mcp: task %s failed", task.TaskID)
+		case TaskStatusCancelled:
+			return nil, fmt.Errorf("mcp: task %s cancelled", task.TaskID)
+		case TaskStatusInputRequired:
+			return nil, &InputRequiredTaskError{Task: task}
+		}
+		wait := taskPollInterval(task.PollIntervalMs)
 		select {
+		case <-time.After(wait):
 		case <-ctx.Done():
-			return false
-		case <-timer.C:
-			return c.isStreamConnected()
-		case <-ticker.C:
+			return nil, ctx.Err()
 		}
+		got, err := c.GetTask(ctx, task.TaskID)
+		if err != nil {
+			return nil, err
+		}
+		task = *got
 	}
 }
 
-// Close shuts down background stream state and best-effort closes the MCP session.
+// InputRequiredTaskError is returned by CallToolAwait when a task reaches the
+// input_required state. The caller inspects Task.InputRequests, calls
+// UpdateTask with the responses, and polls GetTask (or retries CallToolAwait
+// on a fresh call) to resume.
+type InputRequiredTaskError struct {
+	Task Task
+}
+
+func (e *InputRequiredTaskError) Error() string {
+	return "mcp: task " + e.Task.TaskID + " requires input"
+}
+
+// taskPollInterval derives the poll delay from the server's pollIntervalMs
+// hint, with a sane default when unset.
+func taskPollInterval(hint *int64) time.Duration {
+	if hint != nil && *hint > 0 {
+		return time.Duration(*hint) * time.Millisecond
+	}
+	return 250 * time.Millisecond
+}
+
+// Close releases HTTP client state. The 2026-07-28 protocol has no session to
+// tear down (no Mcp-Session-Id, no DELETE).
 func (c *HTTPClient) Close() error {
 	c.closeOnce.Do(func() {
 		c.shutdown()
-
-		c.streamMu.Lock()
-		cancel := c.cancelStream
-		sessionID := c.sessionID
-		c.streamMu.Unlock()
-
-		if cancel != nil {
-			cancel()
-		}
-
-		if sessionID != "" {
-			req, err := http.NewRequestWithContext(context.Background(), http.MethodDelete, c.endpoint, nil)
-			if err == nil {
-				applyHeaders(req, c.headers)
-				req.Header.Set("Mcp-Session-Id", sessionID)
-				resp, err := c.httpClient.Do(req)
-				if err == nil {
-					_, _ = io.Copy(io.Discard, resp.Body)
-					resp.Body.Close()
-				}
-			}
-		}
 	})
 	return nil
 }

--- a/ext/mcp/http_test.go
+++ b/ext/mcp/http_test.go
@@ -3,7 +3,6 @@ package mcp
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -21,8 +20,6 @@ type mockHTTPServer struct {
 	resourceResults   map[string]*ReadResourceResult
 	prompts           []Prompt
 	promptResults     map[string]*PromptResult
-	eventCh           chan string
-	ready             chan struct{}
 }
 
 func newMockHTTPServer() *mockHTTPServer {
@@ -30,8 +27,6 @@ func newMockHTTPServer() *mockHTTPServer {
 		toolResults:     make(map[string]*ToolResult),
 		resourceResults: make(map[string]*ReadResourceResult),
 		promptResults:   make(map[string]*PromptResult),
-		eventCh:         make(chan string, 100),
-		ready:           make(chan struct{}),
 	}
 }
 
@@ -43,43 +38,10 @@ func (m *mockHTTPServer) handler() http.Handler {
 
 func (m *mockHTTPServer) handle(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
-	case http.MethodGet:
-		m.handleStream(w, r)
 	case http.MethodPost:
 		m.handlePost(w, r)
-	case http.MethodDelete:
-		w.WriteHeader(http.StatusNoContent)
 	default:
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-	}
-}
-
-func (m *mockHTTPServer) handleStream(w http.ResponseWriter, r *http.Request) {
-	flusher, ok := w.(http.Flusher)
-	if !ok {
-		http.Error(w, "streaming not supported", http.StatusInternalServerError)
-		return
-	}
-
-	w.Header().Set("Content-Type", "text/event-stream")
-	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("Connection", "keep-alive")
-	w.Header().Set("Mcp-Session-Id", "session-123")
-
-	select {
-	case <-m.ready:
-	default:
-		close(m.ready)
-	}
-
-	for {
-		select {
-		case payload := <-m.eventCh:
-			fmt.Fprintf(w, "event: message\ndata: %s\n\n", payload)
-			flusher.Flush()
-		case <-r.Context().Done():
-			return
-		}
 	}
 }
 
@@ -90,15 +52,13 @@ func (m *mockHTTPServer) handlePost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("Mcp-Session-Id", "session-123")
+	var result any
+	var rpcErr *jsonRPCError
 
 	switch req.Method {
-	case "notifications/initialized":
-		w.WriteHeader(http.StatusAccepted)
-		return
-	case "initialize":
-		m.writeJSONResponse(w, req.ID, map[string]any{
-			"protocolVersion": ProtocolVersion,
+	case "server/discover":
+		result = map[string]any{
+			"protocolVersions": []string{ProtocolVersion},
 			"capabilities": map[string]any{
 				"tools":     map[string]any{"listChanged": true},
 				"resources": map[string]any{"listChanged": true},
@@ -108,14 +68,12 @@ func (m *mockHTTPServer) handlePost(w http.ResponseWriter, r *http.Request) {
 				"name":    "mock-http-server",
 				"version": "1.0.0",
 			},
-		})
-		return
+		}
 	case "tools/list":
 		m.mu.Lock()
 		tools := m.tools
 		m.mu.Unlock()
-		m.writeJSONResponse(w, req.ID, map[string]any{"tools": tools})
-		return
+		result = map[string]any{"tools": tools}
 	case "tools/call":
 		params, _ := json.Marshal(req.Params)
 		var callParams struct {
@@ -124,30 +82,18 @@ func (m *mockHTTPServer) handlePost(w http.ResponseWriter, r *http.Request) {
 		json.Unmarshal(params, &callParams)
 
 		m.mu.Lock()
-		result, ok := m.toolResults[callParams.Name]
+		res, ok := m.toolResults[callParams.Name]
 		m.mu.Unlock()
 		if !ok {
-			m.writeJSONError(w, req.ID, &jsonRPCError{Code: -32601, Message: "tool not found"})
-			return
+			rpcErr = &jsonRPCError{Code: -32601, Message: "tool not found"}
+		} else {
+			result = res
 		}
-		if callParams.Name == "delayed_tool" {
-			payload, _ := json.Marshal(jsonRPCMessage{
-				JSONRPC: "2.0",
-				ID:      rawJSONID(req.ID),
-				Result:  mustRawJSON(tMarshal(result)),
-			})
-			m.eventCh <- string(payload)
-			w.WriteHeader(http.StatusAccepted)
-			return
-		}
-		m.writeJSONResponse(w, req.ID, result)
-		return
 	case "resources/list":
 		m.mu.Lock()
 		resources := m.resources
 		m.mu.Unlock()
-		m.writeJSONResponse(w, req.ID, map[string]any{"resources": resources})
-		return
+		result = map[string]any{"resources": resources}
 	case "resources/read":
 		params, _ := json.Marshal(req.Params)
 		var readParams struct {
@@ -155,26 +101,23 @@ func (m *mockHTTPServer) handlePost(w http.ResponseWriter, r *http.Request) {
 		}
 		json.Unmarshal(params, &readParams)
 		m.mu.Lock()
-		result, ok := m.resourceResults[readParams.URI]
+		res, ok := m.resourceResults[readParams.URI]
 		m.mu.Unlock()
 		if !ok {
-			m.writeJSONError(w, req.ID, &jsonRPCError{Code: -32602, Message: "resource not found"})
-			return
+			rpcErr = &jsonRPCError{Code: -32602, Message: "resource not found"}
+		} else {
+			result = res
 		}
-		m.writeJSONResponse(w, req.ID, result)
-		return
 	case "resources/templates/list":
 		m.mu.Lock()
 		templates := m.resourceTemplates
 		m.mu.Unlock()
-		m.writeJSONResponse(w, req.ID, map[string]any{"resourceTemplates": templates})
-		return
+		result = map[string]any{"resourceTemplates": templates}
 	case "prompts/list":
 		m.mu.Lock()
 		prompts := m.prompts
 		m.mu.Unlock()
-		m.writeJSONResponse(w, req.ID, map[string]any{"prompts": prompts})
-		return
+		result = map[string]any{"prompts": prompts}
 	case "prompts/get":
 		params, _ := json.Marshal(req.Params)
 		var getParams struct {
@@ -182,37 +125,31 @@ func (m *mockHTTPServer) handlePost(w http.ResponseWriter, r *http.Request) {
 		}
 		json.Unmarshal(params, &getParams)
 		m.mu.Lock()
-		result, ok := m.promptResults[getParams.Name]
+		res, ok := m.promptResults[getParams.Name]
 		m.mu.Unlock()
 		if !ok {
-			m.writeJSONError(w, req.ID, &jsonRPCError{Code: -32602, Message: "prompt not found"})
-			return
+			rpcErr = &jsonRPCError{Code: -32602, Message: "prompt not found"}
+		} else {
+			result = res
 		}
-		m.writeJSONResponse(w, req.ID, result)
-		return
 	default:
-		m.writeJSONError(w, req.ID, &jsonRPCError{Code: -32601, Message: "method not found"})
+		rpcErr = &jsonRPCError{Code: -32601, Message: "method not found"}
 	}
-}
 
-func (m *mockHTTPServer) writeJSONResponse(w http.ResponseWriter, id int64, result any) {
-	w.Header().Set("Content-Type", "application/json")
-	payload, _ := json.Marshal(jsonRPCMessage{
+	resp := jsonRPCMessage{
 		JSONRPC: "2.0",
-		ID:      rawJSONID(id),
-		Result:  mustRawJSON(tMarshal(result)),
-	})
-	_, _ = w.Write(payload)
-}
+		ID:      rawJSONID(req.ID),
+	}
+	if rpcErr != nil {
+		resp.Error = rpcErr
+	} else {
+		data, _ := json.Marshal(result)
+		resp.Result = data
+	}
 
-func (m *mockHTTPServer) writeJSONError(w http.ResponseWriter, id int64, rpcErr *jsonRPCError) {
 	w.Header().Set("Content-Type", "application/json")
-	payload, _ := json.Marshal(jsonRPCMessage{
-		JSONRPC: "2.0",
-		ID:      rawJSONID(id),
-		Error:   rpcErr,
-	})
-	_, _ = w.Write(payload)
+	respData, _ := json.Marshal(resp)
+	_, _ = w.Write(respData)
 }
 
 func tMarshal(v any) []byte {
@@ -220,21 +157,17 @@ func tMarshal(v any) []byte {
 	return data
 }
 
-func mustRawJSON(data []byte) json.RawMessage {
-	return json.RawMessage(data)
-}
-
-func TestHTTPClientResourcesPromptsAndAsyncToolCall(t *testing.T) {
+func TestHTTPClientResourcesPromptsAndToolCall(t *testing.T) {
 	mock := newMockHTTPServer()
 	mock.tools = []Tool{
 		{
-			Name:        "delayed_tool",
-			Description: "Resolves asynchronously",
+			Name:        "echo_tool",
+			Description: "Echoes back",
 			InputSchema: json.RawMessage(`{"type":"object"}`),
 		},
 	}
-	mock.toolResults["delayed_tool"] = &ToolResult{
-		Content: []Content{{Type: "text", Text: "async done"}},
+	mock.toolResults["echo_tool"] = &ToolResult{
+		Content: []Content{{Type: "text", Text: "echo done"}},
 	}
 	mock.resources = []Resource{{
 		URI:         "file:///workspace/README.md",
@@ -269,10 +202,8 @@ func TestHTTPClientResourcesPromptsAndAsyncToolCall(t *testing.T) {
 	}
 	defer client.Close()
 
-	select {
-	case <-mock.ready:
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for HTTP notification stream")
+	if _, err := client.Discover(ctx); err != nil {
+		t.Fatalf("Discover failed: %v", err)
 	}
 
 	resources, err := client.ListResources(ctx)
@@ -315,11 +246,11 @@ func TestHTTPClientResourcesPromptsAndAsyncToolCall(t *testing.T) {
 		t.Fatalf("unexpected prompt content: %q", promptResult.TextContent())
 	}
 
-	toolResult, err := client.CallTool(ctx, "delayed_tool", nil)
+	toolResult, err := client.CallTool(ctx, "echo_tool", nil)
 	if err != nil {
 		t.Fatalf("CallTool failed: %v", err)
 	}
-	if toolResult.TextContent() != "async done" {
+	if toolResult.TextContent() != "echo done" {
 		t.Fatalf("unexpected tool result: %q", toolResult.TextContent())
 	}
 
@@ -331,7 +262,7 @@ func TestHTTPClientResourcesPromptsAndAsyncToolCall(t *testing.T) {
 	}
 }
 
-func TestHTTPClientNotificationHandler(t *testing.T) {
+func TestHTTPClientCallToolError(t *testing.T) {
 	mock := newMockHTTPServer()
 	server := httptest.NewServer(mock.handler())
 	defer server.Close()
@@ -345,135 +276,101 @@ func TestHTTPClientNotificationHandler(t *testing.T) {
 	}
 	defer client.Close()
 
-	select {
-	case <-mock.ready:
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for HTTP notification stream")
+	_, err = client.CallTool(ctx, "nonexistent", nil)
+	if err == nil {
+		t.Fatal("expected error for nonexistent tool")
 	}
-
-	received := make(chan string, 1)
-	unregister := client.OnNotification("notifications/prompts/list_changed", func(note Notification) {
-		received <- note.Method
-	})
-	defer unregister()
-
-	payload, _ := json.Marshal(jsonRPCMessage{
-		JSONRPC: "2.0",
-		Method:  "notifications/prompts/list_changed",
-		Params:  json.RawMessage(`{"reason":"refresh"}`),
-	})
-	mock.eventCh <- string(payload)
-
-	select {
-	case method := <-received:
-		if method != "notifications/prompts/list_changed" {
-			t.Fatalf("unexpected method: %s", method)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for notification")
+	if !strings.Contains(err.Error(), "tool not found") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
-func TestHTTPClientCallFailsWhenPOSTStreamClosesWithoutResponse(t *testing.T) {
-	streamReady := make(chan struct{})
-	holdStream := make(chan struct{})
+func TestHTTPClientSendsStatelessMetaAndHeaders(t *testing.T) {
+	var seenHeaders http.Header
+	var seenParams map[string]any
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.Method {
-		case http.MethodGet:
-			flusher, ok := w.(http.Flusher)
-			if !ok {
-				http.Error(w, "streaming not supported", http.StatusInternalServerError)
-				return
-			}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenHeaders = r.Header.Clone()
+		var req jsonRPCRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		_ = json.Unmarshal(req.Params, &seenParams)
 
-			w.Header().Set("Content-Type", "text/event-stream")
-			w.Header().Set("Cache-Control", "no-cache")
-			w.Header().Set("Connection", "keep-alive")
-			w.Header().Set("Mcp-Session-Id", "session-123")
-			flusher.Flush()
-
-			select {
-			case <-streamReady:
-			default:
-				close(streamReady)
-			}
-
-			select {
-			case <-holdStream:
-			case <-r.Context().Done():
-			}
-		case http.MethodPost:
-			var req jsonRPCRequest
-			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-				http.Error(w, "invalid JSON", http.StatusBadRequest)
-				return
-			}
-
-			w.Header().Set("Mcp-Session-Id", "session-123")
-
-			switch req.Method {
-			case "initialize":
-				w.Header().Set("Content-Type", "application/json")
-				payload, _ := json.Marshal(jsonRPCMessage{
-					JSONRPC: "2.0",
-					ID:      rawJSONID(req.ID),
-					Result: mustRawJSON(tMarshal(map[string]any{
-						"protocolVersion": ProtocolVersion,
-						"capabilities": map[string]any{
-							"tools": map[string]any{},
-						},
-						"serverInfo": map[string]any{
-							"name":    "broken-stream-server",
-							"version": "1.0.0",
-						},
-					})),
-				})
-				_, _ = w.Write(payload)
-			case "notifications/initialized":
-				w.WriteHeader(http.StatusAccepted)
-			case "tools/call":
-				w.Header().Set("Content-Type", "text/event-stream")
-				if flusher, ok := w.(http.Flusher); ok {
-					flusher.Flush()
-				}
-			default:
-				http.Error(w, "method not found", http.StatusNotFound)
-			}
-		case http.MethodDelete:
-			w.WriteHeader(http.StatusNoContent)
-		default:
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-		}
+		w.Header().Set("Content-Type", "application/json")
+		resp, _ := json.Marshal(jsonRPCMessage{
+			JSONRPC: "2.0",
+			ID:      rawJSONID(req.ID),
+			Result:  mustRawJSON(tMarshal(map[string]any{"tools": []Tool{}})),
+		})
+		_, _ = w.Write(resp)
 	}))
-	defer func() {
-		close(holdStream)
-		server.Close()
-	}()
+	defer srv.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	client, err := NewHTTPClient(ctx, server.URL)
+	client, err := NewHTTPClient(ctx, srv.URL)
 	if err != nil {
 		t.Fatalf("failed to create HTTP client: %v", err)
 	}
 	defer client.Close()
 
-	select {
-	case <-streamReady:
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for HTTP notification stream")
+	if _, err := client.ListTools(ctx); err != nil {
+		t.Fatalf("ListTools failed: %v", err)
 	}
 
-	callCtx, cancelCall := context.WithTimeout(context.Background(), 500*time.Millisecond)
-	defer cancelCall()
-
-	_, err = client.CallTool(callCtx, "broken_stream_tool", nil)
-	if err == nil {
-		t.Fatal("expected CallTool to fail when POST SSE stream closes without a response")
+	if got := seenHeaders.Get("Mcp-Method"); got != "tools/list" {
+		t.Fatalf("Mcp-Method header = %q, want tools/list", got)
 	}
-	if !strings.Contains(err.Error(), "connection closed while waiting for response") {
-		t.Fatalf("unexpected error: %v", err)
+	if got := seenHeaders.Get("MCP-Protocol-Version"); got != ProtocolVersion {
+		t.Fatalf("MCP-Protocol-Version header = %q, want %s", got, ProtocolVersion)
+	}
+
+	meta, ok := seenParams["_meta"].(map[string]any)
+	if !ok {
+		t.Fatalf("request params missing _meta: %+v", seenParams)
+	}
+	if pv, _ := meta[MetaProtocolVersion].(string); pv != ProtocolVersion {
+		t.Fatalf("_meta.protocolVersion = %v, want %s", meta[MetaProtocolVersion], ProtocolVersion)
+	}
+	if _, ok := meta[MetaClientCapabilities].(map[string]any); !ok {
+		t.Fatalf("_meta.clientCapabilities missing or wrong type: %+v", meta[MetaClientCapabilities])
+	}
+}
+
+func TestHTTPClientCallToolSendsMcpNameHeader(t *testing.T) {
+	var seenHeaders http.Header
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenHeaders = r.Header.Clone()
+		var req jsonRPCRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+
+		w.Header().Set("Content-Type", "application/json")
+		resp, _ := json.Marshal(jsonRPCMessage{
+			JSONRPC: "2.0",
+			ID:      rawJSONID(req.ID),
+			Result:  mustRawJSON(tMarshal(&ToolResult{Content: []Content{{Type: "text", Text: "ok"}}})),
+		})
+		_, _ = w.Write(resp)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	client, err := NewHTTPClient(ctx, srv.URL)
+	if err != nil {
+		t.Fatalf("failed to create HTTP client: %v", err)
+	}
+	defer client.Close()
+
+	if _, err := client.CallTool(ctx, "greet", map[string]any{"name": "world"}); err != nil {
+		t.Fatalf("CallTool failed: %v", err)
+	}
+
+	if got := seenHeaders.Get("Mcp-Method"); got != "tools/call" {
+		t.Fatalf("Mcp-Method header = %q, want tools/call", got)
+	}
+	if got := seenHeaders.Get("Mcp-Name"); got != "greet" {
+		t.Fatalf("Mcp-Name header = %q, want greet", got)
 	}
 }

--- a/ext/mcp/protocol.go
+++ b/ext/mcp/protocol.go
@@ -17,7 +17,62 @@ const (
 	jsonRPCCodeMethodNotFound = -32601
 	jsonRPCCodeInvalidParams  = -32602
 	jsonRPCCodeInternalError  = -32603
+
+	// MCP-specific error codes introduced by the 2026-07-28 specification.
+	// HeaderMismatch is returned when a required request header (Mcp-Method or
+	// Mcp-Name) is present but does not match the JSON-RPC body.
+	jsonRPCCodeHeaderMismatch = -32020
+	// MissingRequiredClientCapability is returned when a server needs a client
+	// capability the client did not declare in _meta.clientCapabilities. Its
+	// data field MUST carry {"requiredCapabilities":[...]}.
+	jsonRPCCodeMissingRequiredClientCapability = -32021
+	// UnsupportedProtocolVersion is returned when the protocol version in the
+	// request _meta or MCP-Protocol-Version header is not supported.
+	jsonRPCCodeUnsupportedProtocolVersion = -32022
 )
+
+// maxMRTRRounds bounds the number of input_required round trips a client will
+// complete for a single logical request before treating the exchange as failed.
+const maxMRTRRounds = 8
+
+// HeaderMismatchError constructs a JSON-RPC -32020 error.
+func HeaderMismatchError(message string) *jsonRPCError {
+	if message == "" {
+		message = "header mismatch"
+	}
+	return &jsonRPCError{
+		Code:    jsonRPCCodeHeaderMismatch,
+		Message: message,
+	}
+}
+
+// MissingRequiredClientCapabilityError constructs a JSON-RPC -32021 error whose
+// data carries the list of capabilities the server required but the client did
+// not declare.
+func MissingRequiredClientCapabilityError(required []string) *jsonRPCError {
+	data, _ := json.Marshal(map[string]any{"requiredCapabilities": required})
+	return &jsonRPCError{
+		Code:    jsonRPCCodeMissingRequiredClientCapability,
+		Message: "missing required client capability",
+		Data:    data,
+	}
+}
+
+// UnsupportedProtocolVersionError constructs a JSON-RPC -32022 error for the
+// given unsupported protocol version. Its data carries the versions this
+// implementation supports and the version that was requested, so the client
+// can retry with a mutually supported version.
+func UnsupportedProtocolVersionError(version string) *jsonRPCError {
+	data, _ := json.Marshal(map[string]any{
+		"supported": SupportedProtocolVersions,
+		"requested": version,
+	})
+	return &jsonRPCError{
+		Code:    jsonRPCCodeUnsupportedProtocolVersion,
+		Message: "unsupported protocol version: " + version,
+		Data:    data,
+	}
+}
 
 // Notification is a server-initiated JSON-RPC notification.
 type Notification struct {
@@ -28,18 +83,28 @@ type Notification struct {
 // NotificationHandler handles a server notification.
 type NotificationHandler func(Notification)
 
-// RequestHandler handles a server-initiated JSON-RPC request.
+// RequestHandler handles a server-initiated JSON-RPC request. In the
+// 2026-07-28 protocol sampling, elicitation, and roots are delivered via MRTR
+// rather than server-initiated requests, so these handlers are now exercised
+// by the client-side MRTR fulfillment path.
 type RequestHandler func(context.Context, json.RawMessage) (any, error)
 
 // RootsProvider returns the current set of roots exposed to an MCP server.
+//
+// Deprecated: Roots are deprecated in the 2026-07-28 protocol (SEP-2577). The
+// provider is still invoked when a server sends a roots/list input request via
+// MRTR; new clients should avoid advertising roots.
 type RootsProvider func(context.Context) ([]Root, error)
 
-// SamplingHandler handles sampling/createMessage requests from an MCP server.
-// Optional sampling surfaces such as tools/context must be advertised via
-// ClientConfig.Capabilities.
+// SamplingHandler handles sampling/createMessage requests. In the 2026-07-28
+// protocol these arrive as MRTR input requests rather than server-initiated
+// JSON-RPC calls.
+//
+// Deprecated: Sampling is deprecated in the 2026-07-28 protocol (SEP-2577).
 type SamplingHandler func(context.Context, *CreateMessageParams) (*CreateMessageResult, error)
 
-// ElicitationHandler handles elicitation/create requests from an MCP server.
+// ElicitationHandler handles elicitation/create requests. In the 2026-07-28
+// protocol these arrive as MRTR input requests.
 type ElicitationHandler func(context.Context, *ElicitationParams) (*ElicitationResult, error)
 
 // ClientConfig configures client-side MCP capabilities exposed to servers.
@@ -59,6 +124,18 @@ func StaticRoots(roots ...Root) RootsProvider {
 	}
 }
 
+// WithTasksExtension returns a ClientConfig that advertises support for the
+// io.modelcontextprotocol/tasks extension in _meta.clientCapabilities.extensions.
+// Clients MUST advertise the extension before the server will return a task
+// (resultType "task") from tools/call, resources/read, or prompts/get.
+func WithTasksExtension(cfg ClientConfig) ClientConfig {
+	if cfg.Capabilities.Extensions == nil {
+		cfg.Capabilities.Extensions = map[string]json.RawMessage{}
+	}
+	cfg.Capabilities.Extensions[ExtensionTasks] = json.RawMessage(`{}`)
+	return cfg
+}
+
 func defaultClientConfig() ClientConfig {
 	return ClientConfig{
 		ClientInfo: &ImplementationInfo{
@@ -70,18 +147,18 @@ func defaultClientConfig() ClientConfig {
 
 // jsonRPCRequest is a JSON-RPC 2.0 request.
 type jsonRPCRequest struct {
-	JSONRPC string `json:"jsonrpc"`
-	ID      int64  `json:"id"`
-	Method  string `json:"method"`
-	Params  any    `json:"params,omitempty"`
+	JSONRPC string          `json:"jsonrpc"`
+	ID      int64           `json:"id"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
 }
 
 // jsonRPCResponse is a JSON-RPC 2.0 response.
 type jsonRPCResponse struct {
-	JSONRPC string        `json:"jsonrpc"`
-	ID      any           `json:"id"`
-	Result  any           `json:"result,omitempty"`
-	Error   *jsonRPCError `json:"error,omitempty"`
+	JSONRPC string          `json:"jsonrpc"`
+	ID      any             `json:"id"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *jsonRPCError   `json:"error,omitempty"`
 }
 
 // jsonRPCMessage is a generic JSON-RPC 2.0 message.
@@ -105,8 +182,9 @@ func (e *jsonRPCError) Error() string {
 	return fmt.Sprintf("JSON-RPC error %d: %s", e.Code, e.Message)
 }
 
-type rpcCall func(context.Context, string, any) (json.RawMessage, error)
-type rpcNotify func(context.Context, string, any) error
+// rpcCaller sends a single JSON-RPC request and returns the raw result body.
+type rpcCaller func(ctx context.Context, method string, params any) (json.RawMessage, error)
+
 type rpcRespond func(context.Context, any, any, *jsonRPCError) error
 
 var samplingCapabilityRegistry sync.Map
@@ -295,6 +373,9 @@ func cloneClientCapabilities(in ClientCapabilities) ClientCapabilities {
 	if in.Experimental != nil {
 		out.Experimental = cloneNestedAnyMap(in.Experimental)
 	}
+	if in.Extensions != nil {
+		out.Extensions = cloneExtensionsMap(in.Extensions)
+	}
 	return out
 }
 
@@ -307,6 +388,30 @@ func cloneNestedAnyMap(in map[string]map[string]any) map[string]map[string]any {
 		out[k] = cloneAnyMap(v)
 	}
 	return out
+}
+
+func cloneExtensionsMap(in map[string]json.RawMessage) map[string]json.RawMessage {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]json.RawMessage, len(in))
+	for k, v := range in {
+		out[k] = append(json.RawMessage(nil), v...)
+	}
+	return out
+}
+
+// tasksAdvertised reports whether this client advertises the tasks extension in
+// its _meta.clientCapabilities.extensions. The low-level round trip treats
+// resultType "task" as valid only when this is true.
+func (s *clientState) tasksAdvertised() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.clientCapabilities.Extensions == nil {
+		return false
+	}
+	_, ok := s.clientCapabilities.Extensions[ExtensionTasks]
+	return ok
 }
 
 // OnNotification registers a handler for a server notification method.
@@ -342,6 +447,10 @@ func (s *clientState) OnNotification(method string, handler NotificationHandler)
 }
 
 // HandleRequest registers or replaces a handler for a server-initiated request.
+// In the 2026-07-28 protocol server-initiated requests are not used for
+// sampling/elicitation/roots; this registry is primarily exercised by the MRTR
+// fulfillment path. It is retained so a misbehaving server that issues a
+// direct request still receives a deterministic response.
 func (s *clientState) HandleRequest(method string, handler RequestHandler) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -352,7 +461,7 @@ func (s *clientState) HandleRequest(method string, handler RequestHandler) {
 	s.requestHandlers[method] = handler
 }
 
-// Capabilities returns the server capabilities observed during initialize.
+// Capabilities returns the server capabilities observed via server/discover.
 func (s *clientState) Capabilities() ServerCapabilities {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -366,7 +475,7 @@ func (s *clientState) ClientCapabilities() ClientCapabilities {
 	return cloneClientCapabilities(s.clientCapabilities)
 }
 
-// ServerInfo returns the server identity observed during initialize.
+// ServerInfo returns the server identity observed via server/discover.
 func (s *clientState) ServerInfo() *ServerInfo {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -377,25 +486,62 @@ func (s *clientState) ServerInfo() *ServerInfo {
 	return &info
 }
 
-// ClientInfo returns the client identity advertised during initialize.
+// ClientInfo returns the client identity advertised on every request.
 func (s *clientState) ClientInfo() ImplementationInfo {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.clientInfo
 }
 
-// Instructions returns the optional server instructions from initialize.
+// Instructions returns the optional server instructions from server/discover.
 func (s *clientState) Instructions() string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.instructions
 }
 
-// ProtocolVersion returns the negotiated MCP protocol version.
+// ProtocolVersion returns the MCP protocol version this client advertises.
 func (s *clientState) ProtocolVersion() string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.protocolVersion
+}
+
+func (s *clientState) setDiscoverResult(result *DiscoverResult) {
+	if result == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(result.SupportedVersions) > 0 {
+		s.protocolVersion = result.SupportedVersions[0]
+	}
+	s.capabilities = cloneServerCapabilities(result.Capabilities)
+	s.instructions = result.Instructions
+	if result.ServerInfo != nil {
+		info := *result.ServerInfo
+		s.serverInfo = &info
+	} else {
+		s.serverInfo = nil
+	}
+}
+
+// requestMeta builds the reserved _meta envelope carried by every stateless
+// request. protocolVersion and clientCapabilities are required; clientInfo is
+// included when set.
+func (s *clientState) requestMeta() RequestMeta {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	caps := cloneClientCapabilities(s.clientCapabilities)
+	meta := RequestMeta{
+		ProtocolVersion:    s.protocolVersion,
+		ClientCapabilities: &caps,
+	}
+	if s.clientInfo.Name != "" {
+		info := s.clientInfo
+		meta.ClientInfo = &info
+	}
+	return meta
 }
 
 func (s *clientState) prepareCall() (int64, chan *jsonRPCMessage, error) {
@@ -525,15 +671,6 @@ func (s *clientState) shutdown() {
 	}
 }
 
-func (s *clientState) failPending() {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	for id, ch := range s.pending {
-		close(ch)
-		delete(s.pending, id)
-	}
-}
-
 func (s *clientState) failPendingCall(id int64) {
 	s.mu.Lock()
 	ch, ok := s.pending[id]
@@ -550,144 +687,405 @@ func (s *clientState) failPendingCall(id int64) {
 	}
 }
 
-func (s *clientState) setInitializeResult(result *InitializeResult) {
-	if result == nil {
-		return
+// mergeRequestMeta marshals params to a JSON object and injects the reserved
+// _meta keys from meta. Existing _meta entries (e.g. progressToken, traceparent)
+// are preserved; the reserved keys always override. A nil params yields an
+// empty object so every request carries _meta.
+func mergeRequestMeta(params any, meta RequestMeta) (json.RawMessage, error) {
+	obj := map[string]json.RawMessage{}
+	if params != nil {
+		raw, err := json.Marshal(params)
+		if err != nil {
+			return nil, err
+		}
+		if len(bytes.TrimSpace(raw)) > 0 && !bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+			if err := json.Unmarshal(raw, &obj); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	metaRaw, err := json.Marshal(meta)
+	if err != nil {
+		return nil, err
+	}
+	if existing, ok := obj["_meta"]; ok && len(bytes.TrimSpace(existing)) > 0 {
+		var existingMap map[string]json.RawMessage
+		if err := json.Unmarshal(existing, &existingMap); err == nil && existingMap != nil {
+			var newMeta map[string]json.RawMessage
+			if err := json.Unmarshal(metaRaw, &newMeta); err != nil {
+				return nil, err
+			}
+			for k, v := range newMeta {
+				existingMap[k] = v
+			}
+			metaRaw, _ = json.Marshal(existingMap)
+		}
+	}
+	obj["_meta"] = metaRaw
+	return json.Marshal(obj)
+}
+
+// readResultType extracts the resultType field from a result body. An absent
+// resultType is treated as "complete" per the 2026-07-28 spec.
+func readResultType(raw json.RawMessage) string {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return ResultTypeComplete
+	}
+	var probe struct {
+		ResultType string `json:"resultType"`
+	}
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		return ResultTypeComplete
+	}
+	if probe.ResultType == "" {
+		return ResultTypeComplete
+	}
+	return probe.ResultType
+}
+
+// stampResultType injects resultType into a marshaled result object if it is
+// absent. Used by the server response layer to stamp "complete" on ordinary
+// results.
+func stampResultType(raw json.RawMessage, rt string) json.RawMessage {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return raw
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return raw
+	}
+	if _, ok := obj["resultType"]; ok {
+		return raw
+	}
+	obj["resultType"] = mustRawJSON([]byte(`"` + rt + `"`))
+	out, err := json.Marshal(obj)
+	if err != nil {
+		return raw
+	}
+	return out
+}
+
+// stampServerInfo injects _meta.io.modelcontextprotocol/serverInfo into a
+// marshaled result object when absent.
+func stampServerInfo(raw json.RawMessage, info ServerInfo) json.RawMessage {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return raw
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return raw
+	}
+	metaRaw, ok := obj["_meta"]
+	if !ok || len(bytes.TrimSpace(metaRaw)) == 0 {
+		metaObj := map[string]any{MetaServerInfo: info}
+		data, _ := json.Marshal(metaObj)
+		obj["_meta"] = data
+		out, err := json.Marshal(obj)
+		if err != nil {
+			return raw
+		}
+		return out
+	}
+	var metaMap map[string]json.RawMessage
+	if err := json.Unmarshal(metaRaw, &metaMap); err != nil {
+		return raw
+	}
+	if _, exists := metaMap[MetaServerInfo]; !exists {
+		serverInfoRaw, _ := json.Marshal(info)
+		metaMap[MetaServerInfo] = serverInfoRaw
+		newMeta, _ := json.Marshal(metaMap)
+		obj["_meta"] = newMeta
+		out, err := json.Marshal(obj)
+		if err != nil {
+			return raw
+		}
+		return out
+	}
+	return raw
+}
+
+func mustRawJSON(data []byte) json.RawMessage {
+	return json.RawMessage(data)
+}
+
+// roundTrip sends method with params via call, carrying the stateless _meta
+// envelope. When mrtr is true, input_required results drive the MRTR loop:
+// each inputRequest is fulfilled via the registered client handlers and the
+// original request is retried with a new JSON-RPC id, merging inputResponses
+// and echoing requestState verbatim. Non-MRTR methods reject input_required.
+// An unrecognized resultType is an error. The final "complete" result body is
+// returned for the caller to unmarshal.
+func (s *clientState) roundTrip(ctx context.Context, call rpcCaller, method string, params any, mrtr bool) (json.RawMessage, error) {
+	baseParams := normalizeParamsMap(params)
+	for range maxMRTRRounds {
+		paramsRaw, err := mergeRequestMeta(baseParams, s.requestMeta())
+		if err != nil {
+			return nil, err
+		}
+		raw, err := call(ctx, method, paramsRaw)
+		if err != nil {
+			return nil, err
+		}
+		switch rt := readResultType(raw); rt {
+		case ResultTypeComplete:
+			return raw, nil
+		case ResultTypeInputRequired:
+			if !mrtr {
+				return nil, fmt.Errorf("mcp: method %q returned input_required but is not MRTR-eligible", method)
+			}
+			var irr InputRequiredResult
+			if err := json.Unmarshal(raw, &irr); err != nil {
+				return nil, fmt.Errorf("mcp: failed to parse input_required result: %w", err)
+			}
+			if len(irr.InputRequests) == 0 && irr.RequestState == "" {
+				return nil, errors.New("mcp: input_required result has no inputRequests or requestState")
+			}
+			responses, err := s.fulfillInputRequests(ctx, irr.InputRequests)
+			if err != nil {
+				return nil, err
+			}
+			retry := cloneParamsMap(baseParams)
+			if len(responses) > 0 {
+				retry["inputResponses"] = responses
+			}
+			if irr.RequestState != "" {
+				retry["requestState"] = irr.RequestState
+			}
+			baseParams = retry
+			continue
+		case ResultTypeTask:
+			// resultType "task" is valid only when the client advertised the
+			// tasks extension; otherwise it is an unexpected result type. The
+			// caller is responsible for parsing the CreateTaskResult and
+			// polling tasks/get (no auto-poll here).
+			if !s.tasksAdvertised() {
+				return nil, fmt.Errorf("mcp: unexpected resultType %q for method %q", rt, method)
+			}
+			return raw, nil
+		default:
+			return nil, fmt.Errorf("mcp: unrecognized resultType %q for method %q", rt, method)
+		}
+	}
+	return nil, fmt.Errorf("mcp: MRTR round limit (%d) exceeded for method %q", maxMRTRRounds, method)
+}
+
+// fulfillInputRequests invokes the registered client handler for each input
+// request and marshals the results into InputResponses keyed by the server
+// identifiers.
+func (s *clientState) fulfillInputRequests(ctx context.Context, reqs InputRequests) (InputResponses, error) {
+	if len(reqs) == 0 {
+		return nil, nil
 	}
 	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.protocolVersion = result.ProtocolVersion
-	s.capabilities = cloneServerCapabilities(result.Capabilities)
-	s.instructions = result.Instructions
-	if result.ServerInfo != nil {
-		info := *result.ServerInfo
-		s.serverInfo = &info
-	} else {
-		s.serverInfo = nil
+	handlers := make(map[string]RequestHandler, len(reqs))
+	for id, ir := range reqs {
+		if h, ok := s.requestHandlers[ir.Method]; ok {
+			handlers[id] = h
+		}
+	}
+	s.mu.Unlock()
+
+	responses := make(InputResponses, len(reqs))
+	for id, ir := range reqs {
+		handler, ok := handlers[id]
+		if !ok {
+			return nil, fmt.Errorf("mcp: no client handler for input request %q (method %q)", id, ir.Method)
+		}
+		result, err := handler(ctx, ir.Params)
+		if err != nil {
+			return nil, fmt.Errorf("mcp: input request %q failed: %w", id, err)
+		}
+		raw, err := json.Marshal(result)
+		if err != nil {
+			return nil, fmt.Errorf("mcp: failed to marshal input response %q: %w", id, err)
+		}
+		responses[id] = raw
+	}
+	return responses, nil
+}
+
+func normalizeParamsMap(params any) map[string]any {
+	if params == nil {
+		return map[string]any{}
+	}
+	switch v := params.(type) {
+	case map[string]any:
+		return cloneParamsMap(v)
+	case json.RawMessage:
+		if len(bytes.TrimSpace(v)) == 0 {
+			return map[string]any{}
+		}
+		var out map[string]any
+		if err := json.Unmarshal(v, &out); err != nil {
+			return map[string]any{}
+		}
+		return out
+	default:
+		raw, err := json.Marshal(params)
+		if err != nil {
+			return map[string]any{}
+		}
+		var out map[string]any
+		if err := json.Unmarshal(raw, &out); err != nil {
+			return map[string]any{}
+		}
+		return out
 	}
 }
 
-func initializeClient(ctx context.Context, state *clientState, call rpcCall, notify rpcNotify) error {
-	params := InitializeParams{
-		ProtocolVersion: protocolVersion,
-		Capabilities:    state.ClientCapabilities(),
-		ClientInfo:      state.ClientInfo(),
+func cloneParamsMap(in map[string]any) map[string]any {
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = v
 	}
+	return out
+}
 
-	result, err := call(ctx, "initialize", params)
+// discover calls server/discover and stores the result on the client state.
+func discover(ctx context.Context, call rpcCaller, state *clientState) (*DiscoverResult, error) {
+	raw, err := state.roundTrip(ctx, call, "server/discover", nil, false)
 	if err != nil {
-		return err
+		return nil, fmt.Errorf("mcp: server/discover failed: %w", err)
 	}
-
-	var init InitializeResult
-	if err := json.Unmarshal(result, &init); err != nil {
-		return fmt.Errorf("mcp: failed to parse initialize result: %w", err)
+	var result DiscoverResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, fmt.Errorf("mcp: failed to parse discover result: %w", err)
 	}
-	state.setInitializeResult(&init)
-
-	return notify(ctx, "notifications/initialized", nil)
+	state.setDiscoverResult(&result)
+	return &result, nil
 }
 
-func notifyRootsListChanged(ctx context.Context, notify rpcNotify) error {
-	return notify(ctx, "notifications/roots/list_changed", nil)
-}
-
-func listTools(ctx context.Context, call rpcCall) ([]Tool, error) {
-	result, err := call(ctx, "tools/list", nil)
+func listTools(ctx context.Context, call rpcCaller, state *clientState) ([]Tool, error) {
+	raw, err := state.roundTrip(ctx, call, "tools/list", nil, false)
 	if err != nil {
-		return nil, fmt.Errorf("mcp: tools/list failed: %w", err)
+		return nil, err
 	}
-
 	var list listToolsResult
-	if err := json.Unmarshal(result, &list); err != nil {
+	if err := json.Unmarshal(raw, &list); err != nil {
 		return nil, fmt.Errorf("mcp: failed to parse tools list: %w", err)
 	}
 	return list.Tools, nil
 }
 
-func callTool(ctx context.Context, call rpcCall, name string, args map[string]any) (*ToolResult, error) {
-	params := map[string]any{
-		"name":      name,
-		"arguments": args,
-	}
-
-	result, err := call(ctx, "tools/call", params)
+func callTool(ctx context.Context, call rpcCaller, state *clientState, name string, args map[string]any) (*ToolResult, error) {
+	raw, err := callToolRaw(ctx, call, state, name, args)
 	if err != nil {
 		return nil, fmt.Errorf("mcp: tools/call failed: %w", err)
 	}
-
+	if rt := readResultType(raw); rt == ResultTypeTask {
+		return nil, errors.New("mcp: tools/call returned a task; use CallToolAwait to poll it")
+	}
 	var toolResult ToolResult
-	if err := json.Unmarshal(result, &toolResult); err != nil {
+	if err := json.Unmarshal(raw, &toolResult); err != nil {
 		return nil, fmt.Errorf("mcp: failed to parse tool result: %w", err)
 	}
 	return &toolResult, nil
 }
 
-func listResources(ctx context.Context, call rpcCall) ([]Resource, error) {
-	result, err := call(ctx, "resources/list", nil)
-	if err != nil {
-		return nil, fmt.Errorf("mcp: resources/list failed: %w", err)
+// callToolRaw issues tools/call and returns the raw result body. Callers inspect
+// the resultType to distinguish a synchronous ToolResult (resultType "complete")
+// from a CreateTaskResult (resultType "task") and poll accordingly.
+func callToolRaw(ctx context.Context, call rpcCaller, state *clientState, name string, args map[string]any) (json.RawMessage, error) {
+	params := map[string]any{
+		"name":      name,
+		"arguments": args,
 	}
+	return state.roundTrip(ctx, call, "tools/call", params, true)
+}
 
+// getTask calls tasks/get and returns the current task state.
+func getTask(ctx context.Context, call rpcCaller, state *clientState, taskID string) (*Task, error) {
+	raw, err := state.roundTrip(ctx, call, "tasks/get", map[string]any{"taskId": taskID}, false)
+	if err != nil {
+		return nil, fmt.Errorf("mcp: tasks/get failed: %w", err)
+	}
+	var task Task
+	if err := json.Unmarshal(raw, &task); err != nil {
+		return nil, fmt.Errorf("mcp: failed to parse task result: %w", err)
+	}
+	return &task, nil
+}
+
+// updateTask calls tasks/update with the client's input responses.
+func updateTask(ctx context.Context, call rpcCaller, state *clientState, taskID string, responses InputResponses) error {
+	params := map[string]any{"taskId": taskID}
+	if len(responses) > 0 {
+		params["inputResponses"] = responses
+	}
+	if _, err := state.roundTrip(ctx, call, "tasks/update", params, false); err != nil {
+		return fmt.Errorf("mcp: tasks/update failed: %w", err)
+	}
+	return nil
+}
+
+// cancelTask calls tasks/cancel for the given task id.
+func cancelTask(ctx context.Context, call rpcCaller, state *clientState, taskID string) error {
+	if _, err := state.roundTrip(ctx, call, "tasks/cancel", map[string]any{"taskId": taskID}, false); err != nil {
+		return fmt.Errorf("mcp: tasks/cancel failed: %w", err)
+	}
+	return nil
+}
+
+func listResources(ctx context.Context, call rpcCaller, state *clientState) ([]Resource, error) {
+	raw, err := state.roundTrip(ctx, call, "resources/list", nil, false)
+	if err != nil {
+		return nil, err
+	}
 	var list listResourcesResult
-	if err := json.Unmarshal(result, &list); err != nil {
+	if err := json.Unmarshal(raw, &list); err != nil {
 		return nil, fmt.Errorf("mcp: failed to parse resources list: %w", err)
 	}
 	return list.Resources, nil
 }
 
-func readResource(ctx context.Context, call rpcCall, uri string) (*ReadResourceResult, error) {
-	result, err := call(ctx, "resources/read", map[string]any{"uri": uri})
+func readResource(ctx context.Context, call rpcCaller, state *clientState, uri string) (*ReadResourceResult, error) {
+	raw, err := state.roundTrip(ctx, call, "resources/read", map[string]any{"uri": uri}, true)
 	if err != nil {
 		return nil, fmt.Errorf("mcp: resources/read failed: %w", err)
 	}
-
 	var readResult ReadResourceResult
-	if err := json.Unmarshal(result, &readResult); err != nil {
+	if err := json.Unmarshal(raw, &readResult); err != nil {
 		return nil, fmt.Errorf("mcp: failed to parse resource contents: %w", err)
 	}
 	return &readResult, nil
 }
 
-func listResourceTemplates(ctx context.Context, call rpcCall) ([]ResourceTemplate, error) {
-	result, err := call(ctx, "resources/templates/list", nil)
+func listResourceTemplates(ctx context.Context, call rpcCaller, state *clientState) ([]ResourceTemplate, error) {
+	raw, err := state.roundTrip(ctx, call, "resources/templates/list", nil, false)
 	if err != nil {
-		return nil, fmt.Errorf("mcp: resources/templates/list failed: %w", err)
+		return nil, err
 	}
-
 	var list listResourceTemplatesResult
-	if err := json.Unmarshal(result, &list); err != nil {
+	if err := json.Unmarshal(raw, &list); err != nil {
 		return nil, fmt.Errorf("mcp: failed to parse resource templates list: %w", err)
 	}
 	return list.ResourceTemplates, nil
 }
 
-func listPrompts(ctx context.Context, call rpcCall) ([]Prompt, error) {
-	result, err := call(ctx, "prompts/list", nil)
+func listPrompts(ctx context.Context, call rpcCaller, state *clientState) ([]Prompt, error) {
+	raw, err := state.roundTrip(ctx, call, "prompts/list", nil, false)
 	if err != nil {
-		return nil, fmt.Errorf("mcp: prompts/list failed: %w", err)
+		return nil, err
 	}
-
 	var list listPromptsResult
-	if err := json.Unmarshal(result, &list); err != nil {
+	if err := json.Unmarshal(raw, &list); err != nil {
 		return nil, fmt.Errorf("mcp: failed to parse prompts list: %w", err)
 	}
 	return list.Prompts, nil
 }
 
-func getPrompt(ctx context.Context, call rpcCall, name string, args map[string]string) (*PromptResult, error) {
+func getPrompt(ctx context.Context, call rpcCaller, state *clientState, name string, args map[string]string) (*PromptResult, error) {
 	params := map[string]any{"name": name}
 	if len(args) > 0 {
 		params["arguments"] = args
 	}
-
-	result, err := call(ctx, "prompts/get", params)
+	raw, err := state.roundTrip(ctx, call, "prompts/get", params, true)
 	if err != nil {
 		return nil, fmt.Errorf("mcp: prompts/get failed: %w", err)
 	}
-
 	var promptResult PromptResult
-	if err := json.Unmarshal(result, &promptResult); err != nil {
+	if err := json.Unmarshal(raw, &promptResult); err != nil {
 		return nil, fmt.Errorf("mcp: failed to parse prompt result: %w", err)
 	}
 	return &promptResult, nil

--- a/ext/mcp/sampling_bridge.go
+++ b/ext/mcp/sampling_bridge.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/fugue-labs/gollem/core"
 )
@@ -14,11 +15,24 @@ import (
 const defaultSamplingMaxTokens = 4096
 
 // SamplingRequester can issue MCP sampling requests.
+//
+// Deprecated: In the 2026-07-28 protocol sampling is delivered via MRTR, not
+// server-initiated JSON-RPC. Server-side code should build a sampling
+// InputRequest via BuildSamplingInputRequest, return it through
+// RequestContext.NeedInput, and parse the client's answer via
+// ParseCreateMessageResult. SamplingRequester is retained for test fakes and
+// for MCPModel, which higher layers may still drive with a custom requester.
 type SamplingRequester interface {
 	CreateMessage(context.Context, *CreateMessageParams) (*CreateMessageResult, error)
 }
 
 // MCPModel exposes MCP sampling as a gollem core.Model.
+//
+// Deprecated: The server-initiated sampling pattern this model was built for is
+// removed in the 2026-07-28 protocol. Server handlers that need the client's
+// model should use MRTR via BuildSamplingInputRequest and
+// ParseCreateMessageResult. MCPModel is retained because it composes cleanly
+// with a SamplingRequester (e.g. a test fake or a higher-layer MRTR driver).
 type MCPModel struct {
 	requester SamplingRequester
 	config    mcpModelConfig
@@ -67,6 +81,9 @@ func WithMCPMetadata(metadata map[string]any) MCPModelOption {
 }
 
 // NewMCPModel constructs a core.Model backed by MCP sampling/createMessage.
+//
+// Deprecated: See MCPModel. Prefer the MRTR helpers (BuildSamplingInputRequest,
+// ParseCreateMessageResult) for new server-side code.
 func NewMCPModel(requester SamplingRequester, opts ...MCPModelOption) *MCPModel {
 	cfg := mcpModelConfig{
 		modelName: "mcp-sampling",
@@ -703,4 +720,77 @@ func marshalSamplingBlocks(blocks []Content) json.RawMessage {
 	default:
 		return MarshalSamplingContentArray(blocks)
 	}
+}
+
+// samplingInputCounter generates stable identifiers for MRTR input requests.
+var samplingInputCounter uint64
+
+// BuildSamplingInputRequest wraps a CreateMessageParams into an MRTR
+// InputRequest with a unique identifier, so a server handler can return it via
+// RequestContext.NeedInput and let the higher layer (e.g. sleepy) drive the
+// round trip. The client fulfills it using its registered SamplingHandler and
+// the answer is parsed with ParseCreateMessageResult.
+func BuildSamplingInputRequest(params *CreateMessageParams) (string, InputRequest) {
+	id := fmt.Sprintf("sampling-%d", atomic.AddUint64(&samplingInputCounter, 1))
+	raw, err := json.Marshal(params)
+	if err != nil {
+		raw = json.RawMessage(`{}`)
+	}
+	return id, InputRequest{Method: "sampling/createMessage", Params: raw}
+}
+
+// ParseCreateMessageResult unmarshals an MRTR input response (the client's
+// answer to a sampling input request) into a CreateMessageResult.
+func ParseCreateMessageResult(raw json.RawMessage) (*CreateMessageResult, error) {
+	if len(raw) == 0 {
+		return nil, errors.New("mcp: empty sampling input response")
+	}
+	var result CreateMessageResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, fmt.Errorf("mcp: failed to parse sampling input response: %w", err)
+	}
+	return &result, nil
+}
+
+// BuildElicitationInputRequest wraps an ElicitationParams into an MRTR
+// InputRequest. The client fulfills it using its registered ElicitationHandler.
+func BuildElicitationInputRequest(params *ElicitationParams) (string, InputRequest) {
+	id := fmt.Sprintf("elicitation-%d", atomic.AddUint64(&samplingInputCounter, 1))
+	raw, err := json.Marshal(params)
+	if err != nil {
+		raw = json.RawMessage(`{}`)
+	}
+	return id, InputRequest{Method: "elicitation/create", Params: raw}
+}
+
+// ParseElicitationResult unmarshals an MRTR input response for elicitation into
+// an ElicitationResult.
+func ParseElicitationResult(raw json.RawMessage) (*ElicitationResult, error) {
+	if len(raw) == 0 {
+		return nil, errors.New("mcp: empty elicitation input response")
+	}
+	var result ElicitationResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, fmt.Errorf("mcp: failed to parse elicitation input response: %w", err)
+	}
+	return &result, nil
+}
+
+// BuildRootsInputRequest builds an MRTR InputRequest for roots/list. The client
+// fulfills it using its registered RootsProvider.
+func BuildRootsInputRequest() (string, InputRequest) {
+	id := fmt.Sprintf("roots-%d", atomic.AddUint64(&samplingInputCounter, 1))
+	return id, InputRequest{Method: "roots/list"}
+}
+
+// ParseListRootsResult unmarshals an MRTR input response for roots/list.
+func ParseListRootsResult(raw json.RawMessage) (*ListRootsResult, error) {
+	if len(raw) == 0 {
+		return nil, errors.New("mcp: empty roots input response")
+	}
+	var result ListRootsResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, fmt.Errorf("mcp: failed to parse roots input response: %w", err)
+	}
+	return &result, nil
 }

--- a/ext/mcp/sampling_bridge_test.go
+++ b/ext/mcp/sampling_bridge_test.go
@@ -312,22 +312,37 @@ func TestNestedSamplingRoundTripOverStdio(t *testing.T) {
 	server := NewServer(WithServerInfo(ServerInfo{Name: "test-server", Version: "1.0.0"}))
 	server.AddTool(Tool{
 		Name:        "ask_client",
-		Description: "Ask the connected client model a question",
+		Description: "Ask the connected client model a question via MRTR sampling",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{"prompt":{"type":"string"}},"required":["prompt"]}`),
 	}, func(ctx context.Context, rc *RequestContext, args map[string]any) (*ToolResult, error) {
-		prompt, _ := args["prompt"].(string)
-		model := NewMCPModel(rc)
-		resp, err := model.Request(ctx, []core.ModelMessage{
-			core.ModelRequest{
-				Parts: []core.ModelRequestPart{
-					core.UserPromptPart{Content: prompt},
-				},
-			},
-		}, &core.ModelSettings{MaxTokens: intPtr(32)}, nil)
-		if err != nil {
-			return nil, err
+		responses := rc.InputResponses()
+		if len(responses) == 0 {
+			prompt, _ := args["prompt"].(string)
+			id, req := BuildSamplingInputRequest(&CreateMessageParams{
+				Messages: []SamplingMessage{{
+					Role:    "user",
+					Content: MarshalSamplingContent(Content{Type: "text", Text: prompt}),
+				}},
+				MaxTokens: 32,
+			})
+			rc.NeedInput(InputRequests{id: req}, "sampling-state-1")
+			return nil, nil
 		}
-		return textToolResult(resp.TextContent()), nil
+		// Retry: parse the sampling answer.
+		for _, raw := range responses {
+			result, err := ParseCreateMessageResult(raw)
+			if err != nil {
+				return nil, err
+			}
+			blocks, err := ParseSamplingContent(result.Content)
+			if err != nil {
+				return nil, err
+			}
+			if len(blocks) > 0 {
+				return textToolResult(blocks[0].Text), nil
+			}
+		}
+		return textToolResult(""), nil
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -373,12 +388,6 @@ func TestNestedSamplingRoundTripOverStdio(t *testing.T) {
 		_ = serverToClientReader.Close()
 	})
 
-	initCtx, initCancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer initCancel()
-	if err := client.initialize(initCtx); err != nil {
-		t.Fatalf("client initialize failed: %v", err)
-	}
-
 	callCtx, callCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer callCancel()
 	result, err := client.CallTool(callCtx, "ask_client", map[string]any{"prompt": "hello from tool"})
@@ -399,5 +408,3 @@ func textToolResult(text string) *ToolResult {
 		Content: []Content{{Type: "text", Text: text}},
 	}
 }
-
-func intPtr(v int) *int { return &v }

--- a/ext/mcp/server.go
+++ b/ext/mcp/server.go
@@ -24,54 +24,185 @@ type serverTool struct {
 	handler    ServerToolHandler
 }
 
-// RequestContext represents a single client request being serviced by an MCP server.
-// Nested client requests such as sampling/createMessage or roots/list must flow through it.
+// RequestContext represents a single client request being serviced by an MCP
+// server. In the 2026-07-28 stateless protocol each request self-describes its
+// client capabilities and identity via _meta; the server MUST NOT infer state
+// from prior requests on the same connection.
+//
+// MRTR: a tool/resource/prompt handler that needs additional information from
+// the client calls NeedInput and then returns a nil result. The dispatch layer
+// detects the recorded *InputRequiredResult and marshals it with resultType
+// "input_required". On retry, the client merges inputResponses and echoes
+// requestState; handlers consume them via InputResponses and RequestState.
 type RequestContext struct {
-	server *Server
+	server        *Server
+	meta          RequestMeta
+	cont          MRTRContinuation
+	headers       map[string]string
+	inputRequired *InputRequiredResult
+	taskCreated   *CreateTaskResult
+	requestID     any
 }
 
-// ClientCapabilities returns the capabilities advertised by the connected client.
-func (rc *RequestContext) ClientCapabilities() ClientCapabilities {
-	if rc == nil || rc.server == nil {
-		return ClientCapabilities{}
-	}
-	return rc.server.ClientCapabilities()
-}
-
-// ClientInfo returns the client identity observed during initialize.
-func (rc *RequestContext) ClientInfo() *ImplementationInfo {
-	if rc == nil || rc.server == nil {
+// RequestID returns the JSON-RPC id of the request this context services.
+func (rc *RequestContext) RequestID() any {
+	if rc == nil {
 		return nil
 	}
-	return rc.server.ClientInfo()
+	return rc.requestID
 }
 
-// ListRoots requests the current roots from the connected client.
-func (rc *RequestContext) ListRoots(ctx context.Context) (*ListRootsResult, error) {
-	if rc == nil || rc.server == nil {
-		return nil, errors.New("mcp: request context is not attached to a server")
+// ClientCapabilities returns the capabilities advertised by the client for this
+// request (from _meta.clientCapabilities).
+func (rc *RequestContext) ClientCapabilities() ClientCapabilities {
+	if rc == nil {
+		return ClientCapabilities{}
 	}
-	return rc.server.listRoots(ctx)
-}
-
-// CreateMessage requests client-side sampling from the connected client.
-func (rc *RequestContext) CreateMessage(ctx context.Context, params *CreateMessageParams) (*CreateMessageResult, error) {
-	if rc == nil || rc.server == nil {
-		return nil, errors.New("mcp: request context is not attached to a server")
+	if rc.meta.ClientCapabilities != nil {
+		return cloneClientCapabilities(*rc.meta.ClientCapabilities)
 	}
-	return rc.server.createMessage(ctx, params)
+	return ClientCapabilities{}
 }
 
-// CreateElicitation requests client-side elicitation from the connected client.
-func (rc *RequestContext) CreateElicitation(ctx context.Context, params *ElicitationParams) (*ElicitationResult, error) {
-	if rc == nil || rc.server == nil {
-		return nil, errors.New("mcp: request context is not attached to a server")
+// ClientInfo returns the client identity advertised for this request, if any.
+func (rc *RequestContext) ClientInfo() *ImplementationInfo {
+	if rc == nil || rc.meta.ClientInfo == nil {
+		return nil
 	}
-	return rc.server.createElicitation(ctx, params)
+	info := *rc.meta.ClientInfo
+	return &info
 }
 
-// Server is a single-session MCP server with tool/resource/prompt registries
-// and support for nested client requests such as sampling and roots/list.
+// ProtocolVersion returns the protocol version the client used for this request.
+func (rc *RequestContext) ProtocolVersion() string {
+	if rc == nil {
+		return ""
+	}
+	return rc.meta.ProtocolVersion
+}
+
+// LogLevel returns the per-request log level the client requested via _meta, if
+// any. Servers MUST NOT emit notifications/message for requests without it.
+func (rc *RequestContext) LogLevel() string {
+	if rc == nil {
+		return ""
+	}
+	return rc.meta.LogLevel
+}
+
+// ClientSupports reports whether the client declared the given capability in
+// this request's _meta.clientCapabilities. Capability is one of "roots",
+// "sampling", or "elicitation".
+func (rc *RequestContext) ClientSupports(capability string) bool {
+	caps := rc.ClientCapabilities()
+	switch capability {
+	case "roots":
+		return caps.Roots != nil
+	case "sampling":
+		return caps.Sampling != nil
+	case "elicitation":
+		return caps.Elicitation != nil
+	default:
+		return false
+	}
+}
+
+// InputResponses returns the answers the client supplied on an MRTR retry, keyed
+// by the server-assigned input request identifiers. Empty on a first request.
+func (rc *RequestContext) InputResponses() InputResponses {
+	if rc == nil {
+		return nil
+	}
+	return rc.cont.InputResponses
+}
+
+// RequestState returns the opaque requestState the client echoed verbatim from
+// the prior InputRequiredResult. It is attacker-controlled; higher layers are
+// responsible for any integrity verification. Empty on a first request.
+func (rc *RequestContext) RequestState() string {
+	if rc == nil {
+		return ""
+	}
+	return rc.cont.RequestState
+}
+
+// XHeader returns the value of an x-mcp-* request header (case-insensitive),
+// or empty if not present. Tool handlers use this to read SEP-2243 custom
+// headers passed from tool params.
+func (rc *RequestContext) XHeader(name string) string {
+	if rc == nil || rc.headers == nil {
+		return ""
+	}
+	for k, v := range rc.headers {
+		if equalFoldASCII(k, name) {
+			return v
+		}
+	}
+	return ""
+}
+
+// NeedInput records an *InputRequiredResult on the request context. A handler
+// calls it when it needs the client to fulfill input requests, then returns a
+// nil result; the dispatch layer detects the recorded value and marshals it
+// with resultType "input_required". The server MUST NOT include an input
+// request for a capability the client did not declare; the response layer
+// validates this and returns MissingRequiredClientCapability if violated.
+// The returned pointer is the recorded value, for inspection or logging.
+func (rc *RequestContext) NeedInput(inputRequests InputRequests, requestState string) *InputRequiredResult {
+	rc.inputRequired = &InputRequiredResult{
+		ResultType:    ResultTypeInputRequired,
+		InputRequests: inputRequests,
+		RequestState:  requestState,
+	}
+	return rc.inputRequired
+}
+
+// ClientSupportsExtension reports whether the client declared support for the
+// given MCP extension in _meta.clientCapabilities.extensions. ext is an
+// extension identifier such as ExtensionTasks.
+func (rc *RequestContext) ClientSupportsExtension(ext string) bool {
+	if rc == nil {
+		return false
+	}
+	caps := rc.ClientCapabilities()
+	if caps.Extensions == nil {
+		return false
+	}
+	_, ok := caps.Extensions[ext]
+	return ok
+}
+
+// CreateTask mints a task in the server's task store and returns a
+// CreateTaskResult (resultType "task") for the client to poll. It is only
+// allowed when the client declared support for the tasks extension; otherwise
+// it returns an error so the handler falls back to a synchronous result. The
+// handler returns the *CreateTaskResult directly; the dispatch layer stamps
+// serverInfo and leaves resultType "task" intact.
+func (rc *RequestContext) CreateTask(initial Task) (*CreateTaskResult, error) {
+	if rc == nil || rc.server == nil {
+		return nil, errors.New("mcp: no server bound to request context")
+	}
+	if !rc.server.tasksEnabled {
+		return nil, errors.New("mcp: tasks extension not enabled on this server")
+	}
+	if !rc.ClientSupportsExtension(ExtensionTasks) {
+		return nil, errors.New("mcp: client did not declare the tasks extension")
+	}
+	if initial.TaskID == "" {
+		initial.TaskID = newTaskID()
+	}
+	if initial.Status == "" {
+		initial.Status = TaskStatusWorking
+	}
+	rc.server.tasks.put(&taskEntry{task: initial})
+	result := &CreateTaskResult{ResultType: ResultTypeTask, Task: initial}
+	rc.taskCreated = result
+	return result, nil
+}
+
+// Server is a stateless MCP server with tool/resource/prompt registries. The
+// 2026-07-28 protocol removes the initialize handshake and sessions: each
+// request is self-describing and servers MUST NOT carry state between requests.
 type Server struct {
 	mu sync.Mutex
 	wg sync.WaitGroup
@@ -91,40 +222,69 @@ type Server struct {
 	prompts           []Prompt
 	promptGetter      PromptGetHandler
 
-	serverInfo   ServerInfo
-	instructions string
-	protocol     string
-	clientInfo   *ImplementationInfo
-	clientCaps   ClientCapabilities
-	clientReady  bool
+	serverInfo      ServerInfo
+	instructions    string
+	protocol        string
+	listCacheTTLMs  int64
+	listCacheScope  string
+	listCacheConfig bool
+
+	hub          *subscriptionHub
+	tasksEnabled bool
+	tasks        *taskStore
 }
 
 // ServerOption configures a Server.
 type ServerOption func(*Server)
 
-// WithServerInfo sets the server identity returned during initialize.
+// WithServerInfo sets the server identity echoed in result _meta and discover.
 func WithServerInfo(info ServerInfo) ServerOption {
 	return func(s *Server) {
 		s.serverInfo = info
 	}
 }
 
-// WithServerInstructions sets initialize.instructions.
+// WithServerInstructions sets the instructions returned by server/discover.
 func WithServerInstructions(instructions string) ServerOption {
 	return func(s *Server) {
 		s.instructions = instructions
 	}
 }
 
-// NewServer constructs a reusable single-session MCP server.
+// WithListCache sets the default cache freshness hints emitted on tools/list,
+// prompts/list, resources/list, resources/templates/list, and resources/read
+// results. ttlMs is the freshness hint in milliseconds; scope is "public" or
+// "private". Defaults are ttlMs=60000 and scope="public".
+func WithListCache(ttlMs int64, scope string) ServerOption {
+	return func(s *Server) {
+		s.listCacheTTLMs = ttlMs
+		s.listCacheConfig = true
+		if scope != "" {
+			s.listCacheScope = scope
+		}
+	}
+}
+
+// WithTasks enables the io.modelcontextprotocol/tasks extension on the server.
+// When enabled, the server advertises the extension in server/discover and
+// RequestContext.CreateTask may be used by tool/resource/prompt handlers to
+// return long-running tasks. Default off so existing servers are unaffected.
+func WithTasks() ServerOption {
+	return func(s *Server) {
+		s.tasksEnabled = true
+	}
+}
+
+// NewServer constructs a reusable stateless MCP server.
 func NewServer(opts ...ServerOption) *Server {
 	s := &Server{
-		pending: make(map[int64]chan *jsonRPCMessage),
-		serverInfo: ServerInfo{
-			Name:    "gollem-mcp-server",
-			Version: "1.0.0",
-		},
-		protocol: ProtocolVersion,
+		pending:        make(map[int64]chan *jsonRPCMessage),
+		serverInfo:     ServerInfo{Name: "gollem-mcp-server", Version: "1.0.0"},
+		protocol:       ProtocolVersion,
+		listCacheTTLMs: defaultListCacheTTLMs,
+		listCacheScope: CacheScopePublic,
+		hub:            newSubscriptionHub(),
+		tasks:          newTaskStore(),
 	}
 	for _, opt := range opts {
 		if opt != nil {
@@ -132,6 +292,44 @@ func NewServer(opts ...ServerOption) *Server {
 		}
 	}
 	return s
+}
+
+// defaultListCacheTTLMs is the default freshness hint (ms) for list/read
+// results when WithListCache has not been used.
+const defaultListCacheTTLMs = 60000
+
+// SetListCache configures the default cache freshness hints for list/read
+// results. ttlMs is a freshness hint in milliseconds; scope is "public" or
+// "private" (empty defaults to "public").
+func (s *Server) SetListCache(ttlMs int64, scope string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.listCacheTTLMs = ttlMs
+	if scope != "" {
+		s.listCacheScope = scope
+	} else {
+		s.listCacheScope = CacheScopePublic
+	}
+	s.listCacheConfig = true
+}
+
+func (s *Server) cacheConfigLocked() (int64, string) {
+	ttl := s.listCacheTTLMs
+	scope := s.listCacheScope
+	if scope == "" {
+		scope = CacheScopePublic
+	}
+	return ttl, scope
+}
+
+func (s *Server) cacheableLocked() CacheableResult {
+	ttl, scope := s.cacheConfigLocked()
+	out := CacheableResult{CacheScope: scope}
+	if ttl > 0 {
+		v := ttl
+		out.TTLMs = &v
+	}
+	return out
 }
 
 // AddTool registers or replaces a server tool.
@@ -164,25 +362,14 @@ func (s *Server) SetPrompts(prompts []Prompt, getter PromptGetHandler) {
 	s.promptGetter = getter
 }
 
-// ClientCapabilities returns the capabilities advertised by the connected client.
-func (s *Server) ClientCapabilities() ClientCapabilities {
+// ServerInfo returns the server identity.
+func (s *Server) ServerInfo() ServerInfo {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return cloneClientCapabilities(s.clientCaps)
+	return s.serverInfo
 }
 
-// ClientInfo returns the client identity observed during initialize.
-func (s *Server) ClientInfo() *ImplementationInfo {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.clientInfo == nil {
-		return nil
-	}
-	info := *s.clientInfo
-	return &info
-}
-
-// ProtocolVersion returns the negotiated protocol version for the current session.
+// ProtocolVersion returns the protocol version this server speaks.
 func (s *Server) ProtocolVersion() string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -192,23 +379,58 @@ func (s *Server) ProtocolVersion() string {
 	return s.protocol
 }
 
-// NotifyToolsListChanged emits notifications/tools/list_changed.
-func (s *Server) NotifyToolsListChanged(ctx context.Context) error {
-	return s.notify(ctx, "notifications/tools/list_changed", nil)
+// NotifyToolsListChanged emits notifications/tools/list_changed to every
+// active subscriptions/listen subscriber that opted in to tools list changes.
+func (s *Server) NotifyToolsListChanged() {
+	s.hub.emit("notifications/tools/list_changed", nil, func(f SubscriptionFilter) bool {
+		return f.ToolsListChanged
+	})
 }
 
-// NotifyResourcesListChanged emits notifications/resources/list_changed.
-func (s *Server) NotifyResourcesListChanged(ctx context.Context) error {
-	return s.notify(ctx, "notifications/resources/list_changed", nil)
+// NotifyResourcesListChanged emits notifications/resources/list_changed to
+// every active subscriber that opted in to resources list changes.
+func (s *Server) NotifyResourcesListChanged() {
+	s.hub.emit("notifications/resources/list_changed", nil, func(f SubscriptionFilter) bool {
+		return f.ResourcesListChanged
+	})
 }
 
-// NotifyPromptsListChanged emits notifications/prompts/list_changed.
-func (s *Server) NotifyPromptsListChanged(ctx context.Context) error {
-	return s.notify(ctx, "notifications/prompts/list_changed", nil)
+// NotifyPromptsListChanged emits notifications/prompts/list_changed to every
+// active subscriber that opted in to prompts list changes.
+func (s *Server) NotifyPromptsListChanged() {
+	s.hub.emit("notifications/prompts/list_changed", nil, func(f SubscriptionFilter) bool {
+		return f.PromptsListChanged
+	})
 }
 
-// HandleMessage handles a single JSON-RPC message. Request dispatch is asynchronous
-// so nested client requests can complete while the read loop continues.
+// NotifyResourceUpdated emits notifications/resources/updated for uri to every
+// active subscriber whose resourceSubscriptions contains uri.
+func (s *Server) NotifyResourceUpdated(uri string) {
+	s.hub.emit("notifications/resources/updated", map[string]any{"uri": uri}, func(f SubscriptionFilter) bool {
+		return containsString(f.ResourceSubscriptions, uri)
+	})
+}
+
+// UpdateTask advances a task in the store. The mutate callback receives the
+// current task and may mutate it in place (e.g. set Status to completed and
+// populate Result). It is the application-facing API for driving long-running
+// tasks created via RequestContext.CreateTask. Unknown task ids are ignored.
+func (s *Server) UpdateTask(taskID string, mutate func(*Task)) {
+	if mutate == nil {
+		return
+	}
+	entry, ok := s.tasks.get(taskID)
+	if !ok {
+		return
+	}
+	entry.update(mutate)
+	// TODO(mcp-2026): notifications/tasks over subscriptions when an active
+	// subscription opts in. Until then clients poll tasks/get.
+}
+
+// HandleMessage handles a single JSON-RPC message. Request dispatch is
+// asynchronous so the read loop continues while a handler runs. Used by
+// framed (stdio) transports that own the response writer.
 func (s *Server) HandleMessage(ctx context.Context, msg *jsonRPCMessage) {
 	if msg == nil {
 		return
@@ -244,86 +466,249 @@ func (s *Server) HandleMessage(ctx context.Context, msg *jsonRPCMessage) {
 }
 
 func (s *Server) handleNotification(msg *jsonRPCMessage) {
-	if msg.Method == "notifications/initialized" {
-		s.mu.Lock()
-		s.clientReady = true
-		s.mu.Unlock()
+	// The 2026-07-28 protocol removes notifications/initialized. The remaining
+	// server-side notification of interest is notifications/cancelled, which a
+	// stdio client uses to cancel an active subscriptions/listen stream.
+	if msg.Method == "notifications/cancelled" {
+		s.handleSubscriptionCancel(msg.Params)
+	}
+}
+
+// handleSubscriptionCancel deregisters the subscriptions/listen stream whose
+// JSON-RPC id matches the cancelled request id and sends it the graceful
+// closure response. Used by stdio where the client cancels via notification.
+func (s *Server) handleSubscriptionCancel(raw json.RawMessage) {
+	if len(raw) == 0 {
+		return
+	}
+	var params struct {
+		RequestID *json.RawMessage `json:"requestId"`
+	}
+	if err := json.Unmarshal(raw, &params); err != nil || params.RequestID == nil {
+		return
+	}
+	id := normalizeID(params.RequestID)
+	key := idKeyString(id)
+	s.hub.mu.Lock()
+	sub, ok := s.hub.subs[key]
+	if ok {
+		delete(s.hub.subs, key)
+	}
+	s.hub.mu.Unlock()
+	if ok && sub.deliver != nil {
+		sub.deliver(subscriptionClosureResponse(id))
 	}
 }
 
 func (s *Server) handleRequest(ctx context.Context, msg *jsonRPCMessage) {
+	resp, streaming := s.dispatchRequestStreaming(ctx, msg, nil)
+	if streaming {
+		// subscriptions/listen owns its own response stream; do not write an
+		// inline JSON-RPC response here.
+		return
+	}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		_ = s.writeResponse(resp.ID, nil, rpcErrorFromError(err))
+		return
+	}
+	_ = s.writeJSON(data)
+}
+
+// dispatchRequest validates the request _meta, dispatches the method, and
+// returns a marshaled response body (with resultType and serverInfo stamped on
+// success). It is shared by the async framed path and the synchronous HTTP
+// path so both honor the same validation and stamping rules. headers carries
+// optional x-mcp-* request headers made available to tool handlers via
+// RequestContext.XHeader. The streaming return is true when the method is
+// subscriptions/listen on a framed transport: the stream owns the response and
+// the caller MUST NOT write an inline response.
+func (s *Server) dispatchRequestWithHeaders(ctx context.Context, msg *jsonRPCMessage, headers map[string]string) jsonRPCResponse {
+	resp, _ := s.dispatchRequestStreaming(ctx, msg, headers)
+	return resp
+}
+
+func (s *Server) dispatchRequestStreaming(ctx context.Context, msg *jsonRPCMessage, headers map[string]string) (jsonRPCResponse, bool) {
 	requestID := normalizeID(msg.ID)
 
-	switch msg.Method {
-	case "initialize":
-		result, rpcErr := s.handleInitialize(msg.Params)
-		_ = s.respond(ctx, requestID, result, rpcErr)
-	case "tools/list":
-		_ = s.respond(ctx, requestID, s.handleToolsList(), nil)
-	case "tools/call":
-		result, rpcErr := s.handleToolsCall(ctx, msg.Params)
-		_ = s.respond(ctx, requestID, result, rpcErr)
-	case "resources/list":
-		_ = s.respond(ctx, requestID, s.handleResourcesList(), nil)
-	case "resources/read":
-		result, rpcErr := s.handleResourcesRead(ctx, msg.Params)
-		_ = s.respond(ctx, requestID, result, rpcErr)
-	case "resources/templates/list":
-		_ = s.respond(ctx, requestID, s.handleResourceTemplatesList(), nil)
-	case "prompts/list":
-		_ = s.respond(ctx, requestID, s.handlePromptsList(), nil)
-	case "prompts/get":
-		result, rpcErr := s.handlePromptGet(ctx, msg.Params)
-		_ = s.respond(ctx, requestID, result, rpcErr)
-	default:
-		_ = s.respond(ctx, requestID, nil, &jsonRPCError{
-			Code:    jsonRPCCodeMethodNotFound,
-			Message: "method not found: " + msg.Method,
-		})
+	meta, metaErr := parseRequestMeta(msg.Params)
+	if metaErr != nil {
+		return jsonRPCResponse{JSONRPC: "2.0", ID: requestID, Error: metaErr}, false
 	}
+
+	cont := parseContinuation(msg.Params)
+	rc := &RequestContext{
+		server:    s,
+		meta:      meta,
+		cont:      cont,
+		headers:   headers,
+		requestID: requestID,
+	}
+
+	result, rpcErr := s.dispatchMethod(ctx, rc, msg.Method, msg.Params)
+	if rpcErr != nil {
+		return jsonRPCResponse{JSONRPC: "2.0", ID: requestID, Error: rpcErr}, false
+	}
+
+	if _, ok := result.(*subscriptionStreamMarker); ok {
+		// The subscription stream has been registered and the ack has been
+		// sent on the shared channel. The graceful-closure response is sent
+		// later by the transport / cancel handler.
+		return jsonRPCResponse{JSONRPC: "2.0", ID: requestID}, true
+	}
+
+	return s.buildSuccessResponse(requestID, rc, result), false
 }
 
-func (s *Server) handleInitialize(raw json.RawMessage) (*InitializeResult, *jsonRPCError) {
-	var params InitializeParams
-	if len(raw) > 0 {
-		if err := json.Unmarshal(raw, &params); err != nil {
-			return nil, &jsonRPCError{
+// HandleRequestSync processes a single JSON-RPC request synchronously and
+// returns the marshaled JSON-RPC response (with resultType and serverInfo
+// stamped on success). Used by stateless transports (HTTP) that return the
+// response inline. headers carries optional x-mcp-* request headers.
+func (s *Server) HandleRequestSync(ctx context.Context, msg *jsonRPCMessage, headers map[string]string) json.RawMessage {
+	resp := s.dispatchRequestWithHeaders(ctx, msg, headers)
+	data, err := json.Marshal(resp)
+	if err != nil {
+		errResp := jsonRPCResponse{JSONRPC: "2.0", ID: resp.ID, Error: rpcErrorFromError(err)}
+		data, _ := json.Marshal(errResp)
+		return data
+	}
+	return data
+}
+
+// buildSuccessResponse stamps resultType and serverInfo onto a marshaled
+// result. *InputRequiredResult results keep resultType "input_required" and are
+// checked for required-capability compliance: a server MUST NOT request a
+// capability the client did not declare in _meta.clientCapabilities.
+// *CreateTaskResult results keep resultType "task" (the tasks extension).
+func (s *Server) buildSuccessResponse(requestID any, rc *RequestContext, result any) jsonRPCResponse {
+	if result == nil {
+		result = struct{}{}
+	}
+	info := s.ServerInfo()
+
+	if irr, ok := result.(*InputRequiredResult); ok {
+		if missing := missingRequiredCapabilities(rc, irr.InputRequests); len(missing) > 0 {
+			return jsonRPCResponse{JSONRPC: "2.0", ID: requestID, Error: MissingRequiredClientCapabilityError(missing)}
+		}
+		raw, err := json.Marshal(irr)
+		if err != nil {
+			return jsonRPCResponse{JSONRPC: "2.0", ID: requestID, Error: rpcErrorFromError(err)}
+		}
+		raw = stampServerInfo(raw, info)
+		return jsonRPCResponse{JSONRPC: "2.0", ID: requestID, Result: raw}
+	}
+
+	if ctr, ok := result.(*CreateTaskResult); ok {
+		// The server MUST NOT return a task to a client that did not declare
+		// the tasks extension; CreateTask already enforces this, but defend
+		// in depth by rejecting any task result to a non-declaring client.
+		if !rc.ClientSupportsExtension(ExtensionTasks) {
+			return jsonRPCResponse{JSONRPC: "2.0", ID: requestID, Error: &jsonRPCError{
 				Code:    jsonRPCCodeInvalidParams,
-				Message: fmt.Sprintf("invalid initialize params: %v", err),
-			}
+				Message: "mcp: server returned a task but the client did not declare the tasks extension",
+			}}
+		}
+		raw, err := json.Marshal(ctr)
+		if err != nil {
+			return jsonRPCResponse{JSONRPC: "2.0", ID: requestID, Error: rpcErrorFromError(err)}
+		}
+		raw = stampServerInfo(raw, info)
+		return jsonRPCResponse{JSONRPC: "2.0", ID: requestID, Result: raw}
+	}
+
+	raw, err := json.Marshal(result)
+	if err != nil {
+		return jsonRPCResponse{JSONRPC: "2.0", ID: requestID, Error: rpcErrorFromError(err)}
+	}
+	raw = stampResultType(raw, ResultTypeComplete)
+	raw = stampServerInfo(raw, info)
+	return jsonRPCResponse{JSONRPC: "2.0", ID: requestID, Result: raw}
+}
+
+func (s *Server) dispatchMethod(ctx context.Context, rc *RequestContext, method string, raw json.RawMessage) (any, *jsonRPCError) {
+	switch method {
+	case "server/discover":
+		return s.handleDiscover(), nil
+	case "tools/list":
+		return s.handleToolsList(), nil
+	case "tools/call":
+		return s.handleToolsCall(ctx, rc, raw)
+	case "resources/list":
+		return s.handleResourcesList(), nil
+	case "resources/read":
+		return s.handleResourcesRead(ctx, rc, raw)
+	case "resources/templates/list":
+		return s.handleResourceTemplatesList(), nil
+	case "prompts/list":
+		return s.handlePromptsList(), nil
+	case "prompts/get":
+		return s.handlePromptGet(ctx, rc, raw)
+	case "subscriptions/listen":
+		return s.handleSubscriptionsListen(rc, raw)
+	case "tasks/get":
+		return s.handleTaskGet(rc, raw)
+	case "tasks/update":
+		return s.handleTaskUpdate(rc, raw)
+	case "tasks/cancel":
+		return s.handleTaskCancel(rc, raw)
+	default:
+		return nil, &jsonRPCError{
+			Code:    jsonRPCCodeMethodNotFound,
+			Message: "method not found: " + method,
 		}
 	}
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.protocol = ProtocolVersion
-	if params.ProtocolVersion != "" {
-		s.protocol = ProtocolVersion
-	}
-	s.clientCaps = cloneClientCapabilities(params.Capabilities)
-	info := params.ClientInfo
-	s.clientInfo = &info
-
-	result := &InitializeResult{
-		ProtocolVersion: s.protocol,
-		Capabilities:    s.serverCapabilitiesLocked(),
-		ServerInfo:      cloneServerInfo(s.serverInfo),
-		Instructions:    s.instructions,
-	}
-	return result, nil
 }
 
-func (s *Server) handleToolsList() map[string]any {
+// handleSubscriptionsListen registers a subscription on the shared (stdio)
+// channel. The ack is sent immediately as the first message; the
+// graceful-closure response is sent on notifications/cancelled or connection
+// drop. On the HTTP transport the POST handler intercepts subscriptions/listen
+// and streams SSE directly, so this path only runs for framed transports.
+func (s *Server) handleSubscriptionsListen(rc *RequestContext, raw json.RawMessage) (any, *jsonRPCError) {
+	filter := parseSubscribeParams(raw)
+	id := rc.requestID
+	ack := ackMessage(id, filter)
+	if err := s.writeJSON(ack); err != nil {
+		return nil, &jsonRPCError{Code: jsonRPCCodeInternalError, Message: "mcp: failed to send subscription ack: " + err.Error()}
+	}
+	sub := &subscription{
+		id:     id,
+		idKey:  idKeyString(id),
+		filter: filter,
+		deliver: func(data []byte) {
+			_ = s.writeJSON(data)
+		},
+	}
+	s.hub.register(sub)
+	return &subscriptionStreamMarker{}, nil
+}
+
+func (s *Server) handleDiscover() *DiscoverResult {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return &DiscoverResult{
+		SupportedVersions: append([]string(nil), SupportedProtocolVersions...),
+		Capabilities:      s.serverCapabilitiesLocked(),
+		ServerInfo:        cloneServerInfo(s.serverInfo),
+		Instructions:      s.instructions,
+		CacheableResult:   s.cacheableLocked(),
+	}
+}
+
+func (s *Server) handleToolsList() *listToolsResult {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	tools := make([]Tool, 0, len(s.tools))
 	for _, tool := range s.tools {
 		tools = append(tools, tool.definition)
 	}
-	return map[string]any{"tools": tools}
+	return &listToolsResult{
+		Tools:           tools,
+		CacheableResult: s.cacheableLocked(),
+	}
 }
 
-func (s *Server) handleToolsCall(ctx context.Context, raw json.RawMessage) (any, *jsonRPCError) {
+func (s *Server) handleToolsCall(ctx context.Context, rc *RequestContext, raw json.RawMessage) (any, *jsonRPCError) {
 	var params struct {
 		Name      string         `json:"name"`
 		Arguments map[string]any `json:"arguments"`
@@ -357,9 +742,15 @@ func (s *Server) handleToolsCall(ctx context.Context, raw json.RawMessage) (any,
 		params.Arguments = map[string]any{}
 	}
 
-	result, err := entry.handler(ctx, &RequestContext{server: s}, params.Arguments)
+	result, err := entry.handler(ctx, rc, params.Arguments)
 	if err != nil {
 		return nil, rpcErrorFromError(err)
+	}
+	if rc.inputRequired != nil {
+		return rc.inputRequired, nil
+	}
+	if rc.taskCreated != nil {
+		return rc.taskCreated, nil
 	}
 	if result == nil {
 		return &ToolResult{Content: []Content{{Type: "text", Text: ""}}}, nil
@@ -367,13 +758,16 @@ func (s *Server) handleToolsCall(ctx context.Context, raw json.RawMessage) (any,
 	return result, nil
 }
 
-func (s *Server) handleResourcesList() map[string]any {
+func (s *Server) handleResourcesList() *listResourcesResult {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return map[string]any{"resources": append([]Resource(nil), s.resources...)}
+	return &listResourcesResult{
+		Resources:       append([]Resource(nil), s.resources...),
+		CacheableResult: s.cacheableLocked(),
+	}
 }
 
-func (s *Server) handleResourcesRead(ctx context.Context, raw json.RawMessage) (any, *jsonRPCError) {
+func (s *Server) handleResourcesRead(ctx context.Context, rc *RequestContext, raw json.RawMessage) (any, *jsonRPCError) {
 	var params struct {
 		URI string `json:"uri"`
 	}
@@ -394,26 +788,50 @@ func (s *Server) handleResourcesRead(ctx context.Context, raw json.RawMessage) (
 		}
 	}
 
-	result, err := reader(ctx, &RequestContext{server: s}, params.URI)
+	result, err := reader(ctx, rc, params.URI)
 	if err != nil {
 		return nil, rpcErrorFromError(err)
+	}
+	if rc.inputRequired != nil {
+		return rc.inputRequired, nil
+	}
+	if rc.taskCreated != nil {
+		return rc.taskCreated, nil
+	}
+	if result == nil {
+		result = &ReadResourceResult{}
+	}
+	s.mu.Lock()
+	cache := s.cacheableLocked()
+	s.mu.Unlock()
+	if result.TTLMs == nil {
+		result.TTLMs = cache.TTLMs
+	}
+	if result.CacheScope == "" {
+		result.CacheScope = cache.CacheScope
 	}
 	return result, nil
 }
 
-func (s *Server) handleResourceTemplatesList() map[string]any {
+func (s *Server) handleResourceTemplatesList() *listResourceTemplatesResult {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return map[string]any{"resourceTemplates": append([]ResourceTemplate(nil), s.resourceTemplates...)}
+	return &listResourceTemplatesResult{
+		ResourceTemplates: append([]ResourceTemplate(nil), s.resourceTemplates...),
+		CacheableResult:   s.cacheableLocked(),
+	}
 }
 
-func (s *Server) handlePromptsList() map[string]any {
+func (s *Server) handlePromptsList() *listPromptsResult {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return map[string]any{"prompts": append([]Prompt(nil), s.prompts...)}
+	return &listPromptsResult{
+		Prompts:         append([]Prompt(nil), s.prompts...),
+		CacheableResult: s.cacheableLocked(),
+	}
 }
 
-func (s *Server) handlePromptGet(ctx context.Context, raw json.RawMessage) (any, *jsonRPCError) {
+func (s *Server) handlePromptGet(ctx context.Context, rc *RequestContext, raw json.RawMessage) (any, *jsonRPCError) {
 	var params struct {
 		Name      string            `json:"name"`
 		Arguments map[string]string `json:"arguments"`
@@ -435,11 +853,84 @@ func (s *Server) handlePromptGet(ctx context.Context, raw json.RawMessage) (any,
 		}
 	}
 
-	result, err := getter(ctx, &RequestContext{server: s}, params.Name, params.Arguments)
+	result, err := getter(ctx, rc, params.Name, params.Arguments)
 	if err != nil {
 		return nil, rpcErrorFromError(err)
 	}
+	if rc.inputRequired != nil {
+		return rc.inputRequired, nil
+	}
+	if rc.taskCreated != nil {
+		return rc.taskCreated, nil
+	}
 	return result, nil
+}
+
+// requireTasks guards the tasks/* methods: the server must have the extension
+// enabled and the client must have declared support for it.
+func (s *Server) requireTasks(rc *RequestContext, method string) *jsonRPCError {
+	if !s.tasksEnabled {
+		return &jsonRPCError{Code: jsonRPCCodeMethodNotFound, Message: "method not found: " + method}
+	}
+	if !rc.ClientSupportsExtension(ExtensionTasks) {
+		return &jsonRPCError{Code: jsonRPCCodeMethodNotFound, Message: "method not found: " + method}
+	}
+	return nil
+}
+
+func (s *Server) handleTaskGet(rc *RequestContext, raw json.RawMessage) (any, *jsonRPCError) {
+	if rpcErr := s.requireTasks(rc, "tasks/get"); rpcErr != nil {
+		return nil, rpcErr
+	}
+	var params struct {
+		TaskID string `json:"taskId"`
+	}
+	if err := json.Unmarshal(raw, &params); err != nil {
+		return nil, &jsonRPCError{Code: jsonRPCCodeInvalidParams, Message: fmt.Sprintf("invalid tasks/get params: %v", err)}
+	}
+	entry, ok := s.tasks.get(params.TaskID)
+	if !ok {
+		return nil, &jsonRPCError{Code: jsonRPCCodeInvalidParams, Message: "task not found: " + params.TaskID}
+	}
+	task := entry.snapshot()
+	return &task, nil
+}
+
+func (s *Server) handleTaskUpdate(rc *RequestContext, raw json.RawMessage) (any, *jsonRPCError) {
+	if rpcErr := s.requireTasks(rc, "tasks/update"); rpcErr != nil {
+		return nil, rpcErr
+	}
+	var params struct {
+		TaskID         string         `json:"taskId"`
+		InputResponses InputResponses `json:"inputResponses"`
+	}
+	if err := json.Unmarshal(raw, &params); err != nil {
+		return nil, &jsonRPCError{Code: jsonRPCCodeInvalidParams, Message: fmt.Sprintf("invalid tasks/update params: %v", err)}
+	}
+	entry, ok := s.tasks.get(params.TaskID)
+	if !ok {
+		return nil, &jsonRPCError{Code: jsonRPCCodeInvalidParams, Message: "task not found: " + params.TaskID}
+	}
+	entry.applyInputResponses(params.InputResponses)
+	return struct{}{}, nil
+}
+
+func (s *Server) handleTaskCancel(rc *RequestContext, raw json.RawMessage) (any, *jsonRPCError) {
+	if rpcErr := s.requireTasks(rc, "tasks/cancel"); rpcErr != nil {
+		return nil, rpcErr
+	}
+	var params struct {
+		TaskID string `json:"taskId"`
+	}
+	if err := json.Unmarshal(raw, &params); err != nil {
+		return nil, &jsonRPCError{Code: jsonRPCCodeInvalidParams, Message: fmt.Sprintf("invalid tasks/cancel params: %v", err)}
+	}
+	entry, ok := s.tasks.get(params.TaskID)
+	if !ok {
+		return nil, &jsonRPCError{Code: jsonRPCCodeInvalidParams, Message: "task not found: " + params.TaskID}
+	}
+	entry.requestCancel()
+	return struct{}{}, nil
 }
 
 func (s *Server) prepareCall() (int64, chan *jsonRPCMessage, error) {
@@ -480,48 +971,7 @@ func (s *Server) awaitResponse(ctx context.Context, id int64, ch chan *jsonRPCMe
 	}
 }
 
-func (s *Server) call(ctx context.Context, method string, params any) (json.RawMessage, error) {
-	id, ch, err := s.prepareCall()
-	if err != nil {
-		return nil, err
-	}
-
-	req := jsonRPCRequest{
-		JSONRPC: "2.0",
-		ID:      id,
-		Method:  method,
-		Params:  params,
-	}
-	data, err := json.Marshal(req)
-	if err != nil {
-		s.removePending(id)
-		return nil, err
-	}
-	if err := s.writeJSON(data); err != nil {
-		s.removePending(id)
-		return nil, err
-	}
-	return s.awaitResponse(ctx, id, ch)
-}
-
-func (s *Server) notify(ctx context.Context, method string, params any) error {
-	req := struct {
-		JSONRPC string `json:"jsonrpc"`
-		Method  string `json:"method"`
-		Params  any    `json:"params,omitempty"`
-	}{
-		JSONRPC: "2.0",
-		Method:  method,
-		Params:  params,
-	}
-	data, err := json.Marshal(req)
-	if err != nil {
-		return err
-	}
-	return s.writeJSON(data)
-}
-
-func (s *Server) respond(_ context.Context, id any, result any, rpcErr *jsonRPCError) error {
+func (s *Server) writeResponse(id any, result json.RawMessage, rpcErr *jsonRPCError) error {
 	resp := jsonRPCResponse{
 		JSONRPC: "2.0",
 		ID:      id,
@@ -553,75 +1003,6 @@ func (s *Server) writeJSON(data []byte) error {
 	return writeFn(data)
 }
 
-func (s *Server) listRoots(ctx context.Context) (*ListRootsResult, error) {
-	caps := s.ClientCapabilities()
-	if caps.Roots == nil {
-		return nil, errors.New("mcp: client does not advertise roots support")
-	}
-	result, err := s.call(ctx, "roots/list", nil)
-	if err != nil {
-		return nil, fmt.Errorf("mcp: roots/list failed: %w", err)
-	}
-	var roots ListRootsResult
-	if err := json.Unmarshal(result, &roots); err != nil {
-		return nil, fmt.Errorf("mcp: failed to parse roots/list result: %w", err)
-	}
-	return &roots, nil
-}
-
-func (s *Server) createMessage(ctx context.Context, params *CreateMessageParams) (*CreateMessageResult, error) {
-	if params == nil {
-		return nil, errors.New("mcp: nil sampling params")
-	}
-	caps := s.ClientCapabilities()
-	if caps.Sampling == nil {
-		return nil, errors.New("mcp: client does not advertise sampling support")
-	}
-	if len(params.Tools) > 0 && caps.Sampling.Tools == nil {
-		return nil, errors.New("mcp: client does not advertise sampling.tools support")
-	}
-	if params.IncludeContext != "" && params.IncludeContext != "none" && caps.Sampling.Context == nil {
-		return nil, errors.New("mcp: client does not advertise sampling.context support")
-	}
-
-	result, err := s.call(ctx, "sampling/createMessage", params)
-	if err != nil {
-		return nil, fmt.Errorf("mcp: sampling/createMessage failed: %w", err)
-	}
-	var sampled CreateMessageResult
-	if err := json.Unmarshal(result, &sampled); err != nil {
-		return nil, fmt.Errorf("mcp: failed to parse sampling/createMessage result: %w", err)
-	}
-	return &sampled, nil
-}
-
-func (s *Server) createElicitation(ctx context.Context, params *ElicitationParams) (*ElicitationResult, error) {
-	if params == nil {
-		return nil, errors.New("mcp: nil elicitation params")
-	}
-	caps := s.ClientCapabilities()
-	if caps.Elicitation == nil {
-		return nil, errors.New("mcp: client does not advertise elicitation support")
-	}
-	mode := params.Mode
-	if mode == "" {
-		mode = "form"
-	}
-	if !supportsElicitationMode(caps.Elicitation, mode) {
-		return nil, fmt.Errorf("mcp: client does not advertise elicitation.%s support", mode)
-	}
-
-	result, err := s.call(ctx, "elicitation/create", params)
-	if err != nil {
-		return nil, fmt.Errorf("mcp: elicitation/create failed: %w", err)
-	}
-	var elicited ElicitationResult
-	if err := json.Unmarshal(result, &elicited); err != nil {
-		return nil, fmt.Errorf("mcp: failed to parse elicitation/create result: %w", err)
-	}
-	return &elicited, nil
-}
-
 // Close marks the current server session closed and fails pending nested requests.
 func (s *Server) Close() error {
 	s.mu.Lock()
@@ -629,6 +1010,9 @@ func (s *Server) Close() error {
 	s.closed = true
 	s.peerEOF = true
 	s.failPendingLocked()
+	if s.hub != nil {
+		s.hub.clear()
+	}
 	return nil
 }
 
@@ -650,6 +1034,9 @@ func (s *Server) markPeerClosed() {
 	defer s.mu.Unlock()
 	s.peerEOF = true
 	s.failPendingLocked()
+	if s.hub != nil {
+		s.hub.clear()
+	}
 }
 
 func (s *Server) failPendingLocked() {
@@ -670,6 +1057,12 @@ func (s *Server) serverCapabilitiesLocked() ServerCapabilities {
 	if len(s.prompts) > 0 || s.promptGetter != nil {
 		caps.Prompts = &PromptCapabilities{}
 	}
+	if s.tasksEnabled {
+		if caps.Extensions == nil {
+			caps.Extensions = map[string]json.RawMessage{}
+		}
+		caps.Extensions[ExtensionTasks] = json.RawMessage(`{}`)
+	}
 	return caps
 }
 
@@ -678,18 +1071,182 @@ func cloneServerInfo(info ServerInfo) *ServerInfo {
 	return &cloned
 }
 
-func supportsElicitationMode(cap *ElicitationCapability, mode string) bool {
-	if cap == nil {
-		return false
+// parseRequestMeta extracts and validates the reserved _meta fields from a
+// request's params. protocolVersion is required and must be supported.
+// clientCapabilities is required. Both missing cases yield -32602; an
+// unsupported version yields -32022.
+func parseRequestMeta(raw json.RawMessage) (RequestMeta, *jsonRPCError) {
+	meta := RequestMeta{}
+	if len(raw) == 0 {
+		return meta, &jsonRPCError{
+			Code:    jsonRPCCodeInvalidParams,
+			Message: "missing required _meta: protocolVersion",
+		}
 	}
-	switch mode {
-	case "", "form":
-		return cap.Form != nil || cap.URL == nil
-	case "url":
-		return cap.URL != nil
+
+	var probe struct {
+		Meta *json.RawMessage `json:"_meta"`
+	}
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		return meta, &jsonRPCError{
+			Code:    jsonRPCCodeInvalidParams,
+			Message: fmt.Sprintf("invalid request params: %v", err),
+		}
+	}
+	if probe.Meta == nil || len(*probe.Meta) == 0 {
+		return meta, &jsonRPCError{
+			Code:    jsonRPCCodeInvalidParams,
+			Message: "missing required _meta: protocolVersion",
+		}
+	}
+
+	var metaMap map[string]json.RawMessage
+	if err := json.Unmarshal(*probe.Meta, &metaMap); err != nil {
+		return meta, &jsonRPCError{
+			Code:    jsonRPCCodeInvalidParams,
+			Message: fmt.Sprintf("invalid _meta: %v", err),
+		}
+	}
+
+	pvRaw, ok := metaMap[MetaProtocolVersion]
+	if !ok || len(pvRaw) == 0 {
+		return meta, &jsonRPCError{
+			Code:    jsonRPCCodeInvalidParams,
+			Message: "missing required _meta: protocolVersion",
+		}
+	}
+	var pv string
+	if err := json.Unmarshal(pvRaw, &pv); err != nil {
+		return meta, &jsonRPCError{
+			Code:    jsonRPCCodeInvalidParams,
+			Message: fmt.Sprintf("invalid _meta protocolVersion: %v", err),
+		}
+	}
+	if !isSupportedProtocolVersion(pv) {
+		return meta, UnsupportedProtocolVersionError(pv)
+	}
+	meta.ProtocolVersion = pv
+
+	capsRaw, ok := metaMap[MetaClientCapabilities]
+	if !ok || len(capsRaw) == 0 {
+		return meta, &jsonRPCError{
+			Code:    jsonRPCCodeInvalidParams,
+			Message: "missing required _meta: clientCapabilities",
+		}
+	}
+	var caps ClientCapabilities
+	if err := json.Unmarshal(capsRaw, &caps); err != nil {
+		return meta, &jsonRPCError{
+			Code:    jsonRPCCodeInvalidParams,
+			Message: fmt.Sprintf("invalid _meta clientCapabilities: %v", err),
+		}
+	}
+	meta.ClientCapabilities = &caps
+
+	if infoRaw, ok := metaMap[MetaClientInfo]; ok && len(infoRaw) > 0 {
+		var info ImplementationInfo
+		if err := json.Unmarshal(infoRaw, &info); err == nil {
+			meta.ClientInfo = &info
+		}
+	}
+	if logRaw, ok := metaMap[MetaLogLevel]; ok && len(logRaw) > 0 {
+		var level string
+		if err := json.Unmarshal(logRaw, &level); err == nil {
+			meta.LogLevel = level
+		}
+	}
+	return meta, nil
+}
+
+// parseContinuation extracts the MRTR retry fields (inputResponses,
+// requestState) from a request's params. Empty on a first (non-retry) request.
+func parseContinuation(raw json.RawMessage) MRTRContinuation {
+	var cont MRTRContinuation
+	if len(raw) == 0 {
+		return cont
+	}
+	var probe struct {
+		InputResponses InputResponses `json:"inputResponses"`
+		RequestState   string         `json:"requestState"`
+	}
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		return cont
+	}
+	return MRTRContinuation{
+		InputResponses: probe.InputResponses,
+		RequestState:   probe.RequestState,
+	}
+}
+
+func isSupportedProtocolVersion(v string) bool {
+	for _, supported := range SupportedProtocolVersions {
+		if supported == v {
+			return true
+		}
+	}
+	return false
+}
+
+// requiredCapabilitiesForInputRequests returns the distinct client capabilities
+// a set of input requests requires, in deterministic order.
+func requiredCapabilitiesForInputRequests(reqs InputRequests) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, ir := range reqs {
+		cap := capabilityForMethod(ir.Method)
+		if cap == "" || seen[cap] {
+			continue
+		}
+		seen[cap] = true
+		out = append(out, cap)
+	}
+	return out
+}
+
+// missingRequiredCapabilities returns the capabilities required by the input
+// requests that the client did not declare on this request.
+func missingRequiredCapabilities(rc *RequestContext, reqs InputRequests) []string {
+	var missing []string
+	for _, cap := range requiredCapabilitiesForInputRequests(reqs) {
+		if !rc.ClientSupports(cap) {
+			missing = append(missing, cap)
+		}
+	}
+	return missing
+}
+
+// capabilityForMethod maps an input request method to the client capability it
+// requires. Returns "" for methods with no capability requirement.
+func capabilityForMethod(method string) string {
+	switch method {
+	case "sampling/createMessage":
+		return "sampling"
+	case "elicitation/create":
+		return "elicitation"
+	case "roots/list":
+		return "roots"
 	default:
+		return ""
+	}
+}
+
+func equalFoldASCII(a, b string) bool {
+	if len(a) != len(b) {
 		return false
 	}
+	for i := range len(a) {
+		ca, cb := a[i], b[i]
+		if ca >= 'A' && ca <= 'Z' {
+			ca += 'a' - 'A'
+		}
+		if cb >= 'A' && cb <= 'Z' {
+			cb += 'a' - 'A'
+		}
+		if ca != cb {
+			return false
+		}
+	}
+	return true
 }
 
 // ServerTransport is the minimal interface implemented by server transports.

--- a/ext/mcp/server_http.go
+++ b/ext/mcp/server_http.go
@@ -3,53 +3,19 @@ package mcp
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
-	"sync"
-	"sync/atomic"
+	"strings"
 )
 
-// HTTPServerTransport serves MCP over the streamable HTTP transport.
-// Each MCP session gets its own cloned Server instance.
+// HTTPServerTransport serves MCP over the stateless streamable HTTP transport.
+// The 2026-07-28 protocol has no sessions: each POST carries a single
+// self-describing JSON-RPC request and returns the result inline as
+// application/json. There is no Mcp-Session-Id, no DELETE teardown, and no SSE
+// resumability. The one long-lived stream is subscriptions/listen, which is
+// delivered as a POST whose response is text/event-stream (SSE); it replaces
+// the old GET endpoint.
 type HTTPServerTransport struct {
-	mu         sync.Mutex
-	template   *Server
-	sessions   map[string]*httpServerSession
-	sessionCtx func(*http.Request) context.Context
-}
-
-// SetSessionContextFunc installs a hook that derives each new MCP
-// session's base context from the HTTP request that initialized it.
-// This is how hosts thread per-connection identity (a workspace
-// resolved from the Authorization header, say) through to tool
-// handlers, whose ctx is the session context.
-//
-// The returned context must NOT be (or derive its cancellation from)
-// the request context — sessions outlive their initializing request.
-// Carry values only, e.g.:
-//
-//	t.SetSessionContextFunc(func(r *http.Request) context.Context {
-//		ws := resolveWorkspace(r.Header.Get("Authorization"))
-//		return context.WithValue(context.Background(), workspaceKey{}, ws)
-//	})
-//
-// A nil hook (the default) and a nil return both mean
-// context.Background().
-func (t *HTTPServerTransport) SetSessionContextFunc(f func(*http.Request) context.Context) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	t.sessionCtx = f
-}
-
-type httpServerSession struct {
-	mu      sync.Mutex
-	id      string
-	server  *Server
-	ctx     context.Context
-	cancel  context.CancelFunc
-	outbox  chan []byte
-	backlog [][]byte
-	closed  bool
+	template *Server
 }
 
 // NewHTTPServerTransport binds a reusable Server template to an HTTP transport.
@@ -57,271 +23,206 @@ func NewHTTPServerTransport(server *Server) *HTTPServerTransport {
 	if server == nil {
 		server = NewServer()
 	}
-	return &HTTPServerTransport{
-		template: server,
-		sessions: make(map[string]*httpServerSession),
-	}
+	return &HTTPServerTransport{template: server}
 }
 
-// Run blocks until ctx is cancelled, then closes all active sessions.
+// Run blocks until ctx is cancelled. The stateless transport holds no
+// per-connection resources to clean up.
 func (t *HTTPServerTransport) Run(ctx context.Context) error {
 	<-ctx.Done()
-	_ = t.Close()
 	return ctx.Err()
 }
 
-// Close shuts down all active HTTP MCP sessions.
-func (t *HTTPServerTransport) Close() error {
-	t.mu.Lock()
-	sessions := make([]*httpServerSession, 0, len(t.sessions))
-	for _, session := range t.sessions {
-		sessions = append(sessions, session)
-	}
-	t.sessions = make(map[string]*httpServerSession)
-	t.mu.Unlock()
+// Close is a no-op for the stateless transport; retained for io.Closer.
+func (t *HTTPServerTransport) Close() error { return nil }
 
-	for _, session := range sessions {
-		session.close()
-	}
-	return nil
-}
-
-// ServeHTTP implements http.Handler for the streamable HTTP MCP transport.
+// ServeHTTP implements http.Handler for the stateless streamable HTTP transport.
 func (t *HTTPServerTransport) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
-		t.handleStream(w, r)
+		t.handleGet(w, r)
 	case http.MethodPost:
 		t.handlePost(w, r)
-	case http.MethodDelete:
-		t.handleDelete(w, r)
 	default:
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 	}
 }
 
-func (t *HTTPServerTransport) handleStream(w http.ResponseWriter, r *http.Request) {
-	flusher, ok := w.(http.Flusher)
-	if !ok {
-		http.Error(w, "streaming not supported", http.StatusInternalServerError)
-		return
-	}
-
-	sessionID := r.Header.Get("Mcp-Session-Id")
-	if sessionID == "" {
-		http.Error(w, "missing Mcp-Session-Id", http.StatusBadRequest)
-		return
-	}
-
-	session, ok := t.getSession(sessionID)
-	if !ok {
-		http.Error(w, "unknown session", http.StatusNotFound)
-		return
-	}
-
-	w.Header().Set("Content-Type", "text/event-stream")
-	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("Connection", "keep-alive")
-	w.Header().Set("Mcp-Session-Id", sessionID)
-
-	for _, payload := range session.drainBacklog() {
-		fmt.Fprintf(w, "event: message\ndata: %s\n\n", payload)
-		flusher.Flush()
-	}
-
-	for {
-		select {
-		case payload, ok := <-session.outbox:
-			if !ok {
-				return
-			}
-			fmt.Fprintf(w, "event: message\ndata: %s\n\n", payload)
-			flusher.Flush()
-		case <-r.Context().Done():
-			return
-		case <-session.ctx.Done():
-			return
-		}
-	}
+// handleGet retains the subscriptions seam for backward compatibility. The
+// 2026-07-28 protocol routes subscriptions/listen through POST (see
+// handlePost), so GET returns 501.
+func (t *HTTPServerTransport) handleGet(w http.ResponseWriter, r *http.Request) {
+	_ = r
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusNotImplemented)
+	_, _ = w.Write([]byte(`{"jsonrpc":"2.0","error":{"code":-32601,"message":"subscriptions/listen is delivered via POST; GET is not supported"}}`))
 }
 
 func (t *HTTPServerTransport) handlePost(w http.ResponseWriter, r *http.Request) {
 	var msg jsonRPCMessage
 	if err := json.NewDecoder(r.Body).Decode(&msg); err != nil {
-		http.Error(w, "invalid JSON", http.StatusBadRequest)
+		writeHTTPJSONRPCError(w, nil, http.StatusBadRequest, &jsonRPCError{
+			Code:    jsonRPCCodeParseError,
+			Message: "invalid JSON: " + err.Error(),
+		})
 		return
 	}
 
-	sessionID := r.Header.Get("Mcp-Session-Id")
-	if msg.Method == "initialize" && sessionID == "" {
-		session := t.newSession(r)
-		w.Header().Set("Content-Type", "application/json")
-		w.Header().Set("Mcp-Session-Id", session.id)
+	// Validate MCP-Protocol-Version header when present.
+	if pv := r.Header.Get("MCP-Protocol-Version"); pv != "" && !isSupportedProtocolVersion(pv) {
+		writeHTTPJSONRPCError(w, normalizeID(msg.ID), http.StatusBadRequest, UnsupportedProtocolVersionError(pv))
+		return
+	}
 
-		result, rpcErr := session.server.handleInitialize(msg.Params)
-		payload, err := json.Marshal(jsonRPCMessage{
-			JSONRPC: "2.0",
-			ID:      rawJSONID(normalizeID(msg.ID)),
-			Result:  mustRawResult(result, rpcErr == nil),
-			Error:   rpcErr,
-		})
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+	// Validate Mcp-Method header when present: must match the JSON-RPC body method.
+	if hMethod := r.Header.Get("Mcp-Method"); hMethod != "" && hMethod != msg.Method {
+		writeHTTPJSONRPCError(w, normalizeID(msg.ID), http.StatusBadRequest, HeaderMismatchError(
+			"Mcp-Method header does not match request method"))
+		return
+	}
+
+	// Validate Mcp-Name header when present: must match the tool/prompt name or
+	// resource uri in the request params.
+	if hName := r.Header.Get("Mcp-Name"); hName != "" {
+		if expected := mcpNameForRequest(msg.Method, msg.Params); expected != "" && expected != hName {
+			writeHTTPJSONRPCError(w, normalizeID(msg.ID), http.StatusBadRequest, HeaderMismatchError(
+				"Mcp-Name header does not match request target"))
 			return
 		}
-		_, _ = w.Write(payload)
+	}
+
+	// subscriptions/listen is the one long-lived stream: switch the response to
+	// text/event-stream and stream notifications until the client disconnects
+	// or the server shuts down.
+	if msg.Method == "subscriptions/listen" {
+		t.handleSubscriptionsListen(w, r, &msg)
 		return
 	}
 
-	if sessionID == "" {
-		http.Error(w, "missing Mcp-Session-Id", http.StatusBadRequest)
-		return
-	}
+	headers := collectXMCPHeaders(r.Header)
+	ctx := r.Context()
+	resp := t.template.HandleRequestSync(ctx, &msg, headers)
 
-	session, ok := t.getSession(sessionID)
-	if !ok {
-		http.Error(w, "unknown session", http.StatusNotFound)
-		return
-	}
-	w.Header().Set("Mcp-Session-Id", sessionID)
-
-	go session.server.HandleMessage(session.ctx, &msg)
-	w.WriteHeader(http.StatusAccepted)
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(resp)
 }
 
-func (t *HTTPServerTransport) handleDelete(w http.ResponseWriter, r *http.Request) {
-	sessionID := r.Header.Get("Mcp-Session-Id")
-	if sessionID == "" {
-		http.Error(w, "missing Mcp-Session-Id", http.StatusBadRequest)
+// handleSubscriptionsListen streams a subscriptions/listen response as SSE. It
+// validates _meta (returning the normal JSON-RPC error response on failure),
+// sends notifications/subscriptions/acknowledged as the first event, then fans
+// out server notifications to the stream until the client disconnects or the
+// server shuts down. On graceful closure it emits the JSON-RPC response to the
+// original request id before returning. No SSE event ids / Last-Event-ID are
+// emitted (no resumability).
+func (t *HTTPServerTransport) handleSubscriptionsListen(w http.ResponseWriter, r *http.Request, msg *jsonRPCMessage) {
+	requestID := normalizeID(msg.ID)
+
+	meta, metaErr := parseRequestMeta(msg.Params)
+	if metaErr != nil {
+		resp := jsonRPCResponse{JSONRPC: "2.0", ID: requestID, Error: metaErr}
+		data, _ := json.Marshal(resp)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(data)
 		return
 	}
 
-	session, ok := t.deleteSession(sessionID)
+	filter := parseSubscribeParams(msg.Params)
+
+	flusher, ok := w.(http.Flusher)
 	if !ok {
-		http.Error(w, "unknown session", http.StatusNotFound)
+		resp := jsonRPCResponse{JSONRPC: "2.0", ID: requestID, Error: &jsonRPCError{
+			Code:    jsonRPCCodeInternalError,
+			Message: "mcp: streaming unsupported by response writer",
+		}}
+		data, _ := json.Marshal(resp)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(data)
 		return
 	}
-	session.close()
-	w.WriteHeader(http.StatusNoContent)
-}
 
-func (t *HTTPServerTransport) newSession(r *http.Request) *httpServerSession {
-	sessionID := generateHTTPSessionID()
-	base := context.Background()
-	t.mu.Lock()
-	hook := t.sessionCtx
-	t.mu.Unlock()
-	if hook != nil {
-		if derived := hook(r); derived != nil {
-			base = derived
+	// Buffered channel: the ack is enqueued first so it is always the first
+	// event, before any notification that arrives after registration.
+	ch := make(chan []byte, 256)
+	ackBytes := ackMessage(requestID, filter)
+	select {
+	case ch <- ackBytes:
+	default:
+	}
+
+	sub := &subscription{
+		id:     requestID,
+		idKey:  idKeyString(requestID),
+		filter: filter,
+		deliver: func(data []byte) {
+			select {
+			case ch <- data:
+			default:
+				// Client is slow; drop the notification rather than block the hub.
+			}
+		},
+	}
+	deregister := t.template.hub.register(sub)
+	defer deregister()
+
+	_ = meta // client capabilities already validated; no further use needed here
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.WriteHeader(http.StatusOK)
+	flusher.Flush()
+
+	ctx := r.Context()
+	for {
+		select {
+		case data := <-ch:
+			if _, err := writeSSEEvent(w, data); err != nil {
+				return
+			}
+			flusher.Flush()
+		case <-ctx.Done():
+			// Graceful closure: emit the JSON-RPC response to the original id,
+			// then close the stream.
+			_, _ = writeSSEEvent(w, subscriptionClosureResponse(requestID))
+			flusher.Flush()
+			return
 		}
 	}
-	ctx, cancel := context.WithCancel(base)
-	server := cloneServerTemplate(t.template)
-	session := &httpServerSession{
-		id:     sessionID,
-		server: server,
-		ctx:    ctx,
-		cancel: cancel,
-		outbox: make(chan []byte, 256),
-	}
-	server.attachWriter(func(data []byte) error {
-		session.enqueue(data)
-		return nil
-	})
-
-	t.mu.Lock()
-	t.sessions[sessionID] = session
-	t.mu.Unlock()
-	return session
 }
 
-func (t *HTTPServerTransport) getSession(id string) (*httpServerSession, bool) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	session, ok := t.sessions[id]
-	return session, ok
+// writeSSEEvent writes a single SSE message event with the given JSON payload.
+func writeSSEEvent(w http.ResponseWriter, data []byte) (int, error) {
+	return w.Write(append(append([]byte("event: message\ndata: "), data...), '\n', '\n'))
 }
 
-func (t *HTTPServerTransport) deleteSession(id string) (*httpServerSession, bool) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	session, ok := t.sessions[id]
-	if ok {
-		delete(t.sessions, id)
+// collectXMCPHeaders returns the x-mcp-* request headers (lowercased keys) so
+// tool handlers can read SEP-2243 custom headers passed from tool params via
+// RequestContext.XHeader.
+func collectXMCPHeaders(header http.Header) map[string]string {
+	out := make(map[string]string)
+	for key, values := range header {
+		if !strings.HasPrefix(strings.ToLower(key), "x-mcp-") {
+			continue
+		}
+		if len(values) == 0 {
+			continue
+		}
+		out[strings.ToLower(key)] = values[0]
 	}
-	return session, ok
-}
-
-func (s *httpServerSession) enqueue(data []byte) {
-	snapshot := append([]byte(nil), data...)
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.closed {
-		return
-	}
-	select {
-	case s.outbox <- snapshot:
-	default:
-		s.backlog = append(s.backlog, snapshot)
-	}
-}
-
-func (s *httpServerSession) drainBacklog() [][]byte {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if len(s.backlog) == 0 {
+	if len(out) == 0 {
 		return nil
 	}
-	items := append([][]byte(nil), s.backlog...)
-	s.backlog = nil
-	return items
+	return out
 }
 
-func (s *httpServerSession) close() {
-	s.mu.Lock()
-	if s.closed {
-		s.mu.Unlock()
-		return
+func writeHTTPJSONRPCError(w http.ResponseWriter, id any, status int, rpcErr *jsonRPCError) {
+	resp := jsonRPCResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error:   rpcErr,
 	}
-	s.closed = true
-	close(s.outbox)
-	s.mu.Unlock()
-	s.cancel()
-	_ = s.server.Close()
+	data, _ := json.Marshal(resp)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, _ = w.Write(data)
 }
-
-func cloneServerTemplate(template *Server) *Server {
-	template.mu.Lock()
-	defer template.mu.Unlock()
-
-	cloned := NewServer(
-		WithServerInfo(template.serverInfo),
-		WithServerInstructions(template.instructions),
-	)
-	cloned.protocol = template.protocol
-	cloned.tools = append([]serverTool(nil), template.tools...)
-	cloned.resources = append([]Resource(nil), template.resources...)
-	cloned.resourceTemplates = append([]ResourceTemplate(nil), template.resourceTemplates...)
-	cloned.resourceReader = template.resourceReader
-	cloned.prompts = append([]Prompt(nil), template.prompts...)
-	cloned.promptGetter = template.promptGetter
-	return cloned
-}
-
-func generateHTTPSessionID() string {
-	return fmt.Sprintf("mcp-%d", httpSessionCounter.Add(1))
-}
-
-func mustRawResult(result any, ok bool) json.RawMessage {
-	if !ok || result == nil {
-		return nil
-	}
-	data, err := json.Marshal(result)
-	if err != nil {
-		return nil
-	}
-	return data
-}
-
-var httpSessionCounter atomic.Int64

--- a/ext/mcp/server_http_test.go
+++ b/ext/mcp/server_http_test.go
@@ -1,178 +1,357 @@
 package mcp
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
-
-	"github.com/fugue-labs/gollem/core"
 )
 
-func TestHTTPServerTransportSamplingRoundTrip(t *testing.T) {
-	server := NewServer(WithServerInfo(ServerInfo{Name: "sleepy-test", Version: "0.1.0"}))
+func TestHTTPServerTransportDiscover(t *testing.T) {
+	server := NewServer(WithServerInfo(ServerInfo{Name: "disc-test", Version: "1.0.0"}))
+	transport := NewHTTPServerTransport(server)
+	httpServer := httptest.NewServer(transport)
+	defer httpServer.Close()
+
+	resp := postJSON(t, httpServer.URL, jsonRPCMessage{
+		JSONRPC: "2.0",
+		ID:      rawJSONID(1),
+		Method:  "server/discover",
+		Params:  mustRawJSON(statelessParams(nil)),
+	})
+
+	if resp.Error != nil {
+		t.Fatalf("discover error: %+v", resp.Error)
+	}
+	var result DiscoverResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("failed to parse discover result: %v", err)
+	}
+	if len(result.SupportedVersions) != 1 || result.SupportedVersions[0] != ProtocolVersion {
+		t.Fatalf("unexpected protocol versions: %+v", result.SupportedVersions)
+	}
+	if result.ServerInfo == nil || result.ServerInfo.Name != "disc-test" {
+		t.Fatalf("unexpected server info: %+v", result.ServerInfo)
+	}
+}
+
+func TestHTTPServerTransportResultTypeAndCache(t *testing.T) {
+	server := NewServer(WithServerInfo(ServerInfo{Name: "cache-test", Version: "1.0.0"}))
 	server.AddTool(Tool{
-		Name:        "ask_client",
-		Description: "Ask the connected client to sample a response",
-		InputSchema: mustRawJSON([]byte(`{"type":"object","properties":{"prompt":{"type":"string"}},"required":["prompt"]}`)),
-	}, func(ctx context.Context, rc *RequestContext, params map[string]any) (*ToolResult, error) {
-		prompt, _ := params["prompt"].(string)
-		resp, err := rc.CreateMessage(ctx, &CreateMessageParams{
-			Messages: []SamplingMessage{{
-				Role:    "user",
-				Content: MarshalSamplingContent(Content{Type: "text", Text: prompt}),
-			}},
-			MaxTokens: 32,
-		})
-		if err != nil {
-			return nil, err
+		Name:        "echo",
+		Description: "echo",
+		InputSchema: json.RawMessage(`{"type":"object"}`),
+	}, func(_ context.Context, _ *RequestContext, _ map[string]any) (*ToolResult, error) {
+		return textToolResult("hi"), nil
+	})
+	transport := NewHTTPServerTransport(server)
+	httpServer := httptest.NewServer(transport)
+	defer httpServer.Close()
+
+	// tools/list stamps resultType "complete" and cacheable fields.
+	listResp := postJSON(t, httpServer.URL, jsonRPCMessage{
+		JSONRPC: "2.0",
+		ID:      rawJSONID(1),
+		Method:  "tools/list",
+		Params:  mustRawJSON(statelessParams(nil)),
+	})
+	if listResp.Error != nil {
+		t.Fatalf("tools/list error: %+v", listResp.Error)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(listResp.Result, &raw); err != nil {
+		t.Fatalf("failed to parse tools/list result: %v", err)
+	}
+	if rt, _ := raw["resultType"].(string); rt != ResultTypeComplete {
+		t.Fatalf("resultType = %v, want %q", raw["resultType"], ResultTypeComplete)
+	}
+	if _, ok := raw["ttlMs"]; !ok {
+		t.Fatalf("expected ttlMs on tools/list result, got %+v", raw)
+	}
+	if scope, _ := raw["cacheScope"].(string); scope != CacheScopePublic {
+		t.Fatalf("cacheScope = %v, want %q", raw["cacheScope"], CacheScopePublic)
+	}
+
+	meta, _ := raw["_meta"].(map[string]any)
+	if si, _ := meta[MetaServerInfo].(map[string]any); si == nil || si["name"] != "cache-test" {
+		t.Fatalf("expected _meta.serverInfo on tools/list result, got %+v", meta)
+	}
+}
+
+func TestHTTPServerTransportMissingProtocolVersion(t *testing.T) {
+	server := NewServer()
+	transport := NewHTTPServerTransport(server)
+	httpServer := httptest.NewServer(transport)
+	defer httpServer.Close()
+
+	// Params with _meta lacking protocolVersion.
+	params := mustRawJSON([]byte(`{"_meta":{"io.modelcontextprotocol/clientCapabilities":{}}}`))
+	resp := postJSON(t, httpServer.URL, jsonRPCMessage{
+		JSONRPC: "2.0",
+		ID:      rawJSONID(1),
+		Method:  "tools/list",
+		Params:  params,
+	})
+	if resp.Error == nil || resp.Error.Code != jsonRPCCodeInvalidParams {
+		t.Fatalf("expected -32602 for missing protocolVersion, got %+v", resp.Error)
+	}
+}
+
+func TestHTTPServerTransportUnsupportedProtocolVersion(t *testing.T) {
+	server := NewServer()
+	transport := NewHTTPServerTransport(server)
+	httpServer := httptest.NewServer(transport)
+	defer httpServer.Close()
+
+	params := mustRawJSON([]byte(`{"_meta":{"io.modelcontextprotocol/protocolVersion":"2025-11-25","io.modelcontextprotocol/clientCapabilities":{}}}`))
+	resp := postJSON(t, httpServer.URL, jsonRPCMessage{
+		JSONRPC: "2.0",
+		ID:      rawJSONID(1),
+		Method:  "tools/list",
+		Params:  params,
+	})
+	if resp.Error == nil || resp.Error.Code != jsonRPCCodeUnsupportedProtocolVersion {
+		t.Fatalf("expected -32022 for unsupported protocol version, got %+v", resp.Error)
+	}
+}
+
+func TestHTTPServerTransportMissingClientCapabilities(t *testing.T) {
+	server := NewServer()
+	transport := NewHTTPServerTransport(server)
+	httpServer := httptest.NewServer(transport)
+	defer httpServer.Close()
+
+	params := mustRawJSON([]byte(`{"_meta":{"io.modelcontextprotocol/protocolVersion":"` + ProtocolVersion + `"}}`))
+	resp := postJSON(t, httpServer.URL, jsonRPCMessage{
+		JSONRPC: "2.0",
+		ID:      rawJSONID(1),
+		Method:  "tools/list",
+		Params:  params,
+	})
+	if resp.Error == nil || resp.Error.Code != jsonRPCCodeInvalidParams {
+		t.Fatalf("expected -32602 for missing clientCapabilities, got %+v", resp.Error)
+	}
+}
+
+func TestHTTPServerTransportHeaderMismatchMethod(t *testing.T) {
+	server := NewServer()
+	transport := NewHTTPServerTransport(server)
+	httpServer := httptest.NewServer(transport)
+	defer httpServer.Close()
+
+	body, _ := json.Marshal(jsonRPCMessage{
+		JSONRPC: "2.0",
+		ID:      rawJSONID(1),
+		Method:  "tools/list",
+		Params:  mustRawJSON(statelessParams(nil)),
+	})
+
+	req, _ := http.NewRequestWithContext(t.Context(), http.MethodPost, httpServer.URL, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Mcp-Method", "tools/call")
+	resp := doHTTP(t, req)
+	if resp.Error == nil || resp.Error.Code != jsonRPCCodeHeaderMismatch {
+		t.Fatalf("expected -32020 HeaderMismatch, got %+v", resp.Error)
+	}
+}
+
+func TestHTTPServerTransportHeaderMismatchName(t *testing.T) {
+	server := NewServer()
+	server.AddTool(Tool{
+		Name:        "greet",
+		Description: "greet",
+		InputSchema: json.RawMessage(`{"type":"object"}`),
+	}, func(_ context.Context, _ *RequestContext, _ map[string]any) (*ToolResult, error) {
+		return textToolResult("hi"), nil
+	})
+	transport := NewHTTPServerTransport(server)
+	httpServer := httptest.NewServer(transport)
+	defer httpServer.Close()
+
+	callParams := mustRawJSON(statelessParams(map[string]any{"name": "greet", "arguments": map[string]any{}}))
+	body, _ := json.Marshal(jsonRPCMessage{
+		JSONRPC: "2.0",
+		ID:      rawJSONID(1),
+		Method:  "tools/call",
+		Params:  callParams,
+	})
+
+	req, _ := http.NewRequestWithContext(t.Context(), http.MethodPost, httpServer.URL, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Mcp-Method", "tools/call")
+	req.Header.Set("Mcp-Name", "wrong_name")
+	resp := doHTTP(t, req)
+	if resp.Error == nil || resp.Error.Code != jsonRPCCodeHeaderMismatch {
+		t.Fatalf("expected -32020 HeaderMismatch for Mcp-Name, got %+v", resp.Error)
+	}
+}
+
+func TestHTTPServerTransportMRTRRoundTrip(t *testing.T) {
+	server := NewServer(WithServerInfo(ServerInfo{Name: "mrtr-test", Version: "1.0.0"}))
+	server.AddTool(Tool{
+		Name:        "ask_name",
+		Description: "Ask the client for their name via elicitation",
+		InputSchema: json.RawMessage(`{"type":"object"}`),
+	}, func(_ context.Context, rc *RequestContext, _ map[string]any) (*ToolResult, error) {
+		responses := rc.InputResponses()
+		if len(responses) == 0 {
+			id, req := BuildElicitationInputRequest(&ElicitationParams{
+				Message:         "What is your name?",
+				RequestedSchema: json.RawMessage(`{"type":"object"}`),
+			})
+			rc.NeedInput(InputRequests{id: req}, "opaque-state-1")
+			return nil, nil
 		}
-		blocks, err := ParseSamplingContent(resp.Content)
-		if err != nil {
-			return nil, err
+		// Retry: consume the elicitation answer.
+		var name string
+		for _, raw := range responses {
+			el, err := ParseElicitationResult(raw)
+			if err != nil {
+				return nil, err
+			}
+			if v, ok := el.Content["name"].(string); ok {
+				name = v
+			}
 		}
-		if len(blocks) == 0 {
-			return textToolResult(""), nil
+		if rc.RequestState() != "opaque-state-1" {
+			return nil, &jsonRPCError{Code: jsonRPCCodeInvalidParams, Message: "requestState not echoed verbatim"}
 		}
-		return textToolResult(blocks[0].Text), nil
+		return textToolResult("hello " + name), nil
 	})
 
 	httpServer := httptest.NewServer(NewHTTPServerTransport(server))
 	defer httpServer.Close()
 
-	clientModel := &recordingModel{
-		requestFn: func(_ context.Context, messages []core.ModelMessage, settings *core.ModelSettings, _ *core.ModelRequestParameters) (*core.ModelResponse, error) {
-			if len(messages) != 1 {
-				t.Fatalf("unexpected nested sampling messages: %+v", messages)
-			}
-			req := messages[0].(core.ModelRequest)
-			if got := req.Parts[0].(core.UserPromptPart).Content; got != "hello from transport" {
-				t.Fatalf("unexpected prompt: %q", got)
-			}
-			if settings == nil || settings.MaxTokens == nil || *settings.MaxTokens != 32 {
-				t.Fatalf("unexpected settings: %+v", settings)
-			}
-			return &core.ModelResponse{
-				ModelName:    "client-model",
-				FinishReason: core.FinishReasonStop,
-				Parts: []core.ModelResponsePart{
-					core.TextPart{Content: "client says hi"},
-				},
-			}, nil
-		},
-	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	client, err := NewHTTPClientWithConfig(ctx, httpServer.URL, ClientConfig{
-		SamplingHandler: ModelSamplingHandler(clientModel),
+		ElicitationHandler: func(_ context.Context, params *ElicitationParams) (*ElicitationResult, error) {
+			if params.Message != "What is your name?" {
+				t.Fatalf("unexpected elicitation message: %q", params.Message)
+			}
+			return &ElicitationResult{Action: "accept", Content: map[string]any{"name": "Trevor"}}, nil
+		},
 	})
 	if err != nil {
 		t.Fatalf("failed to create HTTP client: %v", err)
 	}
 	defer client.Close()
 
-	tools, err := client.ListTools(ctx)
-	if err != nil {
-		t.Fatalf("ListTools failed: %v", err)
-	}
-	if len(tools) != 1 || tools[0].Name != "ask_client" {
-		t.Fatalf("unexpected tools: %+v", tools)
-	}
-
-	result, err := client.CallTool(ctx, "ask_client", map[string]any{"prompt": "hello from transport"})
+	result, err := client.CallTool(ctx, "ask_name", map[string]any{})
 	if err != nil {
 		t.Fatalf("CallTool failed: %v", err)
 	}
-	if got := result.TextContent(); got != "client says hi" {
+	if got := result.TextContent(); got != "hello Trevor" {
 		t.Fatalf("unexpected tool result: %q", got)
 	}
 }
 
-func TestHTTPServerTransportRunClosesSessionsOnCancel(t *testing.T) {
-	transport := NewHTTPServerTransport(NewServer())
-	session := transport.newSession(httptest.NewRequest(http.MethodPost, "/", nil))
-
-	ctx, cancel := context.WithCancel(context.Background())
-	done := make(chan error, 1)
-	go func() {
-		done <- transport.Run(ctx)
-	}()
-
-	cancel()
-
-	select {
-	case err := <-done:
-		if !errors.Is(err, context.Canceled) {
-			t.Fatalf("Run returned %v, want %v", err, context.Canceled)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for transport.Run to return")
-	}
-
-	select {
-	case <-session.ctx.Done():
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for session context to close")
-	}
-
-	transport.mu.Lock()
-	sessionCount := len(transport.sessions)
-	transport.mu.Unlock()
-	if sessionCount != 0 {
-		t.Fatalf("expected all sessions to be closed, found %d", sessionCount)
-	}
-
-	session.mu.Lock()
-	closed := session.closed
-	session.mu.Unlock()
-	if !closed {
-		t.Fatal("expected session to be marked closed")
-	}
-}
-
-// TestHTTPServerTransportSessionContextFunc verifies the per-session
-// context hook: identity derived from the initializing HTTP request
-// (e.g. a workspace resolved from the Authorization header) reaches
-// tool handlers through their ctx, for the whole life of the session.
-func TestHTTPServerTransportSessionContextFunc(t *testing.T) {
-	type wsKey struct{}
-
-	server := NewServer(WithServerInfo(ServerInfo{Name: "ctx-test", Version: "0.1.0"}))
+func TestHTTPServerTransportMissingRequiredClientCapability(t *testing.T) {
+	server := NewServer()
 	server.AddTool(Tool{
-		Name:        "whoami",
-		Description: "Report the session identity",
-		InputSchema: mustRawJSON([]byte(`{"type":"object"}`)),
-	}, func(ctx context.Context, _ *RequestContext, _ map[string]any) (*ToolResult, error) {
-		ws, _ := ctx.Value(wsKey{}).(string)
-		return textToolResult(ws), nil
+		Name:        "need_sampling",
+		Description: "Requires sampling capability the client did not declare",
+		InputSchema: json.RawMessage(`{"type":"object"}`),
+	}, func(_ context.Context, rc *RequestContext, _ map[string]any) (*ToolResult, error) {
+		if len(rc.InputResponses()) > 0 {
+			return textToolResult("done"), nil
+		}
+		id, req := BuildSamplingInputRequest(&CreateMessageParams{
+			Messages:  []SamplingMessage{{Role: "user", Content: MarshalSamplingContent(Content{Type: "text", Text: "hi"})}},
+			MaxTokens: 16,
+		})
+		rc.NeedInput(InputRequests{id: req}, "")
+		return nil, nil
 	})
 
-	transport := NewHTTPServerTransport(server)
-	transport.SetSessionContextFunc(func(r *http.Request) context.Context {
-		return context.WithValue(context.Background(), wsKey{}, r.Header.Get("X-Test-Workspace"))
-	})
-	httpServer := httptest.NewServer(transport)
+	httpServer := httptest.NewServer(NewHTTPServerTransport(server))
 	defer httpServer.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	client, err := NewHTTPClientWithConfig(ctx, httpServer.URL, ClientConfig{},
-		WithHeaders(map[string]string{"X-Test-Workspace": "ws-42"}))
+	// Client advertises no sampling capability.
+	client, err := NewHTTPClientWithConfig(ctx, httpServer.URL, ClientConfig{})
 	if err != nil {
 		t.Fatalf("failed to create HTTP client: %v", err)
 	}
 	defer client.Close()
 
-	result, err := client.CallTool(ctx, "whoami", map[string]any{})
+	_, err = client.CallTool(ctx, "need_sampling", map[string]any{})
+	if err == nil {
+		t.Fatal("expected MissingRequiredClientCapability error")
+	}
+	var rpcErr *jsonRPCError
+	if !errors.As(err, &rpcErr) {
+		t.Fatalf("expected *jsonRPCError, got %T: %v", err, err)
+	}
+	if rpcErr.Code != jsonRPCCodeMissingRequiredClientCapability {
+		t.Fatalf("expected -32021, got %d: %s", rpcErr.Code, rpcErr.Message)
+	}
+	var data struct {
+		RequiredCapabilities []string `json:"requiredCapabilities"`
+	}
+	if err := json.Unmarshal(rpcErr.Data, &data); err != nil {
+		t.Fatalf("failed to parse error data: %v", err)
+	}
+	if len(data.RequiredCapabilities) != 1 || data.RequiredCapabilities[0] != "sampling" {
+		t.Fatalf("expected requiredCapabilities=[sampling], got %+v", data.RequiredCapabilities)
+	}
+}
+
+func TestHTTPServerTransportGETIsSubscriptionsSeam(t *testing.T) {
+	transport := NewHTTPServerTransport(NewServer())
+	httpServer := httptest.NewServer(transport)
+	defer httpServer.Close()
+
+	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, httpServer.URL, nil)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		t.Fatalf("CallTool failed: %v", err)
+		t.Fatalf("GET failed: %v", err)
 	}
-	if got := result.TextContent(); got != "ws-42" {
-		t.Fatalf("session context value did not reach the tool handler: %q", got)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotImplemented {
+		t.Fatalf("expected 501 for subscriptions seam, got %d", resp.StatusCode)
 	}
+}
+
+// statelessParams builds request params carrying the required _meta envelope.
+func statelessParams(extra map[string]any) []byte {
+	meta := map[string]any{
+		MetaProtocolVersion:    ProtocolVersion,
+		MetaClientCapabilities: map[string]any{},
+	}
+	obj := map[string]any{"_meta": meta}
+	for k, v := range extra {
+		obj[k] = v
+	}
+	data, _ := json.Marshal(obj)
+	return data
+}
+
+func postJSON(t *testing.T, url string, msg jsonRPCMessage) *jsonRPCResponse {
+	t.Helper()
+	body, _ := json.Marshal(msg)
+	req, _ := http.NewRequestWithContext(t.Context(), http.MethodPost, url, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	return doHTTP(t, req)
+}
+
+func doHTTP(t *testing.T, req *http.Request) *jsonRPCResponse {
+	t.Helper()
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	var out jsonRPCResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	return &out
 }

--- a/ext/mcp/server_stdio.go
+++ b/ext/mcp/server_stdio.go
@@ -60,7 +60,7 @@ func (t *StdioServerTransport) Run(ctx context.Context) error {
 
 		var msg jsonRPCMessage
 		if err := json.Unmarshal(line, &msg); err != nil {
-			_ = t.server.respond(ctx, nil, nil, &jsonRPCError{
+			_ = t.server.writeResponse(nil, nil, &jsonRPCError{
 				Code:    jsonRPCCodeParseError,
 				Message: "parse error: " + err.Error(),
 			})

--- a/ext/mcp/sse.go
+++ b/ext/mcp/sse.go
@@ -68,11 +68,6 @@ func NewSSEClientWithConfig(ctx context.Context, url string, config ClientConfig
 		return nil, fmt.Errorf("mcp: timed out waiting for endpoint event: %w", ctx.Err())
 	}
 
-	if err := c.initialize(ctx); err != nil {
-		c.Close()
-		return nil, fmt.Errorf("mcp: initialization failed: %w", err)
-	}
-
 	return c, nil
 }
 
@@ -142,10 +137,6 @@ func (c *SSEClient) resolveURL(endpoint string) string {
 	return base[:idx+3+hostEnd] + endpoint
 }
 
-func (c *SSEClient) initialize(ctx context.Context) error {
-	return initializeClient(ctx, c.clientState, c.call, c.notify)
-}
-
 func (c *SSEClient) call(ctx context.Context, method string, params any) (json.RawMessage, error) {
 	id, ch, err := c.prepareCall()
 	if err != nil {
@@ -156,7 +147,16 @@ func (c *SSEClient) call(ctx context.Context, method string, params any) (json.R
 		JSONRPC: "2.0",
 		ID:      id,
 		Method:  method,
-		Params:  params,
+	}
+	if raw, ok := params.(json.RawMessage); ok && len(raw) > 0 {
+		req.Params = raw
+	} else if params != nil {
+		data, mErr := json.Marshal(params)
+		if mErr != nil {
+			c.removePending(id)
+			return nil, mErr
+		}
+		req.Params = data
 	}
 
 	c.mu.Lock()
@@ -193,31 +193,20 @@ func (c *SSEClient) call(ctx context.Context, method string, params any) (json.R
 	return c.awaitResponse(ctx, id, ch)
 }
 
-func (c *SSEClient) notify(ctx context.Context, method string, params any) error {
-	req := struct {
-		JSONRPC string `json:"jsonrpc"`
-		Method  string `json:"method"`
-		Params  any    `json:"params,omitempty"`
-	}{
-		JSONRPC: "2.0",
-		Method:  method,
-		Params:  params,
-	}
-
-	data, err := json.Marshal(req)
-	if err != nil {
-		return err
-	}
-
-	return c.postMessage(ctx, data)
-}
-
 func (c *SSEClient) respond(ctx context.Context, id any, result any, rpcErr *jsonRPCError) error {
 	resp := jsonRPCResponse{
 		JSONRPC: "2.0",
 		ID:      id,
-		Result:  result,
 		Error:   rpcErr,
+	}
+	if raw, ok := result.(json.RawMessage); ok {
+		resp.Result = raw
+	} else if result != nil {
+		data, err := json.Marshal(result)
+		if err != nil {
+			return err
+		}
+		resp.Result = data
 	}
 	data, err := json.Marshal(resp)
 	if err != nil {
@@ -247,44 +236,45 @@ func (c *SSEClient) postMessage(ctx context.Context, data []byte) error {
 	return nil
 }
 
-// ListTools discovers available tools from the MCP server.
-func (c *SSEClient) ListTools(ctx context.Context) ([]Tool, error) {
-	return listTools(ctx, c.call)
+// Discover calls server/discover and caches the server's identity, capabilities,
+// and instructions on the client state.
+func (c *SSEClient) Discover(ctx context.Context) (*DiscoverResult, error) {
+	return discover(ctx, c.call, c.clientState)
 }
 
-// CallTool invokes a tool on the MCP server.
+// ListTools discovers available tools from the MCP server.
+func (c *SSEClient) ListTools(ctx context.Context) ([]Tool, error) {
+	return listTools(ctx, c.call, c.clientState)
+}
+
+// CallTool invokes a tool on the MCP server. tools/call is MRTR-eligible.
 func (c *SSEClient) CallTool(ctx context.Context, name string, args map[string]any) (*ToolResult, error) {
-	return callTool(ctx, c.call, name, args)
+	return callTool(ctx, c.call, c.clientState, name, args)
 }
 
 // ListResources lists resources exposed by the MCP server.
 func (c *SSEClient) ListResources(ctx context.Context) ([]Resource, error) {
-	return listResources(ctx, c.call)
+	return listResources(ctx, c.call, c.clientState)
 }
 
-// ReadResource reads a resource from the MCP server.
+// ReadResource reads a resource from the MCP server. resources/read is MRTR-eligible.
 func (c *SSEClient) ReadResource(ctx context.Context, uri string) (*ReadResourceResult, error) {
-	return readResource(ctx, c.call, uri)
+	return readResource(ctx, c.call, c.clientState, uri)
 }
 
 // ListResourceTemplates lists URI templates exposed by the MCP server.
 func (c *SSEClient) ListResourceTemplates(ctx context.Context) ([]ResourceTemplate, error) {
-	return listResourceTemplates(ctx, c.call)
+	return listResourceTemplates(ctx, c.call, c.clientState)
 }
 
 // ListPrompts lists prompts exposed by the MCP server.
 func (c *SSEClient) ListPrompts(ctx context.Context) ([]Prompt, error) {
-	return listPrompts(ctx, c.call)
+	return listPrompts(ctx, c.call, c.clientState)
 }
 
-// GetPrompt resolves a prompt from the MCP server.
+// GetPrompt resolves a prompt from the MCP server. prompts/get is MRTR-eligible.
 func (c *SSEClient) GetPrompt(ctx context.Context, name string, args map[string]string) (*PromptResult, error) {
-	return getPrompt(ctx, c.call, name, args)
-}
-
-// NotifyRootsListChanged emits notifications/roots/list_changed to the server.
-func (c *SSEClient) NotifyRootsListChanged(ctx context.Context) error {
-	return notifyRootsListChanged(ctx, c.notify)
+	return getPrompt(ctx, c.call, c.clientState, name, args)
 }
 
 // Tools converts MCP tools into core.Tool instances backed by the SSE client.

--- a/ext/mcp/stdio_test.go
+++ b/ext/mcp/stdio_test.go
@@ -57,20 +57,19 @@ func (m *mockStdioServer) serve() {
 			continue
 		}
 
-		// Notifications have ID 0 (our implementation uses int64, starting at 1).
-		// The initialized notification uses no ID in the spec, but our struct
-		// will deserialize it as 0.
-		if req.Method == "notifications/initialized" {
-			continue // notification, no response
+		// Notifications have no id (our request struct leaves ID 0). The
+		// 2026-07-28 protocol no longer uses notifications/initialized.
+		if req.ID == 0 && req.Method != "" {
+			continue
 		}
 
 		var result any
 		var rpcErr *jsonRPCError
 
 		switch req.Method {
-		case "initialize":
+		case "server/discover":
 			result = map[string]any{
-				"protocolVersion": ProtocolVersion,
+				"supportedVersions": []string{ProtocolVersion},
 				"capabilities": map[string]any{
 					"tools":     map[string]any{"listChanged": true},
 					"resources": map[string]any{"listChanged": true},
@@ -169,8 +168,9 @@ func (m *mockStdioServer) serve() {
 
 // newMockStdioClient creates a Client connected to a mock server via pipes.
 // It wires up stdin/stdout pipes with a mock server goroutine, starts
-// readLoop, and performs the initialization handshake — just like
-// NewStdioClient does, but without spawning a subprocess.
+// readLoop, and leaves the client in a stateless (post-2026-07-28) state — no
+// initialize handshake is performed. Tests that need server identity or
+// capabilities call Discover explicitly.
 //
 // The returned Client has no exec.Cmd, so don't call Close() on it directly;
 // the cleanup function handles shutting down pipes instead.
@@ -201,16 +201,6 @@ func newMockStdioClient(t *testing.T, tools []Tool, results map[string]*ToolResu
 	// Start the read loop (same as NewStdioClient).
 	go c.readLoop()
 
-	// Perform initialization handshake.
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	if err := c.initialize(ctx); err != nil {
-		serverWriter.Close()
-		serverReader.Close()
-		t.Fatalf("initialization failed: %v", err)
-	}
-
 	// Clean up: close stdin pipe (kills readLoop), then close server pipes.
 	// We don't call c.Close() because it dereferences c.cmd which is nil.
 	t.Cleanup(func() {
@@ -225,10 +215,27 @@ func newMockStdioClient(t *testing.T, tools []Tool, results map[string]*ToolResu
 	return c
 }
 
-func TestStdioClientInitialize(t *testing.T) {
+func TestStdioClientDiscover(t *testing.T) {
 	c := newMockStdioClient(t, nil, nil)
 	if c.closed {
-		t.Error("client should not be closed after initialization")
+		t.Error("client should not be closed after construction")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	result, err := c.Discover(ctx)
+	if err != nil {
+		t.Fatalf("Discover failed: %v", err)
+	}
+	if len(result.SupportedVersions) != 1 || result.SupportedVersions[0] != ProtocolVersion {
+		t.Fatalf("unexpected protocol versions: %+v", result.SupportedVersions)
+	}
+	if result.ServerInfo == nil || result.ServerInfo.Name != "mock-stdio-server" {
+		t.Fatalf("unexpected server info: %+v", result.ServerInfo)
+	}
+	if c.ServerInfo() == nil || c.ServerInfo().Name != "mock-stdio-server" {
+		t.Fatalf("Discover did not cache server info: %+v", c.ServerInfo())
 	}
 }
 
@@ -779,8 +786,8 @@ func TestStdioClientResourcesAndPrompts(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	if err := c.initialize(ctx); err != nil {
-		t.Fatalf("initialization failed: %v", err)
+	if _, err := c.Discover(ctx); err != nil {
+		t.Fatalf("Discover failed: %v", err)
 	}
 
 	t.Cleanup(func() {

--- a/ext/mcp/subscriptions.go
+++ b/ext/mcp/subscriptions.go
@@ -1,0 +1,188 @@
+package mcp
+
+import (
+	"encoding/json"
+	"sync"
+)
+
+// SubscriptionFilter selects which server notifications a client wants to
+// receive over a subscriptions/listen stream. Every field is optional; a field
+// left false means the client does not want that notification type.
+type SubscriptionFilter struct {
+	ToolsListChanged      bool     `json:"toolsListChanged,omitempty"`
+	PromptsListChanged    bool     `json:"promptsListChanged,omitempty"`
+	ResourcesListChanged  bool     `json:"resourcesListChanged,omitempty"`
+	ResourceSubscriptions []string `json:"resourceSubscriptions,omitempty"`
+}
+
+// SubscribeParams is the params payload for subscriptions/listen.
+type SubscribeParams struct {
+	Notifications SubscriptionFilter `json:"notifications"`
+}
+
+// subscriptionStreamMarker is returned by the subscriptions/listen dispatch case
+// to signal that the subscription stream owns the response; the caller MUST NOT
+// write an inline JSON-RPC response. It is internal to the dispatch layer.
+type subscriptionStreamMarker struct{}
+
+// subscription is a single active subscriptions/listen stream. deliver pushes a
+// fully-built JSON-RPC notification message (bytes) to the consumer; it must be
+// non-blocking so the hub can fan out without holding its lock.
+type subscription struct {
+	id      any    // JSON-RPC id of the subscriptions/listen request
+	idKey   string // stable string key for the hub map
+	filter  SubscriptionFilter
+	deliver func([]byte)
+}
+
+// subscriptionHub tracks active subscriptions/listen streams so server-side
+// NotifyX methods can fan out notifications to the matching subscribers.
+type subscriptionHub struct {
+	mu   sync.Mutex
+	subs map[string]*subscription
+}
+
+func newSubscriptionHub() *subscriptionHub {
+	return &subscriptionHub{subs: make(map[string]*subscription)}
+}
+
+// register adds a subscription and returns a deregister func.
+func (h *subscriptionHub) register(sub *subscription) func() {
+	h.mu.Lock()
+	h.subs[sub.idKey] = sub
+	h.mu.Unlock()
+	return func() {
+		h.mu.Lock()
+		delete(h.subs, sub.idKey)
+		h.mu.Unlock()
+	}
+}
+
+// clear drops all subscriptions. Called on server close / peer EOF so a
+// transport drop does not keep delivering to stale streams.
+func (h *subscriptionHub) clear() {
+	h.mu.Lock()
+	h.subs = make(map[string]*subscription)
+	h.mu.Unlock()
+}
+
+// emit builds a JSON-RPC notification for method with baseParams, injects
+// _meta.io.modelcontextprotocol/subscriptionId per subscriber, and delivers to
+// every subscriber whose match(filter) returns true. baseParams may be nil.
+func (h *subscriptionHub) emit(method string, baseParams map[string]any, match func(SubscriptionFilter) bool) {
+	if h == nil {
+		return
+	}
+	h.mu.Lock()
+	subs := make([]*subscription, 0, len(h.subs))
+	for _, sub := range h.subs {
+		if match != nil && !match(sub.filter) {
+			continue
+		}
+		subs = append(subs, sub)
+	}
+	h.mu.Unlock()
+
+	for _, sub := range subs {
+		params := cloneParamsMap(baseParams)
+		meta, _ := params["_meta"].(map[string]any)
+		if meta == nil {
+			meta = map[string]any{}
+		}
+		meta[MetaSubscriptionID] = sub.id
+		params["_meta"] = meta
+		msg := notificationMessage(method, params)
+		if sub.deliver != nil {
+			sub.deliver(msg)
+		}
+	}
+}
+
+// notificationMessage marshals a JSON-RPC notification (no id) with the given
+// method and params. params may be nil.
+func notificationMessage(method string, params map[string]any) []byte {
+	req := struct {
+		JSONRPC string         `json:"jsonrpc"`
+		Method  string         `json:"method"`
+		Params  map[string]any `json:"params,omitempty"`
+	}{
+		JSONRPC: "2.0",
+		Method:  method,
+		Params:  params,
+	}
+	data, _ := json.Marshal(req)
+	return data
+}
+
+// ackMessage builds the notifications/subscriptions/acknowledged message that
+// the server MUST send as the first message on a subscription stream. The
+// notifications field echoes the honored subset (here: the requested filter,
+// since the server honors every requested type).
+func ackMessage(id any, filter SubscriptionFilter) []byte {
+	params := map[string]any{
+		"notifications": filter,
+		"_meta": map[string]any{
+			MetaSubscriptionID: id,
+		},
+	}
+	return notificationMessage("notifications/subscriptions/acknowledged", params)
+}
+
+// subscriptionClosureResponse builds the graceful-closure JSON-RPC response for
+// the original subscriptions/listen request id. The server SHOULD send it
+// before closing the stream itself.
+func subscriptionClosureResponse(id any) []byte {
+	resp := jsonRPCResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Result: mustRawJSON([]byte(`{"resultType":"complete","_meta":{"` +
+			MetaSubscriptionID + `":` + string(mustRawJSON(marshalID(id))) + `}}`)),
+	}
+	data, _ := json.Marshal(resp)
+	return data
+}
+
+// idKeyString returns a stable, unambiguous string key for a JSON-RPC id. int64
+// and string ids that happen to share a textual form still map to distinct keys
+// because the id is encoded as JSON first.
+func idKeyString(id any) string {
+	return string(mustRawJSON(marshalID(id)))
+}
+
+// marshalID converts a normalized id value to JSON bytes.
+func marshalID(id any) []byte {
+	if id == nil {
+		return []byte("null")
+	}
+	if raw, ok := id.(json.RawMessage); ok {
+		return append([]byte(nil), raw...)
+	}
+	data, _ := json.Marshal(id)
+	return data
+}
+
+// parseSubscribeParams extracts the notifications filter from a
+// subscriptions/listen request's params. A missing notifications object yields
+// an empty filter (no notifications selected).
+func parseSubscribeParams(raw json.RawMessage) SubscriptionFilter {
+	if len(raw) == 0 {
+		return SubscriptionFilter{}
+	}
+	var probe struct {
+		Notifications SubscriptionFilter `json:"notifications"`
+	}
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		return SubscriptionFilter{}
+	}
+	return probe.Notifications
+}
+
+// containsString reports whether s contains v.
+func containsString(s []string, v string) bool {
+	for _, item := range s {
+		if item == v {
+			return true
+		}
+	}
+	return false
+}

--- a/ext/mcp/subscriptions_test.go
+++ b/ext/mcp/subscriptions_test.go
@@ -1,0 +1,289 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestSubscriptionsHTTPAckFirst verifies the server sends
+// notifications/subscriptions/acknowledged as the first message on the stream,
+// carrying the subscription id equal to the listen request's JSON-RPC id.
+func TestSubscriptionsHTTPAckFirst(t *testing.T) {
+	server := NewServer(WithServerInfo(ServerInfo{Name: "subs-test", Version: "1.0.0"}))
+	httpServer := httptest.NewServer(NewHTTPServerTransport(server))
+	defer httpServer.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	client, err := NewHTTPClientWithConfig(ctx, httpServer.URL, ClientConfig{})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	defer client.Close()
+
+	var (
+		mu       sync.Mutex
+		first    Notification
+		gotFirst bool
+	)
+	listenErr := make(chan error, 1)
+	go func() {
+		listenErr <- client.Listen(ctx, SubscriptionFilter{ToolsListChanged: true}, func(n Notification) {
+			mu.Lock()
+			defer mu.Unlock()
+			if !gotFirst {
+				first = n
+				gotFirst = true
+			}
+		})
+	}()
+
+	// Wait for the ack to arrive.
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		mu.Lock()
+		done := gotFirst
+		mu.Unlock()
+		if done {
+			break
+		}
+		if time.Now().After(deadline) {
+			cancel()
+			t.Fatal("timed out waiting for subscription ack")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	if first.Method != "notifications/subscriptions/acknowledged" {
+		t.Fatalf("first method = %q, want notifications/subscriptions/acknowledged", first.Method)
+	}
+	var ackParams struct {
+		Notifications SubscriptionFilter         `json:"notifications"`
+		Meta          map[string]json.RawMessage `json:"_meta"`
+	}
+	if err := json.Unmarshal(first.Params, &ackParams); err != nil {
+		t.Fatalf("parse ack: %v", err)
+	}
+	subIDRaw, ok := ackParams.Meta[MetaSubscriptionID]
+	if !ok {
+		t.Fatalf("ack missing _meta.subscriptionId: %+v", ackParams.Meta)
+	}
+	var subID int64
+	if err := json.Unmarshal(subIDRaw, &subID); err != nil {
+		t.Fatalf("subscriptionId not int: %v", err)
+	}
+	if subID == 0 {
+		t.Fatalf("subscriptionId = 0")
+	}
+	if !ackParams.Notifications.ToolsListChanged {
+		t.Fatalf("ack did not honor toolsListChanged: %+v", ackParams.Notifications)
+	}
+
+	cancel()
+	if err := <-listenErr; err != nil && err != context.Canceled {
+		t.Fatalf("listen returned unexpected error: %v", err)
+	}
+}
+
+// TestSubscriptionsHTTPNotifyToolsListChanged verifies a server-emitted
+// notification reaches the client with the correct subscriptionId, and that a
+// type the client did NOT request is not delivered.
+func TestSubscriptionsHTTPNotifyToolsListChanged(t *testing.T) {
+	server := NewServer(WithServerInfo(ServerInfo{Name: "subs-notify", Version: "1.0.0"}))
+	httpServer := httptest.NewServer(NewHTTPServerTransport(server))
+	defer httpServer.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	client, err := NewHTTPClientWithConfig(ctx, httpServer.URL, ClientConfig{})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	defer client.Close()
+
+	var (
+		mu           sync.Mutex
+		toolsChanged Notification
+		promptsSeen  bool
+		gotTools     bool
+	)
+	listenErr := make(chan error, 1)
+	// Only subscribe to toolsListChanged; promptsListChanged must NOT arrive.
+	go func() {
+		listenErr <- client.Listen(ctx, SubscriptionFilter{ToolsListChanged: true}, func(n Notification) {
+			mu.Lock()
+			defer mu.Unlock()
+			switch n.Method {
+			case "notifications/tools/list_changed":
+				toolsChanged = n
+				gotTools = true
+			case "notifications/prompts/list_changed":
+				promptsSeen = true
+			}
+		})
+	}()
+
+	// Wait for ack, then emit a tools list changed.
+	// Observe whether the listen stream already produced a tools notification
+	// before triggering the server-side notification below.
+	mu.Lock()
+	alreadyGotTools := gotTools
+	mu.Unlock()
+	_ = alreadyGotTools
+	// Give the server a moment to register the subscription.
+	time.Sleep(50 * time.Millisecond)
+	server.NotifyToolsListChanged()
+	server.NotifyPromptsListChanged()
+
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		mu.Lock()
+		done := gotTools
+		mu.Unlock()
+		if done {
+			break
+		}
+		if time.Now().After(deadline) {
+			cancel()
+			t.Fatal("timed out waiting for tools/list_changed notification")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	mu.Lock()
+	if promptsSeen {
+		t.Fatal("received prompts/list_changed despite not subscribing to it")
+	}
+	mu.Unlock()
+
+	var params struct {
+		Meta map[string]json.RawMessage `json:"_meta"`
+	}
+	if err := json.Unmarshal(toolsChanged.Params, &params); err != nil {
+		t.Fatalf("parse tools notification: %v", err)
+	}
+	if _, ok := params.Meta[MetaSubscriptionID]; !ok {
+		t.Fatalf("tools notification missing _meta.subscriptionId: %+v", params.Meta)
+	}
+
+	cancel()
+	if err := <-listenErr; err != nil && err != context.Canceled {
+		t.Fatalf("listen returned unexpected error: %v", err)
+	}
+}
+
+// TestSubscriptionsHTTPResourceUpdatedOnlyForSubscribedURI verifies
+// notifications/resources/updated is delivered only for URIs the client
+// subscribed to.
+func TestSubscriptionsHTTPResourceUpdatedOnlyForSubscribedURI(t *testing.T) {
+	server := NewServer(WithServerInfo(ServerInfo{Name: "subs-uri", Version: "1.0.0"}))
+	httpServer := httptest.NewServer(NewHTTPServerTransport(server))
+	defer httpServer.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	client, err := NewHTTPClientWithConfig(ctx, httpServer.URL, ClientConfig{})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	defer client.Close()
+
+	var (
+		mu       sync.Mutex
+		seenURIs []string
+	)
+	listenErr := make(chan error, 1)
+	go func() {
+		listenErr <- client.Listen(ctx, SubscriptionFilter{
+			ResourceSubscriptions: []string{"file:///a"},
+		}, func(n Notification) {
+			if n.Method != "notifications/resources/updated" {
+				return
+			}
+			var p struct {
+				URI string `json:"uri"`
+			}
+			_ = json.Unmarshal(n.Params, &p)
+			mu.Lock()
+			seenURIs = append(seenURIs, p.URI)
+			mu.Unlock()
+		})
+	}()
+
+	time.Sleep(50 * time.Millisecond) // allow subscription to register
+	server.NotifyResourceUpdated("file:///a")
+	server.NotifyResourceUpdated("file:///b")
+
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		mu.Lock()
+		gotA := containsString(seenURIs, "file:///a")
+		mu.Unlock()
+		if gotA {
+			break
+		}
+		if time.Now().After(deadline) {
+			cancel()
+			t.Fatal("timed out waiting for resources/updated for file:///a")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// Give a brief window for file:///b to (incorrectly) arrive, then assert.
+	time.Sleep(50 * time.Millisecond)
+	mu.Lock()
+	defer mu.Unlock()
+	if containsString(seenURIs, "file:///b") {
+		t.Fatalf("received resources/updated for unsubscribed uri file:///b: %+v", seenURIs)
+	}
+	if !containsString(seenURIs, "file:///a") {
+		t.Fatalf("did not receive resources/updated for file:///a: %+v", seenURIs)
+	}
+
+	cancel()
+	if err := <-listenErr; err != nil && err != context.Canceled {
+		t.Fatalf("listen returned unexpected error: %v", err)
+	}
+}
+
+// TestSubscriptionsHTTPGracefulClosure verifies the server sends the JSON-RPC
+// response to the original request id when the client disconnects (ctx cancel)
+// and that Listen returns cleanly.
+func TestSubscriptionsHTTPGracefulClosure(t *testing.T) {
+	server := NewServer(WithServerInfo(ServerInfo{Name: "subs-close", Version: "1.0.0"}))
+	httpServer := httptest.NewServer(NewHTTPServerTransport(server))
+	defer httpServer.Close()
+
+	listenCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client, err := NewHTTPClientWithConfig(context.Background(), httpServer.URL, ClientConfig{})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	defer client.Close()
+
+	listenErr := make(chan error, 1)
+	go func() {
+		listenErr <- client.Listen(listenCtx, SubscriptionFilter{ToolsListChanged: true}, func(Notification) {})
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-listenErr:
+		if err != nil && err != context.Canceled {
+			t.Fatalf("listen returned unexpected error: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("listen did not return after cancel")
+	}
+}

--- a/ext/mcp/tasks.go
+++ b/ext/mcp/tasks.go
@@ -1,0 +1,155 @@
+package mcp
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"sync"
+	"sync/atomic"
+)
+
+// ResultTypeTask is the resultType value for a CreateTaskResult, indicating the
+// request was converted into a long-running task the client polls via tasks/*.
+const ResultTypeTask = "task"
+
+// Task status values. Working and input_required are non-terminal; completed,
+// failed, and cancelled are terminal.
+const (
+	TaskStatusWorking       = "working"
+	TaskStatusInputRequired = "input_required"
+	TaskStatusCompleted     = "completed"
+	TaskStatusFailed        = "failed"
+	TaskStatusCancelled     = "cancelled"
+)
+
+// Task is the unit of long-running work surfaced by the tasks extension. On
+// completion, Result holds what the original request would have returned; on
+// failure, Error holds a JSON-RPC error; on input_required, InputRequests holds
+// the inputs the client must satisfy via tasks/update.
+type Task struct {
+	TaskID         string          `json:"taskId"`
+	Status         string          `json:"status"`
+	TTLMs          *int64          `json:"ttlMs,omitempty"`
+	PollIntervalMs *int64          `json:"pollIntervalMs,omitempty"`
+	StatusMessage  string          `json:"statusMessage,omitempty"`
+	Result         json.RawMessage `json:"result,omitempty"`
+	Error          *jsonRPCError   `json:"error,omitempty"`
+	InputRequests  InputRequests   `json:"inputRequests,omitempty"`
+}
+
+// CreateTaskResult is returned with resultType "task" when a request is
+// converted into a long-running task.
+type CreateTaskResult struct {
+	ResultType string `json:"resultType"`
+	Task       Task   `json:"task"`
+}
+
+// taskEntry is the server-side store entry for a task. It guards the task with
+// a mutex and accumulates input responses submitted via tasks/update.
+type taskEntry struct {
+	mu              sync.Mutex
+	task            Task
+	pendingInputs   InputResponses
+	cancelRequested bool
+}
+
+func (e *taskEntry) snapshot() Task {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	clone := e.task
+	if e.cancelRequested && !isTerminalStatus(clone.Status) {
+		clone.Status = TaskStatusCancelled
+	}
+	return clone
+}
+
+func (e *taskEntry) update(mutate func(*Task)) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	mutate(&e.task)
+}
+
+func (e *taskEntry) applyInputResponses(responses InputResponses) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.pendingInputs == nil {
+		e.pendingInputs = InputResponses{}
+	}
+	for k, v := range responses {
+		e.pendingInputs[k] = v
+	}
+}
+
+// PendingInputs returns a copy of the input responses submitted so far. The
+// application advances the task by consuming these in its work loop.
+func (e *taskEntry) PendingInputs() InputResponses {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make(InputResponses, len(e.pendingInputs))
+	for k, v := range e.pendingInputs {
+		out[k] = v
+	}
+	return out
+}
+
+func (e *taskEntry) requestCancel() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.cancelRequested = true
+}
+
+func isTerminalStatus(status string) bool {
+	switch status {
+	case TaskStatusCompleted, TaskStatusFailed, TaskStatusCancelled:
+		return true
+	default:
+		return false
+	}
+}
+
+// taskStore is the in-memory backing store for the tasks extension. It is
+// keyed by taskId. A TTL sweeper is intentionally omitted; the store is
+// per-Server and cleared when the server closes.
+type taskStore struct {
+	mu    sync.Mutex
+	tasks map[string]*taskEntry
+}
+
+func newTaskStore() *taskStore {
+	return &taskStore{tasks: make(map[string]*taskEntry)}
+}
+
+func (ts *taskStore) put(e *taskEntry) {
+	ts.mu.Lock()
+	ts.tasks[e.task.TaskID] = e
+	ts.mu.Unlock()
+}
+
+func (ts *taskStore) get(id string) (*taskEntry, bool) {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	e, ok := ts.tasks[id]
+	return e, ok
+}
+
+// newTaskID mints a crypto-random task id. The id is opaque to the client and
+// unguessable so a client cannot poll arbitrary task ids.
+func newTaskID() string {
+	var buf [16]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		// Fall back to a counter if the system RNG is unavailable so task
+		// creation never fails.
+		return fallbackTaskID()
+	}
+	return "task_" + hex.EncodeToString(buf[:])
+}
+
+var fallbackTaskCounter atomic.Uint64
+
+func fallbackTaskID() string {
+	n := fallbackTaskCounter.Add(1)
+	var buf [16]byte
+	binary.BigEndian.PutUint64(buf[:8], n)
+	return "task_" + hex.EncodeToString(buf[:])
+}

--- a/ext/mcp/tasks_test.go
+++ b/ext/mcp/tasks_test.go
@@ -1,0 +1,380 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestTasksDiscoverAdvertisesExtension verifies the server advertises the
+// tasks extension in discover when WithTasks is set, and omits it otherwise.
+func TestTasksDiscoverAdvertisesExtension(t *testing.T) {
+	without := NewServer()
+	withoutRes := without.handleDiscover()
+	if withoutRes.Capabilities.Extensions != nil {
+		if _, ok := withoutRes.Capabilities.Extensions[ExtensionTasks]; ok {
+			t.Fatalf("tasks advertised without WithTasks")
+		}
+	}
+
+	with := NewServer(WithTasks())
+	withRes := with.handleDiscover()
+	if withRes.Capabilities.Extensions == nil {
+		t.Fatal("expected extensions map")
+	}
+	if _, ok := withRes.Capabilities.Extensions[ExtensionTasks]; !ok {
+		t.Fatalf("expected tasks extension to be advertised, got %+v", withRes.Capabilities.Extensions)
+	}
+}
+
+// TestTasksServerReturnsTaskToDeclaringClient verifies a tool handler that
+// calls CreateTask returns a CreateTaskResult (resultType "task") to a client
+// that declared the tasks extension, and that tasks/get transitions
+// working -> completed and returns the final ToolResult.
+func TestTasksServerReturnsTaskToDeclaringClient(t *testing.T) {
+	server := NewServer(WithTasks(), WithServerInfo(ServerInfo{Name: "tasks-test", Version: "1.0.0"}))
+	server.AddTool(Tool{
+		Name:        "long_running",
+		Description: "returns a task then completes",
+		InputSchema: json.RawMessage(`{"type":"object"}`),
+	}, func(_ context.Context, rc *RequestContext, _ map[string]any) (*ToolResult, error) {
+		ctr, err := rc.CreateTask(Task{
+			Status:         TaskStatusWorking,
+			PollIntervalMs: int64Ptr(20),
+		})
+		if err != nil {
+			return nil, err
+		}
+		taskID := ctr.Task.TaskID
+		// Simulate async completion: advance the task after a short delay.
+		go func() {
+			time.Sleep(40 * time.Millisecond)
+			server.UpdateTask(taskID, func(t *Task) {
+				t.Status = TaskStatusCompleted
+				t.Result = mustRawJSON(tMarshal(textToolResult("done")))
+			})
+		}()
+		return nil, nil
+	})
+
+	httpServer := httptest.NewServer(NewHTTPServerTransport(server))
+	defer httpServer.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	client, err := NewHTTPClientWithConfig(ctx, httpServer.URL, WithTasksExtension(ClientConfig{}))
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	defer client.Close()
+
+	var observed []*Task
+	result, err := client.CallToolAwait(ctx, "long_running", map[string]any{}, func(task *Task) {
+		observed = append(observed, task)
+	})
+	if err != nil {
+		t.Fatalf("CallToolAwait: %v", err)
+	}
+	if result == nil || result.TextContent() != "done" {
+		t.Fatalf("unexpected tool result: %+v", result)
+	}
+	if len(observed) == 0 {
+		t.Fatal("expected at least one poll observation")
+	}
+}
+
+// TestTasksServerRefusesTaskToNonDeclaringClient verifies the server does not
+// return a task to a client that did not declare the tasks extension:
+// CreateTask returns an error and the handler falls back to a synchronous result.
+func TestTasksServerRefusesTaskToNonDeclaringClient(t *testing.T) {
+	server := NewServer(WithTasks(), WithServerInfo(ServerInfo{Name: "tasks-fallback", Version: "1.0.0"}))
+	server.AddTool(Tool{
+		Name:        "maybe_task",
+		Description: "falls back when client lacks tasks",
+		InputSchema: json.RawMessage(`{"type":"object"}`),
+	}, func(_ context.Context, rc *RequestContext, _ map[string]any) (*ToolResult, error) {
+		if _, err := rc.CreateTask(Task{Status: TaskStatusWorking}); err == nil {
+			// Client declared the tasks extension; this test expects a fallback.
+			return textToolResult("should-not-happen"), nil
+		}
+		// Client did not declare tasks; fall back to a synchronous result.
+		return textToolResult("synchronous"), nil
+	})
+
+	httpServer := httptest.NewServer(NewHTTPServerTransport(server))
+	defer httpServer.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Client does NOT advertise the tasks extension.
+	client, err := NewHTTPClientWithConfig(ctx, httpServer.URL, ClientConfig{})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	defer client.Close()
+
+	result, err := client.CallTool(ctx, "maybe_task", map[string]any{})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if got := result.TextContent(); got != "synchronous" {
+		t.Fatalf("expected synchronous fallback, got %q", got)
+	}
+}
+
+// TestTasksInputRequiredAndUpdate verifies the input_required flow: a task
+// reaches input_required, the client submits responses via tasks/update, the
+// application consumes them and completes the task, and tasks/get reports
+// completed with the final result.
+func TestTasksInputRequiredAndUpdate(t *testing.T) {
+	server := NewServer(WithTasks(), WithServerInfo(ServerInfo{Name: "tasks-input", Version: "1.0.0"}))
+	server.AddTool(Tool{
+		Name:        "need_input",
+		Description: "task that needs input then completes",
+		InputSchema: json.RawMessage(`{"type":"object"}`),
+	}, func(_ context.Context, rc *RequestContext, _ map[string]any) (*ToolResult, error) {
+		ctr, err := rc.CreateTask(Task{
+			Status: TaskStatusWorking,
+			InputRequests: InputRequests{
+				"answer": {Method: "elicitation/create", Params: json.RawMessage(`{"message":"pick a number"}`)},
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+		taskID := ctr.Task.TaskID
+		go func() {
+			// Move to input_required so the client can see it.
+			server.UpdateTask(taskID, func(t *Task) { t.Status = TaskStatusInputRequired })
+			// Wait for the client to submit input responses.
+			deadline := time.Now().Add(3 * time.Second)
+			for time.Now().Before(deadline) {
+				entry, ok := server.tasks.get(taskID)
+				if !ok {
+					time.Sleep(10 * time.Millisecond)
+					continue
+				}
+				responses := entry.PendingInputs()
+				if len(responses) > 0 {
+					var answer string
+					for _, raw := range responses {
+						var el ElicitationResult
+						if json.Unmarshal(raw, &el) == nil {
+							if v, ok := el.Content["number"].(string); ok {
+								answer = v
+							}
+						}
+					}
+					server.UpdateTask(taskID, func(t *Task) {
+						t.Status = TaskStatusCompleted
+						t.Result = mustRawJSON(tMarshal(textToolResult("got " + answer)))
+					})
+					return
+				}
+				time.Sleep(10 * time.Millisecond)
+			}
+		}()
+		return nil, nil
+	})
+
+	httpServer := httptest.NewServer(NewHTTPServerTransport(server))
+	defer httpServer.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	client, err := NewHTTPClientWithConfig(ctx, httpServer.URL, WithTasksExtension(ClientConfig{
+		ElicitationHandler: func(_ context.Context, _ *ElicitationParams) (*ElicitationResult, error) {
+			return &ElicitationResult{Action: "accept", Content: map[string]any{"number": "42"}}, nil
+		},
+	}))
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	defer client.Close()
+
+	// Issue the call; expect an InputRequiredTaskError.
+	result, err := client.CallToolAwait(ctx, "need_input", map[string]any{}, nil)
+	if err == nil {
+		t.Fatalf("expected InputRequiredTaskError, got result %+v", result)
+	}
+	var ire *InputRequiredTaskError
+	if !errors.As(err, &ire) {
+		t.Fatalf("expected *InputRequiredTaskError, got %T: %v", err, err)
+	}
+	taskID := ire.Task.TaskID
+
+	// Fulfill the input request via tasks/update. The client's elicitation
+	// handler produces the response payload keyed to "answer".
+	respPayload, _ := json.Marshal(&ElicitationResult{Action: "accept", Content: map[string]any{"number": "42"}})
+	if err := client.UpdateTask(ctx, taskID, InputResponses{"answer": respPayload}); err != nil {
+		t.Fatalf("UpdateTask: %v", err)
+	}
+
+	// Poll tasks/get until completed.
+	deadline := time.Now().Add(3 * time.Second)
+	var final *Task
+	for time.Now().Before(deadline) {
+		got, gerr := client.GetTask(ctx, taskID)
+		if gerr != nil {
+			t.Fatalf("GetTask: %v", gerr)
+		}
+		if got.Status == TaskStatusCompleted {
+			final = got
+			break
+		}
+		if got.Status == TaskStatusFailed || got.Status == TaskStatusCancelled {
+			t.Fatalf("task reached %s: %+v", got.Status, got)
+		}
+		time.Sleep(15 * time.Millisecond)
+	}
+	if final == nil {
+		t.Fatal("task did not complete in time")
+	}
+	var toolResult ToolResult
+	if err := json.Unmarshal(final.Result, &toolResult); err != nil {
+		t.Fatalf("parse final result: %v", err)
+	}
+	if toolResult.TextContent() != "got 42" {
+		t.Fatalf("unexpected final result: %q", toolResult.TextContent())
+	}
+}
+
+// TestTasksCancel verifies tasks/cancel acknowledges with an empty result and
+// the task snapshot reflects the cancelled intent.
+func TestTasksCancel(t *testing.T) {
+	server := NewServer(WithTasks(), WithServerInfo(ServerInfo{Name: "tasks-cancel", Version: "1.0.0"}))
+	httpServer := httptest.NewServer(NewHTTPServerTransport(server))
+	defer httpServer.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	client, err := NewHTTPClientWithConfig(ctx, httpServer.URL, WithTasksExtension(ClientConfig{}))
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	defer client.Close()
+
+	// Create a task directly via the store through a tool handler.
+	var taskID string
+	var taskIDMu sync.Mutex
+	server.AddTool(Tool{
+		Name:        "cancellable",
+		Description: "creates a cancellable task",
+		InputSchema: json.RawMessage(`{"type":"object"}`),
+	}, func(_ context.Context, rc *RequestContext, _ map[string]any) (*ToolResult, error) {
+		ctr, err := rc.CreateTask(Task{Status: TaskStatusWorking})
+		if err != nil {
+			return nil, err
+		}
+		taskIDMu.Lock()
+		taskID = ctr.Task.TaskID
+		taskIDMu.Unlock()
+		return nil, nil
+	})
+
+	// Drive the call with CallToolAwait; it will return InputRequiredTaskError
+	// only if input_required, but here the task stays working, so we expect a
+	// context deadline. Instead, use a goroutine and cancel via CancelTask.
+	awaitErr := make(chan error, 1)
+	go func() {
+		_, e := client.CallToolAwait(ctx, "cancellable", map[string]any{}, nil)
+		awaitErr <- e
+	}()
+
+	// Wait for the task id to be minted.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		taskIDMu.Lock()
+		id := taskID
+		taskIDMu.Unlock()
+		if id != "" {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for task id")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	if err := client.CancelTask(ctx, taskID); err != nil {
+		t.Fatalf("CancelTask: %v", err)
+	}
+
+	got, err := client.GetTask(ctx, taskID)
+	if err != nil {
+		t.Fatalf("GetTask after cancel: %v", err)
+	}
+	if got.Status != TaskStatusCancelled {
+		t.Fatalf("expected cancelled status, got %q", got.Status)
+	}
+
+	cancel()
+	<-awaitErr
+}
+
+// TestTasksGetNotFound verifies tasks/get on an unknown id returns -32602.
+func TestTasksGetNotFound(t *testing.T) {
+	server := NewServer(WithTasks(), WithServerInfo(ServerInfo{Name: "tasks-get", Version: "1.0.0"}))
+	httpServer := httptest.NewServer(NewHTTPServerTransport(server))
+	defer httpServer.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	client, err := NewHTTPClientWithConfig(ctx, httpServer.URL, WithTasksExtension(ClientConfig{}))
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	defer client.Close()
+
+	_, err = client.GetTask(ctx, "task_does_not_exist")
+	if err == nil {
+		t.Fatal("expected error for unknown task")
+	}
+	var rpcErr *jsonRPCError
+	if !errors.As(err, &rpcErr) {
+		t.Fatalf("expected *jsonRPCError, got %T: %v", err, err)
+	}
+	if rpcErr.Code != jsonRPCCodeInvalidParams {
+		t.Fatalf("expected -32602, got %d", rpcErr.Code)
+	}
+}
+
+// TestTasksMethodNotEnabled verifies that when WithTasks is not set, tasks/get
+// returns method not found.
+func TestTasksMethodNotEnabled(t *testing.T) {
+	server := NewServer()
+	httpServer := httptest.NewServer(NewHTTPServerTransport(server))
+	defer httpServer.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	client, err := NewHTTPClientWithConfig(ctx, httpServer.URL, WithTasksExtension(ClientConfig{}))
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	defer client.Close()
+
+	_, err = client.GetTask(ctx, "any")
+	if err == nil {
+		t.Fatal("expected error when tasks not enabled")
+	}
+	var rpcErr *jsonRPCError
+	if !errors.As(err, &rpcErr) {
+		t.Fatalf("expected *jsonRPCError, got %T: %v", err, err)
+	}
+	if rpcErr.Code != jsonRPCCodeMethodNotFound {
+		t.Fatalf("expected -32601, got %d: %s", rpcErr.Code, rpcErr.Message)
+	}
+}
+
+func int64Ptr(v int64) *int64 { return &v }

--- a/ext/mcp/types.go
+++ b/ext/mcp/types.go
@@ -7,21 +7,67 @@ import (
 )
 
 const (
-	ProtocolVersion = "2025-11-25"
+	// ProtocolVersion is the MCP revision implemented by this package.
+	ProtocolVersion = "2026-07-28"
 	protocolVersion = ProtocolVersion
 	clientName      = "gollem"
 	clientVersion   = "1.0.0"
+)
+
+// SupportedProtocolVersions lists every protocol revision this implementation
+// accepts. The 2026-07-28 spec is a hard cut: only this revision is supported.
+var SupportedProtocolVersions = []string{ProtocolVersion}
+
+// Reserved _meta keys defined by the 2026-07-28 specification. Every request
+// carries its protocol version and client capabilities inline (there is no
+// initialize handshake), and results echo server identity.
+const (
+	MetaProtocolVersion    = "io.modelcontextprotocol/protocolVersion"
+	MetaClientCapabilities = "io.modelcontextprotocol/clientCapabilities"
+	MetaClientInfo         = "io.modelcontextprotocol/clientInfo"
+	MetaServerInfo         = "io.modelcontextprotocol/serverInfo"
+	MetaLogLevel           = "io.modelcontextprotocol/logLevel"
+	MetaSubscriptionID     = "io.modelcontextprotocol/subscriptionId"
+
+	// OpenTelemetry trace-context propagation keys (SEP-414).
+	MetaTraceParent = "traceparent"
+	MetaTraceState  = "tracestate"
+	MetaBaggage     = "baggage"
+)
+
+// Extension identifiers negotiated via the extensions capability map.
+const (
+	ExtensionTasks = "io.modelcontextprotocol/tasks"
+)
+
+// ResultType discriminates ordinary results from multi round-trip interim
+// results. Results from earlier-protocol servers that omit it are "complete".
+const (
+	ResultTypeComplete      = "complete"
+	ResultTypeInputRequired = "input_required"
+)
+
+// CacheScope controls whether shared intermediaries may cache a result.
+const (
+	CacheScopePublic  = "public"
+	CacheScopePrivate = "private"
 )
 
 // EmptyCapability is used for presence-only MCP capabilities.
 type EmptyCapability struct{}
 
 // ClientCapabilities describes the protocol surfaces exposed by an MCP client.
+//
+// Roots and Sampling are deprecated in 2026-07-28 (SEP-2577); new clients
+// should not advertise them. Elicitation is now delivered via Multi Round-Trip
+// Requests (MRTR) rather than a server-initiated request.
 type ClientCapabilities struct {
 	Roots        *RootsCapability          `json:"roots,omitempty"`
 	Sampling     *ClientSamplingCapability `json:"sampling,omitempty"`
 	Elicitation  *ElicitationCapability    `json:"elicitation,omitempty"`
 	Experimental map[string]map[string]any `json:"experimental,omitempty"`
+	// Extensions negotiates optional MCP extensions beyond the core protocol.
+	Extensions map[string]json.RawMessage `json:"extensions,omitempty"`
 }
 
 // ClientSamplingCapability describes client-side sampling support.
@@ -47,6 +93,8 @@ type ServerCapabilities struct {
 	Prompts      *PromptCapabilities   `json:"prompts,omitempty"`
 	Resources    *ResourceCapabilities `json:"resources,omitempty"`
 	Experimental map[string]any        `json:"experimental,omitempty"`
+	// Extensions advertises optional MCP extensions supported by the server.
+	Extensions map[string]json.RawMessage `json:"extensions,omitempty"`
 }
 
 // ToolCapabilities describes the server's tool support.
@@ -81,13 +129,85 @@ type InitializeParams struct {
 	ClientInfo      ImplementationInfo `json:"clientInfo"`
 }
 
-// InitializeResult is returned by the MCP initialize handshake.
+// InitializeResult is retained only as the payload shape shared with
+// server/discover. The 2026-07-28 protocol removes the initialize handshake;
+// clients learn server identity and capabilities from DiscoverResult or from
+// the serverInfo echoed in each result's _meta.
 type InitializeResult struct {
 	ProtocolVersion string             `json:"protocolVersion"`
 	Capabilities    ServerCapabilities `json:"capabilities"`
 	ServerInfo      *ServerInfo        `json:"serverInfo,omitempty"`
 	Instructions    string             `json:"instructions,omitempty"`
 	Meta            map[string]any     `json:"_meta,omitempty"`
+}
+
+// DiscoverResult is returned by the required server/discover RPC. Clients MAY
+// call it before any other request to select a protocol version up front, or
+// use it as a backward-compatibility probe on STDIO.
+type DiscoverResult struct {
+	SupportedVersions []string           `json:"supportedVersions"`
+	Capabilities      ServerCapabilities `json:"capabilities"`
+	ServerInfo        *ServerInfo        `json:"serverInfo,omitempty"`
+	Instructions      string             `json:"instructions,omitempty"`
+	Meta              map[string]any     `json:"_meta,omitempty"`
+	// CacheableResult carries the ttlMs/cacheScope hints; server/discover
+	// supports caching per the specification.
+	CacheableResult
+}
+
+// RequestMeta is the reserved _meta envelope carried by every stateless
+// request. It replaces the initialize handshake: each request self-describes
+// its protocol version, the client's capabilities, and the client's identity.
+type RequestMeta struct {
+	ProtocolVersion    string              `json:"io.modelcontextprotocol/protocolVersion,omitempty"`
+	ClientCapabilities *ClientCapabilities `json:"io.modelcontextprotocol/clientCapabilities,omitempty"`
+	ClientInfo         *ImplementationInfo `json:"io.modelcontextprotocol/clientInfo,omitempty"`
+	LogLevel           string              `json:"io.modelcontextprotocol/logLevel,omitempty"`
+}
+
+// CacheableResult carries the freshness hints required on list and read
+// results (SEP-2549). TTLMs is a caching hint in milliseconds; CacheScope is
+// "public" or "private". Both are embedded into the wire result.
+type CacheableResult struct {
+	TTLMs      *int64 `json:"ttlMs,omitempty"`
+	CacheScope string `json:"cacheScope,omitempty"`
+}
+
+// InputRequest is a single server-to-client request embedded in an
+// InputRequiredResult. Method is one of "elicitation/create",
+// "sampling/createMessage", or "roots/list"; Params is the corresponding
+// request payload. It replaces the previous server-initiated request pattern.
+type InputRequest struct {
+	Method string          `json:"method"`
+	Params json.RawMessage `json:"params,omitempty"`
+}
+
+// InputRequests maps server-assigned identifiers to the requests a client must
+// fulfill before retrying. Identifiers are unique within a single request.
+type InputRequests map[string]InputRequest
+
+// InputResponses maps the same identifiers to the client's results
+// (ElicitResult, CreateMessageResult, or ListRootsResult), sent on retry.
+type InputResponses map[string]json.RawMessage
+
+// InputRequiredResult is returned with resultType "input_required" when a
+// server needs additional information mid-request. The client fulfills each
+// entry in InputRequests and retries the original call (with a new JSON-RPC
+// id) carrying InputResponses and echoing RequestState verbatim. A server MUST
+// include at least one of InputRequests or RequestState.
+type InputRequiredResult struct {
+	ResultType    string         `json:"resultType"`
+	InputRequests InputRequests  `json:"inputRequests,omitempty"`
+	RequestState  string         `json:"requestState,omitempty"`
+	Meta          map[string]any `json:"_meta,omitempty"`
+}
+
+// MRTRContinuation carries the client's answers on the retry of an MRTR
+// request. It is merged into the request params alongside the original
+// arguments. RequestState is echoed verbatim from the InputRequiredResult.
+type MRTRContinuation struct {
+	InputResponses InputResponses `json:"inputResponses,omitempty"`
+	RequestState   string         `json:"requestState,omitempty"`
 }
 
 // Root is a client-declared root URI visible to the server.
@@ -243,10 +363,13 @@ type ResourceContents struct {
 	Raw      json.RawMessage `json:"-"`
 }
 
-// ReadResourceResult is the result of resources/read.
+// ReadResourceResult is the result of resources/read. The 2026-07-28 spec
+// requires resources/read results to carry the cache freshness hints embedded
+// via CacheableResult.
 type ReadResourceResult struct {
 	Contents []ResourceContents `json:"contents"`
-	Meta     map[string]any     `json:"_meta,omitempty"`
+	CacheableResult
+	Meta map[string]any `json:"_meta,omitempty"`
 }
 
 // ToolResult represents the result of an MCP tool call.
@@ -440,16 +563,20 @@ func stringifyContentFallback(value any) string {
 
 type listToolsResult struct {
 	Tools []Tool `json:"tools"`
+	CacheableResult
 }
 
 type listResourcesResult struct {
 	Resources []Resource `json:"resources"`
+	CacheableResult
 }
 
 type listResourceTemplatesResult struct {
 	ResourceTemplates []ResourceTemplate `json:"resourceTemplates"`
+	CacheableResult
 }
 
 type listPromptsResult struct {
 	Prompts []Prompt `json:"prompts"`
+	CacheableResult
 }


### PR DESCRIPTION
## Summary

Migrates `ext/mcp` to the MCP **2026-07-28** specification as a hard cut (no backward compatibility with 2025-11-25).

### Core protocol
- **Stateless core**: removes the `initialize` / `notifications/initialized` handshake. Every request self-describes via `_meta` (`protocolVersion` REQUIRED, `clientCapabilities` REQUIRED, `clientInfo` SHOULD). Missing required fields -> `-32602`.
- **`server/discover`** RPC returning `supportedVersions`, capabilities, `serverInfo`, instructions, and cacheable hints.
- **`resultType`** REQUIRED on every result (`complete` / `input_required` / `task`), stamped at the marshaling layer.
- **MRTR (multi-round-trip requests)** replaces server-initiated sampling/elicitation/roots. Only `tools/call`, `resources/read`, `prompts/get` may return `input_required`; the client driver fulfills `inputRequests` and retries with `inputResponses` + verbatim `requestState` (max 8 rounds).
- New error codes: `-32020` HeaderMismatch, `-32021` MissingRequiredClientCapability, `-32022` UnsupportedProtocolVersion (with `data`); resource-not-found is now `-32602`.
- Cacheable list/read results (`ttlMs` / `cacheScope`).

### Streamable HTTP
- Removes `Mcp-Session-Id` sessions, DELETE teardown, and SSE resumability.
- Adds `Mcp-Method` / `Mcp-Name` header validation and `x-mcp-*` header passthrough into `RequestContext`.
- Synchronous inline JSON responses via `HandleRequestSync`.

### New subsystems
- **`subscriptions/listen`**: ack-first stream, per-subscription filtering, graceful closure; HTTP delivers it as a long-lived `text/event-stream` POST (replacing the old GET endpoint).
- **`io.modelcontextprotocol/tasks` extension** (opt-in via `WithTasks()`): `CreateTaskResult` (`resultType:"task"`), `tasks/get|update|cancel`, client `CallToolAwait` polling. `notifications/tasks` left as a TODO (polling supported).

### Deprecated (kept compiling)
- `Roots`, `Sampling`, `Logging`, `MCPModel` / `SamplingRequester` are marked Deprecated; MRTR helpers `BuildSamplingInputRequest` / `ParseCreateMessageResult` / `BuildElicitationInputRequest` / `ParseElicitationResult` / `BuildRootsInputRequest` / `ParseListRootsResult` added.

## Verification
- `golangci-lint run ./...` -> 0 issues
- `gofmt -l` clean
- `go build ./...`, `go vet ./...`
- `go test ./ext/mcp/... ./appserver/mcp/... ./cmd/gollem-mcp-server/...` pass; `go test -race ./ext/mcp/...` passes.

Generated with Droid.