### PR TITLE
Bind terminal terminate approvals to exact targets

### DIFF
--- a/appserver/operational_inspector.go
+++ b/appserver/operational_inspector.go
@@ -24,6 +24,7 @@ const (
 	operationalListMaxLimit     = 32
 	operationalCursorMaxBytes   = 2048
 	operationalCommandMaxBytes  = 256
+	operationalTerminateDomain  = "gollem.background-terminal.terminate.v1\x00"
 )
 
 type operationalCursor struct {
@@ -163,6 +164,11 @@ func operationalSnapshotID(kind string, value any) string {
 	}{Kind: kind, Value: value})
 	sum := sha256.Sum256(data)
 	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func operationalTerminalTerminateApprovalItemID(id string) string {
+	sum := sha256.Sum256([]byte(operationalTerminateDomain + id))
+	return "terminal-terminate-sha256:" + hex.EncodeToString(sum[:])
 }
 
 func operationalBackgroundTerminals(root string, snapshots []toolprocess.Snapshot) []protocol.BackgroundTerminal {

--- a/appserver/operational_inspector_test.go
+++ b/appserver/operational_inspector_test.go
@@ -55,6 +55,24 @@ func TestOperationalDisplayTextNormalizesControlAndInvalidUTF8(t *testing.T) {
 	}
 }
 
+func TestOperationalTerminalTerminateApprovalItemIDBindsOpaqueTarget(t *testing.T) {
+	first := operationalTerminalTerminateApprovalItemID("process-1")
+	second := operationalTerminalTerminateApprovalItemID("process-2")
+	if !strings.HasPrefix(first, "terminal-terminate-sha256:") ||
+		len(strings.TrimPrefix(first, "terminal-terminate-sha256:")) != 64 {
+		t.Fatalf("approval item id = %q", first)
+	}
+	if first == second {
+		t.Fatal("different process ids produced the same approval item id")
+	}
+	if strings.Contains(first, "process-1") {
+		t.Fatalf("approval item id leaked native process id: %q", first)
+	}
+	if again := operationalTerminalTerminateApprovalItemID("process-1"); again != first {
+		t.Fatalf("approval item id changed: %q != %q", again, first)
+	}
+}
+
 func TestOperationalPageBoundsRejectsStaleAndMalformedCursors(t *testing.T) {
 	params := protocol.OperationalListParams{Limit: 2}
 	start, end, next, rpcErr := operationalPageBounds(params, "inventory", "sha256:one", 5)

--- a/appserver/protocol/README.md
+++ b/appserver/protocol/README.md
@@ -399,6 +399,13 @@ metadata is bounded, while desktop clients remain responsible for retaining
 native paths in their privileged process and projecting opaque ids to an
 untrusted renderer.
 
+A direct background-terminal terminate request binds its one-shot command
+approval `itemId` to
+`terminal-terminate-sha256:` plus the lowercase SHA-256 of the UTF-8 bytes
+`gollem.background-terminal.terminate.v1\0<terminal-id>`. Privileged clients
+must verify that receipt before accepting the approval. The native terminal id
+does not appear in cleartext in the receipt or enter an untrusted renderer.
+
 ## Exported Thread-Item Prerequisites
 
 The schema exports the exact public `ByteRange`, `TextElement`, `ImageDetail`,

--- a/appserver/server.go
+++ b/appserver/server.go
@@ -1293,7 +1293,11 @@ func (s *Server) handleBackgroundTerminalTerminate(ctx context.Context, raw json
 	if id == "" {
 		return nil, invalidParams("id, terminalId, backgroundTerminalId, or processId is required", nil)
 	}
-	if err := processSvc.Terminate(ctx, id); err != nil {
+	approvalCtx := withRuntimeApprovalItemID(
+		ctx,
+		operationalTerminalTerminateApprovalItemID(id),
+	)
+	if err := processSvc.Terminate(approvalCtx, id); err != nil {
 		return nil, mapError("thread/backgroundTerminals/terminate", err)
 	}
 	waitCtx, cancel := context.WithTimeout(ctx, 2*time.Second)

--- a/appserver/server_test.go
+++ b/appserver/server_test.go
@@ -2480,6 +2480,98 @@ func TestServerBackgroundTerminalTerminateDoesNotClaimSuccessBeforeExit(t *testi
 	}
 }
 
+func TestServerBackgroundTerminalTerminateApprovalBindsTarget(t *testing.T) {
+	ctx := context.Background()
+	approvals := NewApprovalService()
+	processSvc, err := toolprocess.NewService(
+		t.TempDir(),
+		toolprocess.WithApproval(func(ctx context.Context, op toolprocess.Operation) error {
+			if op.Kind == toolprocess.OperationTerminate {
+				return approvals.ProcessApproval(ctx, op)
+			}
+			return nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	server := readyServer(
+		WithProcess(processSvc),
+		WithApprovalService(approvals),
+	)
+
+	spawnResp := server.HandleRequest(ctx, request("process/spawn", map[string]any{
+		"command": "cat",
+	}))
+	if spawnResp.Error != nil {
+		t.Fatalf("process/spawn error: %v", spawnResp.Error)
+	}
+	var running struct {
+		Process processSnapshotResult `json:"process"`
+	}
+	decodeResult(t, spawnResp, &running)
+	t.Cleanup(func() {
+		_ = processSvc.Kill(context.Background(), running.Process.ID)
+		_, _ = processSvc.Wait(context.Background(), running.Process.ID)
+	})
+
+	terminateResult := make(chan protocol.Response, 1)
+	go func() {
+		terminateResult <- server.HandleRequest(
+			ctx,
+			request("thread/backgroundTerminals/terminate", map[string]any{
+				"id": running.Process.ID,
+			}),
+		)
+	}()
+
+	approvalRequest := waitForServerRequest(t, server)
+	if approvalRequest.Method != "item/commandExecution/requestApproval" {
+		t.Fatalf("approval method = %q", approvalRequest.Method)
+	}
+	var approvalParams protocol.CommandExecutionApprovalRequestParams
+	if err := json.Unmarshal(approvalRequest.Params, &approvalParams); err != nil {
+		t.Fatalf("decode command approval params: %v", err)
+	}
+	wantItemID := operationalTerminalTerminateApprovalItemID(running.Process.ID)
+	if approvalParams.ItemID != wantItemID {
+		t.Fatalf("approval item id = %q, want %q", approvalParams.ItemID, wantItemID)
+	}
+	if strings.Contains(approvalParams.ItemID, running.Process.ID) {
+		t.Fatalf("approval item id leaked native process id: %q", approvalParams.ItemID)
+	}
+	if approvalParams.Operation != string(toolprocess.OperationTerminate) ||
+		approvalParams.Signal != "SIGTERM" ||
+		!approvalParams.Destructive {
+		t.Fatalf("terminate approval params = %#v", approvalParams)
+	}
+
+	requestID, _ := approvalRequest.ID.Value().(string)
+	approvalResp := server.HandleRequest(ctx, request("approval/respond", map[string]any{
+		"requestId": requestID,
+		"approved":  true,
+	}))
+	if approvalResp.Error != nil {
+		t.Fatalf("approval/respond error: %v", approvalResp.Error)
+	}
+
+	select {
+	case terminateResp := <-terminateResult:
+		if terminateResp.Error != nil {
+			t.Fatalf("thread/backgroundTerminals/terminate error: %v", terminateResp.Error)
+		}
+		var terminated protocol.BackgroundTerminalTerminateResponse
+		decodeResult(t, terminateResp, &terminated)
+		if !terminated.OK ||
+			terminated.ID != running.Process.ID ||
+			terminated.Terminal.Status != protocol.BackgroundTerminalStatusKilled {
+			t.Fatalf("terminate result = %#v", terminated)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for approved terminate response")
+	}
+}
+
 func TestServerBackgroundTerminalInventoryRejectsStaleCursorAndRedactsArguments(t *testing.T) {
 	ctx := context.Background()
 	processSvc, err := toolprocess.NewService(t.TempDir())


### PR DESCRIPTION
## Summary
- derive a domain-separated opaque approval receipt from the native background-terminal id
- attach that receipt to direct terminal terminate approvals
- document the privileged-client verification contract
- cover deterministic receipt generation and the live spawn/approve/terminate path

## Verification
- focused tests repeated 20 times
- focused race test
- full non-Monty test suite
- full non-Monty race suite
- `go vet`
- `golangci-lint run ./...`
- `go mod tidy` with no diff
- pre-push hook with Monty race skipped per local policy