### PR TITLE
feat(provider): add local endpoint conformance profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,11 +98,15 @@ model := anthropic.New() // reads ANTHROPIC_API_KEY
 |---|---|
 | Anthropic (Claude) | `provider/anthropic` |
 | OpenAI (GPT, o-series) | `provider/openai` |
+| OpenAI-compatible local endpoint | `provider/openai` (`NewLocalEndpoint`) |
 | Google Gemini (Vertex AI) | `provider/vertexai` |
 | Claude via Vertex AI | `provider/vertexai_anthropic` |
 
-All providers support streaming, tool calls, and structured output. Providers implement a
-small `Model` interface, so wrapping or adding one is straightforward.
+The native providers listed above support streaming, tool calls, and structured output.
+`NewLocalEndpoint` is deliberately more conservative: it supports the loopback Chat
+Completions tool-and-streaming surface and leaves structured output, vision, caching, and
+Responses API behavior unavailable until a compatible server proves them. Providers implement
+a small `Model` interface, so wrapping or adding one is straightforward.
 
 ## A production-shaped example
 

--- a/appserver/catalog/catalog.go
+++ b/appserver/catalog/catalog.go
@@ -16,10 +16,11 @@ import (
 )
 
 const (
-	ProviderOpenAI            = "openai"
-	ProviderAnthropic         = "anthropic"
-	ProviderVertexAI          = "vertexai"
-	ProviderVertexAIAnthropic = "vertexai-anthropic"
+	ProviderOpenAI                = "openai"
+	ProviderOpenAICompatibleLocal = "openai-compatible-local"
+	ProviderAnthropic             = "anthropic"
+	ProviderVertexAI              = "vertexai"
+	ProviderVertexAIAnthropic     = "vertexai-anthropic"
 )
 
 var ErrProviderNotFound = errors.New("provider not found")
@@ -248,6 +249,18 @@ func (c *Catalog) defaultProviders() []Provider {
 	openaiConfigured := envConfigured(c.env, "OPENAI_API_KEY") || envConfigured(c.env, "CHATGPT_ACCESS_TOKEN")
 	anthropicConfigured := envConfigured(c.env, "ANTHROPIC_API_KEY")
 	vertexConfigured := envConfigured(c.env, "GOOGLE_CLOUD_PROJECT") || envConfigured(c.env, "GOOGLE_APPLICATION_CREDENTIALS")
+	localConfig, localConfigErr := openaiprovider.LocalEndpointConfigFromLookup(c.env)
+	// Merely having a safe default is not evidence that a local server exists.
+	// Require an explicit local-profile setting before offering it as runnable.
+	localConfigured := localConfigErr == nil && envConfigured(c.env,
+		openaiprovider.LocalEndpointBaseURLEnv,
+		openaiprovider.LocalEndpointModelEnv,
+		openaiprovider.LocalEndpointAPIKeyEnv,
+	)
+	localModel := "llama3"
+	if localConfigured {
+		localModel = localConfig.Model
+	}
 
 	return []Provider{
 		{
@@ -279,6 +292,38 @@ func (c *Catalog) defaultProviders() []Provider {
 				model(ProviderOpenAI, openaiprovider.GPT5Mini, "GPT-5 mini", "Lower-latency GPT-5 family model.", false, textAndImage(), false, capabilities(true, true, true, true, true, true, false), []string{"minimal", "low", "medium", "high"}, "medium"),
 				model(ProviderOpenAI, openaiprovider.GPT5Nano, "GPT-5 nano", "Small GPT-5 family model for fast utility work.", true, textAndImage(), false, capabilities(true, true, true, true, true, true, false), []string{"minimal", "low", "medium", "high"}, "low"),
 				model(ProviderOpenAI, openaiprovider.GPT5Codex, "GPT-5 Codex", "OpenAI coding-specialized model exposed through Gollem's neutral model controls.", false, textAndImage(), false, capabilities(true, true, true, true, true, true, true), []string{"minimal", "low", "medium", "high"}, "medium"),
+			},
+		},
+		{
+			ID:             ProviderOpenAICompatibleLocal,
+			Name:           "Local OpenAI-compatible",
+			Package:        "github.com/fugue-labs/gollem/provider/openai",
+			Description:    "A loopback-only OpenAI Chat Completions endpoint with a configured local model fallback.",
+			Configured:     localConfigured,
+			DefaultModelID: modelID(ProviderOpenAICompatibleLocal, localModel),
+			OptionalEnvVars: []string{
+				openaiprovider.LocalEndpointBaseURLEnv,
+				openaiprovider.LocalEndpointModelEnv,
+				openaiprovider.LocalEndpointAPIKeyEnv,
+			},
+			AuthModes: []string{"local-loopback"},
+			Capabilities: ProviderCapabilities{
+				ToolCalls: true,
+				Streaming: true,
+			},
+			Models: []Model{
+				model(
+					ProviderOpenAICompatibleLocal,
+					localModel,
+					localModel,
+					"Configured local OpenAI-compatible Chat Completions model. Structured output and multimodal capabilities remain unavailable until separately verified.",
+					false,
+					[]string{"text"},
+					false,
+					capabilities(true, false, false, true, false, false, false),
+					nil,
+					"",
+				),
 			},
 		},
 		{

--- a/appserver/catalog/catalog_test.go
+++ b/appserver/catalog/catalog_test.go
@@ -1,8 +1,12 @@
 package catalog
 
 import (
+	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
+
+	openaiprovider "github.com/fugue-labs/gollem/provider/openai"
 )
 
 func TestProviderListReportsConfigurationWithoutSecretValues(t *testing.T) {
@@ -99,6 +103,59 @@ func TestProviderCapabilities(t *testing.T) {
 	_, err = c.ProviderCapabilities("missing")
 	if !errors.Is(err, ErrProviderNotFound) {
 		t.Fatalf("missing provider err = %v, want ErrProviderNotFound", err)
+	}
+}
+
+func TestLocalOpenAICompatibleProviderUsesExplicitSafeConfiguration(t *testing.T) {
+	const baseURL = "http://127.0.0.1:8765/v1"
+	const model = "local-tool-model"
+	const token = "local-secret-value"
+	c := NewDefault(WithEnvLookup(mapEnv(map[string]string{
+		openaiprovider.LocalEndpointBaseURLEnv: baseURL,
+		openaiprovider.LocalEndpointModelEnv:   model,
+		openaiprovider.LocalEndpointAPIKeyEnv:  token,
+	})))
+
+	provider := findProvider(t, c.ListProviders(ProviderListParams{}).Data, ProviderOpenAICompatibleLocal)
+	if !provider.Configured {
+		t.Fatal("explicit valid local profile was not configured")
+	}
+	if !provider.Capabilities.ToolCalls || !provider.Capabilities.Streaming || provider.Capabilities.StructuredOutput || provider.Capabilities.Vision {
+		t.Fatalf("local provider capabilities = %#v", provider.Capabilities)
+	}
+	models, err := c.ListModels(ModelListParams{ProviderID: ProviderOpenAICompatibleLocal})
+	if err != nil {
+		t.Fatalf("ListModels: %v", err)
+	}
+	if len(models.Data) != 1 || models.Data[0].Model != model || !models.Data[0].Capabilities.ToolCalls || !models.Data[0].Capabilities.Streaming {
+		t.Fatalf("local provider models = %#v", models.Data)
+	}
+
+	encoded, err := json.Marshal(provider)
+	if err != nil {
+		t.Fatalf("marshal provider: %v", err)
+	}
+	for _, secret := range []string{baseURL, token} {
+		if strings.Contains(string(encoded), secret) {
+			t.Fatalf("provider metadata leaked local configuration %q: %s", secret, encoded)
+		}
+	}
+}
+
+func TestLocalOpenAICompatibleProviderRequiresExplicitValidConfiguration(t *testing.T) {
+	for name, env := range map[string]map[string]string{
+		"unset": nil,
+		"remote endpoint": {
+			openaiprovider.LocalEndpointBaseURLEnv: "https://example.com/v1",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			c := NewDefault(WithEnvLookup(mapEnv(env)))
+			provider := findProvider(t, c.ListProviders(ProviderListParams{}).Data, ProviderOpenAICompatibleLocal)
+			if provider.Configured {
+				t.Fatalf("local provider was configured for %#v", env)
+			}
+		})
 	}
 }
 

--- a/cmd/gollem/app_server_test.go
+++ b/cmd/gollem/app_server_test.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -22,6 +24,7 @@ import (
 	"github.com/fugue-labs/gollem/appserver/protocol"
 	"github.com/fugue-labs/gollem/appserver/store"
 	"github.com/fugue-labs/gollem/core"
+	openaiprovider "github.com/fugue-labs/gollem/provider/openai"
 )
 
 func TestParseAppServerFlags(t *testing.T) {
@@ -915,6 +918,80 @@ func TestCLIAppServerThreadStartUsesRuntimeProviderFlag(t *testing.T) {
 	})
 	if resp.Error != nil {
 		t.Fatalf("thread/start error: %v", resp.Error)
+	}
+	waitCLINotification(t, server, "turn/completed")
+}
+
+func TestCLIAppServerRuntimeFactoryUsesLocalOpenAICompatibleProfile(t *testing.T) {
+	var requests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Fatalf("path = %q, want /v1/chat/completions", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer local" {
+			t.Fatalf("Authorization = %q, want local credential", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl-local","object":"chat.completion","model":"gpt-5.2-codex","choices":[{"message":{"role":"assistant","content":"runtime reply"},"finish_reason":"stop"}]}`))
+	}))
+	defer server.Close()
+	t.Setenv(openaiprovider.LocalEndpointBaseURLEnv, server.URL)
+	t.Setenv("OPENAI_API_KEY", "must-not-be-used")
+
+	factory := appServerRuntimeModelFactory(appServerFlags{})
+	model, info, err := factory(context.Background(), appserver.RuntimeModelSelection{
+		ProviderID: catalog.ProviderOpenAICompatibleLocal,
+		Model:      "gpt-5.2-codex",
+	})
+	if err != nil {
+		t.Fatalf("factory: %v", err)
+	}
+	if info.ProviderID != catalog.ProviderOpenAICompatibleLocal || info.Model != "gpt-5.2-codex" {
+		t.Fatalf("runtime info = %#v", info)
+	}
+	response, err := model.Request(context.Background(), []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "hello"}}},
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("runtime request: %v", err)
+	}
+	if response.TextContent() != "runtime reply" || requests != 1 {
+		t.Fatalf("runtime response = %#v, requests = %d", response, requests)
+	}
+}
+
+func TestCLIAppServerThreadStartUsesLocalOpenAICompatibleProfile(t *testing.T) {
+	serverFixture := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Fatalf("path = %q, want /v1/chat/completions", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl-local","object":"chat.completion","model":"local-tool-model","choices":[{"message":{"role":"assistant","content":"local thread reply"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":2}}`))
+	}))
+	defer serverFixture.Close()
+	t.Setenv(openaiprovider.LocalEndpointBaseURLEnv, serverFixture.URL)
+	t.Setenv(openaiprovider.LocalEndpointModelEnv, "local-tool-model")
+
+	server, cleanup, err := newCLIAppServer(appServerFlags{
+		workDir:   t.TempDir(),
+		storePath: ":memory:",
+		provider:  catalog.ProviderOpenAICompatibleLocal,
+		stdio:     true,
+	})
+	if err != nil {
+		t.Fatalf("newCLIAppServer: %v", err)
+	}
+	defer cleanup()
+	readyCLIAppServer(t, server)
+
+	response := server.HandleRequest(context.Background(), protocol.Request{
+		ID:     protocol.NewStringID("start-local"),
+		Method: "thread/start",
+		Params: json.RawMessage(`{"prompt":"hello from local provider"}`),
+	})
+	if response.Error != nil {
+		t.Fatalf("thread/start error: %v", response.Error)
 	}
 	waitCLINotification(t, server, "turn/completed")
 }

--- a/cmd/gollem/main.go
+++ b/cmd/gollem/main.go
@@ -2168,6 +2168,15 @@ func createModel(provider, modelName, location, project string, requestTimeout t
 			opts = append(opts, openai.WithModel(modelName))
 		}
 		return openai.New(opts...), nil
+	case "openai-compatible-local":
+		config, err := openai.LocalEndpointConfigFromLookup(os.LookupEnv)
+		if err != nil {
+			return nil, err
+		}
+		if modelName != "" {
+			config.Model = modelName
+		}
+		return openai.NewLocalEndpoint(config, openai.WithHTTPClient(httpClient))
 	case "xai":
 		opts := []openai.Option{openai.WithHTTPClient(httpClient)}
 		if modelName != "" {
@@ -2199,7 +2208,7 @@ func createModel(provider, modelName, location, project string, requestTimeout t
 		}
 		return vertexai_anthropic.New(opts...), nil
 	default:
-		return nil, fmt.Errorf("provider %q not supported (available: test, anthropic, openai, xai, vertexai, vertexai-anthropic)", provider)
+		return nil, fmt.Errorf("provider %q not supported (available: test, anthropic, openai, openai-compatible-local, xai, vertexai, vertexai-anthropic)", provider)
 	}
 }
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -575,6 +575,18 @@ OpenAI provider note:
 - Current limitation: this path is non-streaming (`Request()` flow). Streaming
   UI output still relies on provider streaming support via `RequestStream()`.
 
+Local OpenAI-compatible endpoint note:
+- `openai.NewLocalEndpoint` accepts only HTTP(S) `localhost` or IP-loopback
+  endpoints and forces the Chat Completions protocol. It never inherits
+  `OPENAI_API_KEY` or `OPENAI_BASE_URL`.
+- The Gollem app-server profile is configured only by
+  `GOLLEM_LOCAL_OPENAI_BASE_URL`, `GOLLEM_LOCAL_OPENAI_MODEL`, and optional
+  `GOLLEM_LOCAL_OPENAI_API_KEY`. Those values remain in the Gollem process and
+  are not projected into the provider/model catalog.
+- This profile currently proves tool calls, streaming, and usage through
+  deterministic conformance fixtures. It does not advertise structured output,
+  vision, prompt caching, or Responses API behavior.
+
 | Feature | Anthropic | OpenAI | Vertex AI | Vertex AI Anthropic |
 |---------|-----------|--------|-----------|---------------------|
 | Structured output | Yes | Yes | Yes | Yes |

--- a/provider/conformance/conformance.go
+++ b/provider/conformance/conformance.go
@@ -1,0 +1,142 @@
+// Package conformance provides provider-neutral checks for model-driver tests.
+//
+// Drivers supply their own deterministic protocol fixture and then pass the
+// resulting core.Model to Verify. This keeps wire-format details with each
+// adapter while making capability claims observable at Gollem's model boundary.
+package conformance
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/fugue-labs/gollem/core"
+)
+
+// Claims are the capabilities covered by a deterministic conformance fixture.
+// A driver must not advertise one of these capabilities in Slang unless it has
+// a matching deterministic fixture and this verification passes.
+type Claims struct {
+	ToolCalls bool
+	Streaming bool
+	Usage     bool
+}
+
+// Expectations declares the normalized outputs a deterministic fixture
+// produces. ToolName is required when Claims.ToolCalls is true. StreamText is
+// required when Claims.Streaming is true.
+type Expectations struct {
+	ResponseText string
+	ToolName     string
+	StreamText   string
+}
+
+// Driver binds a provider model to the common capability claims and expected
+// normalized results that its deterministic fixture produces.
+type Driver struct {
+	Name         string
+	Model        core.Model
+	Claims       Claims
+	Expectations Expectations
+}
+
+// Verify exercises the claimed common model surface through core.Model. It is
+// intentionally independent of a provider's HTTP or RPC wire format.
+func Verify(ctx context.Context, driver Driver) error {
+	if strings.TrimSpace(driver.Name) == "" {
+		return errors.New("provider conformance: driver name is required")
+	}
+	if driver.Model == nil {
+		return fmt.Errorf("provider conformance: %s model is required", driver.Name)
+	}
+	if driver.Claims.ToolCalls && strings.TrimSpace(driver.Expectations.ToolName) == "" {
+		return fmt.Errorf("provider conformance: %s tool-capable fixture must expect a tool call", driver.Name)
+	}
+	if driver.Claims.Streaming && strings.TrimSpace(driver.Expectations.StreamText) == "" {
+		return fmt.Errorf("provider conformance: %s streaming fixture must expect stream text", driver.Name)
+	}
+
+	params := &core.ModelRequestParameters{AllowTextOutput: true}
+	if driver.Claims.ToolCalls {
+		params.FunctionTools = []core.ToolDefinition{{
+			Name:        "conformance_echo",
+			Description: "Return the supplied value for deterministic driver testing.",
+			ParametersSchema: core.Schema{
+				"type": "object",
+				"properties": map[string]any{
+					"value": core.Schema{"type": "string"},
+				},
+				"required": []string{"value"},
+			},
+		}}
+	}
+	response, err := driver.Model.Request(ctx, conformanceMessages(), nil, params)
+	if err != nil {
+		return fmt.Errorf("provider conformance: %s request: %w", driver.Name, err)
+	}
+	if response == nil {
+		return fmt.Errorf("provider conformance: %s request returned a nil response", driver.Name)
+	}
+	if err := verifyResponse(driver, response, false); err != nil {
+		return err
+	}
+
+	if !driver.Claims.Streaming {
+		return nil
+	}
+	stream, err := driver.Model.RequestStream(ctx, conformanceMessages(), nil, &core.ModelRequestParameters{AllowTextOutput: true})
+	if err != nil {
+		return fmt.Errorf("provider conformance: %s stream request: %w", driver.Name, err)
+	}
+	defer stream.Close()
+	for {
+		_, err := stream.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("provider conformance: %s stream: %w", driver.Name, err)
+		}
+	}
+	if err := verifyResponse(driver, stream.Response(), true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func verifyResponse(driver Driver, response *core.ModelResponse, streaming bool) error {
+	if response == nil {
+		return fmt.Errorf("provider conformance: %s returned a nil response", driver.Name)
+	}
+	wantText := driver.Expectations.ResponseText
+	if streaming {
+		wantText = driver.Expectations.StreamText
+	}
+	if got := response.TextContent(); got != wantText {
+		return fmt.Errorf("provider conformance: %s text = %q, want %q", driver.Name, got, wantText)
+	}
+	if driver.Claims.ToolCalls && !streaming && !hasToolCall(response.Parts, driver.Expectations.ToolName) {
+		return fmt.Errorf("provider conformance: %s response did not contain tool %q", driver.Name, driver.Expectations.ToolName)
+	}
+	if driver.Claims.Usage && response.Usage.InputTokens+response.Usage.OutputTokens == 0 {
+		return fmt.Errorf("provider conformance: %s response did not report usage", driver.Name)
+	}
+	return nil
+}
+
+func hasToolCall(parts []core.ModelResponsePart, name string) bool {
+	for _, part := range parts {
+		if call, ok := part.(core.ToolCallPart); ok && call.ToolName == name {
+			return true
+		}
+	}
+	return false
+}
+
+func conformanceMessages() []core.ModelMessage {
+	return []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "run conformance"}}},
+	}
+}

--- a/provider/conformance/conformance_test.go
+++ b/provider/conformance/conformance_test.go
@@ -1,0 +1,186 @@
+package conformance_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/fugue-labs/gollem/provider/anthropic"
+	"github.com/fugue-labs/gollem/provider/conformance"
+	"github.com/fugue-labs/gollem/provider/openai"
+)
+
+func TestDeterministicProviderDriverConformance(t *testing.T) {
+	openAIServer := httptest.NewServer(openAIConformanceFixture(t))
+	defer openAIServer.Close()
+	anthropicServer := httptest.NewServer(anthropicConformanceFixture(t))
+	defer anthropicServer.Close()
+
+	cases := []struct {
+		name  string
+		model func() (conformance.Driver, error)
+	}{
+		{
+			name: "native OpenAI",
+			model: func() (conformance.Driver, error) {
+				return conformance.Driver{
+					Name:   "native OpenAI",
+					Model:  openai.New(openai.WithAPIKey("test-openai-key"), openai.WithBaseURL(openAIServer.URL), openai.WithModel("gpt-4o")),
+					Claims: conformance.Claims{ToolCalls: true, Streaming: true, Usage: true},
+					Expectations: conformance.Expectations{
+						ResponseText: "openai response",
+						ToolName:     "conformance_echo",
+						StreamText:   "openai stream",
+					},
+				}, nil
+			},
+		},
+		{
+			name: "OpenAI-compatible local",
+			model: func() (conformance.Driver, error) {
+				model, err := openai.NewLocalEndpoint(openai.LocalEndpointConfig{
+					BaseURL: openAIServer.URL,
+					Model:   "gpt-5.2-codex",
+					Token:   "test-local-key",
+				})
+				if err != nil {
+					return conformance.Driver{}, err
+				}
+				return conformance.Driver{
+					Name:   "OpenAI-compatible local",
+					Model:  model,
+					Claims: conformance.Claims{ToolCalls: true, Streaming: true, Usage: true},
+					Expectations: conformance.Expectations{
+						ResponseText: "openai response",
+						ToolName:     "conformance_echo",
+						StreamText:   "openai stream",
+					},
+				}, nil
+			},
+		},
+		{
+			name: "native Anthropic",
+			model: func() (conformance.Driver, error) {
+				return conformance.Driver{
+					Name:   "native Anthropic",
+					Model:  anthropic.New(anthropic.WithAPIKey("test-anthropic-key"), anthropic.WithBaseURL(anthropicServer.URL), anthropic.WithModel(anthropic.ClaudeSonnet46)),
+					Claims: conformance.Claims{ToolCalls: true, Streaming: true, Usage: true},
+					Expectations: conformance.Expectations{
+						ResponseText: "anthropic response",
+						ToolName:     "conformance_echo",
+						StreamText:   "anthropic stream",
+					},
+				}, nil
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			driver, err := tt.model()
+			if err != nil {
+				t.Fatalf("new driver: %v", err)
+			}
+			if err := conformance.Verify(context.Background(), driver); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestVerifyRejectsUnprovenClaims(t *testing.T) {
+	err := conformance.Verify(context.Background(), conformance.Driver{
+		Name:   "missing tool fixture",
+		Model:  openai.New(openai.WithAPIKey("test-key")),
+		Claims: conformance.Claims{ToolCalls: true},
+	})
+	if err == nil {
+		t.Fatal("Verify accepted a tool claim without an expected tool")
+	}
+}
+
+func openAIConformanceFixture(t *testing.T) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Fatalf("OpenAI path = %q, want /v1/chat/completions", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") == "" {
+			t.Fatal("OpenAI fixture request had no authorization header")
+		}
+		var request struct {
+			Stream bool            `json:"stream"`
+			Tools  json.RawMessage `json:"tools"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatalf("decode OpenAI request: %v", err)
+		}
+		if request.Stream {
+			if len(request.Tools) != 0 && string(request.Tools) != "null" {
+				t.Fatalf("stream request unexpectedly included tools: %s", request.Tools)
+			}
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = fmt.Fprint(w, `data: {"id":"chatcmpl-conformance","object":"chat.completion.chunk","model":"gpt-4o","choices":[{"index":0,"delta":{"content":"openai stream"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":2}}
+
+data: [DONE]
+
+`)
+			return
+		}
+		if len(request.Tools) == 0 || string(request.Tools) == "null" {
+			t.Fatal("tool-capable request did not include tools")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":"chatcmpl-conformance","object":"chat.completion","model":"gpt-4o","choices":[{"message":{"role":"assistant","content":"openai response","tool_calls":[{"id":"call_openai","type":"function","function":{"name":"conformance_echo","arguments":"{\"value\":\"ok\"}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":3,"completion_tokens":2}}`)
+	})
+}
+
+func anthropicConformanceFixture(t *testing.T) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/messages" {
+			t.Fatalf("Anthropic path = %q, want /v1/messages", r.URL.Path)
+		}
+		if r.Header.Get("x-api-key") == "" {
+			t.Fatal("Anthropic fixture request had no API key header")
+		}
+		var request struct {
+			Stream bool            `json:"stream"`
+			Tools  json.RawMessage `json:"tools"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatalf("decode Anthropic request: %v", err)
+		}
+		if request.Stream {
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = fmt.Fprint(w, `event: message_start
+data: {"type":"message_start","message":{"usage":{"input_tokens":3,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"anthropic stream"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":2}}
+
+event: message_stop
+data: {"type":"message_stop"}
+
+`)
+			return
+		}
+		if len(request.Tools) == 0 || string(request.Tools) == "null" {
+			t.Fatal("tool-capable request did not include tools")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":"msg-conformance","role":"assistant","model":"claude-sonnet-4-6","content":[{"type":"text","text":"anthropic response"},{"type":"tool_use","id":"call_anthropic","name":"conformance_echo","input":{"value":"ok"}}],"stop_reason":"tool_use","usage":{"input_tokens":3,"output_tokens":2}}`)
+	})
+}

--- a/provider/openai/doc.go
+++ b/provider/openai/doc.go
@@ -42,6 +42,23 @@
 //	    openai.WithModel("claude-3-sonnet"),
 //	)
 //
+// # Local OpenAI-Compatible Endpoint
+//
+// Use NewLocalEndpoint for a process-owned loopback Chat Completions server:
+//
+//	model, err := openai.NewLocalEndpoint(openai.LocalEndpointConfig{
+//	    BaseURL: "http://127.0.0.1:11434",
+//	    Model:   "my-local-tool-model",
+//	})
+//
+// The profile only accepts HTTP(S) localhost or loopback addresses, always
+// uses Chat Completions, and never inherits OPENAI_API_KEY or OPENAI_BASE_URL.
+// It exposes tool calls and streaming, but does not claim structured output,
+// vision, prompt caching, or Responses API behavior until separately proven.
+// The app-server profile reads GOLLEM_LOCAL_OPENAI_BASE_URL,
+// GOLLEM_LOCAL_OPENAI_MODEL, and GOLLEM_LOCAL_OPENAI_API_KEY from its own
+// process environment; their values are not included in the provider catalog.
+//
 // # Latency Instrumentation
 //
 // WithRequestObserver installs a callback that receives one secret-safe

--- a/provider/openai/local_endpoint.go
+++ b/provider/openai/local_endpoint.go
@@ -1,0 +1,176 @@
+package openai
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"github.com/fugue-labs/gollem/modelutil"
+)
+
+const (
+	// LocalEndpointBaseURLEnv configures the loopback OpenAI-compatible endpoint.
+	// It intentionally accepts only loopback URLs so this profile cannot become an
+	// unreviewed remote-provider escape hatch.
+	LocalEndpointBaseURLEnv = "GOLLEM_LOCAL_OPENAI_BASE_URL"
+	// LocalEndpointModelEnv selects the configured-model fallback when discovery
+	// is unavailable from a local OpenAI-compatible server.
+	LocalEndpointModelEnv = "GOLLEM_LOCAL_OPENAI_MODEL"
+	// LocalEndpointAPIKeyEnv supplies an optional local proxy token. Its value is
+	// kept inside the provider process and is never projected through the catalog.
+	LocalEndpointAPIKeyEnv = "GOLLEM_LOCAL_OPENAI_API_KEY"
+
+	defaultLocalEndpointBaseURL = "http://127.0.0.1:11434"
+	defaultLocalEndpointModel   = "llama3"
+	defaultLocalEndpointAPIKey  = "local"
+)
+
+// LocalEndpointConfig is the process-owned configuration for a trusted local
+// OpenAI-compatible Chat Completions endpoint. It contains no renderer-facing
+// identity and must be normalized before constructing a provider.
+type LocalEndpointConfig struct {
+	BaseURL string
+	Model   string
+	Token   string
+}
+
+// LocalEndpointConfigFromLookup builds a local profile from environment-like
+// configuration. It is injectable for deterministic catalog and runtime tests.
+func LocalEndpointConfigFromLookup(lookup func(string) (string, bool)) (LocalEndpointConfig, error) {
+	config := LocalEndpointConfig{
+		BaseURL: defaultLocalEndpointBaseURL,
+		Model:   defaultLocalEndpointModel,
+		Token:   defaultLocalEndpointAPIKey,
+	}
+	if lookup != nil {
+		if value, ok := lookup(LocalEndpointBaseURLEnv); ok && strings.TrimSpace(value) != "" {
+			config.BaseURL = value
+		}
+		if value, ok := lookup(LocalEndpointModelEnv); ok && strings.TrimSpace(value) != "" {
+			config.Model = value
+		}
+		if value, ok := lookup(LocalEndpointAPIKeyEnv); ok && strings.TrimSpace(value) != "" {
+			config.Token = value
+		}
+	}
+	return NormalizeLocalEndpointConfig(config)
+}
+
+// NormalizeLocalEndpointConfig accepts only HTTP(S) loopback URLs, a bounded
+// configured-model fallback, and a bounded optional local proxy token.
+func NormalizeLocalEndpointConfig(config LocalEndpointConfig) (LocalEndpointConfig, error) {
+	baseURL, err := normalizeLocalEndpointBaseURL(config.BaseURL)
+	if err != nil {
+		return LocalEndpointConfig{}, err
+	}
+	model, err := normalizeLocalEndpointText(config.Model, defaultLocalEndpointModel, "model", 256)
+	if err != nil {
+		return LocalEndpointConfig{}, err
+	}
+	token, err := normalizeLocalEndpointText(config.Token, defaultLocalEndpointAPIKey, "token", 4_096)
+	if err != nil {
+		return LocalEndpointConfig{}, err
+	}
+	return LocalEndpointConfig{BaseURL: baseURL, Model: model, Token: token}, nil
+}
+
+// NewLocalEndpoint creates a conservative OpenAI-compatible local provider.
+// It forces the Chat Completions API and does not inherit OPENAI_API_KEY,
+// Responses API behavior, or OpenAI-specific prompt-cache settings.
+func NewLocalEndpoint(config LocalEndpointConfig, opts ...Option) (*Provider, error) {
+	config, err := NormalizeLocalEndpointConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	options := append([]Option(nil), opts...)
+	options = append(options,
+		WithBaseURL(config.BaseURL),
+		WithModel(config.Model),
+		WithAPIKey(config.Token),
+		withLocalEndpointConstraints(),
+	)
+	return New(options...), nil
+}
+
+func withLocalEndpointConstraints() Option {
+	return func(p *Provider) {
+		p.forceChatCompletions = true
+		p.redactEndpointErrors = true
+		p.useResponses = false
+		p.promptCacheKey = ""
+		p.promptCacheRetention = ""
+		p.serviceTier = ""
+		p.transport = transportHTTP
+		p.wsHTTPFallback = false
+		p.wsHTTPFallbackSet = false
+		p.wsPrevResponseID = ""
+		p.wsLastInputSigs = nil
+		p.reasoningSummary = ""
+		p.reasoningSummaryHandler = nil
+		p.textVerbosity = ""
+		p.chatgptAccountID = ""
+		p.tokenRefresher = nil
+		p.profileOverride = &modelutil.ModelProfile{
+			SupportsToolCalls: true,
+			SupportsStreaming: true,
+			ProviderName:      "openai-compatible-local",
+		}
+	}
+}
+
+func normalizeLocalEndpointBaseURL(raw string) (string, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		value = defaultLocalEndpointBaseURL
+	}
+	parsed, err := url.Parse(value)
+	if err != nil {
+		return "", errors.New("invalid local OpenAI-compatible endpoint")
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", errors.New("local OpenAI-compatible endpoint must use HTTP or HTTPS")
+	}
+	if parsed.User != nil || parsed.Host == "" || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", errors.New("invalid local OpenAI-compatible endpoint")
+	}
+	host := strings.TrimSuffix(strings.ToLower(parsed.Hostname()), ".")
+	if host != "localhost" {
+		ip := net.ParseIP(host)
+		if ip == nil || !ip.IsLoopback() {
+			return "", errors.New("local OpenAI-compatible endpoint must use a loopback host")
+		}
+	}
+	if port := parsed.Port(); port != "" {
+		value, err := strconv.Atoi(port)
+		if err != nil || value < 1 || value > 65_535 {
+			return "", errors.New("invalid local OpenAI-compatible endpoint port")
+		}
+	}
+	path := strings.TrimRight(parsed.EscapedPath(), "/")
+	if path != "" && path != "/v1" {
+		return "", errors.New("local OpenAI-compatible endpoint path must be empty or /v1")
+	}
+	parsed.Path = ""
+	parsed.RawPath = ""
+	return strings.TrimRight(parsed.String(), "/"), nil
+}
+
+func normalizeLocalEndpointText(raw, fallback, name string, maxBytes int) (string, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		value = fallback
+	}
+	if len(value) > maxBytes {
+		return "", fmt.Errorf("local OpenAI-compatible %s exceeds %d bytes", name, maxBytes)
+	}
+	for _, r := range value {
+		if unicode.IsControl(r) {
+			return "", fmt.Errorf("local OpenAI-compatible %s contains a control character", name)
+		}
+	}
+	return value, nil
+}

--- a/provider/openai/local_endpoint_test.go
+++ b/provider/openai/local_endpoint_test.go
@@ -1,0 +1,137 @@
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/fugue-labs/gollem/core"
+)
+
+func TestNormalizeLocalEndpointConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		baseURL string
+		want    string
+		valid   bool
+	}{
+		{name: "loopback IPv4", baseURL: "http://127.0.0.1:8080/v1/", want: "http://127.0.0.1:8080", valid: true},
+		{name: "localhost", baseURL: "https://localhost:8443", want: "https://localhost:8443", valid: true},
+		{name: "loopback IPv6", baseURL: "http://[::1]:8080/v1", want: "http://[::1]:8080", valid: true},
+		{name: "remote host", baseURL: "https://example.com", valid: false},
+		{name: "non HTTP scheme", baseURL: "file:///tmp/model", valid: false},
+		{name: "unexpected path", baseURL: "http://127.0.0.1:8080/api", valid: false},
+		{name: "userinfo", baseURL: "http://token@127.0.0.1:8080", valid: false},
+		{name: "query", baseURL: "http://127.0.0.1:8080?token=secret", valid: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NormalizeLocalEndpointConfig(LocalEndpointConfig{BaseURL: tt.baseURL, Model: "local-tool-model"})
+			if tt.valid {
+				if err != nil {
+					t.Fatalf("NormalizeLocalEndpointConfig: %v", err)
+				}
+				if got.BaseURL != tt.want {
+					t.Fatalf("BaseURL = %q, want %q", got.BaseURL, tt.want)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("NormalizeLocalEndpointConfig unexpectedly succeeded")
+			}
+		})
+	}
+}
+
+func TestLocalEndpointForcesChatCompletionsAndDoesNotInheritOpenAIKey(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "remote-openai-key")
+	t.Setenv("OPENAI_PROMPT_CACHE_KEY", "remote-cache-key")
+	t.Setenv("OPENAI_PROMPT_CACHE_RETENTION", "24h")
+	t.Setenv("OPENAI_SERVICE_TIER", "priority")
+	t.Setenv("OPENAI_TRANSPORT", "websocket")
+	t.Setenv("OPENAI_REASONING_SUMMARY", "detailed")
+	t.Setenv("OPENAI_TEXT_VERBOSITY", "high")
+	var gotAuthorization string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Fatalf("path = %q, want /v1/chat/completions", r.URL.Path)
+		}
+		gotAuthorization = r.Header.Get("Authorization")
+		if got := r.Header.Get("ChatGPT-Account-ID"); got != "" {
+			t.Fatalf("local request inherited ChatGPT account identity %q", got)
+		}
+		var request map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		for _, key := range []string{"prompt_cache_key", "prompt_cache_retention", "service_tier", "reasoning", "text"} {
+			if _, ok := request[key]; ok {
+				t.Fatalf("local request inherited OpenAI setting %q: %#v", key, request)
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl-local","object":"chat.completion","model":"gpt-5.2-codex","choices":[{"message":{"role":"assistant","content":"local reply"},"finish_reason":"stop"}]}`))
+	}))
+	defer server.Close()
+
+	p, err := NewLocalEndpoint(
+		LocalEndpointConfig{BaseURL: server.URL, Model: "gpt-5.2-codex"},
+		WithChatGPTAuth("remote-chatgpt-token", "remote-account"),
+		WithTokenRefresher(func() (string, error) { return "refreshed-remote-token", nil }),
+		WithResumedResponsesChain("resp_remote", []string{"remote-input"}),
+	)
+	if err != nil {
+		t.Fatalf("NewLocalEndpoint: %v", err)
+	}
+	response, err := p.Request(context.Background(), localEndpointTestMessages(), nil, nil)
+	if err != nil {
+		t.Fatalf("Request: %v", err)
+	}
+	if got := response.TextContent(); got != "local reply" {
+		t.Fatalf("response = %q, want local reply", got)
+	}
+	if gotAuthorization != "Bearer local" {
+		t.Fatalf("Authorization = %q, want local key", gotAuthorization)
+	}
+	profile := p.Profile()
+	if !profile.SupportsToolCalls || !profile.SupportsStreaming || profile.SupportsStructuredOutput || profile.SupportsVision {
+		t.Fatalf("local profile = %#v", profile)
+	}
+}
+
+func TestLocalEndpointRedactsUnavailableEndpoint(t *testing.T) {
+	listener, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	baseURL := "http://" + listener.Addr().String()
+	if err := listener.Close(); err != nil {
+		t.Fatalf("close listener: %v", err)
+	}
+
+	p, err := NewLocalEndpoint(LocalEndpointConfig{BaseURL: baseURL, Model: "local-tool-model"})
+	if err != nil {
+		t.Fatalf("NewLocalEndpoint: %v", err)
+	}
+	_, err = p.Request(context.Background(), localEndpointTestMessages(), nil, nil)
+	if err == nil {
+		t.Fatal("Request unexpectedly succeeded")
+	}
+	if strings.Contains(err.Error(), baseURL) || strings.Contains(err.Error(), listener.Addr().String()) {
+		t.Fatalf("unavailable endpoint error leaked endpoint: %v", err)
+	}
+	if got := err.Error(); got != "openai: local endpoint unavailable" {
+		t.Fatalf("error = %q, want redacted local endpoint error", got)
+	}
+}
+
+func localEndpointTestMessages() []core.ModelMessage {
+	return []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "hello"}}},
+	}
+}

--- a/provider/openai/openai.go
+++ b/provider/openai/openai.go
@@ -82,6 +82,9 @@ type Provider struct {
 	wsHTTPFallback          bool
 	wsHTTPFallbackSet       bool
 	useResponses            bool
+	forceChatCompletions    bool
+	profileOverride         *modelutil.ModelProfile
+	redactEndpointErrors    bool
 	disableToolSearch       bool
 	strictModelBinding      bool
 	wsConn                  *responsesWebSocketConn
@@ -322,28 +325,30 @@ func New(opts ...Option) *Provider {
 			p.baseURL = envURL
 		}
 	}
-	if p.promptCacheKey == "" {
-		p.promptCacheKey = os.Getenv("OPENAI_PROMPT_CACHE_KEY")
-	}
-	if p.promptCacheRetention == "" {
-		p.promptCacheRetention = os.Getenv("OPENAI_PROMPT_CACHE_RETENTION")
-	}
-	if p.serviceTier == "" {
-		p.serviceTier = os.Getenv("OPENAI_SERVICE_TIER")
-	}
-	if p.transport == "" {
-		p.transport = os.Getenv("OPENAI_TRANSPORT")
+	if !p.forceChatCompletions {
+		if p.promptCacheKey == "" {
+			p.promptCacheKey = os.Getenv("OPENAI_PROMPT_CACHE_KEY")
+		}
+		if p.promptCacheRetention == "" {
+			p.promptCacheRetention = os.Getenv("OPENAI_PROMPT_CACHE_RETENTION")
+		}
+		if p.serviceTier == "" {
+			p.serviceTier = os.Getenv("OPENAI_SERVICE_TIER")
+		}
+		if p.transport == "" {
+			p.transport = os.Getenv("OPENAI_TRANSPORT")
+		}
 	}
 	p.transport = normalizeTransport(p.transport)
-	if !p.wsHTTPFallbackSet {
+	if !p.forceChatCompletions && !p.wsHTTPFallbackSet {
 		if raw := strings.TrimSpace(os.Getenv("OPENAI_WEBSOCKET_HTTP_FALLBACK")); raw != "" {
 			p.wsHTTPFallback = isTruthy(raw)
 		}
 	}
-	if p.reasoningSummary == "" {
+	if !p.forceChatCompletions && p.reasoningSummary == "" {
 		p.reasoningSummary = os.Getenv("OPENAI_REASONING_SUMMARY")
 	}
-	if p.textVerbosity == "" {
+	if !p.forceChatCompletions && p.textVerbosity == "" {
 		p.textVerbosity = os.Getenv("OPENAI_TEXT_VERBOSITY")
 	}
 	// OPENAI_REQUEST_TRACE=1 installs the default stderr request observer when
@@ -426,6 +431,9 @@ func (p *Provider) NewSession() core.Model {
 		wsHTTPFallback:          p.wsHTTPFallback,
 		wsHTTPFallbackSet:       p.wsHTTPFallbackSet,
 		useResponses:            p.useResponses,
+		forceChatCompletions:    p.forceChatCompletions,
+		profileOverride:         p.profileOverride,
+		redactEndpointErrors:    p.redactEndpointErrors,
 		disableToolSearch:       p.disableToolSearch,
 		strictModelBinding:      p.strictModelBinding,
 		reasoningSummary:        p.reasoningSummary,
@@ -490,7 +498,7 @@ func (p *Provider) Request(ctx context.Context, messages []core.ModelMessage, se
 
 	resp, err := p.doRequest(ctx, chatCompletionsEndpoint, body, ri)
 	if err != nil {
-		if isChatCompletionsMismatch(err) {
+		if !p.forceChatCompletions && isChatCompletionsMismatch(err) {
 			// Some models (e.g. Codex variants) are only available via /v1/responses.
 			p.useResponses = true
 			return p.requestViaResponses(ctx, messages, settings, params, ri)
@@ -543,7 +551,7 @@ func (p *Provider) RequestStream(ctx context.Context, messages []core.ModelMessa
 
 	resp, err := p.doRequest(ctx, chatCompletionsEndpoint, body, ri) //nolint:bodyclose // Response body ownership transfers to streamedResponse.
 	if err != nil {
-		if isChatCompletionsMismatch(err) {
+		if !p.forceChatCompletions && isChatCompletionsMismatch(err) {
 			p.useResponses = true
 			stream, sErr := p.requestStreamViaResponses(ctx, messages, settings, params, ri)
 			if sErr != nil {
@@ -575,6 +583,9 @@ func (p *Provider) responsesEP() string {
 func (p *Provider) doRequest(ctx context.Context, endpoint string, body []byte, ri *requestInstrumentation) (*http.Response, error) {
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+endpoint, bytes.NewReader(body))
 	if err != nil {
+		if p.redactEndpointErrors {
+			return nil, errors.New("openai: local endpoint unavailable")
+		}
 		return nil, fmt.Errorf("openai: failed to create HTTP request: %w", err)
 	}
 	if err := p.setHeaders(httpReq, ri); err != nil {
@@ -585,6 +596,9 @@ func (p *Provider) doRequest(ctx context.Context, endpoint string, body []byte, 
 	resp, err := p.httpClient.Do(httpReq)
 	if err != nil {
 		ri.recordError(err)
+		if p.redactEndpointErrors && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+			return nil, errors.New("openai: local endpoint unavailable")
+		}
 		return nil, fmt.Errorf("openai: HTTP request failed: %w", err)
 	}
 
@@ -709,7 +723,7 @@ func (p *Provider) setHeaders(req *http.Request, ri *requestInstrumentation) err
 }
 
 func (p *Provider) shouldUseResponsesAPI() bool {
-	return p.useResponses || modelNeedsResponsesAPI(p.model)
+	return !p.forceChatCompletions && (p.useResponses || modelNeedsResponsesAPI(p.model))
 }
 
 func (p *Provider) shouldUseResponsesWebSocket() bool {
@@ -835,6 +849,9 @@ func (p *Provider) hasChatGPTAuth() bool {
 // Profile returns the model's capability profile. Vision is supported by
 // GPT-4o, GPT-4o-mini, O-series, and Codex models.
 func (p *Provider) Profile() modelutil.ModelProfile {
+	if p.profileOverride != nil {
+		return *p.profileOverride
+	}
 	return modelutil.ModelProfile{
 		SupportsToolCalls:        true,
 		SupportsStructuredOutput: true,


### PR DESCRIPTION
## Summary
- add a loopback-only OpenAI-compatible local provider profile with process-owned configuration and redacted endpoint failures
- expose the validated profile through the Gollem provider catalog and app-server runtime
- add reusable deterministic provider conformance checks for native OpenAI, native Anthropic, and the local OpenAI-compatible adapter

## Safety and capability boundary
- local setup is explicit and only permits HTTP(S) loopback endpoints
- catalog metadata never exposes endpoint or token values
- local mode forces Chat Completions and does not inherit OpenAI, ChatGPT subscription, Responses, cache, transport, or reasoning configuration
- only tool calls, streaming, and usage are advertised and covered by deterministic fixtures

## Verification
- `golangci-lint run ./...`
- `go test $(go list ./... | grep -v '^github.com/fugue-labs/gollem/ext/monty$')`\n- `go test -race $(go list ./... | grep -v '^github.com/fugue-labs/gollem/ext/monty$')`\n- `go vet ./...`\n- `go mod tidy && git diff --exit-code go.mod go.sum`\n- repository pre-push hook passed with `hooks.skipMontyRace=true`