### PR TITLE
appserver: add restart-safe full-history thread forks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Response-loss-safe full-history thread forks.** The generated
+  `thread/fork` extension accepts a source thread and bounded idempotency key,
+  rejects queued or running source work, and transactionally copies durable
+  turns and items with regenerated identities. Repeating the same request,
+  including after daemon restart, returns the original child without emitting
+  another `thread/started` notification. Forked timelines retain public
+  file-change evidence but never inherit private exact-restoration snapshots.
 - **Restart-safe exact file-change reversal.** Runtime file-change items now
   advertise whether Gollem persisted a private recovery snapshot. The
   `item/fileChange/revert` extension accepts only thread/item identity and an

--- a/appserver/protocol/README.md
+++ b/appserver/protocol/README.md
@@ -518,9 +518,11 @@ Every fixed generated field is required; service tier and reasoning effort are
 explicit nullable values, instruction source arrays/elements are non-null,
 working directories are absolute and normalized, and nested public thread and
 policy values retain their own strict validation. Experimental response fields
-are excluded. The implemented live start/resume/fork handlers still return
-incompatible durable thread/turn maps, so these definitions remain outside the
-method-binding map and do not change runtime JSON or claim producer parity.
+are excluded. The implemented live start/resume handlers still return
+incompatible durable thread/turn maps, and the live fork handler now binds the
+separate Gollem-native history-fork contract described below. These public
+session definitions remain outside the method-binding map and do not claim
+producer parity.
 
 The request-prerequisite layer exports exact standalone `Personality`,
 `SandboxMode`, and `ThreadStartSource` closed string enums. Their fixed public
@@ -536,9 +538,22 @@ Exact standalone `ThreadStartParams`, `ThreadResumeParams`, and
 Optional nullable overrides accept omission or null; resume and fork require an
 open-string thread id; fork alone gives `ephemeral` optional non-null boolean
 semantics. Config values retain strict recursive JSON and request `cwd` remains
-a generic string. The current live handlers require incompatible prompt/input,
-provider/settings, id-alias, title/metadata, and include-item fields, so these
-definitions remain outside method bindings and do not change runtime behavior.
+a generic string. The current live start/resume handlers require incompatible
+prompt/input, provider/settings, and id-alias fields. The live fork handler
+binds a narrower Gollem-native request rather than pretending to apply these
+public session overrides, so the exact public records remain standalone.
+
+`thread/fork` binds Gollem-native `ThreadHistoryForkParams` and
+`ThreadHistoryForkResult` for response-loss-safe full-history copies. Typed
+clients provide only the source thread id and a bounded idempotency key.
+SQLite records that key separately from public thread metadata, refuses new
+forks while the source has queued or running turns, copies durable turns and
+items transactionally with regenerated identities, and returns the same child
+after response loss or process restart. Reused requests do not emit a second
+`thread/started` notification. File-change timeline evidence is retained for
+audit, but private exact-restoration snapshots never transfer to the child and
+the result says so explicitly. Legacy untyped title/metadata/include-item
+requests remain accepted without this typed idempotency guarantee.
 
 Exact standalone `ReasoningSummary`, `TurnStartParams`, and
 `TurnStartResponse` establish the fixed canonical turn-start contract.

--- a/appserver/protocol/account_credit_nudge_values_contract_test.go
+++ b/appserver/protocol/account_credit_nudge_values_contract_test.go
@@ -119,14 +119,14 @@ func TestAccountCreditNudgeValuesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/sendAddCreditsNudgeEmail = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/account_envelope_contract_test.go
+++ b/appserver/protocol/account_envelope_contract_test.go
@@ -268,11 +268,11 @@ func TestAccountEnvelopeContractsRemainStandaloneAndDeferred(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred %s", methodName, method, ok, surface)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
-	if len(Methods()) != 225 || len(WireTypeBindings()) != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 225/72/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(Methods()) != 225 || len(WireTypeBindings()) != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 225/73/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/account_login_completed_notification_contract_test.go
+++ b/appserver/protocol/account_login_completed_notification_contract_test.go
@@ -88,14 +88,14 @@ func TestAccountLoginCompletedNotificationRemainsStandaloneAndDeferred(t *testin
 	if !found {
 		t.Fatal("account/login/completed method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/account_rate_limits_contract_test.go
+++ b/appserver/protocol/account_rate_limits_contract_test.go
@@ -484,14 +484,14 @@ func TestAccountRateLimitContractsRemainStandaloneAndDeferred(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred %s", methodName, method, ok, surface)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/account_token_usage_contract_test.go
+++ b/appserver/protocol/account_token_usage_contract_test.go
@@ -146,14 +146,14 @@ func TestAccountTokenUsageRecordsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/usage/read = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,14 +148,14 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(defs); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,14 +54,14 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_config_contract_test.go
+++ b/appserver/protocol/app_config_contract_test.go
@@ -109,14 +109,14 @@ func TestAppConfigRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppConfig unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_info_contract_test.go
+++ b/appserver/protocol/app_info_contract_test.go
@@ -131,14 +131,14 @@ func TestAppInfoRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_list_updated_notification_contract_test.go
+++ b/appserver/protocol/app_list_updated_notification_contract_test.go
@@ -105,14 +105,14 @@ func TestAppListUpdatedNotificationRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceServerNotification || method.State != MethodDeferredStub {
 		t.Fatalf("app/list/updated = %#v, %v; want deferred server notification", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_metadata_contract_test.go
+++ b/appserver/protocol/app_metadata_contract_test.go
@@ -107,14 +107,14 @@ func TestAppMetadataRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_metadata_leaf_contract_test.go
+++ b/appserver/protocol/app_metadata_leaf_contract_test.go
@@ -157,14 +157,14 @@ func TestAppMetadataLeavesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_summary_contract_test.go
+++ b/appserver/protocol/app_summary_contract_test.go
@@ -87,14 +87,14 @@ func TestAppSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppSummary unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_template_summary_contract_test.go
+++ b/appserver/protocol/app_template_summary_contract_test.go
@@ -107,14 +107,14 @@ func TestAppTemplateSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppTemplateSummary unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_template_unavailable_reason_contract_test.go
+++ b/appserver/protocol/app_template_unavailable_reason_contract_test.go
@@ -71,14 +71,14 @@ func TestAppTemplateUnavailableReasonRemainsStandalone(t *testing.T) {
 			t.Fatalf("AppTemplateUnavailableReason unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_tool_approval_contract_test.go
+++ b/appserver/protocol/app_tool_approval_contract_test.go
@@ -73,14 +73,14 @@ func TestAppToolApprovalRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppToolApproval unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_tools_config_contract_test.go
+++ b/appserver/protocol/app_tools_config_contract_test.go
@@ -140,14 +140,14 @@ func TestAppToolConfigsRemainStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/apply_patch_approval_params_contract_test.go
+++ b/appserver/protocol/apply_patch_approval_params_contract_test.go
@@ -139,14 +139,14 @@ func TestApplyPatchApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ApplyPatchApprovalParams unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(defs); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(defs); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/apps_config_contract_test.go
+++ b/appserver/protocol/apps_config_contract_test.go
@@ -185,14 +185,14 @@ func TestAppsConfigsRemainStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/apps_list_contract_test.go
+++ b/appserver/protocol/apps_list_contract_test.go
@@ -168,14 +168,14 @@ func TestAppsListContractsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/attestation_contract_test.go
+++ b/appserver/protocol/attestation_contract_test.go
@@ -133,14 +133,14 @@ func TestAttestationContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("attestation/generate = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,14 +74,14 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,14 +52,14 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/bindings.go
+++ b/appserver/protocol/bindings.go
@@ -69,6 +69,7 @@ var wireTypeBindings = []WireTypeBinding{
 	{Method: "thread/goal/get", Surface: SurfaceClientRequest, Params: []string{"ThreadGoalGetParams"}, Result: []string{"ThreadGoalGetResponse"}},
 	{Method: "thread/goal/set", Surface: SurfaceClientRequest, Params: []string{"ThreadGoalSetParams"}, Result: []string{"ThreadGoalSetResponse"}},
 	{Method: "thread/goal/updated", Surface: SurfaceServerNotification, Params: []string{"ThreadGoalUpdatedNotification"}},
+	{Method: "thread/fork", Surface: SurfaceClientRequest, Params: []string{"ThreadHistoryForkParams"}, Result: []string{"ThreadHistoryForkResult"}},
 	{Method: "thread/list", Surface: SurfaceClientRequest, Params: []string{"ThreadListParams"}, Result: []string{"ThreadListResult"}},
 	{Method: "thread/loaded/list", Surface: SurfaceClientRequest, Params: []string{"ThreadLoadedListParams"}, Result: []string{"ThreadLoadedListResponse"}},
 	{Method: "thread/memoryMode/set", Surface: SurfaceClientRequest, Params: []string{"ThreadMemoryModeSetParams"}, Result: []string{"ThreadMemoryModeSetResponse"}},

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,14 +148,14 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
+++ b/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
@@ -179,14 +179,14 @@ func TestChatgptAuthTokensRefreshRemainsStandaloneAndDeferred(t *testing.T) {
 	if !found {
 		t.Fatal("refresh method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/collaboration_capability_contract_test.go
+++ b/appserver/protocol/collaboration_capability_contract_test.go
@@ -346,14 +346,14 @@ func TestCollaborationCapabilityContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,14 +102,14 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,14 +217,14 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,14 +146,14 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,14 +321,14 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,14 +67,14 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,14 +200,14 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,14 +228,14 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,11 +169,11 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,14 +332,14 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/dynamic_tool_spec_contract_test.go
+++ b/appserver/protocol/dynamic_tool_spec_contract_test.go
@@ -318,14 +318,14 @@ func TestDynamicToolSpecContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/exec_command_approval_params_contract_test.go
+++ b/appserver/protocol/exec_command_approval_params_contract_test.go
@@ -137,14 +137,14 @@ func TestExecCommandApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ExecCommandApprovalParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(defs); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/experimental_feature_contract_test.go
+++ b/appserver/protocol/experimental_feature_contract_test.go
@@ -41,11 +41,11 @@ func TestExperimentalFeatureContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want implemented client request", methodName, method, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
-	if len(Methods()) != 225 || len(WireTypeBindings()) != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("counts = %d/%d/%d, want 225/72/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(Methods()) != 225 || len(WireTypeBindings()) != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("counts = %d/%d/%d, want 225/73/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,14 +217,14 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,14 +203,14 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -260,14 +260,14 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,14 +244,14 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -162,14 +162,14 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -175,14 +175,14 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,14 +186,14 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,14 +84,14 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/file_change_contract_test.go
+++ b/appserver/protocol/file_change_contract_test.go
@@ -108,14 +108,14 @@ func TestFileChangeRemainsStandalone(t *testing.T) {
 			t.Fatalf("FileChange unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/file_change_output_delta_notification_contract_test.go
+++ b/appserver/protocol/file_change_output_delta_notification_contract_test.go
@@ -100,14 +100,14 @@ func TestFileChangeOutputDeltaNotificationRemainsDeprecatedAndStandalone(t *test
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("item/fileChange/outputDelta = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -381,14 +381,14 @@ func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/guardian_approval_review_action_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_action_contract_test.go
@@ -226,14 +226,14 @@ func TestGuardianApprovalReviewActionRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReviewAction unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
@@ -164,14 +164,14 @@ func TestGuardianApprovalReviewCompletedNotificationRemainsStandalone(t *testing
 			t.Fatalf("completed notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 	for _, method := range Methods() {
 		if (method.Method == "item/autoApprovalReview/started" ||

--- a/appserver/protocol/guardian_approval_review_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_contract_test.go
@@ -139,14 +139,14 @@ func TestGuardianApprovalReviewRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReview unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
@@ -175,14 +175,14 @@ func TestGuardianApprovalReviewStartedNotificationRemainsStandalone(t *testing.T
 			t.Fatalf("started notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 	for _, method := range Methods() {
 		if method.Method == "item/autoApprovalReview/started" && method.State != MethodBlocked {

--- a/appserver/protocol/guardian_enum_foundation_contract_test.go
+++ b/appserver/protocol/guardian_enum_foundation_contract_test.go
@@ -89,14 +89,14 @@ func TestGuardianEnumFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/hook_metadata_list_contract_test.go
+++ b/appserver/protocol/hook_metadata_list_contract_test.go
@@ -352,11 +352,11 @@ func TestHookMetadataListContractsStayStandalone(t *testing.T) {
 			t.Errorf("standalone definition %s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Errorf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Errorf("definition count = %d, want 558", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 {
-		t.Errorf("wire binding count = %d, want 72", got)
+	if got := len(WireTypeBindings()); got != 73 {
+		t.Errorf("wire binding count = %d, want 73", got)
 	}
 	if got := len(ItemPayloadBindings()); got != 5 {
 		t.Errorf("item binding count = %d, want 5", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,14 +102,14 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/hook_run_notification_contract_test.go
+++ b/appserver/protocol/hook_run_notification_contract_test.go
@@ -297,10 +297,10 @@ func TestHookRunNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
-	if len(Methods()) != 225 || len(WireTypeBindings()) != 72 || len(ItemPayloadBindings()) != 5 {
+	if len(Methods()) != 225 || len(WireTypeBindings()) != 73 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("surface changed: %d methods, %d wire bindings, %d item bindings", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 }

--- a/appserver/protocol/hook_value_foundation_contract_test.go
+++ b/appserver/protocol/hook_value_foundation_contract_test.go
@@ -167,14 +167,14 @@ func TestHookValueFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,11 +223,11 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,11 +159,11 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 556 {
-		t.Fatalf("definition count = %d, want 556", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 558 {
+		t.Fatalf("definition count = %d, want 558", len(JSONSchema()["$defs"].(Schema)))
 	}
-	if len(WireTypeBindings()) != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(WireTypeBindings()) != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 
 	generated, err := MarshalTypeScript()

--- a/appserver/protocol/legacy_approval_response_contract_test.go
+++ b/appserver/protocol/legacy_approval_response_contract_test.go
@@ -98,14 +98,14 @@ func TestLegacyApprovalResponsesRemainStandaloneAndNominal(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,14 +127,14 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,14 +276,14 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,14 +57,14 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,14 +70,14 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,14 +227,14 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,14 +74,14 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,14 +114,14 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,14 +130,14 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,14 +148,14 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,14 +102,14 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_oauth_login_contract_test.go
+++ b/appserver/protocol/mcp_server_oauth_login_contract_test.go
@@ -228,11 +228,11 @@ func TestMcpServerOauthLoginContractsRemainStandaloneAndBlocked(t *testing.T) {
 	if !ok || notification.Surface != SurfaceServerNotification || notification.State != MethodBlocked {
 		t.Fatalf("mcpServer/oauthLogin/completed = %#v, %v; want blocked server notification", notification, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
-	if len(Methods()) != 225 || len(WireTypeBindings()) != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("counts = %d/%d/%d, want 225/72/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(Methods()) != 225 || len(WireTypeBindings()) != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("counts = %d/%d/%d, want 225/73/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,14 +70,14 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,14 +116,14 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_status_contract_test.go
+++ b/appserver/protocol/mcp_server_status_contract_test.go
@@ -277,11 +277,11 @@ func TestMcpServerStatusContractsRemainStandalone(t *testing.T) {
 	if !ok || method.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
-	if len(Methods()) != 225 || len(WireTypeBindings()) != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("counts = %d/%d/%d, want 225/72/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(Methods()) != 225 || len(WireTypeBindings()) != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("counts = %d/%d/%d, want 225/73/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,14 +69,14 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,14 +125,14 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,14 +140,14 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,14 +134,14 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,14 +168,14 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,14 +184,14 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,14 +235,14 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,11 +201,11 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,14 +140,14 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,14 +159,14 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,11 +248,11 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/network_approval_context_contract_test.go
+++ b/appserver/protocol/network_approval_context_contract_test.go
@@ -84,14 +84,14 @@ func TestNetworkApprovalContextRemainsStandalone(t *testing.T) {
 			t.Fatalf("NetworkApprovalContext unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,14 +163,14 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/parsed_command_contract_test.go
+++ b/appserver/protocol/parsed_command_contract_test.go
@@ -120,14 +120,14 @@ func TestParsedCommandRemainsStandalone(t *testing.T) {
 			t.Fatalf("ParsedCommand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/permission_profile_list_contract_test.go
+++ b/appserver/protocol/permission_profile_list_contract_test.go
@@ -255,11 +255,11 @@ func TestPermissionProfileListContractsRemainStandalone(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodImplemented {
 		t.Fatalf("permissionProfile/list = %#v, %v; want existing implemented client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
-	if len(Methods()) != 225 || len(WireTypeBindings()) != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("counts = %d/%d/%d, want 225/72/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(Methods()) != 225 || len(WireTypeBindings()) != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("counts = %d/%d/%d, want 225/73/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,14 +127,14 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/process_contracts_contract_test.go
+++ b/appserver/protocol/process_contracts_contract_test.go
@@ -308,14 +308,14 @@ func TestProcessContractsRemainStandaloneFromLegacyRuntime(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want unchanged implemented notification", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,14 +258,14 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,11 +197,11 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 556 {
-		t.Fatalf("definition count = %d, want 556", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 558 {
+		t.Fatalf("definition count = %d, want 558", len(JSONSchema()["$defs"].(Schema)))
 	}
-	if len(WireTypeBindings()) != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(WireTypeBindings()) != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 	names := []string{
 		"ThreadStartedNotification", "ThreadStatusChangedNotification",

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,11 +204,11 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 556 {
-		t.Fatalf("definition count = %d, want 556", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 558 {
+		t.Fatalf("definition count = %d, want 558", len(JSONSchema()["$defs"].(Schema)))
 	}
-	if len(WireTypeBindings()) != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(WireTypeBindings()) != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 	for _, binding := range WireTypeBindings() {
 		if slices.Contains(binding.Params, "Thread") || slices.Contains(binding.Result, "Thread") {

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,11 +197,11 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 556 {
-		t.Fatalf("definition count = %d, want 556", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 558 {
+		t.Fatalf("definition count = %d, want 558", len(JSONSchema()["$defs"].(Schema)))
 	}
-	if len(bindings) != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", len(bindings), len(ItemPayloadBindings()))
+	if len(bindings) != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", len(bindings), len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,11 +146,11 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 556 {
-		t.Fatalf("definition count = %d, want 556", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 558 {
+		t.Fatalf("definition count = %d, want 558", len(JSONSchema()["$defs"].(Schema)))
 	}
-	if len(WireTypeBindings()) != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(WireTypeBindings()) != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 	for _, binding := range WireTypeBindings() {
 		if slices.Contains(binding.Params, "Turn") || slices.Contains(binding.Result, "Turn") {

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,11 +94,11 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 556 {
-		t.Fatalf("definition count = %d, want 556", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 558 {
+		t.Fatalf("definition count = %d, want 558", len(JSONSchema()["$defs"].(Schema)))
 	}
-	if len(WireTypeBindings()) != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(WireTypeBindings()) != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 
 	generated, err := MarshalTypeScript()

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,14 +159,14 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/review_decision_contract_test.go
+++ b/appserver/protocol/review_decision_contract_test.go
@@ -136,14 +136,14 @@ func TestReviewDecisionRemainsStandalone(t *testing.T) {
 			t.Fatalf("ReviewDecision unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(defs); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/runtime_client_types.go
+++ b/appserver/protocol/runtime_client_types.go
@@ -2,6 +2,7 @@ package protocol
 
 import (
 	"encoding/json"
+	"errors"
 	"time"
 )
 
@@ -150,6 +151,70 @@ type ThreadRunStartParams struct {
 type ThreadRunStartResult struct {
 	Thread ThreadRecord `json:"thread"`
 	Turn   TurnRecord   `json:"turn"`
+}
+
+// ThreadHistoryForkParams is Gollem's response-loss-safe full-history fork
+// request. It is distinct from the broader standalone public session contract.
+type ThreadHistoryForkParams struct {
+	ThreadID       string `json:"threadId"`
+	IdempotencyKey string `json:"idempotencyKey"`
+}
+
+func (p *ThreadHistoryForkParams) UnmarshalJSON(data []byte) error {
+	if p == nil {
+		return errors.New("decode thread-history-fork params into nil receiver")
+	}
+	payload, err := decodeRustSerdeObject(
+		data,
+		"thread-history-fork params",
+		"threadId",
+		"idempotencyKey",
+	)
+	if err != nil {
+		return err
+	}
+	var allFields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &allFields); err != nil {
+		return err
+	}
+	if err := rejectThreadItemFields(
+		allFields,
+		"thread-history-fork params",
+		"threadId",
+		"idempotencyKey",
+	); err != nil {
+		return err
+	}
+	threadID, err := decodeRequiredThreadItemValue[string](
+		payload,
+		"thread-history-fork params",
+		"threadId",
+	)
+	if err != nil {
+		return err
+	}
+	idempotencyKey, err := decodeRequiredThreadItemValue[string](
+		payload,
+		"thread-history-fork params",
+		"idempotencyKey",
+	)
+	if err != nil {
+		return err
+	}
+	*p = ThreadHistoryForkParams{
+		ThreadID:       threadID,
+		IdempotencyKey: idempotencyKey,
+	}
+	return nil
+}
+
+type ThreadHistoryForkResult struct {
+	Thread                        ThreadRecord `json:"thread"`
+	SourceThreadID                string       `json:"sourceThreadId"`
+	IdempotencyKey                string       `json:"idempotencyKey"`
+	Reused                        bool         `json:"reused"`
+	HistoryCopied                 bool         `json:"historyCopied"`
+	FileChangeRecoveryTransferred bool         `json:"fileChangeRecoveryTransferred"`
 }
 
 // ThreadHistoryRollbackParams is Gollem's typed history-only rollback request.

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -518,6 +518,8 @@ func wireSchemaDefinitions() Schema {
 		{Name: "ThreadGoalSetResponse", Type: reflect.TypeFor[ThreadGoalSetResponse]()},
 		{Name: "ThreadGoalStatus", Type: reflect.TypeFor[ThreadGoalStatus]()},
 		{Name: "ThreadGoalUpdatedNotification", Type: reflect.TypeFor[ThreadGoalUpdatedNotification]()},
+		{Name: "ThreadHistoryForkParams", Type: reflect.TypeFor[ThreadHistoryForkParams]()},
+		{Name: "ThreadHistoryForkResult", Type: reflect.TypeFor[ThreadHistoryForkResult]()},
 		{Name: "ThreadHistoryRollbackParams", Type: reflect.TypeFor[ThreadHistoryRollbackParams]()},
 		{Name: "ThreadHistoryRollbackRecord", Type: reflect.TypeFor[ThreadHistoryRollbackRecord]()},
 		{Name: "ThreadHistoryRollbackResult", Type: reflect.TypeFor[ThreadHistoryRollbackResult]()},

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -14842,6 +14842,54 @@
       ],
       "type": "object"
     },
+    "ThreadHistoryForkParams": {
+      "additionalProperties": false,
+      "properties": {
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "threadId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "threadId",
+        "idempotencyKey"
+      ],
+      "type": "object"
+    },
+    "ThreadHistoryForkResult": {
+      "additionalProperties": false,
+      "properties": {
+        "fileChangeRecoveryTransferred": {
+          "type": "boolean"
+        },
+        "historyCopied": {
+          "type": "boolean"
+        },
+        "idempotencyKey": {
+          "type": "string"
+        },
+        "reused": {
+          "type": "boolean"
+        },
+        "sourceThreadId": {
+          "type": "string"
+        },
+        "thread": {
+          "$ref": "#/$defs/ThreadRecord"
+        }
+      },
+      "required": [
+        "thread",
+        "sourceThreadId",
+        "idempotencyKey",
+        "reused",
+        "historyCopied",
+        "fileChangeRecoveryTransferred"
+      ],
+      "type": "object"
+    },
     "ThreadHistoryRollbackParams": {
       "additionalProperties": false,
       "properties": {
@@ -20944,6 +20992,16 @@
       "surface": "server-notification",
       "params": [
         "ThreadGoalUpdatedNotification"
+      ]
+    },
+    {
+      "method": "thread/fork",
+      "surface": "client-request",
+      "params": [
+        "ThreadHistoryForkParams"
+      ],
+      "result": [
+        "ThreadHistoryForkResult"
       ]
     },
     {

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,14 +128,14 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,14 +102,14 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,14 +102,14 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/thread_history_fork_contract_test.go
+++ b/appserver/protocol/thread_history_fork_contract_test.go
@@ -1,0 +1,107 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestThreadHistoryForkContractIsGeneratedAndBound(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	params := defs["ThreadHistoryForkParams"].(Schema)
+	assertClosedObjectSchema(t, params, "threadId", "idempotencyKey")
+	assertRecoverySchemaKeys(t, params, "threadId", "idempotencyKey")
+
+	result := defs["ThreadHistoryForkResult"].(Schema)
+	assertClosedObjectSchema(
+		t,
+		result,
+		"thread",
+		"sourceThreadId",
+		"idempotencyKey",
+		"reused",
+		"historyCopied",
+		"fileChangeRecoveryTransferred",
+	)
+	assertRecoverySchemaKeys(
+		t,
+		result,
+		"thread",
+		"sourceThreadId",
+		"idempotencyKey",
+		"reused",
+		"historyCopied",
+		"fileChangeRecoveryTransferred",
+	)
+
+	var binding WireTypeBinding
+	for _, candidate := range WireTypeBindings() {
+		if candidate.Method == "thread/fork" {
+			binding = candidate
+			break
+		}
+	}
+	if binding.Method == "" {
+		t.Fatal("thread/fork binding is missing")
+	}
+	if binding.Surface != SurfaceClientRequest ||
+		!reflect.DeepEqual(binding.Params, []string{"ThreadHistoryForkParams"}) ||
+		!reflect.DeepEqual(binding.Result, []string{"ThreadHistoryForkResult"}) {
+		t.Fatalf("thread/fork binding = %#v", binding)
+	}
+
+	encoded, err := json.Marshal(ThreadHistoryForkParams{
+		ThreadID:       "thread-1",
+		IdempotencyKey: "fork-1",
+	})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if string(encoded) != `{"threadId":"thread-1","idempotencyKey":"fork-1"}` {
+		t.Fatalf("encoded params = %s", encoded)
+	}
+	for _, input := range []string{
+		`{}`,
+		`{"threadId":"thread-1"}`,
+		`{"idempotencyKey":"fork-1"}`,
+		`{"threadId":null,"idempotencyKey":"fork-1"}`,
+		`{"threadId":"thread-1","idempotencyKey":null}`,
+		`{"threadId":1,"idempotencyKey":"fork-1"}`,
+		`{"threadId":"thread-1","idempotencyKey":1}`,
+		`{"threadId":"thread-1","idempotencyKey":"fork-1","includeItems":true}`,
+		`{"threadId":"thread-1","threadId":"thread-2","idempotencyKey":"fork-1"}`,
+		`{"threadId":"thread-1","idempotencyKey":"fork-1","idempotencyKey":"fork-2"}`,
+		`{"threadId":"thread-1","idempotencyKey":"fork-1"} {}`,
+	} {
+		var params ThreadHistoryForkParams
+		if err := json.Unmarshal([]byte(input), &params); err == nil {
+			t.Errorf("ThreadHistoryForkParams accepted %s", input)
+		}
+	}
+	var nilParams *ThreadHistoryForkParams
+	if err := nilParams.UnmarshalJSON([]byte(`{"threadId":"thread-1","idempotencyKey":"fork-1"}`)); err == nil {
+		t.Fatal("nil ThreadHistoryForkParams receiver succeeded")
+	}
+
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	ts := string(generated)
+	for _, want := range []string{
+		`export type ThreadHistoryForkParams = {`,
+		`"idempotencyKey": string;`,
+		`"threadId": string;`,
+		`export type ThreadHistoryForkResult = {`,
+		`"fileChangeRecoveryTransferred": boolean;`,
+		`"historyCopied": boolean;`,
+		`"reused": boolean;`,
+		`"sourceThreadId": string;`,
+		`"thread/fork": ThreadHistoryForkParams;`,
+	} {
+		if !strings.Contains(ts, want) {
+			t.Fatalf("generated TypeScript missing %q", want)
+		}
+	}
+}

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,11 +387,11 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 556 {
-		t.Fatalf("definition count = %d, want 556", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 558 {
+		t.Fatalf("definition count = %d, want 558", len(JSONSchema()["$defs"].(Schema)))
 	}
-	if len(WireTypeBindings()) != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(WireTypeBindings()) != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 	for _, binding := range WireTypeBindings() {
 		if slices.Contains(binding.Params, "ThreadItem") || slices.Contains(binding.Result, "ThreadItem") {

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,11 +94,11 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,11 +273,11 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,11 +194,11 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -240,18 +240,23 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 				!slices.Equal(binding.Result, []string{"ThreadRunStartResult"}) {
 				t.Errorf("thread/start binding = %#v", binding)
 			}
-		case "thread/resume", "thread/fork":
+		case "thread/resume":
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
+		case "thread/fork":
+			if !slices.Equal(binding.Params, []string{"ThreadHistoryForkParams"}) ||
+				!slices.Equal(binding.Result, []string{"ThreadHistoryForkResult"}) {
+				t.Errorf("thread/fork binding = %#v", binding)
+			}
 		}
 	}
 	if !foundRuntimeStart {
 		t.Error("thread/start runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -143,18 +143,23 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 				!slices.Equal(binding.Result, []string{"ThreadRunStartResult"}) {
 				t.Errorf("thread/start binding = %#v", binding)
 			}
-		case "thread/resume", "thread/fork":
+		case "thread/resume":
 			t.Errorf("%s unexpectedly has a wire type binding: %#v", binding.Method, binding)
+		case "thread/fork":
+			if !slices.Equal(binding.Params, []string{"ThreadHistoryForkParams"}) ||
+				!slices.Equal(binding.Result, []string{"ThreadHistoryForkResult"}) {
+				t.Errorf("thread/fork binding = %#v", binding)
+			}
 		}
 	}
 	if !foundRuntimeStart {
 		t.Error("thread/start runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,11 +311,11 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 556 {
-		t.Fatalf("definition count = %d, want 556", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 558 {
+		t.Fatalf("definition count = %d, want 558", len(JSONSchema()["$defs"].(Schema)))
 	}
-	if len(WireTypeBindings()) != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(WireTypeBindings()) != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 
 	generated, err := MarshalTypeScript()

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,11 +220,11 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 556 {
-		t.Fatalf("definition count = %d, want 556", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 558 {
+		t.Fatalf("definition count = %d, want 558", len(JSONSchema()["$defs"].(Schema)))
 	}
-	if len(WireTypeBindings()) != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(WireTypeBindings()) != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 
 	generated, err := MarshalTypeScript()

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -119,11 +119,11 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 	if !foundRuntimeBinding {
 		t.Error("turn/interrupt runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,11 +209,11 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -241,11 +241,11 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 	if !foundRuntimeBinding {
 		t.Error("turn/start runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -156,11 +156,11 @@ func TestTurnSteerContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -3502,6 +3502,20 @@ export type ThreadGoalUpdatedNotification = {
   "turnId": string | null;
 };
 
+export type ThreadHistoryForkParams = {
+  "idempotencyKey": string;
+  "threadId": string;
+};
+
+export type ThreadHistoryForkResult = {
+  "fileChangeRecoveryTransferred": boolean;
+  "historyCopied": boolean;
+  "idempotencyKey": string;
+  "reused": boolean;
+  "sourceThreadId": string;
+  "thread": ThreadRecord;
+};
+
 export type ThreadHistoryRollbackParams = {
   "id"?: string;
   "numTurns": number;
@@ -4378,6 +4392,7 @@ export const wireTypeBindings = [
   { "method": "thread/goal/get", "surface": "client-request", "params": ["ThreadGoalGetParams"], "result": ["ThreadGoalGetResponse"] },
   { "method": "thread/goal/set", "surface": "client-request", "params": ["ThreadGoalSetParams"], "result": ["ThreadGoalSetResponse"] },
   { "method": "thread/goal/updated", "surface": "server-notification", "params": ["ThreadGoalUpdatedNotification"] },
+  { "method": "thread/fork", "surface": "client-request", "params": ["ThreadHistoryForkParams"], "result": ["ThreadHistoryForkResult"] },
   { "method": "thread/list", "surface": "client-request", "params": ["ThreadListParams"], "result": ["ThreadListResult"] },
   { "method": "thread/loaded/list", "surface": "client-request", "params": ["ThreadLoadedListParams"], "result": ["ThreadLoadedListResponse"] },
   { "method": "thread/memoryMode/set", "surface": "client-request", "params": ["ThreadMemoryModeSetParams"], "result": ["ThreadMemoryModeSetResponse"] },
@@ -4453,6 +4468,7 @@ export interface MethodParamsByName {
   "thread/goal/get": ThreadGoalGetParams;
   "thread/goal/set": ThreadGoalSetParams;
   "thread/goal/updated": ThreadGoalUpdatedNotification;
+  "thread/fork": ThreadHistoryForkParams;
   "thread/list": ThreadListParams;
   "thread/loaded/list": ThreadLoadedListParams;
   "thread/memoryMode/set": ThreadMemoryModeSetParams;
@@ -4509,6 +4525,7 @@ export interface MethodResultsByName {
   "thread/goal/clear": ThreadGoalClearResponse;
   "thread/goal/get": ThreadGoalGetResponse;
   "thread/goal/set": ThreadGoalSetResponse;
+  "thread/fork": ThreadHistoryForkResult;
   "thread/list": ThreadListResult;
   "thread/loaded/list": ThreadLoadedListResponse;
   "thread/memoryMode/set": ThreadMemoryModeSetResponse;

--- a/appserver/protocol/typescript/testdata/collaboration_capability_contract.ts
+++ b/appserver/protocol/typescript/testdata/collaboration_capability_contract.ts
@@ -74,7 +74,7 @@ type Contracts = [
   Expect<Equal<ExactMembers<MethodResultsByName[keyof MethodResultsByName], CollaborationCapabilityContracts>, never>>,
   Expect<Equal<ExactMembers<ItemPayloadByKind[keyof ItemPayloadByKind], CollaborationCapabilityContracts>, never>>,
   Expect<Equal<typeof protocolMethods["length"], 225>>,
-  Expect<Equal<typeof wireTypeBindings["length"], 72>>,
+  Expect<Equal<typeof wireTypeBindings["length"], 73>>,
   Expect<Equal<typeof itemPayloadBindings["length"], 5>>,
 ];
 

--- a/appserver/protocol/typescript/testdata/dynamic_tool_spec_contract.ts
+++ b/appserver/protocol/typescript/testdata/dynamic_tool_spec_contract.ts
@@ -58,7 +58,7 @@ type Contracts = [
   Expect<Equal<ExactMembers<MethodResultsByName[keyof MethodResultsByName], DynamicToolSpecContracts>, never>>,
   Expect<Equal<ExactMembers<ItemPayloadByKind[keyof ItemPayloadByKind], DynamicToolSpecContracts>, never>>,
   Expect<Equal<typeof protocolMethods["length"], 225>>,
-  Expect<Equal<typeof wireTypeBindings["length"], 72>>,
+  Expect<Equal<typeof wireTypeBindings["length"], 73>>,
   Expect<Equal<typeof itemPayloadBindings["length"], 5>>,
 ];
 

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,11 +163,11 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
-	if got := len(WireTypeBindings()); got != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 72/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/workspace_messages_contract_test.go
+++ b/appserver/protocol/workspace_messages_contract_test.go
@@ -209,11 +209,11 @@ func TestWorkspaceMessageContractsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/workspaceMessages/read = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 556 {
-		t.Fatalf("definition count = %d, want 556", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
+		t.Fatalf("definition count = %d, want 558", got)
 	}
-	if len(Methods()) != 225 || len(WireTypeBindings()) != 72 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 225/72/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(Methods()) != 225 || len(WireTypeBindings()) != 73 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 225/73/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/server.go
+++ b/appserver/server.go
@@ -855,6 +855,49 @@ func (s *Server) handleThreadFork(ctx context.Context, raw json.RawMessage) (any
 	if sourceID == "" {
 		return nil, invalidParams("sourceThreadId or threadId is required", nil)
 	}
+	if params.IdempotencyKey != nil {
+		sourceID = strings.TrimSpace(sourceID)
+		if sourceID == "" {
+			return nil, invalidParams("threadId is required", nil)
+		}
+		idempotencyKey := strings.TrimSpace(*params.IdempotencyKey)
+		if idempotencyKey == "" || len(idempotencyKey) > 256 {
+			return nil, invalidParams("idempotencyKey must contain 1 to 256 bytes", nil)
+		}
+		if params.SourceThreadID != "" || params.ID != "" || params.Title != "" ||
+			len(params.Metadata) > 0 || params.IncludeItems {
+			return nil, invalidParams(
+				"typed idempotent fork accepts only threadId and idempotencyKey",
+				nil,
+			)
+		}
+		recoveryStore, ok := st.(store.ThreadForkRecoveryStore)
+		if !ok {
+			return nil, protocol.MethodUnavailableErrorWithReason(
+				"thread/fork",
+				"configured store does not support response-loss-safe thread forks",
+			)
+		}
+		prepared, err := recoveryStore.PrepareThreadFork(ctx, store.PrepareThreadForkRequest{
+			SourceThreadID: sourceID,
+			IdempotencyKey: idempotencyKey,
+		})
+		if err != nil {
+			return nil, mapError("thread/fork", err)
+		}
+		s.markThreadLoaded(prepared.Thread)
+		if prepared.Created {
+			s.publishThreadNotification("thread/started", prepared.Thread)
+		}
+		return protocol.ThreadHistoryForkResult{
+			Thread:                        protocolThreadRecord(prepared.Thread),
+			SourceThreadID:                sourceID,
+			IdempotencyKey:                idempotencyKey,
+			Reused:                        !prepared.Created,
+			HistoryCopied:                 true,
+			FileChangeRecoveryTransferred: false,
+		}, nil
+	}
 	thread, err := st.ForkThread(ctx, store.ForkThreadRequest{
 		SourceThreadID: sourceID,
 		Title:          params.Title,
@@ -2289,6 +2332,8 @@ func mapError(method string, err error) *protocol.Error {
 		errors.Is(err, store.ErrThreadDeleted),
 		errors.Is(err, store.ErrTurnNotTerminal),
 		errors.Is(err, store.ErrRetryIdempotencyConflict),
+		errors.Is(err, store.ErrThreadHasActiveTurn),
+		errors.Is(err, store.ErrThreadForkIdempotencyConflict),
 		errors.Is(err, store.ErrFileChangeRevertIdempotencyConflict),
 		errors.Is(err, ErrMemoryRootRequired),
 		errors.Is(err, ErrMemoryRootUnsafe),
@@ -2448,9 +2493,35 @@ type threadForkParams struct {
 	ID             string         `json:"id,omitempty"`
 	ThreadID       string         `json:"threadId,omitempty"`
 	SourceThreadID string         `json:"sourceThreadId,omitempty"`
+	IdempotencyKey *string        `json:"idempotencyKey,omitempty"`
 	Title          string         `json:"title,omitempty"`
 	Metadata       map[string]any `json:"metadata,omitempty"`
 	IncludeItems   bool           `json:"includeItems,omitempty"`
+}
+
+func (p *threadForkParams) UnmarshalJSON(data []byte) error {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+	if _, typed := fields["idempotencyKey"]; typed {
+		var params protocol.ThreadHistoryForkParams
+		if err := json.Unmarshal(data, &params); err != nil {
+			return err
+		}
+		*p = threadForkParams{
+			ThreadID:       params.ThreadID,
+			IdempotencyKey: &params.IdempotencyKey,
+		}
+		return nil
+	}
+	type legacy threadForkParams
+	var params legacy
+	if err := json.Unmarshal(data, &params); err != nil {
+		return err
+	}
+	*p = threadForkParams(params)
+	return nil
 }
 
 type threadTurnsListParams struct {

--- a/appserver/server_test.go
+++ b/appserver/server_test.go
@@ -189,6 +189,139 @@ func TestServerThreadStoreHandlers(t *testing.T) {
 	assertNotificationMethods(t, threadEvents, "thread/status/changed", "thread/archived")
 }
 
+func TestServerThreadForkTypedRequestIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	st, err := store.NewSQLiteStore(filepath.Join(t.TempDir(), "threads.db"))
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	source, err := st.CreateThread(ctx, store.CreateThreadRequest{Title: "Source"})
+	if err != nil {
+		t.Fatalf("CreateThread: %v", err)
+	}
+	turn, err := st.CreateTurn(ctx, store.CreateTurnRequest{ThreadID: source.ID})
+	if err != nil {
+		t.Fatalf("CreateTurn: %v", err)
+	}
+	if _, err := st.CompleteTurn(ctx, store.CompleteTurnRequest{
+		ID:     turn.ID,
+		Status: store.TurnCompleted,
+	}); err != nil {
+		t.Fatalf("CompleteTurn: %v", err)
+	}
+	if _, err := st.AppendItem(ctx, store.AppendItemRequest{
+		ThreadID: source.ID,
+		TurnID:   turn.ID,
+		Kind:     "message",
+		Status:   "completed",
+		Payload:  json.RawMessage(`{"text":"fork me"}`),
+	}); err != nil {
+		t.Fatalf("AppendItem: %v", err)
+	}
+
+	server := readyServer(WithStore(st))
+	params := map[string]any{
+		"threadId":       " \t" + source.ID + "\n",
+		"idempotencyKey": " fork-key ",
+	}
+	firstResponse := server.HandleRequest(ctx, request("thread/fork", params))
+	if firstResponse.Error != nil {
+		t.Fatalf("thread/fork first error: %v", firstResponse.Error)
+	}
+	var first protocol.ThreadHistoryForkResult
+	decodeResult(t, firstResponse, &first)
+	if first.Thread.ID == source.ID ||
+		first.Thread.ForkedFromThreadID != source.ID ||
+		first.SourceThreadID != source.ID ||
+		first.IdempotencyKey != "fork-key" ||
+		first.Reused ||
+		!first.HistoryCopied ||
+		first.FileChangeRecoveryTransferred {
+		t.Fatalf("first fork = %+v", first)
+	}
+	assertNotificationMethods(t, server.DrainNotifications(), "thread/started")
+
+	forkTurns, err := st.ListTurns(ctx, store.TurnFilter{ThreadID: first.Thread.ID})
+	if err != nil {
+		t.Fatalf("ListTurns: %v", err)
+	}
+	forkItems, err := st.ListItems(ctx, store.ItemFilter{ThreadID: first.Thread.ID})
+	if err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+	if len(forkTurns) != 1 || len(forkItems) != 1 ||
+		forkTurns[0].ID == turn.ID || forkItems[0].TurnID != forkTurns[0].ID {
+		t.Fatalf("fork history turns=%+v items=%+v", forkTurns, forkItems)
+	}
+
+	secondResponse := server.HandleRequest(ctx, request("thread/fork", params))
+	if secondResponse.Error != nil {
+		t.Fatalf("thread/fork second error: %v", secondResponse.Error)
+	}
+	var second protocol.ThreadHistoryForkResult
+	decodeResult(t, secondResponse, &second)
+	if !second.Reused || second.Thread.ID != first.Thread.ID {
+		t.Fatalf("second fork = %+v, want reuse of %q", second, first.Thread.ID)
+	}
+	if notifications := server.DrainNotifications(); len(notifications) != 0 {
+		t.Fatalf("reused fork notifications = %+v, want none", notifications)
+	}
+
+	other, err := st.CreateThread(ctx, store.CreateThreadRequest{Title: "Other"})
+	if err != nil {
+		t.Fatalf("CreateThread other: %v", err)
+	}
+	conflict := server.HandleRequest(ctx, request("thread/fork", map[string]any{
+		"threadId":       other.ID,
+		"idempotencyKey": "fork-key",
+	}))
+	if conflict.Error == nil || conflict.Error.Code != protocol.CodeInvalidParams {
+		t.Fatalf("conflicting fork response = %+v, want invalid params", conflict)
+	}
+
+	activeSource, err := st.CreateThread(ctx, store.CreateThreadRequest{Title: "Active"})
+	if err != nil {
+		t.Fatalf("CreateThread active: %v", err)
+	}
+	if _, err := st.CreateTurn(ctx, store.CreateTurnRequest{ThreadID: activeSource.ID}); err != nil {
+		t.Fatalf("CreateTurn active: %v", err)
+	}
+	activeResponse := server.HandleRequest(ctx, request("thread/fork", map[string]any{
+		"threadId":       activeSource.ID,
+		"idempotencyKey": "active-key",
+	}))
+	if activeResponse.Error == nil || activeResponse.Error.Code != protocol.CodeInvalidParams {
+		t.Fatalf("active fork response = %+v, want invalid params", activeResponse)
+	}
+
+	mixed := server.HandleRequest(ctx, request("thread/fork", map[string]any{
+		"threadId":       source.ID,
+		"idempotencyKey": "other-key",
+		"includeItems":   true,
+	}))
+	if mixed.Error == nil || mixed.Error.Code != protocol.CodeInvalidParams {
+		t.Fatalf("mixed typed/legacy response = %+v, want invalid params", mixed)
+	}
+	for _, key := range []string{"", " \t\n"} {
+		invalid := server.HandleRequest(ctx, request("thread/fork", map[string]any{
+			"threadId":       source.ID,
+			"idempotencyKey": key,
+		}))
+		if invalid.Error == nil || invalid.Error.Code != protocol.CodeInvalidParams {
+			t.Fatalf("thread/fork key %q response = %+v, want invalid params", key, invalid)
+		}
+	}
+	blankSource := server.HandleRequest(ctx, request("thread/fork", map[string]any{
+		"threadId":       " \t\n",
+		"idempotencyKey": "blank-source",
+	}))
+	if blankSource.Error == nil || blankSource.Error.Code != protocol.CodeInvalidParams {
+		t.Fatalf("blank source response = %+v, want invalid params", blankSource)
+	}
+}
+
 func TestServerThreadApproveGuardianDeniedActionDeferredStub(t *testing.T) {
 	ctx := context.Background()
 	st, err := store.NewSQLiteStore(filepath.Join(t.TempDir(), "threads.db"))

--- a/appserver/store/sqlite.go
+++ b/appserver/store/sqlite.go
@@ -18,6 +18,7 @@ const timeFormat = time.RFC3339Nano
 
 var _ Store = (*SQLiteStore)(nil)
 var _ RuntimeRecoveryStore = (*SQLiteStore)(nil)
+var _ ThreadForkRecoveryStore = (*SQLiteStore)(nil)
 var _ FileChangeRecoveryStore = (*SQLiteStore)(nil)
 
 // SQLiteStore persists app-server state in SQLite.
@@ -111,6 +112,13 @@ func (s *SQLiteStore) init() error {
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_app_items_thread_seq ON app_items(thread_id, seq)`,
 		`CREATE INDEX IF NOT EXISTS idx_app_items_turn_seq ON app_items(turn_id, seq)`,
+		`CREATE TABLE IF NOT EXISTS app_thread_forks (
+			idempotency_key TEXT PRIMARY KEY,
+			source_thread_id TEXT NOT NULL,
+			fork_thread_id TEXT NOT NULL UNIQUE,
+			created_at TEXT NOT NULL
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_app_thread_forks_source ON app_thread_forks(source_thread_id, created_at)`,
 		`CREATE TABLE IF NOT EXISTS app_file_change_recovery (
 			item_id TEXT PRIMARY KEY,
 			thread_id TEXT NOT NULL,
@@ -337,6 +345,113 @@ func (s *SQLiteStore) ForkThread(ctx context.Context, req ForkThreadRequest) (*T
 		return nil, err
 	}
 	return cloneThread(fork), nil
+}
+
+// PrepareThreadFork atomically creates or reuses one full-history fork for an
+// idempotency key. A new fork is rejected while the source has active work.
+func (s *SQLiteStore) PrepareThreadFork(
+	ctx context.Context,
+	req PrepareThreadForkRequest,
+) (*PrepareThreadForkResult, error) {
+	ctx = normalizeContext(ctx)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	req.SourceThreadID = strings.TrimSpace(req.SourceThreadID)
+	req.IdempotencyKey = strings.TrimSpace(req.IdempotencyKey)
+	if req.SourceThreadID == "" {
+		return nil, ErrThreadNotFound
+	}
+	if req.IdempotencyKey == "" || len(req.IdempotencyKey) > 256 {
+		return nil, errors.New("appserver/store: fork idempotency key must contain 1 to 256 bytes")
+	}
+
+	var result *PrepareThreadForkResult
+	if err := s.withTx(ctx, func(tx *sql.Tx) error {
+		var existingSourceID, existingForkID string
+		err := tx.QueryRowContext(
+			ctx,
+			`SELECT source_thread_id, fork_thread_id
+			 FROM app_thread_forks
+			 WHERE idempotency_key = ?`,
+			req.IdempotencyKey,
+		).Scan(&existingSourceID, &existingForkID)
+		switch {
+		case err == nil:
+			if existingSourceID != req.SourceThreadID {
+				return ErrThreadForkIdempotencyConflict
+			}
+			fork, loadErr := loadThreadTx(ctx, tx, existingForkID)
+			if loadErr != nil {
+				return fmt.Errorf("load prepared fork %q: %w", existingForkID, loadErr)
+			}
+			result = &PrepareThreadForkResult{Thread: cloneThread(fork), Created: false}
+			return nil
+		case !errors.Is(err, sql.ErrNoRows):
+			return fmt.Errorf("read prepared thread fork: %w", err)
+		}
+
+		source, err := loadThreadTx(ctx, tx, req.SourceThreadID)
+		if err != nil {
+			return err
+		}
+		if source.Status == ThreadDeleted {
+			return ErrThreadDeleted
+		}
+		var active int
+		err = tx.QueryRowContext(
+			ctx,
+			`SELECT 1
+			 FROM app_turns
+			 WHERE thread_id = ? AND status IN (?, ?)
+			 LIMIT 1`,
+			source.ID,
+			TurnQueued,
+			TurnRunning,
+		).Scan(&active)
+		switch {
+		case err == nil:
+			return ErrThreadHasActiveTurn
+		case !errors.Is(err, sql.ErrNoRows):
+			return fmt.Errorf("check active source turns: %w", err)
+		}
+
+		now := time.Now().UTC()
+		fork := &Thread{
+			ID:                 newID("thread"),
+			Title:              source.Title,
+			Workspace:          source.Workspace,
+			Status:             ThreadActive,
+			ForkedFromThreadID: source.ID,
+			Settings:           cloneMap(source.Settings),
+			Metadata:           cloneMap(source.Metadata),
+			CreatedAt:          now,
+			UpdatedAt:          now,
+		}
+		if err := saveThreadTx(ctx, tx, fork); err != nil {
+			return err
+		}
+		if err := copyThreadHistoryTx(ctx, tx, source.ID, fork.ID, now); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(
+			ctx,
+			`INSERT INTO app_thread_forks (
+				idempotency_key, source_thread_id, fork_thread_id, created_at
+			) VALUES (?, ?, ?, ?)`,
+			req.IdempotencyKey,
+			source.ID,
+			fork.ID,
+			now.Format(timeFormat),
+		); err != nil {
+			return fmt.Errorf("save prepared thread fork: %w", err)
+		}
+		result = &PrepareThreadForkResult{Thread: cloneThread(fork), Created: true}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return result, nil
 }
 
 // UpdateThreadTitle implements Store.

--- a/appserver/store/sqlite_test.go
+++ b/appserver/store/sqlite_test.go
@@ -1221,6 +1221,98 @@ func TestSQLiteStoreForkCopiesThreadHistory(t *testing.T) {
 	}
 }
 
+func TestSQLiteStorePrepareThreadForkIsDurableAndIdempotent(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "appserver.db")
+	s := newTestSQLiteStore(t, path)
+
+	source, err := s.CreateThread(ctx, CreateThreadRequest{Title: "Source"})
+	if err != nil {
+		t.Fatalf("CreateThread source: %v", err)
+	}
+	active, err := s.CreateTurn(ctx, CreateTurnRequest{
+		ThreadID: source.ID,
+		Input:    json.RawMessage(`{"prompt":"fork me"}`),
+	})
+	if err != nil {
+		t.Fatalf("CreateTurn: %v", err)
+	}
+	if _, err := s.PrepareThreadFork(ctx, PrepareThreadForkRequest{
+		SourceThreadID: source.ID,
+		IdempotencyKey: "fork-key",
+	}); !errors.Is(err, ErrThreadHasActiveTurn) {
+		t.Fatalf("active fork error = %v, want ErrThreadHasActiveTurn", err)
+	}
+	if _, err := s.CompleteTurn(ctx, CompleteTurnRequest{
+		ID:     active.ID,
+		Status: TurnCompleted,
+		Result: json.RawMessage(`{"text":"done"}`),
+	}); err != nil {
+		t.Fatalf("CompleteTurn: %v", err)
+	}
+	if _, err := s.AppendItem(ctx, AppendItemRequest{
+		ThreadID: source.ID,
+		TurnID:   active.ID,
+		Kind:     "message",
+		Status:   "completed",
+		Payload:  json.RawMessage(`{"text":"done"}`),
+	}); err != nil {
+		t.Fatalf("AppendItem: %v", err)
+	}
+
+	first, err := s.PrepareThreadFork(ctx, PrepareThreadForkRequest{
+		SourceThreadID: source.ID,
+		IdempotencyKey: "fork-key",
+	})
+	if err != nil {
+		t.Fatalf("PrepareThreadFork first: %v", err)
+	}
+	if !first.Created || first.Thread.ID == source.ID ||
+		first.Thread.ForkedFromThreadID != source.ID {
+		t.Fatalf("first fork = %+v", first)
+	}
+	second, err := s.PrepareThreadFork(ctx, PrepareThreadForkRequest{
+		SourceThreadID: source.ID,
+		IdempotencyKey: "fork-key",
+	})
+	if err != nil {
+		t.Fatalf("PrepareThreadFork second: %v", err)
+	}
+	if second.Created || second.Thread.ID != first.Thread.ID {
+		t.Fatalf("second fork = %+v, want reuse of %q", second, first.Thread.ID)
+	}
+
+	other, err := s.CreateThread(ctx, CreateThreadRequest{Title: "Other"})
+	if err != nil {
+		t.Fatalf("CreateThread other: %v", err)
+	}
+	if _, err := s.PrepareThreadFork(ctx, PrepareThreadForkRequest{
+		SourceThreadID: other.ID,
+		IdempotencyKey: "fork-key",
+	}); !errors.Is(err, ErrThreadForkIdempotencyConflict) {
+		t.Fatalf("conflicting fork error = %v, want ErrThreadForkIdempotencyConflict", err)
+	}
+
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	reopened, err := NewSQLiteStore(path)
+	if err != nil {
+		t.Fatalf("NewSQLiteStore reopen: %v", err)
+	}
+	t.Cleanup(func() { _ = reopened.Close() })
+	third, err := reopened.PrepareThreadFork(ctx, PrepareThreadForkRequest{
+		SourceThreadID: source.ID,
+		IdempotencyKey: "fork-key",
+	})
+	if err != nil {
+		t.Fatalf("PrepareThreadFork reopened: %v", err)
+	}
+	if third.Created || third.Thread.ID != first.Thread.ID {
+		t.Fatalf("reopened fork = %+v, want reuse of %q", third, first.Thread.ID)
+	}
+}
+
 func TestSQLiteStoreForkDisablesFileChangeRevertEvidence(t *testing.T) {
 	ctx := context.Background()
 	s := newTestSQLiteStore(t, filepath.Join(t.TempDir(), "appserver.db"))

--- a/appserver/store/types.go
+++ b/appserver/store/types.go
@@ -34,6 +34,8 @@ var (
 	ErrStoreClosed                         = errors.New("appserver/store: store is closed")
 	ErrTurnNotTerminal                     = errors.New("appserver/store: turn is not terminal")
 	ErrRetryIdempotencyConflict            = errors.New("appserver/store: retry idempotency key is already bound to another turn")
+	ErrThreadHasActiveTurn                 = errors.New("appserver/store: thread has an active turn")
+	ErrThreadForkIdempotencyConflict       = errors.New("appserver/store: fork idempotency key is already bound")
 	ErrFileChangeRevertIdempotencyConflict = errors.New("appserver/store: file-change revert idempotency key is already bound")
 )
 
@@ -105,6 +107,16 @@ type ForkThreadRequest struct {
 	Title          string
 	Metadata       map[string]any
 	IncludeItems   bool
+}
+
+type PrepareThreadForkRequest struct {
+	SourceThreadID string
+	IdempotencyKey string
+}
+
+type PrepareThreadForkResult struct {
+	Thread  *Thread
+	Created bool
 }
 
 type UpdateThreadSettingsRequest struct {
@@ -287,6 +299,12 @@ type Store interface {
 type RuntimeRecoveryStore interface {
 	PrepareTurnRetry(context.Context, PrepareTurnRetryRequest) (*PrepareTurnRetryResult, error)
 	RecoverOrphanedTurns(context.Context, RecoverOrphanedTurnsRequest) (*RecoverOrphanedTurnsResult, error)
+}
+
+// ThreadForkRecoveryStore is the optional persistence capability required for
+// response-loss-safe full-history forks.
+type ThreadForkRecoveryStore interface {
+	PrepareThreadFork(context.Context, PrepareThreadForkRequest) (*PrepareThreadForkResult, error)
 }
 
 // FileChangeRecoveryStore is the optional persistence capability required for


### PR DESCRIPTION
## Summary

- bind a strict Gollem-native `thread/fork` request/result contract while preserving the legacy untyped request path
- atomically create or reuse full-history forks by durable idempotency key, reject queued/running source turns, regenerate copied turn/item identities, and suppress duplicate `thread/started` notifications
- preserve public file-change timeline evidence while explicitly refusing to transfer private exact-restoration snapshots
- generate and document the JSON Schema and TypeScript surface, including malformed-input, conflict, active-turn, response-loss, and process-restart coverage

## Verification

- `go test` across all 60 packages except `ext/monty`
- repository pre-push hook: `golangci-lint`, full non-Monty `go test -race`, `go vet`, and module-tidy verification
- `golangci-lint run ./appserver/...` (`0 issues`)
- protocol generation repeated twice with byte-identical schema and TypeScript output
- exact binary `3fe9d5869533042bb70734224d94c766a0d2594b`, SHA-256 `ec13b0c7b5307fc8c5384826088132d7e462de3d9487ddc7087be67ea9aff5b2`
- real JSONL daemon smoke: terminal source history copied with regenerated IDs; same-key replay after daemon restart returned the same child and emitted zero duplicate start notifications