### PR TITLE
feat: consume live turn steering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Durable live turn steering.** The app server now binds the exact public
+  `turn/steer` request and response, requires thread and expected-active-turn
+  correlation, and queues text instructions for the next safe model-request
+  boundary. A durable steer item moves from queued to completed only after the
+  next provider stream starts; interruption or terminal completion first marks
+  it failed, and only completed instructions replay into later turns. Stable
+  client message ids make active-turn response retries idempotent and reject
+  conflicting text.
 - **Response-loss-safe full-history thread forks.** The generated
   `thread/fork` extension accepts a source thread and bounded idempotency key,
   rejects queued or running source work, and transactionally copies durable

--- a/appserver/protocol/README.md
+++ b/appserver/protocol/README.md
@@ -349,14 +349,15 @@ result after process exit.
 
 ## Version 1 Runtime Client Bindings
 
-Generated clients can discover providers and models, start and interrupt live
-runs, and consume the current streaming lifecycle without an untyped JSON
-escape hatch. `provider/list` and `model/list` bind the provider-aware catalog
-records; `thread/start`, `turn/start`, `turn/retry`, and `turn/interrupt` bind
-durable thread/turn results; and `thread/started`, `turn/started`,
-`turn/completed`, `item/agentMessage/delta`, and
-`item/reasoning/textDelta` bind the live notification records. The registry
-now contains 70 method bindings and five durable item bindings.
+Generated clients can discover providers and models, start, steer, and
+interrupt live runs, and consume the current streaming lifecycle without an
+untyped JSON escape hatch. `provider/list` and `model/list` bind the
+provider-aware catalog records; `thread/start`, `turn/start`, `turn/steer`,
+`turn/retry`, and `turn/interrupt` bind durable thread/turn results; and
+`thread/started`, `turn/started`, `turn/completed`,
+`item/agentMessage/delta`, and `item/reasoning/textDelta` bind the live
+notification records. The registry now contains 74 method bindings and five
+durable item bindings.
 
 The live names are intentionally explicit: `ModelCatalog*`, `ThreadRun*`,
 `TurnRun*`, and `Runtime*`. Exact standalone public `ModelList*`,
@@ -580,13 +581,26 @@ live handler accepts a legacy id alias without required thread correlation and
 returns a richer durable interrupt result, so these definitions remain outside
 method bindings pending a separate compatibility migration.
 
-Exact standalone `TurnSteerParams` and `TurnSteerResponse` establish the fixed
-canonical turn-steer contract. The params require thread id, strict user input,
-and an expected active turn id, with optional nullable client message id; the
-response requires turn id. The current live handler instead accepts turn-id and
-prompt aliases, does not enforce the public active-turn precondition, persists
-a durable steer item, and returns richer status fields, so these definitions
-remain outside method bindings pending a separate compatibility migration.
+Exact `TurnSteerParams` and `TurnSteerResponse` establish the fixed canonical
+turn-steer contract. The params require thread id, strict user input, and an
+expected active turn id, with optional nullable client message id; the response
+requires turn id. The live handler binds these exact contracts,
+requires the supplied thread and expected turn to identify the active run, and
+currently accepts only text user-input parts. Other valid public input variants
+fail explicitly until the runtime supports multimodal steering.
+
+Accepted text is persisted as a queued `steer` timeline item before it becomes
+visible to the run. At most 64 instructions may remain pending; further
+requests receive an overloaded error and a failed durable item. The agent
+consumes queued instructions in order at the next safe model-request boundary
+after the current response and any tool results. The item becomes completed
+only after that next provider stream starts; interruption, terminal completion,
+or request failure first marks it failed. Only completed steer items enter
+later thread-history replay. Repeating the same non-empty client message id and
+text while the turn remains active reuses the original item; reusing the id for
+different text fails closed. Clients reconcile the durable item through
+lifecycle notifications or a fresh `thread/read`. Steering does not cancel an
+in-flight provider stream and is not same-execution resume.
 
 `TurnRunRetryParams` and `TurnRunRetryResult` define Gollem's restart-safe
 retry extension. Typed clients must persist a non-empty idempotency key before

--- a/appserver/protocol/account_credit_nudge_values_contract_test.go
+++ b/appserver/protocol/account_credit_nudge_values_contract_test.go
@@ -125,8 +125,8 @@ func TestAccountCreditNudgeValuesRemainStandaloneAndDeferred(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/account_envelope_contract_test.go
+++ b/appserver/protocol/account_envelope_contract_test.go
@@ -271,8 +271,8 @@ func TestAccountEnvelopeContractsRemainStandaloneAndDeferred(t *testing.T) {
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
 		t.Fatalf("definition count = %d, want 558", got)
 	}
-	if len(Methods()) != 225 || len(WireTypeBindings()) != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 225/73/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(Methods()) != 225 || len(WireTypeBindings()) != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 225/74/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/account_login_completed_notification_contract_test.go
+++ b/appserver/protocol/account_login_completed_notification_contract_test.go
@@ -94,8 +94,8 @@ func TestAccountLoginCompletedNotificationRemainsStandaloneAndDeferred(t *testin
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/account_rate_limits_contract_test.go
+++ b/appserver/protocol/account_rate_limits_contract_test.go
@@ -490,8 +490,8 @@ func TestAccountRateLimitContractsRemainStandaloneAndDeferred(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/account_token_usage_contract_test.go
+++ b/appserver/protocol/account_token_usage_contract_test.go
@@ -152,8 +152,8 @@ func TestAccountTokenUsageRecordsRemainStandaloneAndDeferred(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -154,8 +154,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -60,8 +60,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_config_contract_test.go
+++ b/appserver/protocol/app_config_contract_test.go
@@ -115,8 +115,8 @@ func TestAppConfigRemainsStandaloneAndUnbound(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_info_contract_test.go
+++ b/appserver/protocol/app_info_contract_test.go
@@ -137,8 +137,8 @@ func TestAppInfoRemainsStandaloneAndDeferred(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_list_updated_notification_contract_test.go
+++ b/appserver/protocol/app_list_updated_notification_contract_test.go
@@ -111,8 +111,8 @@ func TestAppListUpdatedNotificationRemainsStandaloneAndDeferred(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_metadata_contract_test.go
+++ b/appserver/protocol/app_metadata_contract_test.go
@@ -113,8 +113,8 @@ func TestAppMetadataRemainsStandaloneAndDeferred(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_metadata_leaf_contract_test.go
+++ b/appserver/protocol/app_metadata_leaf_contract_test.go
@@ -163,8 +163,8 @@ func TestAppMetadataLeavesRemainStandaloneAndDeferred(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_summary_contract_test.go
+++ b/appserver/protocol/app_summary_contract_test.go
@@ -93,8 +93,8 @@ func TestAppSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_template_summary_contract_test.go
+++ b/appserver/protocol/app_template_summary_contract_test.go
@@ -113,8 +113,8 @@ func TestAppTemplateSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_template_unavailable_reason_contract_test.go
+++ b/appserver/protocol/app_template_unavailable_reason_contract_test.go
@@ -77,8 +77,8 @@ func TestAppTemplateUnavailableReasonRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_tool_approval_contract_test.go
+++ b/appserver/protocol/app_tool_approval_contract_test.go
@@ -79,8 +79,8 @@ func TestAppToolApprovalRemainsStandaloneAndUnbound(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_tools_config_contract_test.go
+++ b/appserver/protocol/app_tools_config_contract_test.go
@@ -146,8 +146,8 @@ func TestAppToolConfigsRemainStandaloneAndUnbound(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/apply_patch_approval_params_contract_test.go
+++ b/appserver/protocol/apply_patch_approval_params_contract_test.go
@@ -145,8 +145,8 @@ func TestApplyPatchApprovalParamsRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/apps_config_contract_test.go
+++ b/appserver/protocol/apps_config_contract_test.go
@@ -191,8 +191,8 @@ func TestAppsConfigsRemainStandaloneAndUnbound(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/apps_list_contract_test.go
+++ b/appserver/protocol/apps_list_contract_test.go
@@ -174,8 +174,8 @@ func TestAppsListContractsRemainStandaloneAndDeferred(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/attestation_contract_test.go
+++ b/appserver/protocol/attestation_contract_test.go
@@ -139,8 +139,8 @@ func TestAttestationContractsRemainStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -80,8 +80,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -58,8 +58,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/bindings.go
+++ b/appserver/protocol/bindings.go
@@ -90,6 +90,7 @@ var wireTypeBindings = []WireTypeBinding{
 	{Method: "turn/retry", Surface: SurfaceGollemExtension, Params: []string{"TurnRunRetryParams"}, Result: []string{"TurnRunRetryResult"}},
 	{Method: "turn/start", Surface: SurfaceClientRequest, Params: []string{"TurnRunStartParams"}, Result: []string{"TurnRunStartResult"}},
 	{Method: "turn/started", Surface: SurfaceServerNotification, Params: []string{"RuntimeTurnNotification"}},
+	{Method: "turn/steer", Surface: SurfaceClientRequest, Params: []string{"TurnSteerParams"}, Result: []string{"TurnSteerResponse"}},
 }
 
 var itemPayloadBindings = []ItemPayloadBinding{

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -154,8 +154,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
+++ b/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
@@ -185,8 +185,8 @@ func TestChatgptAuthTokensRefreshRemainsStandaloneAndDeferred(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/collaboration_capability_contract_test.go
+++ b/appserver/protocol/collaboration_capability_contract_test.go
@@ -352,8 +352,8 @@ func TestCollaborationCapabilityContractsRemainStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -108,8 +108,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -223,8 +223,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -152,8 +152,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -327,8 +327,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -73,8 +73,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -206,8 +206,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -234,8 +234,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -172,8 +172,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
 		t.Fatalf("definition count = %d, want 558", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -338,8 +338,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/dynamic_tool_spec_contract_test.go
+++ b/appserver/protocol/dynamic_tool_spec_contract_test.go
@@ -324,8 +324,8 @@ func TestDynamicToolSpecContractsRemainStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/exec_command_approval_params_contract_test.go
+++ b/appserver/protocol/exec_command_approval_params_contract_test.go
@@ -143,8 +143,8 @@ func TestExecCommandApprovalParamsRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/experimental_feature_contract_test.go
+++ b/appserver/protocol/experimental_feature_contract_test.go
@@ -44,8 +44,8 @@ func TestExperimentalFeatureContractsRemainStandalone(t *testing.T) {
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
 		t.Fatalf("definition count = %d, want 558", got)
 	}
-	if len(Methods()) != 225 || len(WireTypeBindings()) != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("counts = %d/%d/%d, want 225/73/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(Methods()) != 225 || len(WireTypeBindings()) != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("counts = %d/%d/%d, want 225/74/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -223,8 +223,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -209,8 +209,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -266,8 +266,8 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -250,8 +250,8 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -168,8 +168,8 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -181,8 +181,8 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -192,8 +192,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -90,8 +90,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/file_change_contract_test.go
+++ b/appserver/protocol/file_change_contract_test.go
@@ -114,8 +114,8 @@ func TestFileChangeRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/file_change_output_delta_notification_contract_test.go
+++ b/appserver/protocol/file_change_output_delta_notification_contract_test.go
@@ -106,8 +106,8 @@ func TestFileChangeOutputDeltaNotificationRemainsDeprecatedAndStandalone(t *test
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -387,8 +387,8 @@ func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/guardian_approval_review_action_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_action_contract_test.go
@@ -232,8 +232,8 @@ func TestGuardianApprovalReviewActionRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
@@ -170,8 +170,8 @@ func TestGuardianApprovalReviewCompletedNotificationRemainsStandalone(t *testing
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 	for _, method := range Methods() {
 		if (method.Method == "item/autoApprovalReview/started" ||

--- a/appserver/protocol/guardian_approval_review_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_contract_test.go
@@ -145,8 +145,8 @@ func TestGuardianApprovalReviewRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
@@ -181,8 +181,8 @@ func TestGuardianApprovalReviewStartedNotificationRemainsStandalone(t *testing.T
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 	for _, method := range Methods() {
 		if method.Method == "item/autoApprovalReview/started" && method.State != MethodBlocked {

--- a/appserver/protocol/guardian_enum_foundation_contract_test.go
+++ b/appserver/protocol/guardian_enum_foundation_contract_test.go
@@ -95,8 +95,8 @@ func TestGuardianEnumFoundationRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/hook_metadata_list_contract_test.go
+++ b/appserver/protocol/hook_metadata_list_contract_test.go
@@ -355,8 +355,8 @@ func TestHookMetadataListContractsStayStandalone(t *testing.T) {
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
 		t.Errorf("definition count = %d, want 558", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 {
-		t.Errorf("wire binding count = %d, want 73", got)
+	if got := len(WireTypeBindings()); got != 74 {
+		t.Errorf("wire binding count = %d, want 74", got)
 	}
 	if got := len(ItemPayloadBindings()); got != 5 {
 		t.Errorf("item binding count = %d, want 5", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -108,8 +108,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/hook_run_notification_contract_test.go
+++ b/appserver/protocol/hook_run_notification_contract_test.go
@@ -300,7 +300,7 @@ func TestHookRunNotificationsRemainStandalone(t *testing.T) {
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
 		t.Fatalf("definition count = %d, want 558", got)
 	}
-	if len(Methods()) != 225 || len(WireTypeBindings()) != 73 || len(ItemPayloadBindings()) != 5 {
+	if len(Methods()) != 225 || len(WireTypeBindings()) != 74 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("surface changed: %d methods, %d wire bindings, %d item bindings", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 }

--- a/appserver/protocol/hook_value_foundation_contract_test.go
+++ b/appserver/protocol/hook_value_foundation_contract_test.go
@@ -173,8 +173,8 @@ func TestHookValueFoundationRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -226,8 +226,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
 		t.Fatalf("definition count = %d, want 558", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -162,8 +162,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(JSONSchema()["$defs"].(Schema)) != 558 {
 		t.Fatalf("definition count = %d, want 558", len(JSONSchema()["$defs"].(Schema)))
 	}
-	if len(WireTypeBindings()) != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(WireTypeBindings()) != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 
 	generated, err := MarshalTypeScript()

--- a/appserver/protocol/legacy_approval_response_contract_test.go
+++ b/appserver/protocol/legacy_approval_response_contract_test.go
@@ -104,8 +104,8 @@ func TestLegacyApprovalResponsesRemainStandaloneAndNominal(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -133,8 +133,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -282,8 +282,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -63,8 +63,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -76,8 +76,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -233,8 +233,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -80,8 +80,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -120,8 +120,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -136,8 +136,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -154,8 +154,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -108,8 +108,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_oauth_login_contract_test.go
+++ b/appserver/protocol/mcp_server_oauth_login_contract_test.go
@@ -231,8 +231,8 @@ func TestMcpServerOauthLoginContractsRemainStandaloneAndBlocked(t *testing.T) {
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
 		t.Fatalf("definition count = %d, want 558", got)
 	}
-	if len(Methods()) != 225 || len(WireTypeBindings()) != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("counts = %d/%d/%d, want 225/73/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(Methods()) != 225 || len(WireTypeBindings()) != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("counts = %d/%d/%d, want 225/74/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -76,8 +76,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -122,8 +122,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_status_contract_test.go
+++ b/appserver/protocol/mcp_server_status_contract_test.go
@@ -280,8 +280,8 @@ func TestMcpServerStatusContractsRemainStandalone(t *testing.T) {
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
 		t.Fatalf("definition count = %d, want 558", got)
 	}
-	if len(Methods()) != 225 || len(WireTypeBindings()) != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("counts = %d/%d/%d, want 225/73/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(Methods()) != 225 || len(WireTypeBindings()) != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("counts = %d/%d/%d, want 225/74/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -75,8 +75,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -131,8 +131,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -146,8 +146,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -174,8 +174,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -190,8 +190,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -241,8 +241,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -204,8 +204,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
 		t.Fatalf("definition count = %d, want 558", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -146,8 +146,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -165,8 +165,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -251,8 +251,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
 		t.Fatalf("definition count = %d, want 558", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/network_approval_context_contract_test.go
+++ b/appserver/protocol/network_approval_context_contract_test.go
@@ -90,8 +90,8 @@ func TestNetworkApprovalContextRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -169,8 +169,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/parsed_command_contract_test.go
+++ b/appserver/protocol/parsed_command_contract_test.go
@@ -126,8 +126,8 @@ func TestParsedCommandRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/permission_profile_list_contract_test.go
+++ b/appserver/protocol/permission_profile_list_contract_test.go
@@ -258,8 +258,8 @@ func TestPermissionProfileListContractsRemainStandalone(t *testing.T) {
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
 		t.Fatalf("definition count = %d, want 558", got)
 	}
-	if len(Methods()) != 225 || len(WireTypeBindings()) != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("counts = %d/%d/%d, want 225/73/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(Methods()) != 225 || len(WireTypeBindings()) != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("counts = %d/%d/%d, want 225/74/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -133,8 +133,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/process_contracts_contract_test.go
+++ b/appserver/protocol/process_contracts_contract_test.go
@@ -314,8 +314,8 @@ func TestProcessContractsRemainStandaloneFromLegacyRuntime(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -264,8 +264,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -200,8 +200,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 	if len(JSONSchema()["$defs"].(Schema)) != 558 {
 		t.Fatalf("definition count = %d, want 558", len(JSONSchema()["$defs"].(Schema)))
 	}
-	if len(WireTypeBindings()) != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(WireTypeBindings()) != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 	names := []string{
 		"ThreadStartedNotification", "ThreadStatusChangedNotification",

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -207,8 +207,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if len(JSONSchema()["$defs"].(Schema)) != 558 {
 		t.Fatalf("definition count = %d, want 558", len(JSONSchema()["$defs"].(Schema)))
 	}
-	if len(WireTypeBindings()) != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(WireTypeBindings()) != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 	for _, binding := range WireTypeBindings() {
 		if slices.Contains(binding.Params, "Thread") || slices.Contains(binding.Result, "Thread") {

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -200,8 +200,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 	if len(JSONSchema()["$defs"].(Schema)) != 558 {
 		t.Fatalf("definition count = %d, want 558", len(JSONSchema()["$defs"].(Schema)))
 	}
-	if len(bindings) != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", len(bindings), len(ItemPayloadBindings()))
+	if len(bindings) != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", len(bindings), len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -149,8 +149,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if len(JSONSchema()["$defs"].(Schema)) != 558 {
 		t.Fatalf("definition count = %d, want 558", len(JSONSchema()["$defs"].(Schema)))
 	}
-	if len(WireTypeBindings()) != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(WireTypeBindings()) != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 	for _, binding := range WireTypeBindings() {
 		if slices.Contains(binding.Params, "Turn") || slices.Contains(binding.Result, "Turn") {

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -97,8 +97,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 	if len(JSONSchema()["$defs"].(Schema)) != 558 {
 		t.Fatalf("definition count = %d, want 558", len(JSONSchema()["$defs"].(Schema)))
 	}
-	if len(WireTypeBindings()) != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(WireTypeBindings()) != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 
 	generated, err := MarshalTypeScript()

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -165,8 +165,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/review_decision_contract_test.go
+++ b/appserver/protocol/review_decision_contract_test.go
@@ -142,8 +142,8 @@ func TestReviewDecisionRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/runtime_client_types_contract_test.go
+++ b/appserver/protocol/runtime_client_types_contract_test.go
@@ -48,6 +48,10 @@ func TestRuntimeClientBindingsAreExact(t *testing.T) {
 			Method: "turn/start", Surface: SurfaceClientRequest,
 			Params: []string{"TurnRunStartParams"}, Result: []string{"TurnRunStartResult"},
 		},
+		"turn/steer": {
+			Method: "turn/steer", Surface: SurfaceClientRequest,
+			Params: []string{"TurnSteerParams"}, Result: []string{"TurnSteerResponse"},
+		},
 		"turn/started": {
 			Method: "turn/started", Surface: SurfaceServerNotification,
 			Params: []string{"RuntimeTurnNotification"},

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -21182,6 +21182,16 @@
       "params": [
         "RuntimeTurnNotification"
       ]
+    },
+    {
+      "method": "turn/steer",
+      "surface": "client-request",
+      "params": [
+        "TurnSteerParams"
+      ],
+      "result": [
+        "TurnSteerResponse"
+      ]
     }
   ]
 }

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -134,8 +134,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -108,8 +108,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -108,8 +108,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 225 {
 		t.Fatalf("methods = %d, want 225", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -390,8 +390,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 	if len(JSONSchema()["$defs"].(Schema)) != 558 {
 		t.Fatalf("definition count = %d, want 558", len(JSONSchema()["$defs"].(Schema)))
 	}
-	if len(WireTypeBindings()) != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(WireTypeBindings()) != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 	for _, binding := range WireTypeBindings() {
 		if slices.Contains(binding.Params, "ThreadItem") || slices.Contains(binding.Result, "ThreadItem") {

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -97,8 +97,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
 		t.Fatalf("definition count = %d, want 558", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -276,8 +276,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
 		t.Fatalf("definition count = %d, want 558", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -197,8 +197,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
 		t.Fatalf("definition count = %d, want 558", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -255,8 +255,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
 		t.Fatalf("definition count = %d, want 558", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -158,8 +158,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
 		t.Fatalf("definition count = %d, want 558", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -314,8 +314,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 	if len(JSONSchema()["$defs"].(Schema)) != 558 {
 		t.Fatalf("definition count = %d, want 558", len(JSONSchema()["$defs"].(Schema)))
 	}
-	if len(WireTypeBindings()) != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(WireTypeBindings()) != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 
 	generated, err := MarshalTypeScript()

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -223,8 +223,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 	if len(JSONSchema()["$defs"].(Schema)) != 558 {
 		t.Fatalf("definition count = %d, want 558", len(JSONSchema()["$defs"].(Schema)))
 	}
-	if len(WireTypeBindings()) != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(WireTypeBindings()) != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 
 	generated, err := MarshalTypeScript()

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -122,8 +122,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
 		t.Fatalf("definition count = %d, want 558", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -212,8 +212,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
 		t.Fatalf("definition count = %d, want 558", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -244,8 +244,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
 		t.Fatalf("definition count = %d, want 558", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -150,17 +150,25 @@ func TestTurnSteerResponseWireContract(t *testing.T) {
 	}
 }
 
-func TestTurnSteerContractsRemainStandalone(t *testing.T) {
+func TestTurnSteerContractsAreBoundToLiveRuntime(t *testing.T) {
+	found := false
 	for _, binding := range WireTypeBindings() {
 		if binding.Method == "turn/steer" {
-			t.Fatalf("turn/steer unexpectedly bound: %#v", binding)
+			found = true
+			if !slices.Equal(binding.Params, []string{"TurnSteerParams"}) ||
+				!slices.Equal(binding.Result, []string{"TurnSteerResponse"}) {
+				t.Fatalf("turn/steer binding = %#v", binding)
+			}
 		}
+	}
+	if !found {
+		t.Fatal("turn/steer runtime binding missing")
 	}
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
 		t.Fatalf("definition count = %d, want 558", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/turn_steer_types.go
+++ b/appserver/protocol/turn_steer_types.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 )
 
-// TurnSteerParams is the exact fixed public turn-steer request. It remains
-// standalone from Gollem's prompt-alias live handler contract.
+// TurnSteerParams is the exact fixed public turn-steer request accepted by the
+// live runtime.
 type TurnSteerParams struct {
 	ThreadID            string      `json:"threadId"`
 	ClientUserMessageID *string     `json:"clientUserMessageId,omitempty"`

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -4413,6 +4413,7 @@ export const wireTypeBindings = [
   { "method": "turn/retry", "surface": "gollem-extension", "params": ["TurnRunRetryParams"], "result": ["TurnRunRetryResult"] },
   { "method": "turn/start", "surface": "client-request", "params": ["TurnRunStartParams"], "result": ["TurnRunStartResult"] },
   { "method": "turn/started", "surface": "server-notification", "params": ["RuntimeTurnNotification"] },
+  { "method": "turn/steer", "surface": "client-request", "params": ["TurnSteerParams"], "result": ["TurnSteerResponse"] },
 ] as const satisfies readonly WireTypeBinding[];
 
 export interface MethodParamsByName {
@@ -4489,6 +4490,7 @@ export interface MethodParamsByName {
   "turn/retry": TurnRunRetryParams;
   "turn/start": TurnRunStartParams;
   "turn/started": RuntimeTurnNotification;
+  "turn/steer": TurnSteerParams;
 }
 
 export interface MethodResultsByName {
@@ -4539,6 +4541,7 @@ export interface MethodResultsByName {
   "turn/interrupt": TurnRunInterruptResult;
   "turn/retry": TurnRunRetryResult;
   "turn/start": TurnRunStartResult;
+  "turn/steer": TurnSteerResponse;
 }
 
 export type BoundRequestMethod = Extract<

--- a/appserver/protocol/typescript/testdata/collaboration_capability_contract.ts
+++ b/appserver/protocol/typescript/testdata/collaboration_capability_contract.ts
@@ -74,7 +74,7 @@ type Contracts = [
   Expect<Equal<ExactMembers<MethodResultsByName[keyof MethodResultsByName], CollaborationCapabilityContracts>, never>>,
   Expect<Equal<ExactMembers<ItemPayloadByKind[keyof ItemPayloadByKind], CollaborationCapabilityContracts>, never>>,
   Expect<Equal<typeof protocolMethods["length"], 225>>,
-  Expect<Equal<typeof wireTypeBindings["length"], 73>>,
+  Expect<Equal<typeof wireTypeBindings["length"], 74>>,
   Expect<Equal<typeof itemPayloadBindings["length"], 5>>,
 ];
 

--- a/appserver/protocol/typescript/testdata/dynamic_tool_spec_contract.ts
+++ b/appserver/protocol/typescript/testdata/dynamic_tool_spec_contract.ts
@@ -58,7 +58,7 @@ type Contracts = [
   Expect<Equal<ExactMembers<MethodResultsByName[keyof MethodResultsByName], DynamicToolSpecContracts>, never>>,
   Expect<Equal<ExactMembers<ItemPayloadByKind[keyof ItemPayloadByKind], DynamicToolSpecContracts>, never>>,
   Expect<Equal<typeof protocolMethods["length"], 225>>,
-  Expect<Equal<typeof wireTypeBindings["length"], 73>>,
+  Expect<Equal<typeof wireTypeBindings["length"], 74>>,
   Expect<Equal<typeof itemPayloadBindings["length"], 5>>,
 ];
 

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -166,8 +166,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
 		t.Fatalf("definition count = %d, want 558", got)
 	}
-	if got := len(WireTypeBindings()); got != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 73/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 74/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/workspace_messages_contract_test.go
+++ b/appserver/protocol/workspace_messages_contract_test.go
@@ -212,8 +212,8 @@ func TestWorkspaceMessageContractsRemainStandaloneAndDeferred(t *testing.T) {
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 558 {
 		t.Fatalf("definition count = %d, want 558", got)
 	}
-	if len(Methods()) != 225 || len(WireTypeBindings()) != 73 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 225/73/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(Methods()) != 225 || len(WireTypeBindings()) != 74 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 225/74/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/runtime.go
+++ b/appserver/runtime.go
@@ -94,6 +94,7 @@ type RuntimeStartRequest struct {
 	Selection     RuntimeModelSelection
 	ModelSettings core.ModelSettings
 	History       []core.ModelMessage
+	steerQueue    *core.SteerQueue
 }
 
 type RuntimeStartResult struct {
@@ -148,6 +149,7 @@ func runtimeStartLeaseHeld(ctx context.Context, service *RuntimeService) bool {
 
 type activeRuntimeTurn struct {
 	cancel context.CancelFunc
+	*runtimeSteerState
 }
 
 func (s *RuntimeService) Start(ctx context.Context, st store.Store, notifier runtimeNotifier, req RuntimeStartRequest) (*RuntimeStartResult, error) {
@@ -215,7 +217,9 @@ func (s *RuntimeService) Start(ctx context.Context, st store.Store, notifier run
 		cancel()
 		return nil, failUnownedTurn(st, started, ErrRuntimeTurnActive)
 	}
-	s.active[started.ID] = &activeRuntimeTurn{cancel: cancel}
+	active := newActiveRuntimeTurn(cancel, st, notifier, started)
+	req.steerQueue = active.queue
+	s.active[started.ID] = active
 	s.wg.Add(1)
 	s.mu.Unlock()
 
@@ -318,7 +322,8 @@ func (s *RuntimeService) Retry(ctx context.Context, st store.Store, notifier run
 		s.failPreparedRetry(st, started, ErrRuntimeTurnActive)
 		return nil, ErrRuntimeTurnActive
 	}
-	s.active[started.ID] = &activeRuntimeTurn{cancel: cancel}
+	active := newActiveRuntimeTurn(cancel, st, notifier, started)
+	s.active[started.ID] = active
 	s.wg.Add(1)
 	s.mu.Unlock()
 
@@ -332,6 +337,7 @@ func (s *RuntimeService) Retry(ctx context.Context, st store.Store, notifier run
 		Selection:     req.Selection,
 		ModelSettings: req.ModelSettings,
 		History:       append([]core.ModelMessage(nil), req.History...),
+		steerQueue:    active.queue,
 	}
 	go func() {
 		defer s.wg.Done()
@@ -448,7 +454,11 @@ func (s *RuntimeService) run(ctx context.Context, st store.Store, notifier runti
 
 	ctx = withRuntimeTurnContext(ctx, turn.ThreadID, turn.ID)
 	model, info, err := s.modelFactory(ctx, req.Selection)
+	if err == nil && model == nil {
+		err = ErrRuntimeNotConfigured
+	}
 	if err != nil {
+		req.steerQueue.RejectAll(err)
 		s.complete(st, notifier, turn, store.TurnFailed, nil, err, info)
 		return
 	}
@@ -505,6 +515,9 @@ func (s *RuntimeService) run(ctx context.Context, st store.Store, notifier runti
 	}
 	if hasRuntimeModelSettings(req.ModelSettings) {
 		runOpts = append(runOpts, core.WithRunModelSettings(req.ModelSettings))
+	}
+	if req.steerQueue != nil {
+		runOpts = append(runOpts, core.WithSteerQueue(req.steerQueue))
 	}
 	stream, err := agent.RunStream(ctx, req.Prompt, runOpts...)
 	if err != nil {
@@ -684,6 +697,19 @@ func publishItemCompleted(notifier runtimeNotifier, turn *store.Turn, item *stor
 		return
 	}
 	notifier.PublishNotification("item/completed", runtimeItemNotificationParams{
+		ThreadID: turn.ThreadID,
+		TurnID:   turn.ID,
+		ItemID:   item.ID,
+		Item:     protocolTimelineItem(item),
+		At:       time.Now().UTC(),
+	})
+}
+
+func publishItemStarted(notifier runtimeNotifier, turn *store.Turn, item *store.Item) {
+	if notifier == nil || turn == nil || item == nil {
+		return
+	}
+	notifier.PublishNotification("item/started", runtimeItemNotificationParams{
 		ThreadID: turn.ThreadID,
 		TurnID:   turn.ID,
 		ItemID:   item.ID,

--- a/appserver/runtime_history.go
+++ b/appserver/runtime_history.go
@@ -3,6 +3,7 @@ package appserver
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -76,6 +77,7 @@ func boundedRuntimeReplayItems(items []*store.Item) []*store.Item {
 }
 
 func runtimeMessagesFromItems(items []*store.Item) []core.ModelMessage {
+	items = runtimeItemsInReplayOrder(items)
 	builder := runtimeHistoryBuilder{
 		dynamicParents: make(map[string]struct{}),
 		callIDCounts:   make(map[string]int),
@@ -98,6 +100,10 @@ func runtimeMessagesFromItems(items []*store.Item) []core.ModelMessage {
 			}
 		case "message":
 			if message, ok := runtimeMessageFromStoredItem(item.Payload); ok {
+				messages = append(messages, message)
+			}
+		case runtimeSteerItemKind:
+			if message, ok := runtimeMessageFromSteerItem(item); ok {
 				messages = append(messages, message)
 			}
 		case runtimeDynamicToolCallItemKind:
@@ -128,6 +134,36 @@ func runtimeMessagesFromItems(items []*store.Item) []core.ModelMessage {
 		}
 	}
 	return messages
+}
+
+func runtimeItemsInReplayOrder(items []*store.Item) []*store.Item {
+	ordered := append([]*store.Item(nil), items...)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		leftSeq, leftAfter := runtimeReplayOrder(ordered[i])
+		rightSeq, rightAfter := runtimeReplayOrder(ordered[j])
+		if leftSeq != rightSeq {
+			return leftSeq < rightSeq
+		}
+		return !leftAfter && rightAfter
+	})
+	return ordered
+}
+
+func runtimeReplayOrder(item *store.Item) (int64, bool) {
+	if item == nil {
+		return 0, false
+	}
+	if item.Kind != runtimeSteerItemKind || item.Status != runtimeSteerStatusComplete {
+		return item.Seq, false
+	}
+	var payload runtimeSteerPayload
+	if json.Unmarshal(item.Payload, &payload) == nil &&
+		payload.Status == runtimeSteerStatusComplete &&
+		payload.ConsumedAfterSeq >= item.Seq &&
+		payload.ConsumedAfterSeq > 0 {
+		return payload.ConsumedAfterSeq, true
+	}
+	return item.Seq, false
 }
 
 func (b *runtimeHistoryBuilder) collectDynamicParents(items []*store.Item) {
@@ -231,6 +267,29 @@ func runtimeMessageFromStoredItem(raw json.RawMessage) (core.ModelMessage, bool)
 	default:
 		return nil, false
 	}
+}
+
+func runtimeMessageFromSteerItem(item *store.Item) (core.ModelMessage, bool) {
+	if item == nil || item.Status != runtimeSteerStatusComplete {
+		return nil, false
+	}
+	var payload runtimeSteerPayload
+	if err := json.Unmarshal(item.Payload, &payload); err != nil ||
+		payload.Status != runtimeSteerStatusComplete ||
+		payload.ConsumedAfterSeq < item.Seq ||
+		payload.ConsumedAfterSeq <= 0 ||
+		payload.ConsumedAt == nil ||
+		strings.TrimSpace(payload.Message) == "" {
+		return nil, false
+	}
+	consumedAt := payload.ConsumedAt.UTC()
+	return core.ModelRequest{
+		Parts: []core.ModelRequestPart{core.UserPromptPart{
+			Content:   payload.Message,
+			Timestamp: consumedAt,
+		}},
+		Timestamp: consumedAt,
+	}, true
 }
 
 func runtimeReplayDynamicToolRecord(item *store.Item) (runtimeReplayToolRecord, bool) {

--- a/appserver/runtime_history_test.go
+++ b/appserver/runtime_history_test.go
@@ -180,6 +180,144 @@ func TestRuntimeMessagesFromItemsReconstructsMixedToolHistory(t *testing.T) {
 	}
 }
 
+func TestRuntimeMessagesFromItemsReplaysOnlyConsumedSteers(t *testing.T) {
+	now := time.Now().UTC()
+	consumedAt := now.Add(2 * time.Second)
+	failedAt := now.Add(3 * time.Second)
+	items := []*store.Item{
+		{
+			ID:     "completed-steer",
+			Seq:    1,
+			Kind:   runtimeSteerItemKind,
+			Status: runtimeSteerStatusComplete,
+			Payload: mustRuntimeJSON(runtimeSteerPayload{
+				ClientUserMessageID: "client-completed",
+				Message:             "use the focused test result",
+				Status:              runtimeSteerStatusComplete,
+				QueuedAt:            now,
+				ConsumedAfterSeq:    1,
+				ConsumedAt:          &consumedAt,
+			}),
+		},
+		{
+			ID:     "queued-steer",
+			Seq:    2,
+			Kind:   runtimeSteerItemKind,
+			Status: runtimeSteerStatusQueued,
+			Payload: mustRuntimeJSON(runtimeSteerPayload{
+				ClientUserMessageID: "client-queued",
+				Message:             "do not replay queued",
+				Status:              runtimeSteerStatusQueued,
+				QueuedAt:            now,
+			}),
+		},
+		{
+			ID:     "failed-steer",
+			Seq:    3,
+			Kind:   runtimeSteerItemKind,
+			Status: runtimeSteerStatusFailed,
+			Payload: mustRuntimeJSON(runtimeSteerPayload{
+				ClientUserMessageID: "client-failed",
+				Message:             "do not replay failed",
+				Status:              runtimeSteerStatusFailed,
+				QueuedAt:            now,
+				FailedAt:            &failedAt,
+				Error:               "turn interrupted",
+			}),
+		},
+		{
+			ID:     "partial-steer",
+			Seq:    4,
+			Kind:   runtimeSteerItemKind,
+			Status: runtimeSteerStatusComplete,
+			Payload: mustRuntimeJSON(runtimeSteerPayload{
+				ClientUserMessageID: "client-partial",
+				Message:             "do not replay partial persistence",
+				Status:              runtimeSteerStatusQueued,
+				QueuedAt:            now,
+			}),
+		},
+		{
+			ID:      "malformed-steer",
+			Seq:     5,
+			Kind:    runtimeSteerItemKind,
+			Status:  runtimeSteerStatusComplete,
+			Payload: json.RawMessage(`{"message":`),
+		},
+		{
+			ID:     "backward-boundary-steer",
+			Seq:    6,
+			Kind:   runtimeSteerItemKind,
+			Status: runtimeSteerStatusComplete,
+			Payload: mustRuntimeJSON(runtimeSteerPayload{
+				ClientUserMessageID: "client-backward",
+				Message:             "do not replay corrupt boundary",
+				Status:              runtimeSteerStatusComplete,
+				QueuedAt:            now,
+				ConsumedAfterSeq:    5,
+				ConsumedAt:          &consumedAt,
+			}),
+		},
+	}
+
+	messages := runtimeMessagesFromItems(items)
+	if len(messages) != 1 {
+		t.Fatalf("messages = %#v, want only the consumed steer", messages)
+	}
+	assertRuntimeUserPrompt(t, messages[0], "use the focused test result")
+	request, ok := messages[0].(core.ModelRequest)
+	if !ok || !request.Timestamp.Equal(consumedAt) {
+		t.Fatalf("consumed steer timestamp = %#v, want %s", messages[0], consumedAt)
+	}
+}
+
+func TestRuntimeMessagesFromItemsOrdersConsumedSteerAfterToolBoundary(t *testing.T) {
+	now := time.Now().UTC()
+	consumedAt := now.Add(4 * time.Second)
+	success := true
+	items := []*store.Item{
+		runtimeHistoryMessageItem("message-user", "user", "inspect first", now),
+		{
+			ID:     "steer-before-tool-item",
+			Seq:    2,
+			Kind:   runtimeSteerItemKind,
+			Status: runtimeSteerStatusComplete,
+			Payload: mustRuntimeJSON(runtimeSteerPayload{
+				ClientUserMessageID: "client-boundary",
+				Message:             "adjust after tool",
+				Status:              runtimeSteerStatusComplete,
+				QueuedAt:            now.Add(time.Second),
+				ConsumedAfterSeq:    3,
+				ConsumedAt:          &consumedAt,
+			}),
+			CreatedAt: now.Add(time.Second),
+			UpdatedAt: consumedAt,
+		},
+		runtimeHistoryDynamicToolItem("tool-after-queue", runtimeDynamicToolCallPayload{
+			Tool:         "workspace_read_file",
+			Arguments:    map[string]any{"path": "README.md"},
+			Status:       runtimeToolStatusCompleted,
+			ContentItems: []runtimeDynamicToolCallContentItem{{Type: "inputText", Text: "contents"}},
+			Success:      &success,
+		}, now.Add(2*time.Second)),
+		runtimeHistoryMessageItem("message-assistant", "assistant", "adjusted answer", now.Add(5*time.Second)),
+	}
+	for i, item := range items {
+		if item.Seq == 0 {
+			item.Seq = int64(i + 1)
+		}
+	}
+
+	messages := runtimeMessagesFromItems(items)
+	if len(messages) != 5 {
+		t.Fatalf("messages = %#v, want user + tool pair + steer + assistant", messages)
+	}
+	assertRuntimeUserPrompt(t, messages[0], "inspect first")
+	assertRuntimeReplayPair(t, messages[1], messages[2], "workspace_read_file", "tool-after-queue", false, "contents")
+	assertRuntimeUserPrompt(t, messages[3], "adjust after tool")
+	assertRuntimeAssistantText(t, messages[4], "adjusted answer")
+}
+
 func TestRuntimeMessagesFromItemsReconstructsStandaloneOperationalItems(t *testing.T) {
 	now := time.Now().UTC()
 	output := "tests passed\n... tool output truncated ...\nfinal line"

--- a/appserver/runtime_params.go
+++ b/appserver/runtime_params.go
@@ -43,14 +43,6 @@ const (
 type turnStartParams = protocol.TurnRunStartParams
 type turnIDParams = protocol.TurnRunInterruptParams
 
-type turnSteerParams struct {
-	ID      string `json:"id,omitempty"`
-	TurnID  string `json:"turnId,omitempty"`
-	Prompt  string `json:"prompt,omitempty"`
-	Message string `json:"message,omitempty"`
-	Text    string `json:"text,omitempty"`
-}
-
 type turnRetryParams struct {
 	ID             string         `json:"id,omitempty"`
 	TurnID         string         `json:"turnId,omitempty"`
@@ -192,11 +184,4 @@ func firstRaw(values ...json.RawMessage) json.RawMessage {
 		}
 	}
 	return nil
-}
-
-func runtimeSteerReason(accepted bool) string {
-	if accepted {
-		return "steer message recorded for the active turn"
-	}
-	return "turn is not currently active; steer message was recorded for audit only"
 }

--- a/appserver/runtime_steer.go
+++ b/appserver/runtime_steer.go
@@ -1,0 +1,312 @@
+package appserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/fugue-labs/gollem/appserver/protocol"
+	"github.com/fugue-labs/gollem/appserver/store"
+	"github.com/fugue-labs/gollem/core"
+	"github.com/google/uuid"
+)
+
+const (
+	runtimeSteerItemKind       = "steer"
+	runtimeSteerMessageMaxSize = 64 << 10
+	runtimeSteerIDMaxSize      = 256
+	runtimeSteerStatusQueued   = "queued"
+	runtimeSteerStatusComplete = "completed"
+	runtimeSteerStatusFailed   = "failed"
+)
+
+var (
+	ErrRuntimeSteerIdempotencyConflict = errors.New("appserver/runtime: steer idempotency conflict")
+	ErrRuntimeSteerMessageTooLarge     = errors.New("appserver/runtime: steer message is too large")
+	ErrRuntimeSteerIDTooLarge          = errors.New("appserver/runtime: steer client message ID is too large")
+)
+
+type RuntimeSteerRequest struct {
+	ThreadID            string
+	TurnID              string
+	ClientUserMessageID string
+	Message             string
+}
+
+type RuntimeSteerResult struct {
+	TurnID              string
+	ClientUserMessageID string
+	Item                *store.Item
+	Reused              bool
+}
+
+type runtimeSteerPayload struct {
+	ClientUserMessageID string     `json:"clientUserMessageId"`
+	Message             string     `json:"message"`
+	Status              string     `json:"status"`
+	QueuedAt            time.Time  `json:"queuedAt"`
+	ConsumedAfterSeq    int64      `json:"consumedAfterSeq,omitempty"`
+	ConsumedAt          *time.Time `json:"consumedAt,omitempty"`
+	FailedAt            *time.Time `json:"failedAt,omitempty"`
+	Error               string     `json:"error,omitempty"`
+}
+
+type runtimeSteerItemState struct {
+	item             *store.Item
+	payload          runtimeSteerPayload
+	preparedAfterSeq int64
+	acceptErr        error
+}
+
+type runtimeSteerState struct {
+	mu       sync.Mutex
+	store    store.Store
+	notifier runtimeNotifier
+	turn     *store.Turn
+	queue    *core.SteerQueue
+	byClient map[string]*runtimeSteerItemState
+	byItem   map[string]*runtimeSteerItemState
+}
+
+func newActiveRuntimeTurn(
+	cancel context.CancelFunc,
+	st store.Store,
+	notifier runtimeNotifier,
+	turn *store.Turn,
+) *activeRuntimeTurn {
+	state := &runtimeSteerState{
+		store:    st,
+		notifier: notifier,
+		turn:     turn,
+		byClient: make(map[string]*runtimeSteerItemState),
+		byItem:   make(map[string]*runtimeSteerItemState),
+	}
+	state.queue = core.NewSteerQueue(core.SteerQueueHooks{
+		OnPrepared: state.prepare,
+		OnConsumed: state.consume,
+		OnRejected: state.reject,
+	})
+	return &activeRuntimeTurn{cancel: cancel, runtimeSteerState: state}
+}
+
+func (s *RuntimeService) Steer(
+	ctx context.Context,
+	req RuntimeSteerRequest,
+) (*RuntimeSteerResult, error) {
+	if s == nil {
+		return nil, ErrRuntimeNotConfigured
+	}
+	req.ThreadID = strings.TrimSpace(req.ThreadID)
+	req.TurnID = strings.TrimSpace(req.TurnID)
+	req.ClientUserMessageID = strings.TrimSpace(req.ClientUserMessageID)
+	req.Message = strings.TrimSpace(req.Message)
+	if req.ThreadID == "" || req.TurnID == "" {
+		return nil, store.ErrTurnNotFound
+	}
+	if req.Message == "" {
+		return nil, core.ErrSteerMessageEmpty
+	}
+	if len(req.Message) > runtimeSteerMessageMaxSize {
+		return nil, fmt.Errorf("%w: maximum is %d bytes", ErrRuntimeSteerMessageTooLarge, runtimeSteerMessageMaxSize)
+	}
+	if req.ClientUserMessageID == "" {
+		req.ClientUserMessageID = uuid.NewString()
+	}
+	if len(req.ClientUserMessageID) > runtimeSteerIDMaxSize {
+		return nil, fmt.Errorf("%w: maximum is %d bytes", ErrRuntimeSteerIDTooLarge, runtimeSteerIDMaxSize)
+	}
+
+	s.mu.Lock()
+	active := s.active[req.TurnID]
+	s.mu.Unlock()
+	if active == nil || active.runtimeSteerState == nil {
+		return nil, ErrRuntimeTurnNotActive
+	}
+	return active.enqueue(ctx, req)
+}
+
+func (s *activeRuntimeTurn) enqueue(
+	ctx context.Context,
+	req RuntimeSteerRequest,
+) (*RuntimeSteerResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.turn == nil || s.turn.ID != req.TurnID || s.turn.ThreadID != req.ThreadID {
+		return nil, store.ErrTurnNotFound
+	}
+	if existing := s.byClient[req.ClientUserMessageID]; existing != nil {
+		if existing.payload.Message != req.Message {
+			return nil, ErrRuntimeSteerIdempotencyConflict
+		}
+		if existing.acceptErr != nil {
+			return nil, existing.acceptErr
+		}
+		item := existing.item
+		if refreshed, err := s.store.GetItem(ctx, item.ID); err == nil {
+			item = refreshed
+		}
+		return &RuntimeSteerResult{
+			TurnID:              req.TurnID,
+			ClientUserMessageID: req.ClientUserMessageID,
+			Item:                item,
+			Reused:              true,
+		}, nil
+	}
+
+	queuedAt := time.Now().UTC()
+	payload := runtimeSteerPayload{
+		ClientUserMessageID: req.ClientUserMessageID,
+		Message:             req.Message,
+		Status:              runtimeSteerStatusQueued,
+		QueuedAt:            queuedAt,
+	}
+	item, err := s.store.AppendItem(ctx, store.AppendItemRequest{
+		ThreadID: req.ThreadID,
+		TurnID:   req.TurnID,
+		Kind:     runtimeSteerItemKind,
+		Status:   runtimeSteerStatusQueued,
+		Payload:  mustRuntimeJSON(payload),
+	})
+	if err != nil {
+		return nil, err
+	}
+	state := &runtimeSteerItemState{item: item, payload: payload}
+	s.byClient[req.ClientUserMessageID] = state
+	s.byItem[item.ID] = state
+	publishItemStarted(s.notifier, s.turn, item)
+	if err := s.queue.Enqueue(core.SteerMessage{
+		ID:       item.ID,
+		Text:     req.Message,
+		QueuedAt: queuedAt,
+	}); err != nil {
+		state.acceptErr = ErrRuntimeTurnNotActive
+		if errors.Is(err, core.ErrSteerQueueFull) {
+			state.acceptErr = err
+		}
+		s.failLocked(state, err)
+		return nil, state.acceptErr
+	}
+	return &RuntimeSteerResult{
+		TurnID:              req.TurnID,
+		ClientUserMessageID: req.ClientUserMessageID,
+		Item:                item,
+	}, nil
+}
+
+func (s *runtimeSteerState) prepare(messages []core.SteerMessage) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	items, err := s.store.ListItems(context.Background(), store.ItemFilter{
+		ThreadID: s.turn.ThreadID,
+		TurnID:   s.turn.ID,
+	})
+	if err != nil {
+		return fmt.Errorf("list steer consumption boundary: %w", err)
+	}
+	var consumedAfterSeq int64
+	for _, item := range items {
+		if item != nil && item.Seq > consumedAfterSeq {
+			consumedAfterSeq = item.Seq
+		}
+	}
+	if consumedAfterSeq == 0 {
+		return errors.New("steer consumption boundary is unavailable")
+	}
+	for _, message := range messages {
+		state := s.byItem[message.ID]
+		if state == nil || state.item == nil {
+			return fmt.Errorf("steer item %q is unavailable", message.ID)
+		}
+		if consumedAfterSeq < state.item.Seq {
+			return fmt.Errorf("steer item %q is beyond consumption boundary", message.ID)
+		}
+		state.preparedAfterSeq = consumedAfterSeq
+	}
+	return nil
+}
+
+func (s *runtimeSteerState) consume(message core.SteerMessage) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state := s.byItem[message.ID]
+	if state == nil {
+		return fmt.Errorf("steer item %q is unavailable", message.ID)
+	}
+	if state.preparedAfterSeq == 0 {
+		return fmt.Errorf("steer item %q has no prepared consumption boundary", message.ID)
+	}
+	now := time.Now().UTC()
+	state.payload.Status = runtimeSteerStatusComplete
+	state.payload.ConsumedAfterSeq = state.preparedAfterSeq
+	state.payload.ConsumedAt = &now
+	state.payload.FailedAt = nil
+	state.payload.Error = ""
+	item, err := s.store.UpdateItem(context.Background(), store.UpdateItemRequest{
+		ID:      state.item.ID,
+		Status:  runtimeSteerStatusComplete,
+		Payload: mustRuntimeJSON(state.payload),
+	})
+	if err != nil {
+		return err
+	}
+	state.item = item
+	publishItemCompleted(s.notifier, s.turn, item)
+	return nil
+}
+
+func (s *runtimeSteerState) reject(message core.SteerMessage, reason error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if state := s.byItem[message.ID]; state != nil {
+		s.failLocked(state, reason)
+	}
+}
+
+func (s *runtimeSteerState) failLocked(state *runtimeSteerItemState, reason error) {
+	if state == nil || state.item == nil {
+		return
+	}
+	now := time.Now().UTC()
+	state.payload.Status = runtimeSteerStatusFailed
+	state.preparedAfterSeq = 0
+	state.payload.ConsumedAfterSeq = 0
+	state.payload.ConsumedAt = nil
+	state.payload.FailedAt = &now
+	if reason != nil {
+		state.payload.Error = reason.Error()
+	}
+	item, err := s.store.UpdateItem(context.Background(), store.UpdateItemRequest{
+		ID:      state.item.ID,
+		Status:  runtimeSteerStatusFailed,
+		Payload: mustRuntimeJSON(state.payload),
+	})
+	if err != nil {
+		return
+	}
+	state.item = item
+	publishItemCompleted(s.notifier, s.turn, item)
+}
+
+func runtimeSteerText(input []protocol.UserInput) (string, error) {
+	if len(input) == 0 {
+		return "", errors.New("turn steer input must contain at least one text item")
+	}
+	parts := make([]string, 0, len(input))
+	for _, item := range input {
+		if item.Type != "text" {
+			return "", fmt.Errorf("turn steer input type %q is not supported by the live runtime", item.Type)
+		}
+		text := strings.TrimSpace(item.Text)
+		if text != "" {
+			parts = append(parts, text)
+		}
+	}
+	message := strings.TrimSpace(strings.Join(parts, "\n\n"))
+	if message == "" {
+		return "", core.ErrSteerMessageEmpty
+	}
+	return message, nil
+}

--- a/appserver/runtime_test.go
+++ b/appserver/runtime_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -19,6 +21,32 @@ type turnStartupFailureStore struct {
 	appendErr error
 	startErr  error
 	updateErr error
+}
+
+type failNextRuntimeItemListStore struct {
+	store.Store
+	mu       sync.Mutex
+	failNext bool
+}
+
+func (s *failNextRuntimeItemListStore) arm() {
+	s.mu.Lock()
+	s.failNext = true
+	s.mu.Unlock()
+}
+
+func (s *failNextRuntimeItemListStore) ListItems(
+	ctx context.Context,
+	filter store.ItemFilter,
+) ([]*store.Item, error) {
+	s.mu.Lock()
+	fail := s.failNext
+	s.failNext = false
+	s.mu.Unlock()
+	if fail {
+		return nil, errors.New("item boundary unavailable")
+	}
+	return s.Store.ListItems(ctx, filter)
 }
 
 func (s turnStartupFailureStore) AppendItem(
@@ -1063,13 +1091,13 @@ func TestRuntimeShutdownRejectsNewStarts(t *testing.T) {
 	}
 }
 
-func TestServerRuntimeTurnSteerRecordsActiveMessage(t *testing.T) {
+func TestServerRuntimeTurnSteerIsConsumedAndCompleted(t *testing.T) {
 	ctx := context.Background()
 	st := newRuntimeTestStore(t)
-	model := &blockingRuntimeModel{started: make(chan struct{})}
+	model := newSteerRuntimeModel()
 	server := readyServer(
 		WithStore(st),
-		WithRuntimeService(NewRuntimeService(WithRuntimeModel(model, RuntimeModelInfo{ProviderID: "test", Model: "blocking"}))),
+		WithRuntimeService(NewRuntimeService(WithRuntimeModel(model, RuntimeModelInfo{ProviderID: "test", Model: "steer"}))),
 	)
 
 	startResp := server.HandleRequest(ctx, request("thread/start", map[string]any{"prompt": "block"}))
@@ -1080,29 +1108,532 @@ func TestServerRuntimeTurnSteerRecordsActiveMessage(t *testing.T) {
 		Turn *store.Turn `json:"turn"`
 	}
 	decodeResult(t, startResp, &started)
-	waitForBlockingModel(t, model)
+	model.waitStarted(t)
 
 	steerResp := server.HandleRequest(ctx, request("turn/steer", map[string]any{
-		"turnId":  started.Turn.ID,
-		"message": "adjust course",
+		"threadId":            started.Turn.ThreadID,
+		"expectedTurnId":      started.Turn.ID,
+		"clientUserMessageId": "steer-client-1",
+		"input": []map[string]any{{
+			"type":          "text",
+			"text":          "adjust course",
+			"text_elements": []any{},
+		}},
 	}))
 	if steerResp.Error != nil {
 		t.Fatalf("turn/steer error: %v", steerResp.Error)
 	}
 	var steer struct {
-		Accepted bool        `json:"accepted"`
-		Item     *store.Item `json:"item"`
+		TurnID string `json:"turnId"`
 	}
 	decodeResult(t, steerResp, &steer)
-	if !steer.Accepted || steer.Item == nil || steer.Item.Kind != "steer" || steer.Item.Status != "queued" {
+	if steer.TurnID != started.Turn.ID {
 		t.Fatalf("turn/steer result = %#v", steer)
 	}
+	model.releaseFirst()
+	notifications := waitForNotificationSet(t, server, "turn/completed")
+	assertRuntimeSteerNotificationOrder(t, notifications)
+	assertRuntimeSteerDeltaBoundary(t, notifications)
 
-	interruptResp := server.HandleRequest(ctx, request("turn/interrupt", map[string]any{"turnId": started.Turn.ID}))
-	if interruptResp.Error != nil {
-		t.Fatalf("turn/interrupt error: %v", interruptResp.Error)
+	calls := model.callsSnapshot()
+	if len(calls) != 2 || !runtimeMessagesContainText(calls[1], "adjust course") {
+		t.Fatalf("model calls = %#v, want consumed steer in second request", calls)
+	}
+	readResp := server.HandleRequest(ctx, request("thread/read", map[string]any{
+		"threadId": started.Turn.ThreadID,
+	}))
+	if readResp.Error != nil {
+		t.Fatalf("thread/read error: %v", readResp.Error)
+	}
+	var read protocol.ThreadReadResult
+	decodeResult(t, readResp, &read)
+	var steerItem *protocol.TimelineItem
+	for i := range read.Items {
+		if read.Items[i].Kind == runtimeSteerItemKind {
+			steerItem = &read.Items[i]
+		}
+	}
+	if steerItem == nil || steerItem.Status != runtimeSteerStatusComplete {
+		t.Fatalf("public steer item = %#v, want completed", steerItem)
+	}
+	var payload struct {
+		ClientUserMessageID string     `json:"clientUserMessageId"`
+		Status              string     `json:"status"`
+		ConsumedAfterSeq    int64      `json:"consumedAfterSeq"`
+		ConsumedAt          *time.Time `json:"consumedAt"`
+	}
+	if err := json.Unmarshal(steerItem.Payload, &payload); err != nil {
+		t.Fatalf("decode public steer payload: %v", err)
+	}
+	if payload.ClientUserMessageID != "steer-client-1" ||
+		payload.Status != runtimeSteerStatusComplete ||
+		payload.ConsumedAfterSeq <= 0 ||
+		payload.ConsumedAt == nil {
+		t.Fatalf("steer payload = %#v", payload)
+	}
+}
+
+func TestServerRuntimeTurnSteerRejectsMismatchedUnsupportedAndOversizedInput(t *testing.T) {
+	ctx, st, server, model, turn := startSteerRuntimeTest(t)
+	cases := []struct {
+		name   string
+		params map[string]any
+	}{
+		{
+			name: "mismatched thread",
+			params: runtimeSteerTestParams(
+				"wrong-thread", turn.ID, "mismatch-thread", "do not enqueue",
+			),
+		},
+		{
+			name: "mismatched turn",
+			params: runtimeSteerTestParams(
+				turn.ThreadID, "wrong-turn", "mismatch-turn", "do not enqueue",
+			),
+		},
+		{
+			name: "unsupported image input",
+			params: map[string]any{
+				"threadId":            turn.ThreadID,
+				"expectedTurnId":      turn.ID,
+				"clientUserMessageId": "unsupported-image",
+				"input": []map[string]any{{
+					"type": "image",
+					"url":  "image.png",
+				}},
+			},
+		},
+		{
+			name: "oversized message",
+			params: runtimeSteerTestParams(
+				turn.ThreadID, turn.ID, "oversized-message",
+				strings.Repeat("x", runtimeSteerMessageMaxSize+1),
+			),
+		},
+		{
+			name: "oversized client ID",
+			params: runtimeSteerTestParams(
+				turn.ThreadID, turn.ID,
+				strings.Repeat("x", runtimeSteerIDMaxSize+1), "do not enqueue",
+			),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := server.HandleRequest(ctx, request("turn/steer", tc.params))
+			if resp.Error == nil || resp.Error.Code != protocol.CodeInvalidParams {
+				t.Fatalf("turn/steer error = %#v, want invalid params", resp.Error)
+			}
+		})
+	}
+
+	items, err := st.ListItems(ctx, store.ItemFilter{ThreadID: turn.ThreadID, TurnID: turn.ID})
+	if err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+	for _, item := range items {
+		if item.Kind == runtimeSteerItemKind {
+			t.Fatalf("rejected steer persisted item %#v", item)
+		}
+	}
+	if interrupt := server.HandleRequest(ctx, request("turn/interrupt", map[string]any{"turnId": turn.ID})); interrupt.Error != nil {
+		t.Fatalf("turn/interrupt error: %v", interrupt.Error)
 	}
 	waitForNotificationSet(t, server, "turn/completed")
+	if got := len(model.callsSnapshot()); got != 1 {
+		t.Fatalf("model calls = %d, want only initial request", got)
+	}
+}
+
+func TestServerRuntimeTurnSteerIsIdempotentWhileActive(t *testing.T) {
+	ctx, st, server, model, turn := startSteerRuntimeTest(t)
+	params := runtimeSteerTestParams(
+		turn.ThreadID, turn.ID, "stable-client-message", "adjust once",
+	)
+	for attempt := 1; attempt <= 2; attempt++ {
+		resp := server.HandleRequest(ctx, request("turn/steer", params))
+		if resp.Error != nil {
+			t.Fatalf("turn/steer attempt %d error: %v", attempt, resp.Error)
+		}
+		var result protocol.TurnSteerResponse
+		decodeResult(t, resp, &result)
+		if result.TurnID != turn.ID {
+			t.Fatalf("turn/steer attempt %d result = %#v", attempt, result)
+		}
+	}
+	conflict := server.HandleRequest(ctx, request("turn/steer", runtimeSteerTestParams(
+		turn.ThreadID, turn.ID, "stable-client-message", "different instruction",
+	)))
+	if conflict.Error == nil || conflict.Error.Code != protocol.CodeInvalidParams {
+		t.Fatalf("conflicting turn/steer error = %#v, want invalid params", conflict.Error)
+	}
+
+	items, err := st.ListItems(ctx, store.ItemFilter{ThreadID: turn.ThreadID, TurnID: turn.ID})
+	if err != nil {
+		t.Fatalf("ListItems before consume: %v", err)
+	}
+	if got := runtimeSteerItemCount(items); got != 1 {
+		t.Fatalf("steer items before consume = %d, want 1", got)
+	}
+
+	model.releaseFirst()
+	waitForNotificationSet(t, server, "turn/completed")
+	calls := model.callsSnapshot()
+	if len(calls) != 2 || runtimeMessageTextCount(calls[1], "adjust once") != 1 {
+		t.Fatalf("model calls = %#v, want one idempotent steer in second request", calls)
+	}
+	items, err = st.ListItems(ctx, store.ItemFilter{ThreadID: turn.ThreadID, TurnID: turn.ID})
+	if err != nil {
+		t.Fatalf("ListItems after consume: %v", err)
+	}
+	if got := runtimeSteerItemCount(items); got != 1 {
+		t.Fatalf("steer items after consume = %d, want 1", got)
+	}
+}
+
+func TestServerRuntimeTurnSteerQueueCapacityIsDurableAndIdempotent(t *testing.T) {
+	ctx, st, server, _, turn := startSteerRuntimeTest(t)
+	for i := range core.SteerQueueMaxPending {
+		resp := server.HandleRequest(ctx, request("turn/steer", runtimeSteerTestParams(
+			turn.ThreadID,
+			turn.ID,
+			"capacity-"+strings.Repeat("x", i+1),
+			"queued instruction",
+		)))
+		if resp.Error != nil {
+			t.Fatalf("turn/steer %d error: %v", i, resp.Error)
+		}
+	}
+	overflow := runtimeSteerTestParams(
+		turn.ThreadID, turn.ID, "capacity-overflow", "overflow instruction",
+	)
+	for attempt := 1; attempt <= 2; attempt++ {
+		resp := server.HandleRequest(ctx, request("turn/steer", overflow))
+		if resp.Error == nil || resp.Error.Code != protocol.CodeOverloaded {
+			t.Fatalf("overflow attempt %d error = %#v, want overloaded", attempt, resp.Error)
+		}
+	}
+
+	items, err := st.ListItems(ctx, store.ItemFilter{ThreadID: turn.ThreadID, TurnID: turn.ID})
+	if err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+	if got := runtimeSteerItemCount(items); got != core.SteerQueueMaxPending+1 {
+		t.Fatalf("steer items = %d, want %d", got, core.SteerQueueMaxPending+1)
+	}
+	foundOverflow := false
+	for _, item := range items {
+		if item.Kind != runtimeSteerItemKind {
+			continue
+		}
+		var payload runtimeSteerPayload
+		if err := json.Unmarshal(item.Payload, &payload); err != nil {
+			t.Fatalf("decode steer payload: %v", err)
+		}
+		if payload.ClientUserMessageID == "capacity-overflow" {
+			foundOverflow = true
+			if item.Status != runtimeSteerStatusFailed ||
+				payload.Status != runtimeSteerStatusFailed ||
+				!strings.Contains(payload.Error, core.ErrSteerQueueFull.Error()) {
+				t.Fatalf("overflow item = %#v, payload = %#v", item, payload)
+			}
+		}
+	}
+	if !foundOverflow {
+		t.Fatal("durable overflow steer item not found")
+	}
+	if interrupt := server.HandleRequest(ctx, request("turn/interrupt", map[string]any{"turnId": turn.ID})); interrupt.Error != nil {
+		t.Fatalf("turn/interrupt error: %v", interrupt.Error)
+	}
+	waitForNotificationSet(t, server, "turn/completed")
+}
+
+func TestServerRuntimeTurnSteerFailsWhenInterruptedBeforeConsumption(t *testing.T) {
+	ctx, st, server, model, turn := startSteerRuntimeTest(t)
+	resp := server.HandleRequest(ctx, request("turn/steer", runtimeSteerTestParams(
+		turn.ThreadID, turn.ID, "interrupt-client-message", "never consume",
+	)))
+	if resp.Error != nil {
+		t.Fatalf("turn/steer error: %v", resp.Error)
+	}
+	if interrupt := server.HandleRequest(ctx, request("turn/interrupt", map[string]any{"turnId": turn.ID})); interrupt.Error != nil {
+		t.Fatalf("turn/interrupt error: %v", interrupt.Error)
+	}
+	notifications := waitForNotificationSet(t, server, "turn/completed")
+	assertRuntimeSteerNotificationOrder(t, notifications)
+
+	if got := len(model.callsSnapshot()); got != 1 {
+		t.Fatalf("model calls = %d, want no request containing interrupted steer", got)
+	}
+	items, err := st.ListItems(ctx, store.ItemFilter{ThreadID: turn.ThreadID, TurnID: turn.ID})
+	if err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+	var steerItem *store.Item
+	for _, item := range items {
+		if item.Kind == runtimeSteerItemKind {
+			steerItem = item
+			break
+		}
+	}
+	if steerItem == nil || steerItem.Status != runtimeSteerStatusFailed {
+		t.Fatalf("steer item = %#v, want failed", steerItem)
+	}
+	var payload runtimeSteerPayload
+	if err := json.Unmarshal(steerItem.Payload, &payload); err != nil {
+		t.Fatalf("decode steer payload: %v", err)
+	}
+	if payload.Status != runtimeSteerStatusFailed ||
+		payload.FailedAt == nil ||
+		payload.ConsumedAt != nil ||
+		payload.Error == "" {
+		t.Fatalf("steer payload = %#v, want rejected before consumption", payload)
+	}
+}
+
+func TestServerRuntimeTurnSteerFailsWhenModelFactoryCannotStart(t *testing.T) {
+	ctx := context.Background()
+	st := newRuntimeTestStore(t)
+	factoryStarted := make(chan struct{})
+	releaseFactory := make(chan struct{})
+	runtimeSvc := NewRuntimeService(WithRuntimeModelFactory(func(
+		context.Context,
+		RuntimeModelSelection,
+	) (core.Model, RuntimeModelInfo, error) {
+		close(factoryStarted)
+		<-releaseFactory
+		return nil, RuntimeModelInfo{ProviderID: "unavailable"}, errors.New("model factory unavailable")
+	}))
+	server := readyServer(WithStore(st), WithRuntimeService(runtimeSvc))
+	startResp := server.HandleRequest(ctx, request("thread/start", map[string]any{"prompt": "wait for factory"}))
+	if startResp.Error != nil {
+		t.Fatalf("thread/start error: %v", startResp.Error)
+	}
+	var started struct {
+		Turn *store.Turn `json:"turn"`
+	}
+	decodeResult(t, startResp, &started)
+	select {
+	case <-factoryStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("model factory did not start")
+	}
+
+	steerResp := server.HandleRequest(ctx, request("turn/steer", runtimeSteerTestParams(
+		started.Turn.ThreadID, started.Turn.ID, "factory-failure", "cannot consume",
+	)))
+	if steerResp.Error != nil {
+		t.Fatalf("turn/steer error: %v", steerResp.Error)
+	}
+	close(releaseFactory)
+	notifications := waitForNotificationSet(t, server, "turn/completed")
+	assertRuntimeSteerNotificationOrder(t, notifications)
+
+	items, err := st.ListItems(ctx, store.ItemFilter{
+		ThreadID: started.Turn.ThreadID,
+		TurnID:   started.Turn.ID,
+	})
+	if err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+	for _, item := range items {
+		if item.Kind != runtimeSteerItemKind {
+			continue
+		}
+		if item.Status != runtimeSteerStatusFailed {
+			t.Fatalf("steer item status = %q, want failed", item.Status)
+		}
+		var payload runtimeSteerPayload
+		if err := json.Unmarshal(item.Payload, &payload); err != nil {
+			t.Fatalf("decode steer payload: %v", err)
+		}
+		if payload.FailedAt == nil || payload.ConsumedAt != nil || !strings.Contains(payload.Error, "model factory unavailable") {
+			t.Fatalf("steer payload = %#v", payload)
+		}
+		return
+	}
+	t.Fatal("steer item not found")
+}
+
+func TestServerRuntimeTurnSteerFailsClosedWhenConsumptionBoundaryCannotPersist(t *testing.T) {
+	ctx := context.Background()
+	base := newRuntimeTestStore(t)
+	failing := &failNextRuntimeItemListStore{Store: base}
+	model := newSteerRuntimeModel()
+	server := readyServer(
+		WithStore(failing),
+		WithRuntimeService(NewRuntimeService(WithRuntimeModel(
+			model,
+			RuntimeModelInfo{ProviderID: "test", Model: "steer"},
+		))),
+	)
+	startResp := server.HandleRequest(ctx, request("thread/start", map[string]any{"prompt": "block"}))
+	if startResp.Error != nil {
+		t.Fatalf("thread/start error: %v", startResp.Error)
+	}
+	var started struct {
+		Turn *store.Turn `json:"turn"`
+	}
+	decodeResult(t, startResp, &started)
+	model.waitStarted(t)
+	steerResp := server.HandleRequest(ctx, request("turn/steer", runtimeSteerTestParams(
+		started.Turn.ThreadID, started.Turn.ID, "boundary-failure", "fail closed",
+	)))
+	if steerResp.Error != nil {
+		t.Fatalf("turn/steer error: %v", steerResp.Error)
+	}
+
+	failing.arm()
+	model.releaseFirst()
+	waitForNotificationSet(t, server, "turn/completed")
+	turn, err := base.GetTurn(ctx, started.Turn.ID)
+	if err != nil {
+		t.Fatalf("GetTurn: %v", err)
+	}
+	if turn.Status != store.TurnFailed || !strings.Contains(turn.Error, "item boundary unavailable") {
+		t.Fatalf("turn = %#v, want failed consumption acknowledgement", turn)
+	}
+	items, err := base.ListItems(ctx, store.ItemFilter{
+		ThreadID: started.Turn.ThreadID,
+		TurnID:   started.Turn.ID,
+	})
+	if err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+	for _, item := range items {
+		if item.Kind != runtimeSteerItemKind {
+			continue
+		}
+		var payload runtimeSteerPayload
+		if err := json.Unmarshal(item.Payload, &payload); err != nil {
+			t.Fatalf("decode steer payload: %v", err)
+		}
+		if item.Status != runtimeSteerStatusFailed ||
+			payload.Status != runtimeSteerStatusFailed ||
+			payload.ConsumedAfterSeq != 0 ||
+			payload.ConsumedAt != nil ||
+			payload.FailedAt == nil {
+			t.Fatalf("failed steer item = %#v, payload = %#v", item, payload)
+		}
+		return
+	}
+	t.Fatal("steer item not found")
+}
+
+func startSteerRuntimeTest(
+	t *testing.T,
+) (context.Context, *store.SQLiteStore, *Server, *steerRuntimeModel, *store.Turn) {
+	t.Helper()
+	ctx := context.Background()
+	st := newRuntimeTestStore(t)
+	model := newSteerRuntimeModel()
+	server := readyServer(
+		WithStore(st),
+		WithRuntimeService(NewRuntimeService(WithRuntimeModel(
+			model,
+			RuntimeModelInfo{ProviderID: "test", Model: "steer"},
+		))),
+	)
+	startResp := server.HandleRequest(ctx, request("thread/start", map[string]any{"prompt": "block"}))
+	if startResp.Error != nil {
+		t.Fatalf("thread/start error: %v", startResp.Error)
+	}
+	var started struct {
+		Turn *store.Turn `json:"turn"`
+	}
+	decodeResult(t, startResp, &started)
+	model.waitStarted(t)
+	return ctx, st, server, model, started.Turn
+}
+
+func runtimeSteerTestParams(threadID, turnID, clientID, message string) map[string]any {
+	return map[string]any{
+		"threadId":            threadID,
+		"expectedTurnId":      turnID,
+		"clientUserMessageId": clientID,
+		"input": []map[string]any{{
+			"type":          "text",
+			"text":          message,
+			"text_elements": []any{},
+		}},
+	}
+}
+
+func runtimeSteerItemCount(items []*store.Item) int {
+	count := 0
+	for _, item := range items {
+		if item != nil && item.Kind == runtimeSteerItemKind {
+			count++
+		}
+	}
+	return count
+}
+
+func assertRuntimeSteerNotificationOrder(t *testing.T, notifications []protocol.Notification) {
+	t.Helper()
+	started := -1
+	completed := -1
+	for i, notification := range notifications {
+		if notification.Method != "item/started" && notification.Method != "item/completed" {
+			continue
+		}
+		var params runtimeItemNotificationParams
+		if err := json.Unmarshal(notification.Params, &params); err != nil {
+			t.Fatalf("decode %s: %v", notification.Method, err)
+		}
+		if params.Item == nil || params.Item.Kind != runtimeSteerItemKind {
+			continue
+		}
+		switch notification.Method {
+		case "item/started":
+			started = i
+		case "item/completed":
+			completed = i
+		}
+	}
+	if started < 0 || completed < 0 || started >= completed {
+		t.Fatalf("steer lifecycle order = started:%d completed:%d in %v", started, completed, notificationMethods(notifications))
+	}
+}
+
+func assertRuntimeSteerDeltaBoundary(t *testing.T, notifications []protocol.Notification) {
+	t.Helper()
+	firstDelta := -1
+	completed := -1
+	secondDelta := -1
+	for i, notification := range notifications {
+		switch notification.Method {
+		case "item/agentMessage/delta":
+			var params runtimeDeltaNotificationParams
+			if err := json.Unmarshal(notification.Params, &params); err != nil {
+				t.Fatalf("decode agent-message delta: %v", err)
+			}
+			switch params.Delta {
+			case "first answer":
+				firstDelta = i
+			case "steered answer":
+				secondDelta = i
+			}
+		case "item/completed":
+			var params runtimeItemNotificationParams
+			if err := json.Unmarshal(notification.Params, &params); err != nil {
+				t.Fatalf("decode item/completed: %v", err)
+			}
+			if params.Item != nil && params.Item.Kind == runtimeSteerItemKind {
+				completed = i
+			}
+		}
+	}
+	if firstDelta < 0 || completed < 0 || secondDelta < 0 ||
+		firstDelta >= completed || completed >= secondDelta {
+		t.Fatalf(
+			"steer delta boundary = first:%d completed:%d second:%d in %v",
+			firstDelta,
+			completed,
+			secondDelta,
+			notificationMethods(notifications),
+		)
+	}
 }
 
 func newRuntimeTestStore(t *testing.T) *store.SQLiteStore {
@@ -1314,3 +1845,160 @@ func waitForBlockingModel(t *testing.T, model *blockingRuntimeModel) {
 		t.Fatal("blocking model did not start")
 	}
 }
+
+type steerRuntimeModel struct {
+	mu      sync.Mutex
+	calls   [][]core.ModelMessage
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func newSteerRuntimeModel() *steerRuntimeModel {
+	return &steerRuntimeModel{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+}
+
+func (m *steerRuntimeModel) Request(
+	context.Context,
+	[]core.ModelMessage,
+	*core.ModelSettings,
+	*core.ModelRequestParameters,
+) (*core.ModelResponse, error) {
+	return nil, errors.New("streaming required")
+}
+
+func (m *steerRuntimeModel) RequestStream(
+	ctx context.Context,
+	messages []core.ModelMessage,
+	_ *core.ModelSettings,
+	_ *core.ModelRequestParameters,
+) (core.StreamedResponse, error) {
+	m.mu.Lock()
+	call := append([]core.ModelMessage(nil), messages...)
+	m.calls = append(m.calls, call)
+	index := len(m.calls)
+	m.mu.Unlock()
+	if index == 1 {
+		m.once.Do(func() { close(m.started) })
+		return &gatedRuntimeStream{
+			ctx:      ctx,
+			release:  m.release,
+			response: core.TextResponse("first answer"),
+		}, nil
+	}
+	return newRuntimeResponseStream(core.TextResponse("steered answer")), nil
+}
+
+func (*steerRuntimeModel) ModelName() string { return "steer" }
+
+func (m *steerRuntimeModel) waitStarted(t *testing.T) {
+	t.Helper()
+	select {
+	case <-m.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("steer model did not start")
+	}
+}
+
+func (m *steerRuntimeModel) releaseFirst() {
+	close(m.release)
+}
+
+func (m *steerRuntimeModel) callsSnapshot() [][]core.ModelMessage {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([][]core.ModelMessage, len(m.calls))
+	for i := range m.calls {
+		out[i] = append([]core.ModelMessage(nil), m.calls[i]...)
+	}
+	return out
+}
+
+func runtimeMessagesContainText(messages []core.ModelMessage, want string) bool {
+	return runtimeMessageTextCount(messages, want) > 0
+}
+
+func runtimeMessageTextCount(messages []core.ModelMessage, want string) int {
+	count := 0
+	for _, message := range messages {
+		request, ok := message.(core.ModelRequest)
+		if !ok {
+			continue
+		}
+		for _, part := range request.Parts {
+			if prompt, ok := part.(core.UserPromptPart); ok && prompt.Content == want {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+type gatedRuntimeStream struct {
+	ctx      context.Context
+	release  <-chan struct{}
+	response *core.ModelResponse
+	inner    core.StreamedResponse
+}
+
+func (s *gatedRuntimeStream) Next() (core.ModelResponseStreamEvent, error) {
+	if s.inner == nil {
+		select {
+		case <-s.ctx.Done():
+			return nil, s.ctx.Err()
+		case <-s.release:
+			s.inner = newRuntimeResponseStream(s.response)
+		}
+	}
+	return s.inner.Next()
+}
+
+func (s *gatedRuntimeStream) Response() *core.ModelResponse {
+	if s.inner == nil {
+		return s.response
+	}
+	return s.inner.Response()
+}
+
+func (s *gatedRuntimeStream) Usage() core.Usage {
+	if s.inner == nil {
+		return s.response.Usage
+	}
+	return s.inner.Usage()
+}
+
+func (s *gatedRuntimeStream) Close() error {
+	if s.inner != nil {
+		return s.inner.Close()
+	}
+	return nil
+}
+
+func newRuntimeResponseStream(response *core.ModelResponse) core.StreamedResponse {
+	return &runtimeResponseStream{response: response}
+}
+
+type runtimeResponseStream struct {
+	response *core.ModelResponse
+	phase    int
+}
+
+func (s *runtimeResponseStream) Next() (core.ModelResponseStreamEvent, error) {
+	switch s.phase {
+	case 0:
+		s.phase++
+		return core.PartStartEvent{Index: 0, Part: s.response.Parts[0]}, nil
+	case 1:
+		s.phase++
+		return core.PartEndEvent{Index: 0}, nil
+	default:
+		return nil, io.EOF
+	}
+}
+
+func (s *runtimeResponseStream) Response() *core.ModelResponse { return s.response }
+func (s *runtimeResponseStream) Usage() core.Usage             { return s.response.Usage }
+func (s *runtimeResponseStream) Close() error                  { return nil }

--- a/appserver/scheduler.go
+++ b/appserver/scheduler.go
@@ -103,7 +103,7 @@ func RequestScheduleFor(method string, params json.RawMessage) RequestSchedule {
 	case "thread/list", "thread/search", "thread/loaded/list", "thread/unsubscribe", "thread/read", "thread/fork", "thread/compact/start", "thread/shellCommand", "thread/approveGuardianDeniedAction", "thread/rollback", "thread/archive", "thread/unarchive", "thread/delete", "thread/settings/update",
 		"thread/goal/get", "thread/goal/set", "thread/goal/clear", "thread/metadata/update", "thread/memoryMode/set",
 		"thread/name/set", "thread/turns/list", "thread/items/list", "thread/inject_items",
-		"thread/start", "thread/resume", "turn/start", "turn/retry":
+		"thread/start", "thread/resume", "turn/start", "turn/steer", "turn/retry":
 		return RequestSchedule{Scope: "thread", Serial: true}
 	case "item/fileChange/revert":
 		return RequestSchedule{Scope: "file-change-revert", Serial: true}

--- a/appserver/scheduler_test.go
+++ b/appserver/scheduler_test.go
@@ -163,6 +163,7 @@ func TestRequestScheduleForThreadControls(t *testing.T) {
 		"thread/resume",
 		"turn/start",
 		"turn/retry",
+		"turn/steer",
 	}
 	for _, method := range methods {
 		t.Run(method, func(t *testing.T) {

--- a/appserver/server.go
+++ b/appserver/server.go
@@ -1382,46 +1382,40 @@ func (s *Server) handleTurnInterrupt(ctx context.Context, raw json.RawMessage) (
 }
 
 func (s *Server) handleTurnSteer(ctx context.Context, raw json.RawMessage) (any, *protocol.Error) {
-	st, runtimeSvc, rpcErr := s.requireRuntime("turn/steer")
+	_, runtimeSvc, rpcErr := s.requireRuntime("turn/steer")
 	if rpcErr != nil {
 		return nil, rpcErr
 	}
-	var params turnSteerParams
+	var params protocol.TurnSteerParams
 	if rpcErr := decodeParams(raw, &params); rpcErr != nil {
 		return nil, rpcErr
 	}
-	turnID := firstNonEmpty(params.TurnID, params.ID)
-	if turnID == "" {
-		return nil, invalidParams("turnId is required", nil)
+	params.ThreadID = strings.TrimSpace(params.ThreadID)
+	params.ExpectedTurnID = strings.TrimSpace(params.ExpectedTurnID)
+	if params.ThreadID == "" {
+		return nil, invalidParams("threadId is required", nil)
 	}
-	message := strings.TrimSpace(firstNonEmpty(params.Prompt, params.Message, params.Text))
-	if message == "" {
-		return nil, invalidParams("message is required", nil)
+	if params.ExpectedTurnID == "" {
+		return nil, invalidParams("expectedTurnId is required", nil)
 	}
-	turn, err := st.GetTurn(ctx, turnID)
+	message, err := runtimeSteerText(params.Input)
 	if err != nil {
-		return nil, mapError("turn/steer", err)
+		return nil, invalidParams("invalid steer input", err)
 	}
-	item, err := st.AppendItem(ctx, store.AppendItemRequest{
-		ThreadID: turn.ThreadID,
-		TurnID:   turn.ID,
-		Kind:     "steer",
-		Status:   "queued",
-		Payload: mustRuntimeJSON(map[string]any{
-			"message": message,
-			"at":      time.Now().UTC(),
-		}),
+	clientUserMessageID := ""
+	if params.ClientUserMessageID != nil {
+		clientUserMessageID = *params.ClientUserMessageID
+	}
+	result, err := runtimeSvc.Steer(ctx, RuntimeSteerRequest{
+		ThreadID:            params.ThreadID,
+		TurnID:              params.ExpectedTurnID,
+		ClientUserMessageID: clientUserMessageID,
+		Message:             message,
 	})
 	if err != nil {
 		return nil, mapError("turn/steer", err)
 	}
-	accepted := runtimeSvc.IsActive(turn.ID)
-	return map[string]any{
-		"accepted": accepted,
-		"turnId":   turn.ID,
-		"item":     item,
-		"reason":   runtimeSteerReason(accepted),
-	}, nil
+	return protocol.TurnSteerResponse{TurnID: result.TurnID}, nil
 }
 
 func (s *Server) handleTurnRetry(ctx context.Context, raw json.RawMessage) (any, *protocol.Error) {
@@ -2319,6 +2313,8 @@ func mapError(method string, err error) *protocol.Error {
 	switch {
 	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
 		return rpcError(protocol.CodeInvalidRequest, "request context ended", err)
+	case errors.Is(err, core.ErrSteerQueueFull):
+		return rpcError(protocol.CodeOverloaded, "steer queue is full", err)
 	case errors.Is(err, toolprocess.ErrPTYUnsupported):
 		return protocol.MethodUnavailableErrorWithReason(method, "pty resize is not supported until a PTY backend is configured")
 	case errors.Is(err, toolfs.ErrPathOutsideRoot),
@@ -2355,7 +2351,12 @@ func mapError(method string, err error) *protocol.Error {
 		errors.Is(err, ErrMemoryRootRequired),
 		errors.Is(err, ErrMemoryRootUnsafe),
 		errors.Is(err, ErrWorkspaceRevertInProgress),
-		errors.Is(err, ErrRuntimePromptEmpty):
+		errors.Is(err, ErrRuntimePromptEmpty),
+		errors.Is(err, ErrRuntimeTurnNotActive),
+		errors.Is(err, ErrRuntimeSteerIdempotencyConflict),
+		errors.Is(err, ErrRuntimeSteerMessageTooLarge),
+		errors.Is(err, ErrRuntimeSteerIDTooLarge),
+		errors.Is(err, core.ErrSteerMessageEmpty):
 		return invalidParams("invalid params", err)
 	case errors.Is(err, toolfs.ErrApprovalDenied),
 		errors.Is(err, toolgit.ErrApprovalDenied),

--- a/core/agent.go
+++ b/core/agent.go
@@ -452,6 +452,7 @@ type runConfig struct {
 	batchConcurrency    int
 	detach              <-chan struct{}
 	toolState           map[string]any
+	steerQueue          *SteerQueue
 }
 
 // WithRunDeps sets dependencies available to tools via RunContext.
@@ -516,6 +517,14 @@ func WithDetach(ch <-chan struct{}) RunOption {
 	}
 }
 
+// WithSteerQueue attaches a queue consumed at safe model-request boundaries.
+// It is supported by RunStream; synchronous Run rejects this option.
+func WithSteerQueue(queue *SteerQueue) RunOption {
+	return func(c *runConfig) {
+		c.steerQueue = queue
+	}
+}
+
 func (a *Agent[T]) ensureOutputSchema() *OutputSchema {
 	a.outputSchemaMu.Lock()
 	defer a.outputSchemaMu.Unlock()
@@ -530,6 +539,10 @@ func (a *Agent[T]) Run(ctx context.Context, prompt string, opts ...RunOption) (*
 	cfg := &runConfig{}
 	for _, opt := range opts {
 		opt(cfg)
+	}
+	if cfg.steerQueue != nil {
+		cfg.steerQueue.close(ErrSteeringNeedsStreaming)
+		return nil, ErrSteeringNeedsStreaming
 	}
 
 	// Build output schema.
@@ -623,10 +636,12 @@ func (a *Agent[T]) RunStream(ctx context.Context, prompt string, opts ...RunOpti
 	var err error
 	prompt, err = a.applyInputGuardrails(ctx, state, deps, prompt, true)
 	if err != nil {
+		cfg.steerQueue.close(err)
 		return nil, err
 	}
 
 	if err := a.bootstrapRunMessages(ctx, state, prompt, deps, cfg.deferredResults, cfg.initialRequestParts); err != nil {
+		cfg.steerQueue.close(err)
 		return nil, err
 	}
 
@@ -663,7 +678,19 @@ func (a *Agent[T]) RunStream(ctx context.Context, prompt string, opts ...RunOpti
 		outputToolNames[ot.Name] = true
 	}
 
-	stream := newAgentStream(a, ctx, state, settings, limits, deps, prompt, allTools, toolMap, outputToolNames)
+	stream := newAgentStream(
+		a,
+		ctx,
+		state,
+		settings,
+		limits,
+		deps,
+		prompt,
+		allTools,
+		toolMap,
+		outputToolNames,
+		cfg.steerQueue,
+	)
 
 	initialMessages := make([]ModelMessage, len(state.messages))
 	copy(initialMessages, state.messages)

--- a/core/steer.go
+++ b/core/steer.go
@@ -1,0 +1,149 @@
+package core
+
+import (
+	"errors"
+	"strings"
+	"sync"
+	"time"
+)
+
+var (
+	ErrSteerQueueClosed       = errors.New("core: steer queue is closed")
+	ErrSteerQueueFull         = errors.New("core: steer queue is full")
+	ErrSteerMessageEmpty      = errors.New("core: steer message is empty")
+	ErrSteeringNeedsStreaming = errors.New("core: steering requires RunStream")
+)
+
+// SteerQueueMaxPending bounds instructions waiting for a safe request boundary.
+const SteerQueueMaxPending = 64
+
+// SteerMessage is one user instruction queued for the next safe model-request
+// boundary of an active streaming run.
+type SteerMessage struct {
+	ID       string
+	Text     string
+	QueuedAt time.Time
+}
+
+// SteerQueueHooks let a runtime prepare a durable request boundary, acknowledge
+// when an instruction enters that request, or reject it when the run ends first.
+type SteerQueueHooks struct {
+	OnPrepared func([]SteerMessage) error
+	OnConsumed func(SteerMessage) error
+	OnRejected func(SteerMessage, error)
+}
+
+// SteerQueue accepts concurrent steering instructions for one streaming run.
+// The agent owns draining and terminal closure.
+type SteerQueue struct {
+	mu      sync.Mutex
+	pending []SteerMessage
+	closed  bool
+	hooks   SteerQueueHooks
+}
+
+func NewSteerQueue(hooks SteerQueueHooks) *SteerQueue {
+	return &SteerQueue{hooks: hooks}
+}
+
+func (q *SteerQueue) Enqueue(message SteerMessage) error {
+	if q == nil {
+		return ErrSteerQueueClosed
+	}
+	message.Text = strings.TrimSpace(message.Text)
+	if message.Text == "" {
+		return ErrSteerMessageEmpty
+	}
+	if message.QueuedAt.IsZero() {
+		message.QueuedAt = time.Now().UTC()
+	}
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.closed {
+		return ErrSteerQueueClosed
+	}
+	if len(q.pending) >= SteerQueueMaxPending {
+		return ErrSteerQueueFull
+	}
+	q.pending = append(q.pending, message)
+	return nil
+}
+
+// RejectAll closes the queue and rejects every instruction that has not
+// entered a model request. It is intended for runtime setup failures before an
+// agent stream takes ownership.
+func (q *SteerQueue) RejectAll(reason error) {
+	q.close(reason)
+}
+
+func (q *SteerQueue) take(terminal bool) []SteerMessage {
+	if q == nil {
+		return nil
+	}
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.closed {
+		return nil
+	}
+	if len(q.pending) == 0 {
+		if terminal {
+			q.closed = true
+		}
+		return nil
+	}
+	messages := append([]SteerMessage(nil), q.pending...)
+	q.pending = nil
+	return messages
+}
+
+func (q *SteerQueue) consumed(messages []SteerMessage) error {
+	if q == nil || len(messages) == 0 || q.hooks.OnConsumed == nil {
+		return nil
+	}
+	for i, message := range messages {
+		if err := q.hooks.OnConsumed(message); err != nil {
+			q.reject(messages[i:], err)
+			return err
+		}
+	}
+	return nil
+}
+
+func (q *SteerQueue) prepared(messages []SteerMessage) error {
+	if q == nil || len(messages) == 0 || q.hooks.OnPrepared == nil {
+		return nil
+	}
+	if err := q.hooks.OnPrepared(append([]SteerMessage(nil), messages...)); err != nil {
+		q.reject(messages, err)
+		return err
+	}
+	return nil
+}
+
+func (q *SteerQueue) reject(messages []SteerMessage, reason error) {
+	if q == nil || len(messages) == 0 || q.hooks.OnRejected == nil {
+		return
+	}
+	for _, message := range messages {
+		q.hooks.OnRejected(message, reason)
+	}
+}
+
+func (q *SteerQueue) close(reason error) {
+	if q == nil {
+		return
+	}
+	if reason == nil {
+		reason = ErrSteerQueueClosed
+	}
+	q.mu.Lock()
+	if q.closed {
+		q.mu.Unlock()
+		return
+	}
+	q.closed = true
+	pending := append([]SteerMessage(nil), q.pending...)
+	q.pending = nil
+	q.mu.Unlock()
+	q.reject(pending, reason)
+}

--- a/core/steer_test.go
+++ b/core/steer_test.go
@@ -1,0 +1,320 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"io"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestRunStreamConsumesQueuedSteerBeforeTerminalResult(t *testing.T) {
+	model := NewTestModel(TextResponse("first answer"), TextResponse("steered answer"))
+	var consumed []SteerMessage
+	queue := NewSteerQueue(SteerQueueHooks{
+		OnConsumed: func(message SteerMessage) error {
+			consumed = append(consumed, message)
+			return nil
+		},
+	})
+	agent := NewAgent[string](model)
+	stream, err := agent.RunStream(context.Background(), "initial prompt", WithSteerQueue(queue))
+	if err != nil {
+		t.Fatalf("RunStream: %v", err)
+	}
+	if err := queue.Enqueue(SteerMessage{ID: "steer-1", Text: "change direction"}); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+
+	result, err := stream.Result()
+	if err != nil {
+		t.Fatalf("Result: %v", err)
+	}
+	if result.Output != "steered answer" {
+		t.Fatalf("output = %q, want steered answer", result.Output)
+	}
+	if len(consumed) != 1 || consumed[0].ID != "steer-1" {
+		t.Fatalf("consumed = %#v", consumed)
+	}
+
+	calls := model.Calls()
+	if len(calls) != 2 {
+		t.Fatalf("model calls = %d, want 2", len(calls))
+	}
+	assertSteerMessage(t, calls[1].Messages, "change direction")
+	if err := queue.Enqueue(SteerMessage{ID: "late", Text: "too late"}); !errors.Is(err, ErrSteerQueueClosed) {
+		t.Fatalf("late Enqueue error = %v, want ErrSteerQueueClosed", err)
+	}
+}
+
+func TestRunStreamRejectsPendingSteerWhenStreamFails(t *testing.T) {
+	model := &failingSteerModel{}
+	var rejected []SteerMessage
+	queue := NewSteerQueue(SteerQueueHooks{
+		OnRejected: func(message SteerMessage, _ error) {
+			rejected = append(rejected, message)
+		},
+	})
+	agent := NewAgent[string](model)
+	stream, err := agent.RunStream(context.Background(), "initial", WithSteerQueue(queue))
+	if err != nil {
+		t.Fatalf("RunStream: %v", err)
+	}
+	if err := queue.Enqueue(SteerMessage{ID: "steer-failed", Text: "never consumed"}); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if _, err := stream.Result(); err == nil {
+		t.Fatal("Result succeeded")
+	}
+	if len(rejected) != 1 || rejected[0].ID != "steer-failed" {
+		t.Fatalf("rejected = %#v", rejected)
+	}
+}
+
+func TestRunStreamRejectsPendingSteerWhenStartupGuardrailFails(t *testing.T) {
+	var rejected []SteerMessage
+	queue := NewSteerQueue(SteerQueueHooks{
+		OnRejected: func(message SteerMessage, _ error) {
+			rejected = append(rejected, message)
+		},
+	})
+	if err := queue.Enqueue(SteerMessage{ID: "steer-startup", Text: "never starts"}); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	agent := NewAgent[string](
+		NewTestModel(TextResponse("unused")),
+		WithInputGuardrail[string]("reject", func(context.Context, string) (string, error) {
+			return "", errors.New("startup rejected")
+		}),
+	)
+
+	if _, err := agent.RunStream(context.Background(), "initial", WithSteerQueue(queue)); err == nil {
+		t.Fatal("RunStream succeeded")
+	}
+	if len(rejected) != 1 || rejected[0].ID != "steer-startup" {
+		t.Fatalf("rejected = %#v", rejected)
+	}
+	if err := queue.Enqueue(SteerMessage{ID: "late", Text: "too late"}); !errors.Is(err, ErrSteerQueueClosed) {
+		t.Fatalf("late Enqueue error = %v, want ErrSteerQueueClosed", err)
+	}
+}
+
+func TestRunStreamConsumesQueuedSteersInOrderAfterToolResults(t *testing.T) {
+	type echoParams struct {
+		Text string `json:"text"`
+	}
+	model := NewTestModel(
+		ToolCallResponseWithID("echo", `{"text":"tool result"}`, "tool-call"),
+		TextResponse("steered answer"),
+	)
+	echo := FuncTool[echoParams]("echo", "Echo text.", func(_ context.Context, params echoParams) (string, error) {
+		return params.Text, nil
+	})
+	var consumed []string
+	queue := NewSteerQueue(SteerQueueHooks{
+		OnConsumed: func(message SteerMessage) error {
+			consumed = append(consumed, message.ID)
+			return nil
+		},
+	})
+	agent := NewAgent[string](model, WithTools[string](echo))
+	stream, err := agent.RunStream(context.Background(), "initial", WithSteerQueue(queue))
+	if err != nil {
+		t.Fatalf("RunStream: %v", err)
+	}
+	for _, message := range []SteerMessage{
+		{ID: "first", Text: "first adjustment"},
+		{ID: "second", Text: "second adjustment"},
+	} {
+		if err := queue.Enqueue(message); err != nil {
+			t.Fatalf("Enqueue(%s): %v", message.ID, err)
+		}
+	}
+
+	result, err := stream.Result()
+	if err != nil {
+		t.Fatalf("Result: %v", err)
+	}
+	if result.Output != "steered answer" || !slices.Equal(consumed, []string{"first", "second"}) {
+		t.Fatalf("result = %q, consumed = %v", result.Output, consumed)
+	}
+	calls := model.Calls()
+	if len(calls) != 2 {
+		t.Fatalf("model calls = %d, want 2", len(calls))
+	}
+	messages := calls[1].Messages
+	if len(messages) < 2 {
+		t.Fatalf("second request messages = %#v", messages)
+	}
+	toolResults, ok := messages[len(messages)-2].(ModelRequest)
+	if !ok || len(toolResults.Parts) != 1 {
+		t.Fatalf("tool result message = %#v", messages[len(messages)-2])
+	}
+	if _, ok := toolResults.Parts[0].(ToolReturnPart); !ok {
+		t.Fatalf("tool result part = %#v", toolResults.Parts[0])
+	}
+	steerRequest, ok := messages[len(messages)-1].(ModelRequest)
+	if !ok || len(steerRequest.Parts) != 2 {
+		t.Fatalf("steer request = %#v", messages[len(messages)-1])
+	}
+	for i, want := range []string{"first adjustment", "second adjustment"} {
+		part, ok := steerRequest.Parts[i].(UserPromptPart)
+		if !ok || part.Content != want {
+			t.Fatalf("steer part %d = %#v, want %q", i, steerRequest.Parts[i], want)
+		}
+	}
+}
+
+func TestRunRejectsSteerQueueForSynchronousExecution(t *testing.T) {
+	var rejected []SteerMessage
+	queue := NewSteerQueue(SteerQueueHooks{
+		OnRejected: func(message SteerMessage, _ error) {
+			rejected = append(rejected, message)
+		},
+	})
+	if err := queue.Enqueue(SteerMessage{ID: "sync", Text: "cannot steer sync"}); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	agent := NewAgent[string](NewTestModel(TextResponse("unused")))
+
+	if _, err := agent.Run(context.Background(), "initial", WithSteerQueue(queue)); !errors.Is(err, ErrSteeringNeedsStreaming) {
+		t.Fatalf("Run error = %v, want ErrSteeringNeedsStreaming", err)
+	}
+	if len(rejected) != 1 || rejected[0].ID != "sync" {
+		t.Fatalf("rejected = %#v", rejected)
+	}
+}
+
+func TestSteerQueueRejectsPendingInstructionsOverCapacity(t *testing.T) {
+	queue := NewSteerQueue(SteerQueueHooks{})
+	for i := range SteerQueueMaxPending {
+		if err := queue.Enqueue(SteerMessage{ID: "queued", Text: "queued"}); err != nil {
+			t.Fatalf("Enqueue(%d): %v", i, err)
+		}
+	}
+	if err := queue.Enqueue(SteerMessage{ID: "overflow", Text: "too many"}); !errors.Is(err, ErrSteerQueueFull) {
+		t.Fatalf("overflow Enqueue error = %v, want ErrSteerQueueFull", err)
+	}
+}
+
+func TestRunStreamConsumesSteerOnImmediateResponseInterceptorRetry(t *testing.T) {
+	model := NewTestModel(TextResponse("drop this"), TextResponse("after retry"))
+	dropped := false
+	agent := NewAgent[string](
+		model,
+		WithResponseInterceptor[string](func(context.Context, *ModelResponse) InterceptResult {
+			if !dropped {
+				dropped = true
+				return InterceptResult{Action: MessageDrop}
+			}
+			return InterceptResult{Action: MessageAllow}
+		}),
+	)
+	var consumed []SteerMessage
+	queue := NewSteerQueue(SteerQueueHooks{
+		OnConsumed: func(message SteerMessage) error {
+			consumed = append(consumed, message)
+			return nil
+		},
+	})
+	stream, err := agent.RunStream(context.Background(), "initial", WithSteerQueue(queue))
+	if err != nil {
+		t.Fatalf("RunStream: %v", err)
+	}
+	if err := queue.Enqueue(SteerMessage{ID: "interceptor", Text: "include on retry"}); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	result, err := stream.Result()
+	if err != nil {
+		t.Fatalf("Result: %v", err)
+	}
+	if result.Output != "after retry" || len(consumed) != 1 || consumed[0].ID != "interceptor" {
+		t.Fatalf("result = %q, consumed = %#v", result.Output, consumed)
+	}
+	calls := model.Calls()
+	if len(calls) != 2 {
+		t.Fatalf("model calls = %d, want 2", len(calls))
+	}
+	assertSteerMessage(t, calls[1].Messages, "include on retry")
+}
+
+func TestRunStreamRejectsSteerBeforeProviderRequestWhenPreparationFails(t *testing.T) {
+	model := NewTestModel(TextResponse("first answer"), TextResponse("must not start"))
+	var rejected []SteerMessage
+	queue := NewSteerQueue(SteerQueueHooks{
+		OnPrepared: func([]SteerMessage) error {
+			return errors.New("boundary unavailable")
+		},
+		OnRejected: func(message SteerMessage, _ error) {
+			rejected = append(rejected, message)
+		},
+	})
+	agent := NewAgent[string](model)
+	stream, err := agent.RunStream(context.Background(), "initial", WithSteerQueue(queue))
+	if err != nil {
+		t.Fatalf("RunStream: %v", err)
+	}
+	if err := queue.Enqueue(SteerMessage{ID: "prepare", Text: "must not send"}); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if _, err := stream.Result(); err == nil || !strings.Contains(err.Error(), "boundary unavailable") {
+		t.Fatalf("Result error = %v, want preparation failure", err)
+	}
+	if len(model.Calls()) != 1 {
+		t.Fatalf("model calls = %d, want no request after preparation failure", len(model.Calls()))
+	}
+	if len(rejected) != 1 || rejected[0].ID != "prepare" {
+		t.Fatalf("rejected = %#v", rejected)
+	}
+}
+
+func assertSteerMessage(t *testing.T, messages []ModelMessage, want string) {
+	t.Helper()
+	for _, message := range messages {
+		request, ok := message.(ModelRequest)
+		if !ok {
+			continue
+		}
+		for _, part := range request.Parts {
+			if prompt, ok := part.(UserPromptPart); ok && prompt.Content == want {
+				return
+			}
+		}
+	}
+	t.Fatalf("messages = %#v, missing steer %q", messages, want)
+}
+
+type failingSteerModel struct{}
+
+func (*failingSteerModel) Request(
+	context.Context,
+	[]ModelMessage,
+	*ModelSettings,
+	*ModelRequestParameters,
+) (*ModelResponse, error) {
+	return nil, errors.New("not used")
+}
+
+func (*failingSteerModel) RequestStream(
+	context.Context,
+	[]ModelMessage,
+	*ModelSettings,
+	*ModelRequestParameters,
+) (StreamedResponse, error) {
+	return failingSteerStream{}, nil
+}
+
+func (*failingSteerModel) ModelName() string { return "failing-steer" }
+
+type failingSteerStream struct{}
+
+func (failingSteerStream) Next() (ModelResponseStreamEvent, error) {
+	return nil, errors.New("stream failed")
+}
+
+func (failingSteerStream) Response() *ModelResponse { return nil }
+func (failingSteerStream) Usage() Usage             { return Usage{} }
+func (failingSteerStream) Close() error             { return nil }
+
+var _ = io.EOF

--- a/core/stream.go
+++ b/core/stream.go
@@ -161,12 +161,14 @@ type agentStream[T any] struct {
 	allTools []Tool
 	toolMap  map[string]*Tool
 	outNames map[string]bool
+	steers   *SteerQueue
 
 	current         StreamedResponse
 	currentTurnRC   *RunContext
 	currentModelRC  *RunContext
 	currentReqStart time.Time
 	finalResponse   *ModelResponse
+	pendingSteers   []SteerMessage
 
 	done   bool
 	result *RunResult[T]
@@ -186,6 +188,7 @@ func newAgentStream[T any](
 	allTools []Tool,
 	toolMap map[string]*Tool,
 	outNames map[string]bool,
+	steers *SteerQueue,
 ) *agentStream[T] {
 	return &agentStream[T]{
 		agent:    agent,
@@ -198,6 +201,7 @@ func newAgentStream[T any](
 		allTools: allTools,
 		toolMap:  toolMap,
 		outNames: outNames,
+		steers:   steers,
 	}
 }
 
@@ -562,7 +566,14 @@ func (s *agentStream[T]) startTurn() error {
 		stream, err = s.agent.model.RequestStream(s.ctx, messages, settings, params)
 	}
 	if err != nil {
+		s.rejectPendingSteers(err)
 		streamErr := fmt.Errorf("model stream request failed: %w", err)
+		s.emitStreamTurnCompleted(nil, streamErr)
+		return streamErr
+	}
+	if err := s.acknowledgePendingSteers(); err != nil {
+		_ = stream.Close()
+		streamErr := fmt.Errorf("acknowledge steer consumption: %w", err)
 		s.emitStreamTurnCompleted(nil, streamErr)
 		return streamErr
 	}
@@ -606,6 +617,10 @@ func (s *agentStream[T]) completeTurn() error {
 
 	if len(s.agent.responseInterceptors) > 0 {
 		if runResponseInterceptors(s.ctx, s.agent.responseInterceptors, resp) {
+			if _, err := s.queueSteersForNextRequest(false); err != nil {
+				s.completeActiveTurn(resp, err)
+				return err
+			}
 			s.completeActiveTurn(resp, nil)
 			return nil
 		}
@@ -715,6 +730,7 @@ func (s *agentStream[T]) completeTurn() error {
 		})
 	}
 	if len(deferredReqs) > 0 {
+		s.steers.close(errors.New("run is waiting for deferred input"))
 		fireTurnEnd()
 		s.completeActiveTurn(resp, nil)
 		if s.agent.eventBus != nil {
@@ -742,6 +758,18 @@ func (s *agentStream[T]) completeTurn() error {
 				Usage:            s.state.usage,
 			},
 		}
+	}
+	terminal := result != nil
+	queuedSteers, err := s.queueSteersForNextRequest(terminal)
+	if err != nil {
+		fireTurnEnd()
+		s.completeActiveTurn(resp, err)
+		return err
+	}
+	if queuedSteers {
+		fireTurnEnd()
+		s.completeActiveTurn(resp, nil)
+		return nil
 	}
 	if result != nil {
 		fireTurnEnd()
@@ -787,6 +815,8 @@ func (s *agentStream[T]) finish(result *RunResult[T], runErr error) {
 		s.currentTurnRC = nil
 		s.currentModelRC = nil
 	}
+	s.rejectPendingSteers(runErr)
+	s.steers.close(runErr)
 
 	s.done = true
 	s.result = result
@@ -811,4 +841,48 @@ func (s *agentStream[T]) finish(result *RunResult[T], runErr error) {
 			}
 		}
 	})
+}
+
+func (s *agentStream[T]) queueSteersForNextRequest(terminal bool) (bool, error) {
+	steers := s.steers.take(terminal)
+	if len(steers) == 0 {
+		return false, nil
+	}
+	if err := s.steers.prepared(steers); err != nil {
+		return false, fmt.Errorf("prepare steer consumption: %w", err)
+	}
+	parts := make([]ModelRequestPart, 0, len(steers))
+	for _, message := range steers {
+		parts = append(parts, UserPromptPart{
+			Content:   message.Text,
+			Timestamp: message.QueuedAt,
+		})
+	}
+	s.state.messages = append(s.state.messages, ModelRequest{
+		Parts:     parts,
+		Timestamp: time.Now(),
+	})
+	s.pendingSteers = append(s.pendingSteers, steers...)
+	return true, nil
+}
+
+func (s *agentStream[T]) acknowledgePendingSteers() error {
+	if len(s.pendingSteers) == 0 {
+		return nil
+	}
+	messages := append([]SteerMessage(nil), s.pendingSteers...)
+	s.pendingSteers = nil
+	return s.steers.consumed(messages)
+}
+
+func (s *agentStream[T]) rejectPendingSteers(reason error) {
+	if len(s.pendingSteers) == 0 {
+		return
+	}
+	if reason == nil {
+		reason = ErrSteerQueueClosed
+	}
+	messages := append([]SteerMessage(nil), s.pendingSteers...)
+	s.pendingSteers = nil
+	s.steers.reject(messages, reason)
 }


### PR DESCRIPTION
## Summary

- bind the exact public `turn/steer` contract to the active Gollem runtime
- queue bounded, ordered steering instructions at safe model-request boundaries with durable prepare/consume/fail receipts
- preserve active-turn idempotency, reject mismatched or unsupported input, and replay only completed steers at their recorded item-sequence boundary
- regenerate schema and TypeScript bindings and document the runtime semantics

## Verification

- `go test -race ./core ./appserver -count=1`
- full repository race package set excluding `ext/monty`
- `go test ./appserver/protocol -count=1`
- `go vet ./...`
- `golangci-lint run --timeout=5m ./...` (0 issues)
- `go mod tidy` with no module diff
- `git diff --check`

Local Monty execution was skipped per project workflow preference; hosted CI remains unchanged.