### PR TITLE
test(provider): verify in-flight cancellation

### DIFF
--- a/docs/PROVIDER_DRIVER_CONFORMANCE.md
+++ b/docs/PROVIDER_DRIVER_CONFORMANCE.md
@@ -1,0 +1,53 @@
+# Provider Driver Conformance
+
+This matrix is the authority for the common provider behavior that Slang may
+present as runnable. A `proven` entry has deterministic fixture coverage through
+the provider-neutral `core.Model` boundary. An entry marked `unsupported` must
+remain unavailable in the catalog and renderer. `Not yet proven` is not a claim
+of behavior and must not enable a control solely on provider identity.
+
+## Common Driver Matrix
+
+| Behavior | Native OpenAI | OpenAI-compatible local | Native Anthropic | Evidence |
+| --- | --- | --- | --- | --- |
+| Non-stream text response | Proven | Proven | Proven | `provider/conformance` |
+| Function-tool request and normalized tool call | Proven | Proven | Proven | `provider/conformance` |
+| Streaming text and terminal usage | Proven | Proven | Proven | `provider/conformance` |
+| In-flight request cancellation | Proven | Proven | Proven | `provider/conformance` |
+| Structured output | Catalog-supported | Unsupported | Catalog-supported | Provider-specific tests; no common conformance claim yet |
+| Vision | Catalog-supported | Unsupported | Catalog-supported | Provider-specific tests; no common conformance claim yet |
+| Reasoning visibility | Catalog-supported where applicable | Unsupported | Catalog-supported where applicable | Provider-specific tests; no common conformance claim yet |
+| Prompt cache / Responses API | Catalog-supported where applicable | Unsupported | Catalog-supported where applicable | Provider-specific tests; no common conformance claim yet |
+| Malformed stream normalization | Not yet proven | Not yet proven | Not yet proven | Follow-up conformance scenario required |
+| Partial-stream / peer disconnect result | Not yet proven | Not yet proven | Not yet proven | Follow-up conformance scenario required |
+| Timeout and retryability classification | Not yet proven | Not yet proven | Not yet proven | Follow-up conformance scenario required |
+| Endpoint health probe and capability mismatch | Not yet proven | Not yet proven | Not yet proven | Must remain a typed unavailable/degraded state |
+
+`Catalog-supported` means the catalog may expose the capability only for the
+listed provider/model profile. It does not make that behavior part of the common
+driver contract until a deterministic conformance scenario covers it.
+
+## Custody And Local Endpoint Rules
+
+- Credentials, base URLs, headers, raw payloads, and transport identity remain
+  inside the Gollem process. Catalog entries expose only provider IDs, model IDs,
+  capability descriptors, and configuration variable names.
+- The local OpenAI-compatible profile accepts only loopback HTTP(S) endpoints,
+  forces Chat Completions, and does not inherit OpenAI Responses, ChatGPT,
+  prompt-cache, or remote transport settings.
+- A local endpoint connection failure is a bounded `local endpoint unavailable`
+  error. It must not reveal the endpoint or local token through app-server,
+  catalog, or renderer diagnostics.
+
+## Adding Or Expanding A Claim
+
+1. Add a deterministic fixture scenario to `provider/conformance` for every
+   claimed driver.
+2. Assert the same normalized `core.Model` result and terminal behavior for all
+   drivers that claim it.
+3. Add provider-specific tests when a wire format needs richer assertions.
+4. Update the catalog capability and Slang control gate only after the common
+   scenario is green.
+5. Keep unsupported and not-yet-proven behavior visible only as typed
+   unavailable or degraded state; do not silently fall back to another provider
+   surface.

--- a/provider/conformance/conformance.go
+++ b/provider/conformance/conformance.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"github.com/fugue-labs/gollem/core"
 )
@@ -19,9 +20,10 @@ import (
 // A driver must not advertise one of these capabilities in Slang unless it has
 // a matching deterministic fixture and this verification passes.
 type Claims struct {
-	ToolCalls bool
-	Streaming bool
-	Usage     bool
+	ToolCalls    bool
+	Streaming    bool
+	Usage        bool
+	Cancellation bool
 }
 
 // Expectations declares the normalized outputs a deterministic fixture
@@ -36,10 +38,11 @@ type Expectations struct {
 // Driver binds a provider model to the common capability claims and expected
 // normalized results that its deterministic fixture produces.
 type Driver struct {
-	Name         string
-	Model        core.Model
-	Claims       Claims
-	Expectations Expectations
+	Name              string
+	Model             core.Model
+	Claims            Claims
+	Expectations      Expectations
+	CancellationReady <-chan struct{}
 }
 
 // Verify exercises the claimed common model surface through core.Model. It is
@@ -56,6 +59,9 @@ func Verify(ctx context.Context, driver Driver) error {
 	}
 	if driver.Claims.Streaming && strings.TrimSpace(driver.Expectations.StreamText) == "" {
 		return fmt.Errorf("provider conformance: %s streaming fixture must expect stream text", driver.Name)
+	}
+	if driver.Claims.Cancellation && driver.CancellationReady == nil {
+		return fmt.Errorf("provider conformance: %s cancellation-capable fixture must signal request start", driver.Name)
 	}
 
 	params := &core.ModelRequestParameters{AllowTextOutput: true}
@@ -82,6 +88,11 @@ func Verify(ctx context.Context, driver Driver) error {
 	if err := verifyResponse(driver, response, false); err != nil {
 		return err
 	}
+	if driver.Claims.Cancellation {
+		if err := verifyCancellation(ctx, driver); err != nil {
+			return err
+		}
+	}
 
 	if !driver.Claims.Streaming {
 		return nil
@@ -104,6 +115,35 @@ func Verify(ctx context.Context, driver Driver) error {
 		return err
 	}
 	return nil
+}
+
+func verifyCancellation(ctx context.Context, driver Driver) error {
+	requestContext, cancel := context.WithCancel(ctx)
+	defer cancel()
+	result := make(chan error, 1)
+	go func() {
+		_, err := driver.Model.Request(requestContext, cancellationMessages(), nil, &core.ModelRequestParameters{AllowTextOutput: true})
+		result <- err
+	}()
+
+	select {
+	case <-driver.CancellationReady:
+		cancel()
+	case <-ctx.Done():
+		return fmt.Errorf("provider conformance: %s cancellation request did not start: %w", driver.Name, ctx.Err())
+	case <-time.After(time.Second):
+		return fmt.Errorf("provider conformance: %s cancellation request did not start", driver.Name)
+	}
+
+	select {
+	case err := <-result:
+		if !errors.Is(err, context.Canceled) {
+			return fmt.Errorf("provider conformance: %s cancellation error, want context canceled: %w", driver.Name, err)
+		}
+		return nil
+	case <-time.After(time.Second):
+		return fmt.Errorf("provider conformance: %s cancellation request did not finish", driver.Name)
+	}
 }
 
 func verifyResponse(driver Driver, response *core.ModelResponse, streaming bool) error {
@@ -138,5 +178,11 @@ func hasToolCall(parts []core.ModelResponsePart, name string) bool {
 func conformanceMessages() []core.ModelMessage {
 	return []core.ModelMessage{
 		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "run conformance"}}},
+	}
+}
+
+func cancellationMessages() []core.ModelMessage {
+	return []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "cancel conformance"}}},
 	}
 }

--- a/provider/conformance/conformance_test.go
+++ b/provider/conformance/conformance_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/fugue-labs/gollem/provider/anthropic"
@@ -14,9 +16,11 @@ import (
 )
 
 func TestDeterministicProviderDriverConformance(t *testing.T) {
-	openAIServer := httptest.NewServer(openAIConformanceFixture(t))
+	openAICancellationReady := make(chan struct{})
+	openAIServer := httptest.NewServer(openAIConformanceFixture(t, openAICancellationReady))
 	defer openAIServer.Close()
-	anthropicServer := httptest.NewServer(anthropicConformanceFixture(t))
+	anthropicCancellationReady := make(chan struct{})
+	anthropicServer := httptest.NewServer(anthropicConformanceFixture(t, anthropicCancellationReady))
 	defer anthropicServer.Close()
 
 	cases := []struct {
@@ -27,9 +31,10 @@ func TestDeterministicProviderDriverConformance(t *testing.T) {
 			name: "native OpenAI",
 			model: func() (conformance.Driver, error) {
 				return conformance.Driver{
-					Name:   "native OpenAI",
-					Model:  openai.New(openai.WithAPIKey("test-openai-key"), openai.WithBaseURL(openAIServer.URL), openai.WithModel("gpt-4o")),
-					Claims: conformance.Claims{ToolCalls: true, Streaming: true, Usage: true},
+					Name:              "native OpenAI",
+					Model:             openai.New(openai.WithAPIKey("test-openai-key"), openai.WithBaseURL(openAIServer.URL), openai.WithModel("gpt-4o")),
+					Claims:            conformance.Claims{ToolCalls: true, Streaming: true, Usage: true, Cancellation: true},
+					CancellationReady: openAICancellationReady,
 					Expectations: conformance.Expectations{
 						ResponseText: "openai response",
 						ToolName:     "conformance_echo",
@@ -50,9 +55,10 @@ func TestDeterministicProviderDriverConformance(t *testing.T) {
 					return conformance.Driver{}, err
 				}
 				return conformance.Driver{
-					Name:   "OpenAI-compatible local",
-					Model:  model,
-					Claims: conformance.Claims{ToolCalls: true, Streaming: true, Usage: true},
+					Name:              "OpenAI-compatible local",
+					Model:             model,
+					Claims:            conformance.Claims{ToolCalls: true, Streaming: true, Usage: true, Cancellation: true},
+					CancellationReady: openAICancellationReady,
 					Expectations: conformance.Expectations{
 						ResponseText: "openai response",
 						ToolName:     "conformance_echo",
@@ -65,9 +71,10 @@ func TestDeterministicProviderDriverConformance(t *testing.T) {
 			name: "native Anthropic",
 			model: func() (conformance.Driver, error) {
 				return conformance.Driver{
-					Name:   "native Anthropic",
-					Model:  anthropic.New(anthropic.WithAPIKey("test-anthropic-key"), anthropic.WithBaseURL(anthropicServer.URL), anthropic.WithModel(anthropic.ClaudeSonnet46)),
-					Claims: conformance.Claims{ToolCalls: true, Streaming: true, Usage: true},
+					Name:              "native Anthropic",
+					Model:             anthropic.New(anthropic.WithAPIKey("test-anthropic-key"), anthropic.WithBaseURL(anthropicServer.URL), anthropic.WithModel(anthropic.ClaudeSonnet46)),
+					Claims:            conformance.Claims{ToolCalls: true, Streaming: true, Usage: true, Cancellation: true},
+					CancellationReady: anthropicCancellationReady,
 					Expectations: conformance.Expectations{
 						ResponseText: "anthropic response",
 						ToolName:     "conformance_echo",
@@ -100,9 +107,17 @@ func TestVerifyRejectsUnprovenClaims(t *testing.T) {
 	if err == nil {
 		t.Fatal("Verify accepted a tool claim without an expected tool")
 	}
+	err = conformance.Verify(context.Background(), conformance.Driver{
+		Name:   "missing cancellation fixture",
+		Model:  openai.New(openai.WithAPIKey("test-key")),
+		Claims: conformance.Claims{Cancellation: true},
+	})
+	if err == nil {
+		t.Fatal("Verify accepted a cancellation claim without a start signal")
+	}
 }
 
-func openAIConformanceFixture(t *testing.T) http.Handler {
+func openAIConformanceFixture(t *testing.T, cancellationReady chan<- struct{}) http.Handler {
 	t.Helper()
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/chat/completions" {
@@ -111,11 +126,19 @@ func openAIConformanceFixture(t *testing.T) http.Handler {
 		if r.Header.Get("Authorization") == "" {
 			t.Fatal("OpenAI fixture request had no authorization header")
 		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read OpenAI request: %v", err)
+		}
+		if strings.Contains(string(body), "cancel conformance") {
+			waitForCancellation(r, cancellationReady)
+			return
+		}
 		var request struct {
 			Stream bool            `json:"stream"`
 			Tools  json.RawMessage `json:"tools"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		if err := json.Unmarshal(body, &request); err != nil {
 			t.Fatalf("decode OpenAI request: %v", err)
 		}
 		if request.Stream {
@@ -138,7 +161,7 @@ data: [DONE]
 	})
 }
 
-func anthropicConformanceFixture(t *testing.T) http.Handler {
+func anthropicConformanceFixture(t *testing.T, cancellationReady chan<- struct{}) http.Handler {
 	t.Helper()
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/messages" {
@@ -147,11 +170,19 @@ func anthropicConformanceFixture(t *testing.T) http.Handler {
 		if r.Header.Get("x-api-key") == "" {
 			t.Fatal("Anthropic fixture request had no API key header")
 		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read Anthropic request: %v", err)
+		}
+		if strings.Contains(string(body), "cancel conformance") {
+			waitForCancellation(r, cancellationReady)
+			return
+		}
 		var request struct {
 			Stream bool            `json:"stream"`
 			Tools  json.RawMessage `json:"tools"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		if err := json.Unmarshal(body, &request); err != nil {
 			t.Fatalf("decode Anthropic request: %v", err)
 		}
 		if request.Stream {
@@ -183,4 +214,13 @@ data: {"type":"message_stop"}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = fmt.Fprint(w, `{"id":"msg-conformance","role":"assistant","model":"claude-sonnet-4-6","content":[{"type":"text","text":"anthropic response"},{"type":"tool_use","id":"call_anthropic","name":"conformance_echo","input":{"value":"ok"}}],"stop_reason":"tool_use","usage":{"input_tokens":3,"output_tokens":2}}`)
 	})
+}
+
+func waitForCancellation(request *http.Request, ready chan<- struct{}) {
+	select {
+	case ready <- struct{}{}:
+	case <-request.Context().Done():
+		return
+	}
+	<-request.Context().Done()
 }


### PR DESCRIPTION
## Summary
- extend the reusable provider conformance harness with deterministic in-flight cancellation
- prove cancellation for native OpenAI, the loopback OpenAI-compatible local adapter, and native Anthropic
- publish the common capability matrix, including explicitly unproven malformed-stream, disconnect, timeout, health, and mismatch paths

## Verification
- `go test -race ./provider/conformance`
- `golangci-lint run ./provider/conformance/...`
- `go test $(go list ./... | grep -v '^github.com/fugue-labs/gollem/ext/monty$')`\n- `go vet $(go list ./... | grep -v '^github.com/fugue-labs/gollem/ext/monty$')`\n- repository pre-push gate