### PR TITLE
fix(catalog): provide local model reasoning default

### DIFF
--- a/appserver/catalog/catalog.go
+++ b/appserver/catalog/catalog.go
@@ -322,7 +322,7 @@ func (c *Catalog) defaultProviders() []Provider {
 					false,
 					capabilities(true, false, false, true, false, false, false),
 					nil,
-					"",
+					"low",
 				),
 			},
 		},

--- a/appserver/catalog/catalog_test.go
+++ b/appserver/catalog/catalog_test.go
@@ -130,6 +130,9 @@ func TestLocalOpenAICompatibleProviderUsesExplicitSafeConfiguration(t *testing.T
 	if len(models.Data) != 1 || models.Data[0].Model != model || !models.Data[0].Capabilities.ToolCalls || !models.Data[0].Capabilities.Streaming {
 		t.Fatalf("local provider models = %#v", models.Data)
 	}
+	if models.Data[0].DefaultReasoningEffort != "low" {
+		t.Fatalf("local provider default reasoning effort = %q, want low", models.Data[0].DefaultReasoningEffort)
+	}
 
 	encoded, err := json.Marshal(provider)
 	if err != nil {


### PR DESCRIPTION
## Summary
- emit a non-empty catalog default reasoning effort for the local OpenAI-compatible model
- cover the exact local catalog contract

## Verification
- `go test $(go list ./... | grep -v '^github.com/fugue-labs/gollem/ext/monty$')`\n- `go vet $(go list ./... | grep -v '^github.com/fugue-labs/gollem/ext/monty$')`\n- `golangci-lint run ./appserver/catalog/... ./appserver/protocol/...`\n- Slang runtime validator and local-provider Electron workflow against the built head