### PR TITLE
fix(openai): preserve recorded timing sentinel

### DIFF
--- a/provider/openai/instrumentation.go
+++ b/provider/openai/instrumentation.go
@@ -193,6 +193,13 @@ type requestInstrumentation struct {
 	terminalRecorded   bool
 }
 
+func recordedDurationSince(start time.Time) time.Duration {
+	if elapsed := time.Since(start); elapsed > 0 {
+		return elapsed
+	}
+	return time.Nanosecond
+}
+
 // newRequestInstrumentation returns a ready accumulator, or nil when there is
 // no observer. Callers should keep the nil result rather than wrapping it.
 func newRequestInstrumentation(obs RequestObserver, transport, model string) *requestInstrumentation {
@@ -242,7 +249,7 @@ func (ri *requestInstrumentation) endTokenRefresh() {
 	if ri == nil || ri.tokenSt.IsZero() {
 		return
 	}
-	ri.trace.TokenRefreshDuration = time.Since(ri.tokenSt)
+	ri.trace.TokenRefreshDuration = recordedDurationSince(ri.tokenSt)
 }
 
 func (ri *requestInstrumentation) recordHeaders(status int) {
@@ -250,7 +257,7 @@ func (ri *requestInstrumentation) recordHeaders(status int) {
 		return
 	}
 	ri.headersRecorded = true
-	ri.trace.TimeToHeaders = time.Since(ri.start)
+	ri.trace.TimeToHeaders = recordedDurationSince(ri.start)
 	ri.trace.HTTPStatus = status
 }
 
@@ -259,7 +266,7 @@ func (ri *requestInstrumentation) recordFirstEvent() {
 		return
 	}
 	ri.firstEventRecorded = true
-	ri.trace.TimeToFirstEvent = time.Since(ri.start)
+	ri.trace.TimeToFirstEvent = recordedDurationSince(ri.start)
 }
 
 func (ri *requestInstrumentation) recordFirstToken() {
@@ -267,7 +274,7 @@ func (ri *requestInstrumentation) recordFirstToken() {
 		return
 	}
 	ri.firstTokenRecorded = true
-	ri.trace.TimeToFirstToken = time.Since(ri.start)
+	ri.trace.TimeToFirstToken = recordedDurationSince(ri.start)
 }
 
 func (ri *requestInstrumentation) recordTerminal() {
@@ -275,7 +282,7 @@ func (ri *requestInstrumentation) recordTerminal() {
 		return
 	}
 	ri.terminalRecorded = true
-	ri.trace.TimeToTerminal = time.Since(ri.start)
+	ri.trace.TimeToTerminal = recordedDurationSince(ri.start)
 }
 
 // recordTerminalFailure records the terminal timing for an in-band Responses
@@ -380,7 +387,7 @@ func (ri *requestInstrumentation) finish() {
 		return
 	}
 	ri.finished = true
-	ri.trace.TotalDuration = time.Since(ri.start)
+	ri.trace.TotalDuration = recordedDurationSince(ri.start)
 	ri.obs(ri.trace)
 }
 

--- a/provider/openai/instrumentation_test.go
+++ b/provider/openai/instrumentation_test.go
@@ -889,6 +889,12 @@ func TestRequestInstrumentationRecordTerminalFailure(t *testing.T) {
 	}
 }
 
+func TestRecordedDurationSinceIsNeverZero(t *testing.T) {
+	if got := recordedDurationSince(time.Now().Add(time.Hour)); got != time.Nanosecond {
+		t.Fatalf("future start duration = %v, want %v", got, time.Nanosecond)
+	}
+}
+
 // TestEstimateResponsesRequestBytes is a small direct test of the helper used
 // to give the WS trace a request size.
 func TestEstimateResponsesRequestBytes(t *testing.T) {


### PR DESCRIPTION
## Summary
- clamp recorded instrumentation durations to one nanosecond when the clock delta is non-positive
- keep zero reserved for the existing not-recorded sentinel
- add a deterministic regression test for clock-resolution edge cases

## Verification
- `go test ./provider/openai -run 'TestRequestInstrumentationRecordTerminalFailure|TestRecordedDurationSinceIsNeverZero' -count=100`\n- `go test -race ./provider/openai -count=1`\n- `golangci-lint run ./provider/openai/...`\n- repository pre-push lint, non-Monty race, vet, and tidy gates