### PR TITLE
test(provider): verify terminal stream contracts

### DIFF
--- a/core/errors.go
+++ b/core/errors.go
@@ -90,3 +90,30 @@ type ModelHTTPError struct {
 func (e *ModelHTTPError) Error() string {
 	return fmt.Sprintf("%s (status %d)", e.Message, e.StatusCode)
 }
+
+// StreamIncompleteError indicates that a provider closed a stream before it
+// supplied its documented terminal event. The partial response remains
+// available from the stream for callers that can safely present it as partial.
+type StreamIncompleteError struct {
+	Provider string
+}
+
+func (e *StreamIncompleteError) Error() string {
+	if e.Provider == "" {
+		return "model stream ended before a terminal event"
+	}
+	return e.Provider + " stream ended before a terminal event"
+}
+
+// StreamProtocolError indicates malformed provider stream data. It deliberately
+// excludes raw event data so protocol failures cannot disclose provider payloads.
+type StreamProtocolError struct {
+	Provider string
+}
+
+func (e *StreamProtocolError) Error() string {
+	if e.Provider == "" {
+		return "model stream contained malformed protocol data"
+	}
+	return e.Provider + " stream contained malformed protocol data"
+}

--- a/docs/PROVIDER_DRIVER_CONFORMANCE.md
+++ b/docs/PROVIDER_DRIVER_CONFORMANCE.md
@@ -18,8 +18,9 @@ of behavior and must not enable a control solely on provider identity.
 | Vision | Catalog-supported | Unsupported | Catalog-supported | Provider-specific tests; no common conformance claim yet |
 | Reasoning visibility | Catalog-supported where applicable | Unsupported | Catalog-supported where applicable | Provider-specific tests; no common conformance claim yet |
 | Prompt cache / Responses API | Catalog-supported where applicable | Unsupported | Catalog-supported where applicable | Provider-specific tests; no common conformance claim yet |
-| Malformed stream normalization | Not yet proven | Not yet proven | Not yet proven | Follow-up conformance scenario required |
-| Partial-stream / peer disconnect result | Not yet proven | Not yet proven | Not yet proven | Follow-up conformance scenario required |
+| Malformed JSON stream event normalization | Proven | Proven | Proven | `provider/conformance` plus provider parser tests; returns `StreamProtocolError` without raw event data |
+| Abrupt EOF partial-stream result | Proven | Proven | Proven | `provider/conformance` plus provider parser tests; preserves partial response and returns `StreamIncompleteError` |
+| Read-error peer-disconnect classification | Not yet proven | Not yet proven | Not yet proven | Follow-up conformance scenario required |
 | Timeout and retryability classification | Not yet proven | Not yet proven | Not yet proven | Follow-up conformance scenario required |
 | Endpoint health probe and capability mismatch | Not yet proven | Not yet proven | Not yet proven | Must remain a typed unavailable/degraded state |
 

--- a/provider/anthropic/anthropic_test.go
+++ b/provider/anthropic/anthropic_test.go
@@ -3,6 +3,7 @@ package anthropic
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -562,6 +563,45 @@ func TestParseSSEStreamNoSpaceAfterColon(t *testing.T) {
 	}
 	if tp.Content != "OK" {
 		t.Errorf("text = %q, want 'OK'", tp.Content)
+	}
+}
+
+func TestParseSSEStreamIncompleteEOFPreservesPartialResponse(t *testing.T) {
+	sseData := `event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"partial"}}
+
+`
+	stream := newStreamedResponse(io.NopCloser(strings.NewReader(sseData)), ClaudeSonnet46)
+
+	if _, err := stream.Next(); err != nil {
+		t.Fatalf("first Next() error = %v", err)
+	}
+	if _, err := stream.Next(); err != nil {
+		t.Fatalf("second Next() error = %v", err)
+	}
+	_, err := stream.Next()
+	var incomplete *core.StreamIncompleteError
+	if !errors.As(err, &incomplete) {
+		t.Fatalf("Next() error = %v, want StreamIncompleteError", err)
+	}
+	if got := stream.Response().TextContent(); got != "partial" {
+		t.Fatalf("partial response text = %q, want %q", got, "partial")
+	}
+}
+
+func TestParseSSEStreamRejectsMalformedJSONEvent(t *testing.T) {
+	stream := newStreamedResponse(io.NopCloser(strings.NewReader("event: message_start\ndata: {\"fixture_sensitive\":\n\n")), ClaudeSonnet46)
+
+	_, err := stream.Next()
+	var protocol *core.StreamProtocolError
+	if !errors.As(err, &protocol) {
+		t.Fatalf("Next() error = %v, want StreamProtocolError", err)
+	}
+	if strings.Contains(err.Error(), "fixture_sensitive") {
+		t.Fatalf("protocol error leaked raw stream data: %v", err)
 	}
 }
 

--- a/provider/anthropic/stream.go
+++ b/provider/anthropic/stream.go
@@ -3,8 +3,10 @@ package anthropic
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 	"time"
 
@@ -56,6 +58,10 @@ func (s *streamedResponse) Next() (core.ModelResponseStreamEvent, error) {
 
 		event, err := s.readSSEEvent()
 		if err != nil {
+			if errors.Is(err, io.EOF) {
+				s.failStream(&core.StreamIncompleteError{Provider: "anthropic"})
+				return nil, s.streamErr
+			}
 			return nil, err
 		}
 
@@ -116,6 +122,8 @@ func (s *streamedResponse) processSSEEvent(event *sseEvent) (core.ModelResponseS
 		}
 		if err := json.Unmarshal([]byte(event.Data), &msg); err == nil {
 			s.usage = mapUsage(msg.Message.Usage)
+		} else {
+			return s.failProtocol()
 		}
 		return nil, false
 
@@ -125,7 +133,7 @@ func (s *streamedResponse) processSSEEvent(event *sseEvent) (core.ModelResponseS
 			ContentBlock json.RawMessage `json:"content_block"`
 		}
 		if err := json.Unmarshal([]byte(event.Data), &block); err != nil {
-			return nil, false
+			return s.failProtocol()
 		}
 
 		var blockType struct {
@@ -137,7 +145,7 @@ func (s *streamedResponse) processSSEEvent(event *sseEvent) (core.ModelResponseS
 			Signature string `json:"signature,omitempty"`
 		}
 		if err := json.Unmarshal(block.ContentBlock, &blockType); err != nil {
-			return nil, false
+			return s.failProtocol()
 		}
 
 		var part core.ModelResponsePart
@@ -183,7 +191,7 @@ func (s *streamedResponse) processSSEEvent(event *sseEvent) (core.ModelResponseS
 			} `json:"delta"`
 		}
 		if err := json.Unmarshal([]byte(event.Data), &delta); err != nil {
-			return nil, false
+			return s.failProtocol()
 		}
 
 		switch delta.Delta.Type {
@@ -232,7 +240,7 @@ func (s *streamedResponse) processSSEEvent(event *sseEvent) (core.ModelResponseS
 			Index int `json:"index"`
 		}
 		if err := json.Unmarshal([]byte(event.Data), &block); err != nil {
-			return nil, false
+			return s.failProtocol()
 		}
 
 		// Finalize the part.
@@ -266,15 +274,19 @@ func (s *streamedResponse) processSSEEvent(event *sseEvent) (core.ModelResponseS
 			if md.Usage.OutputTokens > 0 {
 				s.usage.OutputTokens = md.Usage.OutputTokens
 			}
+		} else {
+			return s.failProtocol()
 		}
 		return nil, false
 
 	case "message_stop":
 		s.done = true
+		s.finalizeAll()
 		return nil, false
 
 	case "error":
 		s.done = true
+		s.finalizeAll()
 		// Parse error event data to propagate a meaningful error.
 		var errData struct {
 			Error struct {
@@ -292,6 +304,40 @@ func (s *streamedResponse) processSSEEvent(event *sseEvent) (core.ModelResponseS
 	default:
 		return nil, false
 	}
+}
+
+func (s *streamedResponse) failProtocol() (core.ModelResponseStreamEvent, bool) {
+	s.failStream(&core.StreamProtocolError{Provider: "anthropic"})
+	return nil, false
+}
+
+func (s *streamedResponse) failStream(err error) {
+	s.done = true
+	s.finalizeAll()
+	s.streamErr = err
+}
+
+func (s *streamedResponse) finalizeAll() {
+	indices := make([]int, 0, len(s.currentParts))
+	for index := range s.currentParts {
+		indices = append(indices, index)
+	}
+	sort.Ints(indices)
+	for _, index := range indices {
+		part := s.currentParts[index]
+		if toolCall, ok := part.(core.ToolCallPart); ok {
+			if args, ok := s.argsBuffers[index]; ok {
+				toolCall.ArgsJSON = args.String()
+			}
+			if toolCall.ArgsJSON == "" {
+				toolCall.ArgsJSON = "{}"
+			}
+			part = toolCall
+		}
+		s.parts = append(s.parts, part)
+	}
+	s.currentParts = make(map[int]core.ModelResponsePart)
+	s.argsBuffers = make(map[int]*strings.Builder)
 }
 
 // Response returns the complete ModelResponse built from the stream.

--- a/provider/conformance/conformance.go
+++ b/provider/conformance/conformance.go
@@ -20,10 +20,12 @@ import (
 // A driver must not advertise one of these capabilities in Slang unless it has
 // a matching deterministic fixture and this verification passes.
 type Claims struct {
-	ToolCalls    bool
-	Streaming    bool
-	Usage        bool
-	Cancellation bool
+	ToolCalls       bool
+	Streaming       bool
+	Usage           bool
+	Cancellation    bool
+	PartialStream   bool
+	MalformedStream bool
 }
 
 // Expectations declares the normalized outputs a deterministic fixture
@@ -33,6 +35,7 @@ type Expectations struct {
 	ResponseText string
 	ToolName     string
 	StreamText   string
+	PartialText  string
 }
 
 // Driver binds a provider model to the common capability claims and expected
@@ -62,6 +65,9 @@ func Verify(ctx context.Context, driver Driver) error {
 	}
 	if driver.Claims.Cancellation && driver.CancellationReady == nil {
 		return fmt.Errorf("provider conformance: %s cancellation-capable fixture must signal request start", driver.Name)
+	}
+	if driver.Claims.PartialStream && strings.TrimSpace(driver.Expectations.PartialText) == "" {
+		return fmt.Errorf("provider conformance: %s partial-stream fixture must expect partial text", driver.Name)
 	}
 
 	params := &core.ModelRequestParameters{AllowTextOutput: true}
@@ -114,6 +120,16 @@ func Verify(ctx context.Context, driver Driver) error {
 	if err := verifyResponse(driver, stream.Response(), true); err != nil {
 		return err
 	}
+	if driver.Claims.PartialStream {
+		if err := verifyPartialStream(ctx, driver); err != nil {
+			return err
+		}
+	}
+	if driver.Claims.MalformedStream {
+		if err := verifyMalformedStream(ctx, driver); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -143,6 +159,48 @@ func verifyCancellation(ctx context.Context, driver Driver) error {
 		return nil
 	case <-time.After(time.Second):
 		return fmt.Errorf("provider conformance: %s cancellation request did not finish", driver.Name)
+	}
+}
+
+func verifyPartialStream(ctx context.Context, driver Driver) error {
+	stream, err := driver.Model.RequestStream(ctx, partialStreamMessages(), nil, &core.ModelRequestParameters{AllowTextOutput: true})
+	if err != nil {
+		return fmt.Errorf("provider conformance: %s partial stream request: %w", driver.Name, err)
+	}
+	defer stream.Close()
+	for {
+		_, err := stream.Next()
+		if err == nil {
+			continue
+		}
+		var incomplete *core.StreamIncompleteError
+		if !errors.As(err, &incomplete) {
+			return fmt.Errorf("provider conformance: %s partial stream error = %w, want StreamIncompleteError", driver.Name, err)
+		}
+		break
+	}
+	if got := stream.Response().TextContent(); got != driver.Expectations.PartialText {
+		return fmt.Errorf("provider conformance: %s partial text = %q, want %q", driver.Name, got, driver.Expectations.PartialText)
+	}
+	return nil
+}
+
+func verifyMalformedStream(ctx context.Context, driver Driver) error {
+	stream, err := driver.Model.RequestStream(ctx, malformedStreamMessages(), nil, &core.ModelRequestParameters{AllowTextOutput: true})
+	if err != nil {
+		return fmt.Errorf("provider conformance: %s malformed stream request: %w", driver.Name, err)
+	}
+	defer stream.Close()
+	for {
+		_, err := stream.Next()
+		if err == nil {
+			continue
+		}
+		var protocol *core.StreamProtocolError
+		if !errors.As(err, &protocol) {
+			return fmt.Errorf("provider conformance: %s malformed stream error = %w, want StreamProtocolError", driver.Name, err)
+		}
+		return nil
 	}
 }
 
@@ -184,5 +242,17 @@ func conformanceMessages() []core.ModelMessage {
 func cancellationMessages() []core.ModelMessage {
 	return []core.ModelMessage{
 		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "cancel conformance"}}},
+	}
+}
+
+func partialStreamMessages() []core.ModelMessage {
+	return []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "partial stream conformance"}}},
+	}
+}
+
+func malformedStreamMessages() []core.ModelMessage {
+	return []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "malformed stream conformance"}}},
 	}
 }

--- a/provider/conformance/conformance_test.go
+++ b/provider/conformance/conformance_test.go
@@ -33,12 +33,13 @@ func TestDeterministicProviderDriverConformance(t *testing.T) {
 				return conformance.Driver{
 					Name:              "native OpenAI",
 					Model:             openai.New(openai.WithAPIKey("test-openai-key"), openai.WithBaseURL(openAIServer.URL), openai.WithModel("gpt-4o")),
-					Claims:            conformance.Claims{ToolCalls: true, Streaming: true, Usage: true, Cancellation: true},
+					Claims:            conformance.Claims{ToolCalls: true, Streaming: true, Usage: true, Cancellation: true, PartialStream: true, MalformedStream: true},
 					CancellationReady: openAICancellationReady,
 					Expectations: conformance.Expectations{
 						ResponseText: "openai response",
 						ToolName:     "conformance_echo",
 						StreamText:   "openai stream",
+						PartialText:  "openai partial",
 					},
 				}, nil
 			},
@@ -57,12 +58,13 @@ func TestDeterministicProviderDriverConformance(t *testing.T) {
 				return conformance.Driver{
 					Name:              "OpenAI-compatible local",
 					Model:             model,
-					Claims:            conformance.Claims{ToolCalls: true, Streaming: true, Usage: true, Cancellation: true},
+					Claims:            conformance.Claims{ToolCalls: true, Streaming: true, Usage: true, Cancellation: true, PartialStream: true, MalformedStream: true},
 					CancellationReady: openAICancellationReady,
 					Expectations: conformance.Expectations{
 						ResponseText: "openai response",
 						ToolName:     "conformance_echo",
 						StreamText:   "openai stream",
+						PartialText:  "openai partial",
 					},
 				}, nil
 			},
@@ -73,12 +75,13 @@ func TestDeterministicProviderDriverConformance(t *testing.T) {
 				return conformance.Driver{
 					Name:              "native Anthropic",
 					Model:             anthropic.New(anthropic.WithAPIKey("test-anthropic-key"), anthropic.WithBaseURL(anthropicServer.URL), anthropic.WithModel(anthropic.ClaudeSonnet46)),
-					Claims:            conformance.Claims{ToolCalls: true, Streaming: true, Usage: true, Cancellation: true},
+					Claims:            conformance.Claims{ToolCalls: true, Streaming: true, Usage: true, Cancellation: true, PartialStream: true, MalformedStream: true},
 					CancellationReady: anthropicCancellationReady,
 					Expectations: conformance.Expectations{
 						ResponseText: "anthropic response",
 						ToolName:     "conformance_echo",
 						StreamText:   "anthropic stream",
+						PartialText:  "anthropic partial",
 					},
 				}, nil
 			},
@@ -115,6 +118,14 @@ func TestVerifyRejectsUnprovenClaims(t *testing.T) {
 	if err == nil {
 		t.Fatal("Verify accepted a cancellation claim without a start signal")
 	}
+	err = conformance.Verify(context.Background(), conformance.Driver{
+		Name:   "missing partial stream fixture",
+		Model:  openai.New(openai.WithAPIKey("test-key")),
+		Claims: conformance.Claims{PartialStream: true},
+	})
+	if err == nil {
+		t.Fatal("Verify accepted a partial stream claim without expected partial text")
+	}
 }
 
 func openAIConformanceFixture(t *testing.T, cancellationReady chan<- struct{}) http.Handler {
@@ -132,6 +143,16 @@ func openAIConformanceFixture(t *testing.T, cancellationReady chan<- struct{}) h
 		}
 		if strings.Contains(string(body), "cancel conformance") {
 			waitForCancellation(r, cancellationReady)
+			return
+		}
+		if strings.Contains(string(body), "partial stream conformance") {
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = fmt.Fprint(w, "data: {\"id\":\"chatcmpl-partial\",\"object\":\"chat.completion.chunk\",\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"openai partial\"},\"finish_reason\":null}]}\n\n")
+			return
+		}
+		if strings.Contains(string(body), "malformed stream conformance") {
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = fmt.Fprint(w, "data: {\"fixture_sensitive\":\n\n")
 			return
 		}
 		var request struct {
@@ -176,6 +197,16 @@ func anthropicConformanceFixture(t *testing.T, cancellationReady chan<- struct{}
 		}
 		if strings.Contains(string(body), "cancel conformance") {
 			waitForCancellation(r, cancellationReady)
+			return
+		}
+		if strings.Contains(string(body), "partial stream conformance") {
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = fmt.Fprint(w, "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"anthropic partial\"}}\n\n")
+			return
+		}
+		if strings.Contains(string(body), "malformed stream conformance") {
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = fmt.Fprint(w, "event: content_block_delta\ndata: {\"fixture_sensitive\":\n\n")
 			return
 		}
 		var request struct {

--- a/provider/openai/openai_test.go
+++ b/provider/openai/openai_test.go
@@ -2511,6 +2511,37 @@ func TestParseSSEStreamEOFWithoutDone(t *testing.T) {
 	}
 }
 
+func TestParseSSEStreamIncompleteEOFPreservesPartialResponse(t *testing.T) {
+	body := io.NopCloser(strings.NewReader("data: {\"id\":\"chatcmpl-partial\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"partial\"},\"finish_reason\":null}]}\n\n"))
+	stream := newStreamedResponse(body, "gpt-4o")
+
+	if _, err := stream.Next(); err != nil {
+		t.Fatalf("first Next() error = %v", err)
+	}
+	_, err := stream.Next()
+	var incomplete *core.StreamIncompleteError
+	if !errors.As(err, &incomplete) {
+		t.Fatalf("Next() error = %v, want StreamIncompleteError", err)
+	}
+	if got := stream.Response().TextContent(); got != "partial" {
+		t.Fatalf("partial response text = %q, want %q", got, "partial")
+	}
+}
+
+func TestParseSSEStreamRejectsMalformedJSONEvent(t *testing.T) {
+	body := io.NopCloser(strings.NewReader("data: {\"fixture_sensitive\":\n\n"))
+	stream := newStreamedResponse(body, "gpt-4o")
+
+	_, err := stream.Next()
+	var protocol *core.StreamProtocolError
+	if !errors.As(err, &protocol) {
+		t.Fatalf("Next() error = %v, want StreamProtocolError", err)
+	}
+	if strings.Contains(err.Error(), "fixture_sensitive") {
+		t.Fatalf("protocol error leaked raw stream data: %v", err)
+	}
+}
+
 // --- Stream: empty tool call args get "{}" in finalization ---
 
 func TestParseSSEStreamEmptyToolCallArgs(t *testing.T) {

--- a/provider/openai/responses_stream.go
+++ b/provider/openai/responses_stream.go
@@ -37,6 +37,7 @@ type responsesStreamedResponse struct {
 
 	stopReason core.FinishReason
 	done       bool
+	terminal   bool
 	streamErr  error // non-nil if server sent an error mid-stream
 
 	// instrumentation receives per-request latency updates; nil = no-op. It is
@@ -114,26 +115,11 @@ func (s *responsesStreamedResponse) Next() (core.ModelResponseStreamEvent, error
 
 		if !s.scanner.Scan() {
 			if err := s.scanner.Err(); err != nil {
-				// Some providers deliver a terminal response event and then abort the
-				// underlying HTTP/2 stream before sending [DONE]. Once we have the
-				// completed response payload, treat the stream as successfully done.
-				if !s.done {
-					s.instrumentation.recordError(err)
-					s.instrumentation.finish()
-					return nil, fmt.Errorf("openai: SSE read error: %w", err)
-				}
-			}
-			// Scanner exhausted without a terminal response event.
-			s.done = true
-			if err := s.finalizeModelIdentity(); err != nil {
-				s.streamErr = err
 				s.instrumentation.recordError(err)
 				s.instrumentation.finish()
-				return nil, err
+				return nil, fmt.Errorf("openai: SSE read error: %w", err)
 			}
-			s.finalize()
-			s.instrumentation.finish()
-			return nil, io.EOF
+			return s.failIncompleteStream()
 		}
 
 		line := s.scanner.Text()
@@ -143,20 +129,19 @@ func (s *responsesStreamedResponse) Next() (core.ModelResponseStreamEvent, error
 		data := strings.TrimPrefix(line, "data:")
 		data = strings.TrimPrefix(data, " ")
 		if data == "[DONE]" {
-			s.done = true
-			if err := s.finalizeModelIdentity(); err != nil {
-				s.streamErr = err
-				s.instrumentation.recordError(err)
-				s.instrumentation.finish()
-				return nil, err
+			if !s.terminal {
+				return s.failIncompleteStream()
 			}
-			s.finalize()
+			s.done = true
 			s.instrumentation.finish()
 			return nil, io.EOF
 		}
 
 		var event responsesStreamEvent
 		if json.Unmarshal([]byte(data), &event) != nil {
+			if strings.HasPrefix(strings.TrimSpace(data), "{") {
+				return s.failStream(&core.StreamProtocolError{Provider: "openai"})
+			}
 			continue
 		}
 		s.instrumentation.recordFirstEvent()
@@ -170,6 +155,22 @@ func (s *responsesStreamedResponse) Next() (core.ModelResponseStreamEvent, error
 			return events[0], nil
 		}
 	}
+}
+
+func (s *responsesStreamedResponse) failStream(err error) (core.ModelResponseStreamEvent, error) {
+	s.done = true
+	s.finalize()
+	s.streamErr = err
+	s.instrumentation.recordError(err)
+	s.instrumentation.finish()
+	return nil, err
+}
+
+func (s *responsesStreamedResponse) failIncompleteStream() (core.ModelResponseStreamEvent, error) {
+	if err := s.finalizeModelIdentity(); err != nil {
+		return s.failStream(err)
+	}
+	return s.failStream(&core.StreamIncompleteError{Provider: "openai"})
 }
 
 func (s *responsesStreamedResponse) processEvent(event *responsesStreamEvent) []core.ModelResponseStreamEvent {
@@ -194,6 +195,7 @@ func (s *responsesStreamedResponse) processEvent(event *responsesStreamEvent) []
 		return nil
 
 	case "response.failed":
+		s.terminal = true
 		s.done = true
 		s.finalize()
 		// response.failed is a terminal outcome; record terminal timing so a
@@ -225,6 +227,7 @@ func (s *responsesStreamedResponse) processEvent(event *responsesStreamEvent) []
 
 	case "response.incomplete":
 		s.stopReason = core.FinishReasonLength
+		s.terminal = true
 		s.done = true
 		// Extract usage from the response payload (incomplete responses
 		// still report token counts) and finalize accumulated parts.
@@ -491,6 +494,7 @@ func (s *responsesStreamedResponse) handleCompleted(respJSON json.RawMessage) {
 	if err := s.finalizeModelIdentity(); err != nil {
 		s.streamErr = err
 	}
+	s.terminal = true
 	s.done = true
 	s.finalize()
 	s.instrumentation.recordTerminal()

--- a/provider/openai/responses_stream_test.go
+++ b/provider/openai/responses_stream_test.go
@@ -3,6 +3,7 @@ package openai
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -197,6 +198,38 @@ data: [DONE]
 	// Usage should be extracted from the incomplete response.
 	if resp.Usage.InputTokens != 100 || resp.Usage.OutputTokens != 50 {
 		t.Errorf("expected usage {100, 50}, got %+v", resp.Usage)
+	}
+}
+
+func TestResponsesStreamedResponse_IncompleteEOFPreservesPartialResponse(t *testing.T) {
+	sse := `data: {"type":"response.output_text.delta","delta":"partial"}
+
+`
+	s := newResponsesStreamedResponse(io.NopCloser(strings.NewReader(sse)), "gpt-5")
+
+	if _, err := s.Next(); err != nil {
+		t.Fatalf("first Next() error = %v", err)
+	}
+	_, err := s.Next()
+	var incomplete *core.StreamIncompleteError
+	if !errors.As(err, &incomplete) {
+		t.Fatalf("Next() error = %v, want StreamIncompleteError", err)
+	}
+	if got := s.Response().TextContent(); got != "partial" {
+		t.Fatalf("partial response text = %q, want %q", got, "partial")
+	}
+}
+
+func TestResponsesStreamedResponse_RejectsMalformedJSONEvent(t *testing.T) {
+	s := newResponsesStreamedResponse(io.NopCloser(strings.NewReader("data: {\"fixture_sensitive\":\n\n")), "gpt-5")
+
+	_, err := s.Next()
+	var protocol *core.StreamProtocolError
+	if !errors.As(err, &protocol) {
+		t.Fatalf("Next() error = %v, want StreamProtocolError", err)
+	}
+	if strings.Contains(err.Error(), "fixture_sensitive") {
+		t.Fatalf("protocol error leaked raw stream data: %v", err)
 	}
 }
 

--- a/provider/openai/stream.go
+++ b/provider/openai/stream.go
@@ -24,6 +24,7 @@ type streamedResponse struct {
 	parts        []core.ModelResponsePart
 	stopReason   core.FinishReason
 	done         bool
+	terminal     bool
 	streamErr    error // non-nil if server sent an error mid-stream
 
 	// instrumentation receives per-request latency updates; nil = no-op. It is
@@ -126,6 +127,9 @@ func (s *streamedResponse) Next() (core.ModelResponseStreamEvent, error) {
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				if strings.TrimSpace(line) == "" {
+					if !s.terminal {
+						return s.failIncompleteStream()
+					}
 					s.done = true
 					if modelErr := s.finalizeModelIdentity(); modelErr != nil {
 						s.streamErr = modelErr
@@ -158,6 +162,7 @@ func (s *streamedResponse) Next() (core.ModelResponseStreamEvent, error) {
 
 		// Check for stream termination.
 		if data == "[DONE]" {
+			s.terminal = true
 			s.done = true
 			if err := s.finalizeModelIdentity(); err != nil {
 				s.streamErr = err
@@ -172,6 +177,9 @@ func (s *streamedResponse) Next() (core.ModelResponseStreamEvent, error) {
 
 		var chunk apiChunk
 		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+			if strings.HasPrefix(strings.TrimSpace(data), "{") {
+				return s.failStream(&core.StreamProtocolError{Provider: "openai"})
+			}
 			continue
 		}
 		if chunk.Model != "" {
@@ -216,6 +224,7 @@ func (s *streamedResponse) Next() (core.ModelResponseStreamEvent, error) {
 		// Check finish reason.
 		if choice.FinishReason != nil {
 			s.stopReason = mapFinishReasonStr(*choice.FinishReason)
+			s.terminal = true
 		}
 
 		var events []core.ModelResponseStreamEvent
@@ -240,6 +249,22 @@ func (s *streamedResponse) Next() (core.ModelResponseStreamEvent, error) {
 			return events[0], nil
 		}
 	}
+}
+
+func (s *streamedResponse) failStream(err error) (core.ModelResponseStreamEvent, error) {
+	s.done = true
+	s.finalizeAll()
+	s.streamErr = err
+	s.instrumentation.recordError(err)
+	s.instrumentation.finish()
+	return nil, err
+}
+
+func (s *streamedResponse) failIncompleteStream() (core.ModelResponseStreamEvent, error) {
+	if err := s.finalizeModelIdentity(); err != nil {
+		return s.failStream(err)
+	}
+	return s.failStream(&core.StreamIncompleteError{Provider: "openai"})
 }
 
 func (s *streamedResponse) finalizeModelIdentity() error {


### PR DESCRIPTION
## Summary
- classify abrupt nonterminal EOF as a typed incomplete stream while preserving partial output
- reject malformed JSON SSE events with source-free typed protocol errors
- prove the behavior for native OpenAI, OpenAI-compatible local, and native Anthropic through the common fixture matrix

## Verification
- `go test $(go list ./... | grep -v '^github.com/fugue-labs/gollem/ext/monty$')`\n- `go test -race ./provider/openai ./provider/anthropic ./provider/conformance`\n- `go vet $(go list ./... | grep -v '^github.com/fugue-labs/gollem/ext/monty$')`\n- `golangci-lint run ./...`\n- local pre-push gate (race excluding Monty, lint, vet, tidy)