### PR TITLE
feat: validate durable reasoning settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Capability-validated durable reasoning effort.** Runtime thread starts,
+  turn starts/resumes, and retries now reject explicit reasoning effort when
+  the selected catalog model is unknown, does not advertise reasoning, or
+  does not advertise that exact effort. Supported explicit choices are stored
+  in thread settings and turn input, inherited by later turns, and recovered
+  by retries instead of becoming renderer-only state.
 - **Durable live turn steering.** The app server now binds the exact public
   `turn/steer` request and response, requires thread and expected-active-turn
   correlation, and queues text instructions for the next safe model-request

--- a/appserver/protocol/README.md
+++ b/appserver/protocol/README.md
@@ -368,6 +368,16 @@ public contracts. Catalog responses expose configuration state and required
 environment-variable names, never credential values; runtime requests contain
 selection and model settings but no credential-bearing fields.
 
+An explicit `reasoningEffort` is accepted only when the selected catalog model
+advertises reasoning and that exact effort. Validation happens before
+`thread/start` creates a thread and before `turn/start`, `thread/resume`, or
+`turn/retry` creates a turn. Supported choices are copied into durable thread
+settings and native runtime turn input; later turns inherit the thread choice,
+and retry recovers the source turn choice when the request omits it. Clients
+must still gate controls from the selected model's capability record. A model
+or effort absent from that record is unavailable rather than optimistically
+forwarded to a provider.
+
 ## Exported Thread-Item Prerequisites
 
 The schema exports the exact public `ByteRange`, `TextElement`, `ImageDetail`,

--- a/appserver/runtime.go
+++ b/appserver/runtime.go
@@ -176,12 +176,13 @@ func (s *RuntimeService) Start(ctx context.Context, st store.Store, notifier run
 	s.mu.Unlock()
 	if len(req.Input) == 0 {
 		input, err := json.Marshal(runtimeTurnInput{
-			Prompt:      req.Prompt,
-			ProviderID:  req.Selection.ProviderID,
-			Provider:    req.Selection.Provider,
-			Model:       req.Selection.Model,
-			Metadata:    cloneRuntimeMap(req.Metadata),
-			SubmittedAt: time.Now().UTC(),
+			Prompt:          req.Prompt,
+			ProviderID:      req.Selection.ProviderID,
+			Provider:        req.Selection.Provider,
+			Model:           req.Selection.Model,
+			ReasoningEffort: runtimeReasoningEffort(req.ModelSettings),
+			Metadata:        cloneRuntimeMap(req.Metadata),
+			SubmittedAt:     time.Now().UTC(),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("marshal runtime input: %w", err)
@@ -620,12 +621,20 @@ func statusFromRuntimeError(err error) store.TurnStatus {
 }
 
 type runtimeTurnInput struct {
-	Prompt      string         `json:"prompt"`
-	ProviderID  string         `json:"providerId,omitempty"`
-	Provider    string         `json:"provider,omitempty"`
-	Model       string         `json:"model,omitempty"`
-	Metadata    map[string]any `json:"metadata,omitempty"`
-	SubmittedAt time.Time      `json:"submittedAt"`
+	Prompt          string         `json:"prompt"`
+	ProviderID      string         `json:"providerId,omitempty"`
+	Provider        string         `json:"provider,omitempty"`
+	Model           string         `json:"model,omitempty"`
+	ReasoningEffort string         `json:"reasoningEffort,omitempty"`
+	Metadata        map[string]any `json:"metadata,omitempty"`
+	SubmittedAt     time.Time      `json:"submittedAt"`
+}
+
+func runtimeReasoningEffort(settings core.ModelSettings) string {
+	if settings.ReasoningEffort == nil {
+		return ""
+	}
+	return strings.TrimSpace(*settings.ReasoningEffort)
 }
 
 type runtimeResultPayload struct {

--- a/appserver/runtime_params.go
+++ b/appserver/runtime_params.go
@@ -133,6 +133,48 @@ func runtimeModelSettingsFromParams(params RuntimeModelParams) core.ModelSetting
 	return settings
 }
 
+func runtimeModelSettingsFromInput(input json.RawMessage) core.ModelSettings {
+	var stored runtimeTurnInput
+	if len(input) == 0 || json.Unmarshal(input, &stored) != nil {
+		return core.ModelSettings{}
+	}
+	effort := strings.TrimSpace(stored.ReasoningEffort)
+	if effort == "" {
+		return core.ModelSettings{}
+	}
+	return core.ModelSettings{ReasoningEffort: &effort}
+}
+
+func runtimeModelSettingsWithThreadDefaults(
+	settings core.ModelSettings,
+	threadSettings map[string]any,
+) core.ModelSettings {
+	if settings.ReasoningEffort == nil {
+		if effort := stringSetting(threadSettings, "reasoningEffort"); effort != "" {
+			settings.ReasoningEffort = &effort
+		}
+	}
+	return settings
+}
+
+func mergeRuntimeReasoningIntoSettings(
+	settings map[string]any,
+	reasoningEffort *string,
+) map[string]any {
+	if reasoningEffort == nil {
+		return settings
+	}
+	effort := strings.TrimSpace(*reasoningEffort)
+	if effort == "" {
+		return settings
+	}
+	if settings == nil {
+		settings = make(map[string]any)
+	}
+	settings["reasoningEffort"] = effort
+	return settings
+}
+
 func cloneSettings(settings map[string]any) map[string]any {
 	if len(settings) == 0 {
 		return nil

--- a/appserver/runtime_reasoning.go
+++ b/appserver/runtime_reasoning.go
@@ -1,0 +1,68 @@
+package appserver
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/fugue-labs/gollem/appserver/catalog"
+	"github.com/fugue-labs/gollem/core"
+)
+
+func validateRuntimeReasoningSelection(
+	catalogService *catalog.Catalog,
+	selection RuntimeModelSelection,
+	settings core.ModelSettings,
+) error {
+	if settings.ReasoningEffort == nil {
+		return nil
+	}
+	effort := strings.TrimSpace(*settings.ReasoningEffort)
+	if effort == "" {
+		return errors.New("reasoning effort must not be empty")
+	}
+	providerID := strings.TrimSpace(firstNonEmpty(selection.ProviderID, selection.Provider))
+	modelName := strings.TrimSpace(selection.Model)
+	if providerID == "" {
+		return fmt.Errorf("provider capability is unavailable for reasoning effort %q", effort)
+	}
+	includeHidden := true
+	response, err := catalogService.ListModels(catalog.ModelListParams{
+		ProviderID:    providerID,
+		IncludeHidden: &includeHidden,
+	})
+	if err != nil {
+		return fmt.Errorf("read model capability: %w", err)
+	}
+	var selected *catalog.Model
+	for index := range response.Data {
+		model := &response.Data[index]
+		if modelName == "" {
+			if model.IsDefault {
+				selected = model
+				break
+			}
+			continue
+		}
+		if model.ID == modelName || model.Model == modelName {
+			selected = model
+			break
+		}
+	}
+	if selected == nil {
+		return fmt.Errorf("model capability is unavailable for %q", modelName)
+	}
+	if !selected.Capabilities.Reasoning {
+		return fmt.Errorf("model %q does not advertise reasoning", selected.ID)
+	}
+	for _, option := range selected.SupportedReasoningEfforts {
+		if strings.TrimSpace(option.ReasoningEffort) == effort {
+			return nil
+		}
+	}
+	return fmt.Errorf(
+		"model %q does not advertise reasoning effort %q",
+		selected.ID,
+		effort,
+	)
+}

--- a/appserver/runtime_test.go
+++ b/appserver/runtime_test.go
@@ -119,6 +119,160 @@ func TestRuntimeStartFailureTerminalizesCreatedTurn(t *testing.T) {
 	}
 }
 
+func TestRuntimeStartPersistsExplicitReasoningEffort(t *testing.T) {
+	ctx := context.Background()
+	st := newRuntimeTestStore(t)
+	thread, err := st.CreateThread(ctx, store.CreateThreadRequest{Title: "Reasoning receipt"})
+	if err != nil {
+		t.Fatalf("CreateThread: %v", err)
+	}
+	effort := "high"
+	runtimeSvc := NewRuntimeService(WithRuntimeModel(
+		core.NewTestModel(core.TextResponse("done")),
+		RuntimeModelInfo{ProviderID: "openai", Model: "gpt-5"},
+	))
+
+	started, err := runtimeSvc.Start(ctx, st, nil, RuntimeStartRequest{
+		ThreadID: thread.ID,
+		Prompt:   "persist the selected effort",
+		Selection: RuntimeModelSelection{
+			ProviderID: "openai",
+			Model:      "gpt-5",
+		},
+		ModelSettings: core.ModelSettings{ReasoningEffort: &effort},
+	})
+	if err != nil {
+		t.Fatalf("RuntimeService.Start: %v", err)
+	}
+	var input runtimeTurnInput
+	if err := json.Unmarshal(started.Turn.Input, &input); err != nil {
+		t.Fatalf("decode turn input: %v", err)
+	}
+	if input.ReasoningEffort != effort {
+		t.Fatalf("turn reasoning effort = %q, want %q", input.ReasoningEffort, effort)
+	}
+	inherited := runtimeModelSettingsFromInput(started.Turn.Input)
+	if inherited.ReasoningEffort == nil || *inherited.ReasoningEffort != effort {
+		t.Fatalf("inherited reasoning settings = %#v, want %q", inherited, effort)
+	}
+}
+
+func TestServerRuntimeReasoningEffortFailsClosedAgainstModelCatalog(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		model      string
+		effort     string
+		wantCode   int
+		wantReason string
+	}{
+		{
+			name:       "model does not advertise reasoning",
+			model:      "gpt-4o",
+			effort:     "high",
+			wantCode:   protocol.CodeInvalidParams,
+			wantReason: "does not advertise reasoning",
+		},
+		{
+			name:       "effort is not advertised",
+			model:      "gpt-5",
+			effort:     "ultra",
+			wantCode:   protocol.CodeInvalidParams,
+			wantReason: "does not advertise reasoning effort",
+		},
+		{
+			name:       "model is unknown",
+			model:      "future-model",
+			effort:     "high",
+			wantCode:   protocol.CodeInvalidParams,
+			wantReason: "model capability is unavailable",
+		},
+		{
+			name:   "advertised effort",
+			model:  "gpt-5",
+			effort: "high",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			st := newRuntimeTestStore(t)
+			server := readyServer(
+				WithStore(st),
+				WithRuntimeService(NewRuntimeService(WithRuntimeModel(
+					core.NewTestModel(core.TextResponse("done")),
+					RuntimeModelInfo{ProviderID: "openai", Model: tc.model},
+				))),
+			)
+			response := server.HandleRequest(ctx, request("thread/start", map[string]any{
+				"workspace":       t.TempDir(),
+				"prompt":          "use explicit reasoning",
+				"providerId":      "openai",
+				"model":           tc.model,
+				"reasoningEffort": tc.effort,
+			}))
+			if tc.wantCode != 0 {
+				if response.Error == nil || response.Error.Code != tc.wantCode {
+					t.Fatalf("thread/start error = %#v, want code %d", response.Error, tc.wantCode)
+				}
+				if !strings.Contains(response.Error.Message, tc.wantReason) {
+					t.Fatalf("thread/start error = %q, want %q", response.Error.Message, tc.wantReason)
+				}
+				threads, err := st.ListThreads(ctx, store.ThreadFilter{})
+				if err != nil {
+					t.Fatalf("ListThreads: %v", err)
+				}
+				if len(threads) != 0 {
+					t.Fatalf("invalid reasoning created %d threads", len(threads))
+				}
+				return
+			}
+			if response.Error != nil {
+				t.Fatalf("thread/start error: %v", response.Error)
+			}
+			var result protocol.ThreadRunStartResult
+			decodeResult(t, response, &result)
+			var input runtimeTurnInput
+			if err := json.Unmarshal(result.Turn.Input, &input); err != nil {
+				t.Fatalf("decode turn input: %v", err)
+			}
+			if input.ReasoningEffort != tc.effort {
+				t.Fatalf("turn reasoning effort = %q, want %q", input.ReasoningEffort, tc.effort)
+			}
+			storedThread, err := st.GetThread(ctx, result.Thread.ID)
+			if err != nil {
+				t.Fatalf("GetThread: %v", err)
+			}
+			if storedThread.Settings["reasoningEffort"] != tc.effort {
+				t.Fatalf(
+					"thread reasoning setting = %#v, want %q",
+					storedThread.Settings["reasoningEffort"],
+					tc.effort,
+				)
+			}
+			waitForNotificationSet(t, server, "turn/completed")
+			nextResponse := server.HandleRequest(ctx, request("turn/start", map[string]any{
+				"threadId": result.Thread.ID,
+				"prompt":   "inherit the thread reasoning setting",
+			}))
+			if nextResponse.Error != nil {
+				t.Fatalf("inherited turn/start error: %v", nextResponse.Error)
+			}
+			var next protocol.TurnRunStartResult
+			decodeResult(t, nextResponse, &next)
+			var nextInput runtimeTurnInput
+			if err := json.Unmarshal(next.Turn.Input, &nextInput); err != nil {
+				t.Fatalf("decode inherited turn input: %v", err)
+			}
+			if nextInput.ReasoningEffort != tc.effort {
+				t.Fatalf(
+					"inherited turn reasoning effort = %q, want %q",
+					nextInput.ReasoningEffort,
+					tc.effort,
+				)
+			}
+		})
+	}
+}
+
 func TestServerThreadCompactStartFailureTerminalizesCreatedTurn(t *testing.T) {
 	for _, tc := range []struct {
 		name      string

--- a/appserver/server.go
+++ b/appserver/server.go
@@ -750,6 +750,12 @@ func (s *Server) handleThreadStart(ctx context.Context, raw json.RawMessage) (an
 	}
 	settings := cloneSettings(params.Settings)
 	settings = mergeRuntimeSelectionIntoSettings(settings, params.ProviderID, params.Provider, params.Model)
+	selection := runtimeSelectionFromParams(params.ProviderID, params.Provider, params.Model)
+	modelSettings := runtimeModelSettingsFromParams(params.RuntimeModelParams)
+	settings = mergeRuntimeReasoningIntoSettings(settings, modelSettings.ReasoningEffort)
+	if err := validateRuntimeReasoningSelection(s.catalog, selection, modelSettings); err != nil {
+		return nil, invalidParams(err.Error(), err)
+	}
 	ctx, releaseStart, err := runtimeSvc.acquireStartLease(ctx, s)
 	if err != nil {
 		return nil, mapError("thread/start", err)
@@ -771,8 +777,8 @@ func (s *Server) handleThreadStart(ctx context.Context, raw json.RawMessage) (an
 		Prompt:        prompt,
 		Input:         params.Input,
 		Metadata:      params.Metadata,
-		Selection:     runtimeSelectionFromParams(params.ProviderID, params.Provider, params.Model),
-		ModelSettings: runtimeModelSettingsFromParams(params.RuntimeModelParams),
+		Selection:     selection,
+		ModelSettings: modelSettings,
 	})
 	if err != nil {
 		return nil, mapError("thread/start", err)
@@ -1456,6 +1462,13 @@ func (s *Server) handleTurnRetry(ctx context.Context, raw json.RawMessage) (any,
 	}
 	selection := runtimeSelectionFromParams(params.ProviderID, params.Provider, params.Model)
 	selection = mergeRuntimeSelection(selection, runtimeSelectionFromInput(source.Input))
+	modelSettings := runtimeModelSettingsFromParams(params.RuntimeModelParams)
+	if modelSettings.ReasoningEffort == nil {
+		modelSettings = runtimeModelSettingsFromInput(source.Input)
+	}
+	if err := validateRuntimeReasoningSelection(s.catalog, selection, modelSettings); err != nil {
+		return nil, invalidParams(err.Error(), err)
+	}
 	retry, err := runtimeSvc.Retry(ctx, st, s, RuntimeRetryRequest{
 		SourceTurnID:   source.ID,
 		IdempotencyKey: idempotencyKey,
@@ -1463,7 +1476,7 @@ func (s *Server) handleTurnRetry(ctx context.Context, raw json.RawMessage) (any,
 		Input:          firstRaw(params.Input, source.Input),
 		Metadata:       params.Metadata,
 		Selection:      selection,
-		ModelSettings:  runtimeModelSettingsFromParams(params.RuntimeModelParams),
+		ModelSettings:  modelSettings,
 		History:        history,
 	})
 	if err != nil {
@@ -1501,13 +1514,18 @@ func (s *Server) startTurnWithParams(ctx context.Context, method string, params 
 	}
 	selection := runtimeSelectionFromParams(params.ProviderID, params.Provider, params.Model)
 	selection = runtimeSelectionWithThreadDefaults(selection, thread.Settings)
+	modelSettings := runtimeModelSettingsFromParams(params.RuntimeModelParams)
+	modelSettings = runtimeModelSettingsWithThreadDefaults(modelSettings, thread.Settings)
+	if err := validateRuntimeReasoningSelection(s.catalog, selection, modelSettings); err != nil {
+		return nil, invalidParams(err.Error(), err)
+	}
 	turn, err := runtimeSvc.Start(ctx, st, s, RuntimeStartRequest{
 		ThreadID:      thread.ID,
 		Prompt:        prompt,
 		Input:         params.Input,
 		Metadata:      params.Metadata,
 		Selection:     selection,
-		ModelSettings: runtimeModelSettingsFromParams(params.RuntimeModelParams),
+		ModelSettings: modelSettings,
 		History:       history,
 	})
 	if err != nil {


### PR DESCRIPTION
Validates explicit reasoning effort against the selected model catalog before thread or turn creation, persists supported choices in thread settings and turn input, and inherits them across later turns and retries. Includes fail-closed and durable receipt coverage.\n\nLocal verification: focused app-server tests, full app-server tests, app-server race, full vet, full golangci-lint, go mod tidy, generated protocol freshness, and diff checks. Local Monty was intentionally skipped; hosted CI remains authoritative.