### PR TITLE
fix(mcp): harden stateless MCP against review findings

### DIFF
--- a/ext/mcp/mcp_review_fixes_test.go
+++ b/ext/mcp/mcp_review_fixes_test.go
@@ -1,0 +1,95 @@
+package mcp
+
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+)
+
+func TestNormalizeIDPreservesLargeIntegersVerbatim(t *testing.T) {
+	// An integer beyond int64 must not be rounded through float64; it is echoed
+	// back to the client verbatim so the response can be correlated.
+	big := json.RawMessage("123456789012345678901234567890")
+	got := normalizeID(&big)
+	raw, ok := got.(json.RawMessage)
+	if !ok {
+		t.Fatalf("normalizeID(large int) = %T, want json.RawMessage", got)
+	}
+	if string(raw) != string(big) {
+		t.Fatalf("normalizeID(large int) = %s, want %s", raw, big)
+	}
+
+	if got := normalizeID(ptrRaw(`1`)); got != int64(1) {
+		t.Fatalf("normalizeID(1) = %#v, want int64(1)", got)
+	}
+	if got := normalizeID(ptrRaw(`"abc"`)); got != "abc" {
+		t.Fatalf("normalizeID(\"abc\") = %#v, want \"abc\"", got)
+	}
+}
+
+func ptrRaw(s string) *json.RawMessage {
+	raw := json.RawMessage(s)
+	return &raw
+}
+
+func TestSubscriptionHubKeepsClientsWithSameRequestIDIndependent(t *testing.T) {
+	hub := newSubscriptionHub()
+
+	var mu sync.Mutex
+	counts := map[string]int{}
+	newSub := func(name string) (*subscription, func()) {
+		sub := &subscription{
+			id:     int64(1), // both stateless clients reuse request id 1
+			filter: SubscriptionFilter{ToolsListChanged: true},
+			deliver: func([]byte) {
+				mu.Lock()
+				counts[name]++
+				mu.Unlock()
+			},
+		}
+		return sub, hub.register(sub)
+	}
+
+	_, deregA := newSub("a")
+	_, deregB := newSub("b")
+
+	hub.emit("notifications/tools/list_changed", nil, func(f SubscriptionFilter) bool {
+		return f.ToolsListChanged
+	})
+
+	mu.Lock()
+	if counts["a"] != 1 || counts["b"] != 1 {
+		mu.Unlock()
+		t.Fatalf("both same-id streams should receive one notification, got %v", counts)
+	}
+	mu.Unlock()
+
+	// Deregistering one stream must not remove the other.
+	deregA()
+	hub.emit("notifications/tools/list_changed", nil, func(f SubscriptionFilter) bool {
+		return f.ToolsListChanged
+	})
+	mu.Lock()
+	if counts["a"] != 1 {
+		mu.Unlock()
+		t.Fatalf("deregistered stream a still delivered: %v", counts)
+	}
+	if counts["b"] != 2 {
+		mu.Unlock()
+		t.Fatalf("stream b should still be active, got %v", counts)
+	}
+	mu.Unlock()
+	deregB()
+}
+
+func TestClientStateMRTRRoundsConfigurable(t *testing.T) {
+	if s := newClientState(); s.maxMRTRRounds != defaultMaxMRTRRounds {
+		t.Fatalf("default maxMRTRRounds = %d, want %d", s.maxMRTRRounds, defaultMaxMRTRRounds)
+	}
+	if s := newClientState(ClientConfig{MaxMRTRRounds: 20}); s.maxMRTRRounds != 20 {
+		t.Fatalf("configured maxMRTRRounds = %d, want 20", s.maxMRTRRounds)
+	}
+	if s := newClientState(ClientConfig{MaxMRTRRounds: -5}); s.maxMRTRRounds != defaultMaxMRTRRounds {
+		t.Fatalf("negative maxMRTRRounds = %d, want default %d", s.maxMRTRRounds, defaultMaxMRTRRounds)
+	}
+}

--- a/ext/mcp/protocol.go
+++ b/ext/mcp/protocol.go
@@ -31,9 +31,14 @@ const (
 	jsonRPCCodeUnsupportedProtocolVersion = -32022
 )
 
-// maxMRTRRounds bounds the number of input_required round trips a client will
-// complete for a single logical request before treating the exchange as failed.
-const maxMRTRRounds = 8
+// defaultMaxMRTRRounds bounds the number of input_required round trips a client
+// will complete for a single logical request before treating the exchange as
+// failed. Each round corresponds to one server-driven input request (e.g. a
+// single sampling call), so the default is generous enough to cover a caller's
+// full per-request retry policy (retries plus fallbacks plus empty/backoff
+// responses) without imposing a hidden lower limit. Callers with heavier
+// policies can raise it via ClientConfig.MaxMRTRRounds.
+const defaultMaxMRTRRounds = 64
 
 // HeaderMismatchError constructs a JSON-RPC -32020 error.
 func HeaderMismatchError(message string) *jsonRPCError {
@@ -114,6 +119,11 @@ type ClientConfig struct {
 	RootsProvider      RootsProvider
 	SamplingHandler    SamplingHandler
 	ElicitationHandler ElicitationHandler
+	// MaxMRTRRounds overrides the number of input_required round trips the
+	// client will complete for a single logical request. Zero or negative uses
+	// defaultMaxMRTRRounds. Set this to at least the caller's worst-case
+	// per-request sampling count so a recoverable exchange is not aborted.
+	MaxMRTRRounds int
 }
 
 // StaticRoots returns a provider that always returns the same roots.
@@ -203,6 +213,7 @@ type clientState struct {
 	instructions         string
 	clientInfo           ImplementationInfo
 	clientCapabilities   ClientCapabilities
+	maxMRTRRounds        int
 }
 
 func newClientState(configs ...ClientConfig) *clientState {
@@ -217,6 +228,12 @@ func newClientState(configs ...ClientConfig) *clientState {
 		cfg.RootsProvider = override.RootsProvider
 		cfg.SamplingHandler = override.SamplingHandler
 		cfg.ElicitationHandler = override.ElicitationHandler
+		cfg.MaxMRTRRounds = override.MaxMRTRRounds
+	}
+
+	maxRounds := cfg.MaxMRTRRounds
+	if maxRounds <= 0 {
+		maxRounds = defaultMaxMRTRRounds
 	}
 
 	state := &clientState{
@@ -224,6 +241,7 @@ func newClientState(configs ...ClientConfig) *clientState {
 		notificationHandlers: make(map[string]map[int64]NotificationHandler),
 		requestHandlers:      make(map[string]RequestHandler),
 		protocolVersion:      protocolVersion,
+		maxMRTRRounds:        maxRounds,
 	}
 
 	if cfg.ClientInfo != nil {
@@ -818,7 +836,11 @@ func mustRawJSON(data []byte) json.RawMessage {
 // returned for the caller to unmarshal.
 func (s *clientState) roundTrip(ctx context.Context, call rpcCaller, method string, params any, mrtr bool) (json.RawMessage, error) {
 	baseParams := normalizeParamsMap(params)
-	for range maxMRTRRounds {
+	maxRounds := s.maxMRTRRounds
+	if maxRounds <= 0 {
+		maxRounds = defaultMaxMRTRRounds
+	}
+	for range maxRounds {
 		paramsRaw, err := mergeRequestMeta(baseParams, s.requestMeta())
 		if err != nil {
 			return nil, err
@@ -867,7 +889,7 @@ func (s *clientState) roundTrip(ctx context.Context, call rpcCaller, method stri
 			return nil, fmt.Errorf("mcp: unrecognized resultType %q for method %q", rt, method)
 		}
 	}
-	return nil, fmt.Errorf("mcp: MRTR round limit (%d) exceeded for method %q", maxMRTRRounds, method)
+	return nil, fmt.Errorf("mcp: MRTR round limit (%d) exceeded for method %q", maxRounds, method)
 }
 
 // fulfillInputRequests invokes the registered client handler for each input
@@ -1166,7 +1188,13 @@ func parsePendingID(raw *json.RawMessage) (int64, error) {
 	return 0, fmt.Errorf("unsupported response id: %s", string(*raw))
 }
 
-// normalizeID converts the raw JSON id to a concrete type for serialization.
+// normalizeID converts the raw JSON id to a concrete type for serialization
+// while preserving the client's exact id. Integers that fit int64 and strings
+// decode to their concrete Go values so the client and server can correlate a
+// response; anything else (integers beyond int64, or otherwise unusual ids) is
+// preserved as raw JSON bytes and echoed verbatim. A previous float64 fallback
+// silently rounded large integers, producing a response id the client could
+// not correlate.
 func normalizeID(raw *json.RawMessage) any {
 	if raw == nil {
 		return nil
@@ -1175,11 +1203,6 @@ func normalizeID(raw *json.RawMessage) any {
 	var intID int64
 	if err := json.Unmarshal(*raw, &intID); err == nil {
 		return intID
-	}
-
-	var floatID float64
-	if err := json.Unmarshal(*raw, &floatID); err == nil {
-		return floatID
 	}
 
 	var strID string

--- a/ext/mcp/server.go
+++ b/ext/mcp/server.go
@@ -488,14 +488,8 @@ func (s *Server) handleSubscriptionCancel(raw json.RawMessage) {
 		return
 	}
 	id := normalizeID(params.RequestID)
-	key := idKeyString(id)
-	s.hub.mu.Lock()
-	sub, ok := s.hub.subs[key]
-	if ok {
-		delete(s.hub.subs, key)
-	}
-	s.hub.mu.Unlock()
-	if ok && sub.deliver != nil {
+	sub := s.hub.deregisterByID(id)
+	if sub != nil && sub.deliver != nil {
 		sub.deliver(subscriptionClosureResponse(id))
 	}
 }
@@ -673,7 +667,7 @@ func (s *Server) handleSubscriptionsListen(rc *RequestContext, raw json.RawMessa
 	}
 	sub := &subscription{
 		id:     id,
-		idKey:  idKeyString(id),
+		key:    nextSubscriptionKey(),
 		filter: filter,
 		deliver: func(data []byte) {
 			_ = s.writeJSON(data)

--- a/ext/mcp/server_http.go
+++ b/ext/mcp/server_http.go
@@ -151,7 +151,7 @@ func (t *HTTPServerTransport) handleSubscriptionsListen(w http.ResponseWriter, r
 
 	sub := &subscription{
 		id:     requestID,
-		idKey:  idKeyString(requestID),
+		key:    nextSubscriptionKey(),
 		filter: filter,
 		deliver: func(data []byte) {
 			select {

--- a/ext/mcp/subscriptions.go
+++ b/ext/mcp/subscriptions.go
@@ -2,7 +2,9 @@ package mcp
 
 import (
 	"encoding/json"
+	"strconv"
 	"sync"
+	"sync/atomic"
 )
 
 // SubscriptionFilter selects which server notifications a client wants to
@@ -29,10 +31,22 @@ type subscriptionStreamMarker struct{}
 // fully-built JSON-RPC notification message (bytes) to the consumer; it must be
 // non-blocking so the hub can fan out without holding its lock.
 type subscription struct {
-	id      any    // JSON-RPC id of the subscriptions/listen request
-	idKey   string // stable string key for the hub map
+	id      any    // JSON-RPC id of the subscriptions/listen request (echoed to the client)
+	key     string // server-generated unique hub key
 	filter  SubscriptionFilter
 	deliver func([]byte)
+}
+
+// subscriptionKeySeq generates process-unique subscription keys. The hub is
+// shared across every stateless HTTP stream, and independent clients commonly
+// reuse the same JSON-RPC request id (e.g. 1), so keying the hub by request id
+// would let a second listener overwrite the first and let one stream's
+// deregistration delete another. A monotonic server-generated key keeps each
+// stream independent regardless of client-chosen ids.
+var subscriptionKeySeq atomic.Uint64
+
+func nextSubscriptionKey() string {
+	return "sub-" + strconv.FormatUint(subscriptionKeySeq.Add(1), 10)
 }
 
 // subscriptionHub tracks active subscriptions/listen streams so server-side
@@ -48,14 +62,34 @@ func newSubscriptionHub() *subscriptionHub {
 
 // register adds a subscription and returns a deregister func.
 func (h *subscriptionHub) register(sub *subscription) func() {
+	if sub.key == "" {
+		sub.key = nextSubscriptionKey()
+	}
 	h.mu.Lock()
-	h.subs[sub.idKey] = sub
+	h.subs[sub.key] = sub
 	h.mu.Unlock()
 	return func() {
 		h.mu.Lock()
-		delete(h.subs, sub.idKey)
+		delete(h.subs, sub.key)
 		h.mu.Unlock()
 	}
+}
+
+// deregisterByID removes and returns the subscription whose JSON-RPC request id
+// matches id. Used by the framed (stdio) cancel path, where the client
+// references its own listen request id on a single connection. HTTP streams
+// deregister via the connection-scoped closure returned by register instead.
+func (h *subscriptionHub) deregisterByID(id any) *subscription {
+	want := idKeyString(id)
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for key, sub := range h.subs {
+		if idKeyString(sub.id) == want {
+			delete(h.subs, key)
+			return sub
+		}
+	}
+	return nil
 }
 
 // clear drops all subscriptions. Called on server close / peer EOF so a

--- a/modelutil/cache_key.go
+++ b/modelutil/cache_key.go
@@ -126,20 +126,60 @@ func normalizeCacheValue(value any, path []string) (any, error) {
 	}
 }
 
+// toolReturnDataPathKey marks the data object of a core tool-return part
+// envelope in the traversal path so its opaque content payload is preserved
+// verbatim rather than normalized as transport metadata.
+const toolReturnDataPathKey = "\x00tool-return-data"
+
 func normalizeCacheMap(value map[string]any, path []string) (map[string]any, error) {
 	out := make(map[string]any, len(value))
-	inSchemaProperties := len(path) > 0 && isSchemaPropertyContainer(path[len(path)-1])
+	last := ""
+	if len(path) > 0 {
+		last = path[len(path)-1]
+	}
+	inSchemaProperties := isSchemaPropertyContainer(last)
+	inToolReturnData := last == toolReturnDataPathKey
+	toolReturnEnvelope := isToolReturnEnvelope(value)
 	for key, raw := range value {
 		if !inSchemaProperties && shouldDropCacheKey(key, value) {
 			continue
 		}
-		normalized, err := normalizeCacheField(key, raw, append(path, key))
+		// The content of a tool-return part is opaque user/tool output.
+		// Applying the metadata drop list, sorting, or canonicalization to it
+		// would let materially different tool results (say {"duration":5}
+		// versus {"duration":10}) collapse to one cache key and return a stale
+		// model response, so preserve it verbatim.
+		if inToolReturnData && normalizedKey(key) == "content" {
+			out[key] = raw
+			continue
+		}
+		childKey := key
+		if toolReturnEnvelope && key == "data" {
+			childKey = toolReturnDataPathKey
+		}
+		normalized, err := normalizeCacheField(key, raw, append(path, childKey))
 		if err != nil {
 			return nil, err
 		}
 		out[key] = normalized
 	}
 	return out, nil
+}
+
+// isToolReturnEnvelope reports whether value is a core tool-return part envelope
+// ({"type":"tool-return","data":{...}}), whose data.content is opaque tool
+// output. It deliberately does not match provider-native content blocks, which
+// carry only "type" (not "data") and whose transport metadata is still
+// normalized to preserve cache hit rates.
+func isToolReturnEnvelope(value map[string]any) bool {
+	if _, ok := value["data"]; !ok {
+		return false
+	}
+	t, ok := value["type"].(string)
+	if !ok {
+		return false
+	}
+	return normalizedKey(t) == "toolreturn"
 }
 
 func normalizeCacheField(key string, raw any, path []string) (any, error) {

--- a/modelutil/cache_key_test.go
+++ b/modelutil/cache_key_test.go
@@ -97,6 +97,42 @@ func TestStableCacheKey_DifferentSemanticContentDiffers(t *testing.T) {
 	}
 }
 
+func TestStableCacheKey_ToolContentWithDropListedKeysStaysDistinct(t *testing.T) {
+	build := func(content map[string]any) []core.ModelMessage {
+		return []core.ModelMessage{
+			core.ModelResponse{
+				Parts: []core.ModelResponsePart{
+					core.ToolCallPart{ToolName: "bench", ArgsJSON: `{}`, ToolCallID: "call-1"},
+				},
+			},
+			core.ModelRequest{
+				Parts: []core.ModelRequestPart{
+					core.ToolReturnPart{
+						ToolName:   "bench",
+						ToolCallID: "call-1",
+						Content:    content,
+					},
+				},
+			},
+		}
+	}
+
+	// "duration" is on the transport metadata drop list, but here it is a
+	// semantic field inside the tool result: 5 and 10 are materially different
+	// outputs and must not share a cache entry.
+	key1 := mustStableKey(t, StableCacheKeyInput{Model: "m", Messages: build(map[string]any{"duration": 5})})
+	key2 := mustStableKey(t, StableCacheKeyInput{Model: "m", Messages: build(map[string]any{"duration": 10})})
+	if key1 == key2 {
+		t.Fatal("stable keys collided for tool results with different duration values")
+	}
+
+	// Identical tool content still produces a stable key.
+	key3 := mustStableKey(t, StableCacheKeyInput{Model: "m", Messages: build(map[string]any{"duration": 5})})
+	if key1 != key3 {
+		t.Fatalf("stable keys differ for identical tool content:\n%s\n%s", key1, key3)
+	}
+}
+
 func TestStableCacheKey_NormalizesSafeOrderingNoise(t *testing.T) {
 	params1 := &core.ModelRequestParameters{
 		FunctionTools: []core.ToolDefinition{


### PR DESCRIPTION
Follow-up to the 2026-07-28 stateless MCP adoption (v0.6.0). Automated review of the sleepy integration surfaced four real correctness/robustness bugs in the stateless MCP surface; this fixes them with regression tests.

## Fixes

1. **MRTR round budget (P1)** - `roundTrip` capped input_required rounds at a hidden constant of 8. Each round is one server-driven sampling call, and a caller's per-request retry policy (retries + full-code fallback + empty/backoff responses) can exceed 8, aborting an otherwise recoverable exchange. Made the budget configurable via `ClientConfig.MaxMRTRRounds` and raised the default to 64.

2. **JSON-RPC id preservation (P2)** - `normalizeID` routed ids through a `float64` fallback that silently rounded integers beyond `int64`, so the echoed response id no longer matched what the client sent. Such ids are now preserved as raw JSON and echoed verbatim.

3. **Subscription hub keying (P1)** - the hub shared across all stateless HTTP streams was keyed by the client's JSON-RPC request id. Independent clients commonly reuse id `1`, so a second listener overwrote the first and one stream's deregistration could delete another. The hub now keys by a server-generated unique id; the framed (stdio) cancel path matches by request id explicitly.

4. **Cache-key tool content (P1)** - `normalizeCacheMap` applied the transport-metadata drop list recursively into every map, including a `ToolReturnPart.Content` payload, so `{"duration":5}` and `{"duration":10}` normalized identically and collided on one cache key (returning a stale model response). Content of a core tool-return envelope is now preserved verbatim. Provider-native content blocks (which carry `type` but not `data`) are still normalized, so the release-gate cache hit rate is unchanged.

## Tests
- `modelutil`: `TestStableCacheKey_ToolContentWithDropListedKeysStaysDistinct`; release-gate benchmark `TestBenchmarkPassesReleaseGateForOpenAIAndAnthropic` still green.
- `ext/mcp`: `TestNormalizeIDPreservesLargeIntegersVerbatim`, `TestSubscriptionHubKeepsClientsWithSameRequestIDIndependent`, `TestClientStateMRTRRoundsConfigurable`.
- Full suite green under `-race` (pre-push gate passed).
