### PR TITLE
Guard thread lifecycle during active turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - **Thread lifecycle changes now serialize with active execution.** Archive and
   soft-delete reject threads with queued or running turns, and archived threads
-  reject new or pre-existing turn starts until explicitly unarchived. Rename
-  remains available during execution because it does not alter run ownership.
+  reject new turns, retries, and pre-existing turn starts until explicitly
+  unarchived. Full-history forks reject active sources instead of copying
+  nonterminal turns, and startup failures terminalize any turn created before
+  execution ownership is established. Rename remains available during execution
+  because it does not alter run ownership.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Thread lifecycle changes now serialize with active execution.** Archive and
+  soft-delete reject threads with queued or running turns, and archived threads
+  reject new or pre-existing turn starts until explicitly unarchived. Rename
+  remains available during execution because it does not alter run ownership.
+
 ### Added
 
 - **Response-loss-safe full-history thread forks.** The generated

--- a/appserver/protocol/README.md
+++ b/appserver/protocol/README.md
@@ -80,6 +80,12 @@ still contains `ThreadRecord`; exact standalone `ThreadUnarchiveResponse`
 contains public `Thread` and remains unbound until the runtime thread/turn/item
 model converges.
 
+Archive and soft-delete are rejected while the target thread has a queued or
+running turn. The check and lifecycle mutation share one store transaction, and
+archived threads cannot create or start turns until `thread/unarchive`
+completes. This prevents lifecycle changes from racing execution across daemon
+clients; set-name remains available because it does not change run ownership.
+
 ## Version 1 Thread Goals
 
 `thread/goal/get`, `thread/goal/set`, and `thread/goal/clear` use the public

--- a/appserver/protocol/README.md
+++ b/appserver/protocol/README.md
@@ -82,8 +82,11 @@ model converges.
 
 Archive and soft-delete are rejected while the target thread has a queued or
 running turn. The check and lifecycle mutation share one store transaction, and
-archived threads cannot create or start turns until `thread/unarchive`
-completes. This prevents lifecycle changes from racing execution across daemon
+archived threads cannot create, retry, or start turns until `thread/unarchive`
+completes. Full-history forks reject active sources rather than copying queued
+or running turn states. Runtime, compaction, and shell-command startup failures
+terminalize turns created before an execution owner is established. Together,
+these rules prevent lifecycle changes from racing execution across daemon
 clients; set-name remains available because it does not change run ownership.
 
 ## Version 1 Thread Goals

--- a/appserver/runtime.go
+++ b/appserver/runtime.go
@@ -201,11 +201,11 @@ func (s *RuntimeService) Start(ctx context.Context, st store.Store, notifier run
 		Status:   "completed",
 		Payload:  mustRuntimeJSON(runtimeMessagePayload{Role: "user", Text: req.Prompt, CreatedAt: time.Now().UTC()}),
 	}); err != nil {
-		return nil, err
+		return nil, failUnownedTurn(st, turn, err)
 	}
 	started, err := st.StartTurn(ctx, turn.ID)
 	if err != nil {
-		return nil, err
+		return nil, failUnownedTurn(st, turn, err)
 	}
 
 	runCtx, cancel := context.WithCancel(context.Background())
@@ -213,7 +213,7 @@ func (s *RuntimeService) Start(ctx context.Context, st store.Store, notifier run
 	if _, exists := s.active[started.ID]; exists {
 		s.mu.Unlock()
 		cancel()
-		return nil, ErrRuntimeTurnActive
+		return nil, failUnownedTurn(st, started, ErrRuntimeTurnActive)
 	}
 	s.active[started.ID] = &activeRuntimeTurn{cancel: cancel}
 	s.wg.Add(1)
@@ -381,14 +381,21 @@ func (s *RuntimeService) acquireStartLease(
 }
 
 func (s *RuntimeService) failPreparedRetry(st store.Store, turn *store.Turn, cause error) {
+	_ = failUnownedTurn(st, turn, cause)
+}
+
+func failUnownedTurn(st store.Store, turn *store.Turn, cause error) error {
 	if st == nil || turn == nil || cause == nil {
-		return
+		return cause
 	}
-	_, _ = st.CompleteTurn(context.Background(), store.CompleteTurnRequest{
+	if _, err := st.CompleteTurn(context.Background(), store.CompleteTurnRequest{
 		ID:     turn.ID,
 		Status: store.TurnFailed,
 		Error:  cause.Error(),
-	})
+	}); err != nil {
+		return errors.Join(cause, fmt.Errorf("terminalize unowned turn %q: %w", turn.ID, err))
+	}
+	return cause
 }
 
 func (s *RuntimeService) IsActive(turnID string) bool {

--- a/appserver/runtime_process_tools_test.go
+++ b/appserver/runtime_process_tools_test.go
@@ -3,6 +3,7 @@ package appserver
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"sync"
 	"testing"
@@ -12,6 +13,91 @@ import (
 	toolprocess "github.com/fugue-labs/gollem/appserver/tools/process"
 	"github.com/fugue-labs/gollem/core"
 )
+
+func TestServerThreadShellCommandStartupFailureDoesNotOrphanTurn(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		appendErr error
+		startErr  error
+	}{
+		{name: "start turn", startErr: errors.New("shell start failure")},
+		{name: "append item", appendErr: errors.New("shell append failure")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			st := newRuntimeTestStore(t)
+			thread, err := st.CreateThread(ctx, store.CreateThreadRequest{
+				Title:     "Shell startup failure",
+				Workspace: t.TempDir(),
+			})
+			if err != nil {
+				t.Fatalf("CreateThread: %v", err)
+			}
+			processSvc, err := toolprocess.NewService(thread.Workspace)
+			if err != nil {
+				t.Fatalf("NewService: %v", err)
+			}
+			failing := turnStartupFailureStore{
+				Store:     st,
+				appendErr: tc.appendErr,
+				startErr:  tc.startErr,
+			}
+			server := readyServer(WithStore(failing), WithProcess(processSvc))
+
+			resp := server.HandleRequest(ctx, request("thread/shellCommand", map[string]any{
+				"threadId": thread.ID,
+				"command":  "printf 'must not run'",
+			}))
+			if resp.Error == nil {
+				t.Fatal("thread/shellCommand unexpectedly succeeded")
+			}
+			turns, err := st.ListTurns(ctx, store.TurnFilter{ThreadID: thread.ID})
+			if err != nil {
+				t.Fatalf("ListTurns: %v", err)
+			}
+			if len(turns) != 1 || turns[0].Status != store.TurnFailed || turns[0].CompletedAt.IsZero() {
+				t.Fatalf("shell startup failure turn = %#v, want one terminal failed turn", turns)
+			}
+		})
+	}
+}
+
+func TestServerThreadShellCommandCompletionTerminalizesTurnWhenItemUpdateFails(t *testing.T) {
+	ctx := context.Background()
+	st := newRuntimeTestStore(t)
+	thread, err := st.CreateThread(ctx, store.CreateThreadRequest{
+		Title:     "Shell completion failure",
+		Workspace: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("CreateThread: %v", err)
+	}
+	processSvc, err := toolprocess.NewService(thread.Workspace)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	failing := turnStartupFailureStore{
+		Store:     st,
+		updateErr: errors.New("item update failure"),
+	}
+	server := readyServer(WithStore(failing), WithProcess(processSvc))
+
+	resp := server.HandleRequest(ctx, request("thread/shellCommand", map[string]any{
+		"threadId": thread.ID,
+		"command":  "printf 'done'",
+	}))
+	if resp.Error == nil {
+		t.Fatal("thread/shellCommand unexpectedly succeeded after item update failure")
+	}
+	waitForNotificationSet(t, server, "turn/completed")
+	turns, err := st.ListTurns(ctx, store.TurnFilter{ThreadID: thread.ID})
+	if err != nil {
+		t.Fatalf("ListTurns: %v", err)
+	}
+	if len(turns) != 1 || turns[0].Status != store.TurnCompleted || turns[0].CompletedAt.IsZero() {
+		t.Fatalf("shell completion failure turn = %#v, want one terminal completed turn", turns)
+	}
+}
 
 func TestProcessRuntimeToolsExposeScopedOperations(t *testing.T) {
 	processSvc, err := toolprocess.NewService(t.TempDir())

--- a/appserver/runtime_test.go
+++ b/appserver/runtime_test.go
@@ -14,6 +14,123 @@ import (
 	"github.com/fugue-labs/gollem/core"
 )
 
+type turnStartupFailureStore struct {
+	store.Store
+	appendErr error
+	startErr  error
+	updateErr error
+}
+
+func (s turnStartupFailureStore) AppendItem(
+	ctx context.Context,
+	req store.AppendItemRequest,
+) (*store.Item, error) {
+	if s.appendErr != nil {
+		return nil, s.appendErr
+	}
+	return s.Store.AppendItem(ctx, req)
+}
+
+func (s turnStartupFailureStore) StartTurn(ctx context.Context, id string) (*store.Turn, error) {
+	if s.startErr != nil {
+		return nil, s.startErr
+	}
+	return s.Store.StartTurn(ctx, id)
+}
+
+func (s turnStartupFailureStore) UpdateItem(
+	ctx context.Context,
+	req store.UpdateItemRequest,
+) (*store.Item, error) {
+	if s.updateErr != nil {
+		return nil, s.updateErr
+	}
+	return s.Store.UpdateItem(ctx, req)
+}
+
+func TestRuntimeStartFailureTerminalizesCreatedTurn(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		appendErr error
+		startErr  error
+	}{
+		{name: "append item", appendErr: errors.New("append startup failure")},
+		{name: "start turn", startErr: errors.New("start startup failure")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			st := newRuntimeTestStore(t)
+			thread, err := st.CreateThread(ctx, store.CreateThreadRequest{Title: "Startup failure"})
+			if err != nil {
+				t.Fatalf("CreateThread: %v", err)
+			}
+			failing := turnStartupFailureStore{
+				Store:     st,
+				appendErr: tc.appendErr,
+				startErr:  tc.startErr,
+			}
+			runtimeSvc := NewRuntimeService(WithRuntimeModel(
+				core.NewTestModel(core.TextResponse("must not run")),
+				RuntimeModelInfo{ProviderID: "test", Model: "test-model"},
+			))
+
+			if _, err := runtimeSvc.Start(ctx, failing, nil, RuntimeStartRequest{
+				ThreadID: thread.ID,
+				Prompt:   "fail before ownership",
+			}); err == nil {
+				t.Fatal("RuntimeService.Start unexpectedly succeeded")
+			}
+			turns, err := st.ListTurns(ctx, store.TurnFilter{ThreadID: thread.ID})
+			if err != nil {
+				t.Fatalf("ListTurns: %v", err)
+			}
+			if len(turns) != 1 || turns[0].Status != store.TurnFailed || turns[0].CompletedAt.IsZero() {
+				t.Fatalf("startup failure turn = %#v, want one terminal failed turn", turns)
+			}
+		})
+	}
+}
+
+func TestServerThreadCompactStartFailureTerminalizesCreatedTurn(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		appendErr error
+		startErr  error
+	}{
+		{name: "start turn", startErr: errors.New("compact start failure")},
+		{name: "append item", appendErr: errors.New("compact append failure")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			st := newRuntimeTestStore(t)
+			thread, err := st.CreateThread(ctx, store.CreateThreadRequest{Title: "Compact failure"})
+			if err != nil {
+				t.Fatalf("CreateThread: %v", err)
+			}
+			failing := turnStartupFailureStore{
+				Store:     st,
+				appendErr: tc.appendErr,
+				startErr:  tc.startErr,
+			}
+			server := readyServer(WithStore(failing))
+
+			resp := server.HandleRequest(ctx, request("thread/compact/start", map[string]any{
+				"threadId": thread.ID,
+			}))
+			if resp.Error == nil {
+				t.Fatal("thread/compact/start unexpectedly succeeded")
+			}
+			turns, err := st.ListTurns(ctx, store.TurnFilter{ThreadID: thread.ID})
+			if err != nil {
+				t.Fatalf("ListTurns: %v", err)
+			}
+			if len(turns) != 1 || turns[0].Status != store.TurnFailed || turns[0].CompletedAt.IsZero() {
+				t.Fatalf("compact failure turn = %#v, want one terminal failed turn", turns)
+			}
+		})
+	}
+}
+
 func TestRuntimeStartLeaseIsSharedAndContextScoped(t *testing.T) {
 	ctx := context.Background()
 	coordinator := NewWorkspaceMutationCoordinator()

--- a/appserver/server.go
+++ b/appserver/server.go
@@ -946,6 +946,22 @@ func (s *Server) handleThreadStatus(ctx context.Context, raw json.RawMessage, me
 		return nil, invalidParams("unsupported thread status", nil)
 	}
 	if err != nil {
+		if errors.Is(err, store.ErrThreadHasActiveTurn) {
+			switch status {
+			case store.ThreadArchived:
+				return nil, rpcError(
+					protocol.CodeInvalidRequest,
+					"cannot archive a thread while a turn is active",
+					nil,
+				)
+			case store.ThreadDeleted:
+				return nil, rpcError(
+					protocol.CodeInvalidRequest,
+					"cannot delete a thread while a turn is active",
+					nil,
+				)
+			}
+		}
 		return nil, mapError(method, err)
 	}
 	if status == store.ThreadDeleted {
@@ -2330,6 +2346,7 @@ func mapError(method string, err error) *protocol.Error {
 		errors.Is(err, store.ErrItemNotFound),
 		errors.Is(err, store.ErrFileChangeRecoveryNotFound),
 		errors.Is(err, store.ErrThreadDeleted),
+		errors.Is(err, store.ErrThreadArchived),
 		errors.Is(err, store.ErrTurnNotTerminal),
 		errors.Is(err, store.ErrRetryIdempotencyConflict),
 		errors.Is(err, store.ErrThreadHasActiveTurn),

--- a/appserver/server_test.go
+++ b/appserver/server_test.go
@@ -125,6 +125,12 @@ func TestServerThreadStoreHandlers(t *testing.T) {
 	if _, err := st.AppendItem(ctx, store.AppendItemRequest{ThreadID: thread.ID, TurnID: turn.ID, Kind: "message", Payload: json.RawMessage(`{"text":"hi"}`)}); err != nil {
 		t.Fatalf("AppendItem: %v", err)
 	}
+	if _, err := st.CompleteTurn(ctx, store.CompleteTurnRequest{
+		ID:     turn.ID,
+		Status: store.TurnCompleted,
+	}); err != nil {
+		t.Fatalf("CompleteTurn: %v", err)
+	}
 
 	server := readyServer(WithStore(st))
 	listResp := server.HandleRequest(ctx, request("thread/list", nil))

--- a/appserver/store/sqlite.go
+++ b/appserver/store/sqlite.go
@@ -280,22 +280,8 @@ func (s *SQLiteStore) setThreadStatus(ctx context.Context, id string, status Thr
 			return ErrThreadDeleted
 		}
 		if status == ThreadArchived || status == ThreadDeleted {
-			var active int
-			err = tx.QueryRowContext(
-				ctx,
-				`SELECT 1
-				 FROM app_turns
-				 WHERE thread_id = ? AND status IN (?, ?)
-				 LIMIT 1`,
-				loaded.ID,
-				TurnQueued,
-				TurnRunning,
-			).Scan(&active)
-			switch {
-			case err == nil:
-				return ErrThreadHasActiveTurn
-			case !errors.Is(err, sql.ErrNoRows):
-				return fmt.Errorf("check active turns before thread lifecycle change: %w", err)
+			if err := ensureThreadHasNoActiveTurnTx(ctx, tx, loaded.ID); err != nil {
+				return err
 			}
 		}
 		now := time.Now().UTC()
@@ -334,6 +320,11 @@ func (s *SQLiteStore) ForkThread(ctx context.Context, req ForkThreadRequest) (*T
 		}
 		if source.Status == ThreadDeleted {
 			return ErrThreadDeleted
+		}
+		if req.IncludeItems {
+			if err := ensureThreadHasNoActiveTurnTx(ctx, tx, source.ID); err != nil {
+				return err
+			}
 		}
 		now := time.Now().UTC()
 		title := req.Title
@@ -417,22 +408,8 @@ func (s *SQLiteStore) PrepareThreadFork(
 		if source.Status == ThreadDeleted {
 			return ErrThreadDeleted
 		}
-		var active int
-		err = tx.QueryRowContext(
-			ctx,
-			`SELECT 1
-			 FROM app_turns
-			 WHERE thread_id = ? AND status IN (?, ?)
-			 LIMIT 1`,
-			source.ID,
-			TurnQueued,
-			TurnRunning,
-		).Scan(&active)
-		switch {
-		case err == nil:
-			return ErrThreadHasActiveTurn
-		case !errors.Is(err, sql.ErrNoRows):
-			return fmt.Errorf("check active source turns: %w", err)
+		if err := ensureThreadHasNoActiveTurnTx(ctx, tx, source.ID); err != nil {
+			return err
 		}
 
 		now := time.Now().UTC()
@@ -732,6 +709,9 @@ func (s *SQLiteStore) PrepareTurnRetry(ctx context.Context, req PrepareTurnRetry
 		if thread.Status == ThreadDeleted {
 			return ErrThreadDeleted
 		}
+		if thread.Status == ThreadArchived {
+			return ErrThreadArchived
+		}
 
 		turns, err := loadAllTurnsTx(ctx, tx)
 		if err != nil {
@@ -781,6 +761,28 @@ func (s *SQLiteStore) PrepareTurnRetry(ctx context.Context, req PrepareTurnRetry
 		return nil, err
 	}
 	return result, nil
+}
+
+func ensureThreadHasNoActiveTurnTx(ctx context.Context, tx *sql.Tx, threadID string) error {
+	var active int
+	err := tx.QueryRowContext(
+		ctx,
+		`SELECT 1
+		 FROM app_turns
+		 WHERE thread_id = ? AND status IN (?, ?)
+		 LIMIT 1`,
+		threadID,
+		TurnQueued,
+		TurnRunning,
+	).Scan(&active)
+	switch {
+	case err == nil:
+		return ErrThreadHasActiveTurn
+	case errors.Is(err, sql.ErrNoRows):
+		return nil
+	default:
+		return fmt.Errorf("check active thread turns: %w", err)
+	}
 }
 
 // RecoverOrphanedTurns terminalizes work whose in-memory execution owner did

--- a/appserver/store/sqlite.go
+++ b/appserver/store/sqlite.go
@@ -279,6 +279,25 @@ func (s *SQLiteStore) setThreadStatus(ctx context.Context, id string, status Thr
 		if loaded.Status == ThreadDeleted && status != ThreadDeleted {
 			return ErrThreadDeleted
 		}
+		if status == ThreadArchived || status == ThreadDeleted {
+			var active int
+			err = tx.QueryRowContext(
+				ctx,
+				`SELECT 1
+				 FROM app_turns
+				 WHERE thread_id = ? AND status IN (?, ?)
+				 LIMIT 1`,
+				loaded.ID,
+				TurnQueued,
+				TurnRunning,
+			).Scan(&active)
+			switch {
+			case err == nil:
+				return ErrThreadHasActiveTurn
+			case !errors.Is(err, sql.ErrNoRows):
+				return fmt.Errorf("check active turns before thread lifecycle change: %w", err)
+			}
+		}
 		now := time.Now().UTC()
 		loaded.Status = status
 		loaded.UpdatedAt = now
@@ -528,8 +547,11 @@ func (s *SQLiteStore) CreateTurn(ctx context.Context, req CreateTurnRequest) (*T
 		if err != nil {
 			return err
 		}
-		if thread.Status == ThreadDeleted {
+		switch thread.Status {
+		case ThreadDeleted:
 			return ErrThreadDeleted
+		case ThreadArchived:
+			return ErrThreadArchived
 		}
 		now := time.Now().UTC()
 		turn = &Turn{
@@ -564,8 +586,11 @@ func (s *SQLiteStore) StartTurn(ctx context.Context, id string) (*Turn, error) {
 		if err != nil {
 			return err
 		}
-		if thread.Status == ThreadDeleted {
+		switch thread.Status {
+		case ThreadDeleted:
 			return ErrThreadDeleted
+		case ThreadArchived:
+			return ErrThreadArchived
 		}
 		now := time.Now().UTC()
 		loaded.Status = TurnRunning

--- a/appserver/store/sqlite_test.go
+++ b/appserver/store/sqlite_test.go
@@ -90,6 +90,57 @@ func TestSQLiteStoreThreadLifecyclePersists(t *testing.T) {
 	}
 }
 
+func TestSQLiteStoreThreadLifecycleRejectsActiveTurnsAndArchivedExecution(t *testing.T) {
+	ctx := context.Background()
+	s := newTestSQLiteStore(t, filepath.Join(t.TempDir(), "appserver.db"))
+
+	thread, err := s.CreateThread(ctx, CreateThreadRequest{Title: "Lifecycle guard"})
+	if err != nil {
+		t.Fatalf("CreateThread: %v", err)
+	}
+	turn, err := s.CreateTurn(ctx, CreateTurnRequest{ThreadID: thread.ID})
+	if err != nil {
+		t.Fatalf("CreateTurn: %v", err)
+	}
+	if _, err := s.ArchiveThread(ctx, thread.ID); !errors.Is(err, ErrThreadHasActiveTurn) {
+		t.Fatalf("ArchiveThread with queued turn error = %v, want ErrThreadHasActiveTurn", err)
+	}
+	if _, err := s.DeleteThread(ctx, thread.ID); !errors.Is(err, ErrThreadHasActiveTurn) {
+		t.Fatalf("DeleteThread with queued turn error = %v, want ErrThreadHasActiveTurn", err)
+	}
+	unchanged, err := s.GetThread(ctx, thread.ID)
+	if err != nil {
+		t.Fatalf("GetThread after rejected lifecycle changes: %v", err)
+	}
+	if unchanged.Status != ThreadActive || !unchanged.ArchivedAt.IsZero() || !unchanged.DeletedAt.IsZero() {
+		t.Fatalf("thread changed after rejected lifecycle controls: %#v", unchanged)
+	}
+
+	if _, err := s.CompleteTurn(ctx, CompleteTurnRequest{
+		ID:     turn.ID,
+		Status: TurnCompleted,
+	}); err != nil {
+		t.Fatalf("CompleteTurn: %v", err)
+	}
+	archived, err := s.ArchiveThread(ctx, thread.ID)
+	if err != nil {
+		t.Fatalf("ArchiveThread after terminal turn: %v", err)
+	}
+	if archived.Status != ThreadArchived {
+		t.Fatalf("archived status = %q, want %q", archived.Status, ThreadArchived)
+	}
+	if _, err := s.CreateTurn(ctx, CreateTurnRequest{ThreadID: thread.ID}); !errors.Is(err, ErrThreadArchived) {
+		t.Fatalf("CreateTurn on archived thread error = %v, want ErrThreadArchived", err)
+	}
+
+	if _, err := s.UnarchiveThread(ctx, thread.ID); err != nil {
+		t.Fatalf("UnarchiveThread: %v", err)
+	}
+	if _, err := s.CreateTurn(ctx, CreateTurnRequest{ThreadID: thread.ID}); err != nil {
+		t.Fatalf("CreateTurn after unarchive: %v", err)
+	}
+}
+
 func TestSQLiteStoreFileChangeRecoverySurvivesRestartAndIsIdempotent(t *testing.T) {
 	ctx := context.Background()
 	path := filepath.Join(t.TempDir(), "appserver.db")
@@ -1573,7 +1624,7 @@ func TestSQLiteStoreRejectsCrossThreadItemTurn(t *testing.T) {
 	}
 }
 
-func TestSQLiteStoreRejectsStartingExistingTurnAfterThreadDeleted(t *testing.T) {
+func TestSQLiteStoreRejectsDeletingActiveTurnAndStartingExistingTurnAfterDelete(t *testing.T) {
 	ctx := context.Background()
 	s := newTestSQLiteStore(t, filepath.Join(t.TempDir(), "appserver.db"))
 
@@ -1585,8 +1636,20 @@ func TestSQLiteStoreRejectsStartingExistingTurnAfterThreadDeleted(t *testing.T) 
 	if err != nil {
 		t.Fatalf("CreateTurn: %v", err)
 	}
+	if _, err := s.DeleteThread(ctx, thread.ID); !errors.Is(err, ErrThreadHasActiveTurn) {
+		t.Fatalf("DeleteThread with queued turn error = %v, want ErrThreadHasActiveTurn", err)
+	}
+	if _, err := s.StartTurn(ctx, turn.ID); err != nil {
+		t.Fatalf("StartTurn: %v", err)
+	}
+	if _, err := s.CompleteTurn(ctx, CompleteTurnRequest{
+		ID:     turn.ID,
+		Status: TurnCompleted,
+	}); err != nil {
+		t.Fatalf("CompleteTurn: %v", err)
+	}
 	if _, err := s.DeleteThread(ctx, thread.ID); err != nil {
-		t.Fatalf("DeleteThread: %v", err)
+		t.Fatalf("DeleteThread after terminal turn: %v", err)
 	}
 	if _, err := s.StartTurn(ctx, turn.ID); !errors.Is(err, ErrThreadDeleted) {
 		t.Fatalf("StartTurn after delete error = %v, want ErrThreadDeleted", err)

--- a/appserver/store/sqlite_test.go
+++ b/appserver/store/sqlite_test.go
@@ -852,6 +852,44 @@ func TestSQLiteStorePrepareTurnRetryIsAtomicAcrossHandlesAndDurable(t *testing.T
 	}
 }
 
+func TestSQLiteStorePrepareTurnRetryRejectsArchivedThread(t *testing.T) {
+	ctx := context.Background()
+	s := newTestSQLiteStore(t, filepath.Join(t.TempDir(), "appserver.db"))
+
+	thread, err := s.CreateThread(ctx, CreateThreadRequest{Title: "Archived retry"})
+	if err != nil {
+		t.Fatalf("CreateThread: %v", err)
+	}
+	source, err := s.CreateTurn(ctx, CreateTurnRequest{ThreadID: thread.ID})
+	if err != nil {
+		t.Fatalf("CreateTurn: %v", err)
+	}
+	if _, err := s.CompleteTurn(ctx, CompleteTurnRequest{
+		ID:     source.ID,
+		Status: TurnFailed,
+		Error:  "expected",
+	}); err != nil {
+		t.Fatalf("CompleteTurn: %v", err)
+	}
+	if _, err := s.ArchiveThread(ctx, thread.ID); err != nil {
+		t.Fatalf("ArchiveThread: %v", err)
+	}
+
+	if _, err := s.PrepareTurnRetry(ctx, PrepareTurnRetryRequest{
+		SourceTurnID:   source.ID,
+		IdempotencyKey: "archived-retry",
+	}); !errors.Is(err, ErrThreadArchived) {
+		t.Fatalf("PrepareTurnRetry archived thread error = %v, want ErrThreadArchived", err)
+	}
+	turns, err := s.ListTurns(ctx, TurnFilter{ThreadID: thread.ID})
+	if err != nil {
+		t.Fatalf("ListTurns: %v", err)
+	}
+	if len(turns) != 1 || turns[0].ID != source.ID {
+		t.Fatalf("archived retry created a turn: %#v", turns)
+	}
+}
+
 func TestSQLiteStoreTurnsAndItemsPersistAndPaginate(t *testing.T) {
 	ctx := context.Background()
 	s := newTestSQLiteStore(t, filepath.Join(t.TempDir(), "appserver.db"))
@@ -1224,6 +1262,12 @@ func TestSQLiteStoreForkCopiesThreadHistory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("AppendItem child: %v", err)
 	}
+	if _, err := s.CompleteTurn(ctx, CompleteTurnRequest{
+		ID:     turn.ID,
+		Status: TurnCompleted,
+	}); err != nil {
+		t.Fatalf("CompleteTurn: %v", err)
+	}
 
 	fork, err := s.ForkThread(ctx, ForkThreadRequest{
 		SourceThreadID: source.ID,
@@ -1269,6 +1313,33 @@ func TestSQLiteStoreForkCopiesThreadHistory(t *testing.T) {
 	}
 	if forkParentPayload.ID != forkItems[0].ID {
 		t.Fatalf("fork parent payload id = %q, want %q", forkParentPayload.ID, forkItems[0].ID)
+	}
+}
+
+func TestSQLiteStoreForkRejectsActiveSource(t *testing.T) {
+	ctx := context.Background()
+	s := newTestSQLiteStore(t, filepath.Join(t.TempDir(), "appserver.db"))
+
+	source, err := s.CreateThread(ctx, CreateThreadRequest{Title: "Active source"})
+	if err != nil {
+		t.Fatalf("CreateThread: %v", err)
+	}
+	if _, err := s.CreateTurn(ctx, CreateTurnRequest{ThreadID: source.ID}); err != nil {
+		t.Fatalf("CreateTurn: %v", err)
+	}
+
+	if _, err := s.ForkThread(ctx, ForkThreadRequest{
+		SourceThreadID: source.ID,
+		IncludeItems:   true,
+	}); !errors.Is(err, ErrThreadHasActiveTurn) {
+		t.Fatalf("ForkThread active source error = %v, want ErrThreadHasActiveTurn", err)
+	}
+	threads, err := s.ListThreads(ctx, ThreadFilter{})
+	if err != nil {
+		t.Fatalf("ListThreads: %v", err)
+	}
+	if len(threads) != 1 || threads[0].ID != source.ID {
+		t.Fatalf("active fork created a thread: %#v", threads)
 	}
 }
 
@@ -1420,6 +1491,12 @@ func TestSQLiteStoreForkDisablesFileChangeRevertEvidence(t *testing.T) {
 		Payload:  json.RawMessage(`{"itemId":"` + item.ID + `","path":"notes.txt"}`),
 	}); err != nil {
 		t.Fatalf("AppendItem receipt: %v", err)
+	}
+	if _, err := s.CompleteTurn(ctx, CompleteTurnRequest{
+		ID:     turn.ID,
+		Status: TurnCompleted,
+	}); err != nil {
+		t.Fatalf("CompleteTurn: %v", err)
 	}
 	fork, err := s.ForkThread(ctx, ForkThreadRequest{SourceThreadID: source.ID, IncludeItems: true})
 	if err != nil {

--- a/appserver/store/types.go
+++ b/appserver/store/types.go
@@ -31,6 +31,7 @@ var (
 	ErrItemNotFound                        = errors.New("appserver/store: item not found")
 	ErrFileChangeRecoveryNotFound          = errors.New("appserver/store: file-change recovery not found")
 	ErrThreadDeleted                       = errors.New("appserver/store: thread is deleted")
+	ErrThreadArchived                      = errors.New("appserver/store: thread is archived")
 	ErrStoreClosed                         = errors.New("appserver/store: store is closed")
 	ErrTurnNotTerminal                     = errors.New("appserver/store: turn is not terminal")
 	ErrRetryIdempotencyConflict            = errors.New("appserver/store: retry idempotency key is already bound to another turn")

--- a/appserver/thread_compact.go
+++ b/appserver/thread_compact.go
@@ -62,7 +62,7 @@ func (s *Server) handleThreadCompactStart(ctx context.Context, raw json.RawMessa
 	}
 	started, err := st.StartTurn(ctx, turn.ID)
 	if err != nil {
-		return nil, mapError("thread/compact/start", err)
+		return nil, mapError("thread/compact/start", failUnownedTurn(st, turn, err))
 	}
 	releaseStart()
 	item, err := st.AppendItem(ctx, store.AppendItemRequest{
@@ -77,7 +77,7 @@ func (s *Server) handleThreadCompactStart(ctx context.Context, raw json.RawMessa
 		}),
 	})
 	if err != nil {
-		return nil, mapError("thread/compact/start", err)
+		return nil, mapError("thread/compact/start", failUnownedTurn(st, started, err))
 	}
 	completed, err := st.CompleteTurn(ctx, store.CompleteTurnRequest{
 		ID:     started.ID,
@@ -88,7 +88,7 @@ func (s *Server) handleThreadCompactStart(ctx context.Context, raw json.RawMessa
 		}),
 	})
 	if err != nil {
-		return nil, mapError("thread/compact/start", err)
+		return nil, mapError("thread/compact/start", failUnownedTurn(st, started, err))
 	}
 	s.markThreadLoaded(thread)
 	publishTurnStarted(s, started)

--- a/appserver/thread_control_protocol_test.go
+++ b/appserver/thread_control_protocol_test.go
@@ -59,3 +59,72 @@ func TestThreadLifecycleControlsUseExportedContracts(t *testing.T) {
 		}
 	}
 }
+
+func TestThreadLifecycleControlsRejectArchiveAndDeleteDuringActiveTurn(t *testing.T) {
+	ctx := context.Background()
+	st := newRuntimeTestStore(t)
+	model := &blockingRuntimeModel{started: make(chan struct{})}
+	server := readyServer(
+		WithStore(st),
+		WithRuntimeService(NewRuntimeService(WithRuntimeModel(
+			model,
+			RuntimeModelInfo{ProviderID: "test", Model: "blocking"},
+		))),
+	)
+
+	start := server.HandleRequest(ctx, request("thread/start", map[string]any{
+		"prompt": "keep running",
+		"title":  "Lifecycle guard",
+	}))
+	if start.Error != nil {
+		t.Fatalf("thread/start error: %v", start.Error)
+	}
+	var started protocol.ThreadRunStartResult
+	decodeResult(t, start, &started)
+	waitForBlockingModel(t, model)
+
+	for method, wantMessage := range map[string]string{
+		"thread/archive": "cannot archive a thread while a turn is active",
+		"thread/delete":  "cannot delete a thread while a turn is active",
+	} {
+		response := server.HandleRequest(ctx, request(method, map[string]any{
+			"threadId": started.Thread.ID,
+		}))
+		if response.Error == nil ||
+			response.Error.Code != protocol.CodeInvalidRequest ||
+			response.Error.Message != wantMessage {
+			t.Fatalf("%s active-turn error = %#v", method, response.Error)
+		}
+	}
+	unchanged, err := st.GetThread(ctx, started.Thread.ID)
+	if err != nil {
+		t.Fatalf("GetThread after rejected lifecycle controls: %v", err)
+	}
+	if unchanged.Status != store.ThreadActive {
+		t.Fatalf("thread status after rejected lifecycle controls = %q", unchanged.Status)
+	}
+
+	rename := server.HandleRequest(ctx, request("thread/name/set", map[string]any{
+		"threadId": started.Thread.ID,
+		"name":     "Still running",
+	}))
+	if rename.Error != nil {
+		t.Fatalf("thread/name/set during active turn error: %v", rename.Error)
+	}
+
+	interrupt := server.HandleRequest(ctx, request("turn/interrupt", map[string]any{
+		"threadId": started.Thread.ID,
+		"turnId":   started.Turn.ID,
+	}))
+	if interrupt.Error != nil {
+		t.Fatalf("turn/interrupt error: %v", interrupt.Error)
+	}
+	waitForNotificationSet(t, server, "turn/completed")
+
+	archive := server.HandleRequest(ctx, request("thread/archive", map[string]any{
+		"threadId": started.Thread.ID,
+	}))
+	if archive.Error != nil {
+		t.Fatalf("thread/archive after terminal turn error: %v", archive.Error)
+	}
+}

--- a/appserver/thread_shell_command.go
+++ b/appserver/thread_shell_command.go
@@ -105,7 +105,7 @@ func (s *Server) handleThreadShellCommand(ctx context.Context, raw json.RawMessa
 	}
 	startedTurn, err := st.StartTurn(ctx, turn.ID)
 	if err != nil {
-		return nil, mapError("thread/shellCommand", err)
+		return nil, mapError("thread/shellCommand", failUnownedTurn(st, turn, err))
 	}
 	releaseStart()
 	item, err := st.AppendItem(ctx, store.AppendItemRequest{
@@ -125,7 +125,7 @@ func (s *Server) handleThreadShellCommand(ctx context.Context, raw json.RawMessa
 		)),
 	})
 	if err != nil {
-		return nil, mapError("thread/shellCommand", err)
+		return nil, mapError("thread/shellCommand", failUnownedTurn(st, startedTurn, err))
 	}
 	s.markThreadLoaded(thread)
 	publishTurnStarted(s, startedTurn)
@@ -184,6 +184,7 @@ func (s *Server) handleThreadShellCommand(ctx context.Context, raw json.RawMessa
 			nil,
 		)),
 	}); err != nil {
+		go s.waitForThreadShellCommand(run)
 		return nil, mapError("thread/shellCommand", err)
 	}
 	go s.waitForThreadShellCommand(run)
@@ -245,9 +246,7 @@ func (s *Server) completeThreadShellCommand(ctx context.Context, run threadShell
 			&completedAt,
 		)),
 	})
-	if err != nil {
-		return
-	}
+	itemErr := err
 	turnStatus := store.TurnCompleted
 	if status != commandExecutionStatusCompleted {
 		turnStatus = store.TurnFailed
@@ -270,7 +269,9 @@ func (s *Server) completeThreadShellCommand(ctx context.Context, run threadShell
 		return
 	}
 	s.publishTurnDiffUpdatedIfChanged(ctx, completedTurn, run.BeforeDiff)
-	publishItemCompleted(s, completedTurn, item)
+	if itemErr == nil {
+		publishItemCompleted(s, completedTurn, item)
+	}
 	publishTurnCompleted(s, completedTurn)
 }
 


### PR DESCRIPTION
## Summary
- reject archive and soft-delete while the thread has queued or running work
- reject turn creation/start on archived threads until explicit unarchive
- preserve rename during execution and document the lifecycle invariant

## Verification
- focused lifecycle tests, repeated 10x under race
- full non-Monty normal suite
- golangci-lint, full non-Monty race suite, go vet, go mod tidy/verify
- deterministic protocol regeneration and git diff checks

Local Monty normal/race/coverage remain skipped per project direction; hosted CI is unchanged.