### PR TITLE
fix(provider): normalize stream transport errors

### DIFF
--- a/core/errors.go
+++ b/core/errors.go
@@ -117,3 +117,18 @@ func (e *StreamProtocolError) Error() string {
 	}
 	return e.Provider + " stream contained malformed protocol data"
 }
+
+// StreamTransportError indicates a non-context read failure after a streaming
+// response has started. The original transport detail is intentionally omitted
+// because it can contain provider or endpoint data; callers may inspect this
+// type to offer an explicit fresh-run recovery path.
+type StreamTransportError struct {
+	Provider string
+}
+
+func (e *StreamTransportError) Error() string {
+	if e.Provider == "" {
+		return "model stream transport failed"
+	}
+	return e.Provider + " stream transport failed"
+}

--- a/docs/PROVIDER_DRIVER_CONFORMANCE.md
+++ b/docs/PROVIDER_DRIVER_CONFORMANCE.md
@@ -20,7 +20,7 @@ of behavior and must not enable a control solely on provider identity.
 | Prompt cache / Responses API | Catalog-supported where applicable | Unsupported | Catalog-supported where applicable | Provider-specific tests; no common conformance claim yet |
 | Malformed JSON stream event normalization | Proven | Proven | Proven | `provider/conformance` plus provider parser tests; returns `StreamProtocolError` without raw event data |
 | Abrupt EOF partial-stream result | Proven | Proven | Proven | `provider/conformance` plus provider parser tests; preserves partial response and returns `StreamIncompleteError` |
-| Read-error peer-disconnect classification | Not yet proven | Not yet proven | Not yet proven | Follow-up conformance scenario required |
+| Read-error peer-disconnect classification | Proven | Proven | Proven | Provider parser tests; returns source-free `StreamTransportError`, while context cancellation remains intact |
 | Timeout and retryability classification | Not yet proven | Not yet proven | Not yet proven | Follow-up conformance scenario required |
 | Endpoint health probe and capability mismatch | Not yet proven | Not yet proven | Not yet proven | Must remain a typed unavailable/degraded state |
 

--- a/provider/anthropic/anthropic.go
+++ b/provider/anthropic/anthropic.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"strconv"
@@ -295,15 +294,10 @@ func (p *Provider) doRequest(ctx context.Context, body []byte) (*http.Response, 
 		return resp, nil
 	}
 
-	respBody, _ := io.ReadAll(resp.Body)
+	classification := readProviderErrorClassification(resp.Body)
 	resp.Body.Close()
 
-	httpErr := &core.ModelHTTPError{
-		Message:    "anthropic API error: " + string(respBody),
-		StatusCode: resp.StatusCode,
-		Body:       string(respBody),
-		ModelName:  p.model,
-	}
+	httpErr := sanitizedProviderHTTPError(resp.StatusCode, classification, p.model)
 
 	// Parse Retry-After header for 429 responses so the model-level
 	// retry (modelutil.RetryModel) can use appropriate backoff.

--- a/provider/anthropic/anthropic_test.go
+++ b/provider/anthropic/anthropic_test.go
@@ -605,6 +605,27 @@ func TestParseSSEStreamRejectsMalformedJSONEvent(t *testing.T) {
 	}
 }
 
+func TestParseSSEStreamNormalizesReadFailure(t *testing.T) {
+	stream := newStreamedResponse(io.NopCloser(streamReadFailure{err: io.ErrUnexpectedEOF}), ClaudeSonnet46)
+
+	_, err := stream.Next()
+	var transport *core.StreamTransportError
+	if !errors.As(err, &transport) {
+		t.Fatalf("Next() error = %v, want StreamTransportError", err)
+	}
+	if strings.Contains(err.Error(), "unexpected EOF") {
+		t.Fatalf("transport error leaked raw read failure: %v", err)
+	}
+}
+
+type streamReadFailure struct {
+	err error
+}
+
+func (r streamReadFailure) Read(_ []byte) (int, error) {
+	return 0, r.err
+}
+
 func TestParseSSEStreamToolCall(t *testing.T) {
 	sseData := `event: message_start
 data: {"type":"message_start","message":{"id":"msg_1","model":"claude-sonnet-4-5","usage":{"input_tokens":10,"output_tokens":0}}}
@@ -837,10 +858,12 @@ data: {"type":"message_stop"}
 	}
 }
 
-func TestRequestHTTPError(t *testing.T) {
+func TestRequestHTTPErrorIsRedacted(t *testing.T) {
+	const secret = "provider-sensitive-request-data"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "30")
 		w.WriteHeader(http.StatusTooManyRequests)
-		w.Write([]byte(`{"error":{"message":"rate limited"}}`))
+		_, _ = w.Write([]byte(`{"error":{"type":"rate_limit_error","message":"` + secret + `"}}`))
 	}))
 	defer server.Close()
 
@@ -857,6 +880,15 @@ func TestRequestHTTPError(t *testing.T) {
 	}
 	if httpErr.StatusCode != http.StatusTooManyRequests {
 		t.Errorf("status = %d, want 429", httpErr.StatusCode)
+	}
+	if strings.Contains(err.Error(), secret) || strings.Contains(httpErr.Body, secret) {
+		t.Fatalf("HTTP error leaked provider body: %#v", httpErr)
+	}
+	if httpErr.Body != "rate_limited" {
+		t.Errorf("classification = %q, want rate_limited", httpErr.Body)
+	}
+	if httpErr.RetryAfter != 30*time.Second {
+		t.Errorf("RetryAfter = %v, want 30s", httpErr.RetryAfter)
 	}
 }
 

--- a/provider/anthropic/provider_error.go
+++ b/provider/anthropic/provider_error.go
@@ -1,0 +1,63 @@
+package anthropic
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/fugue-labs/gollem/core"
+)
+
+// Provider error payloads are untrusted and may echo request data. Keep them
+// bounded for classification and expose only fixed, source-free markers.
+const maxProviderErrorBodyBytes = 64 << 10
+
+var providerErrorMarkers = []struct {
+	marker string
+	terms  []string
+}{
+	{marker: "credits_exhausted", terms: []string{"credits", "spending limit", "billing", "quota exceeded", "plan limit", "subscription"}},
+	{marker: "rate_limited", terms: []string{"rate_limit", "rate limited", "too many requests"}},
+	{marker: "overloaded", terms: []string{"overloaded", "capacity"}},
+	{marker: "authentication", terms: []string{"authentication", "api key", "invalid_api_key", "permission"}},
+	{marker: "context_length", terms: []string{"context length", "too many tokens", "max_tokens"}},
+	{marker: "not_found", terms: []string{"not found", "not_found"}},
+	{marker: "bad_request", terms: []string{"invalid_request", "invalid request"}},
+}
+
+func readProviderErrorClassification(r io.Reader) string {
+	body, _ := io.ReadAll(io.LimitReader(r, maxProviderErrorBodyBytes+1))
+	overflow := len(body) > maxProviderErrorBodyBytes
+	if overflow {
+		body = body[:maxProviderErrorBodyBytes]
+	}
+	classification := classifyProviderErrorBody(string(body))
+	if overflow {
+		return classification + ",response_too_large"
+	}
+	return classification
+}
+
+func classifyProviderErrorBody(body string) string {
+	combined := strings.ToLower(body)
+	for _, candidate := range providerErrorMarkers {
+		for _, term := range candidate.terms {
+			if strings.Contains(combined, term) {
+				return candidate.marker
+			}
+		}
+	}
+	return "provider_error"
+}
+
+func sanitizedProviderHTTPError(status int, classification, model string) *core.ModelHTTPError {
+	if classification == "" {
+		classification = "provider_error"
+	}
+	return &core.ModelHTTPError{
+		Message:    fmt.Sprintf("anthropic API error (HTTP %d; %s)", status, classification),
+		StatusCode: status,
+		Body:       classification,
+		ModelName:  model,
+	}
+}

--- a/provider/anthropic/stream.go
+++ b/provider/anthropic/stream.go
@@ -2,9 +2,9 @@ package anthropic
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"sort"
 	"strings"
@@ -62,7 +62,8 @@ func (s *streamedResponse) Next() (core.ModelResponseStreamEvent, error) {
 				s.failStream(&core.StreamIncompleteError{Provider: "anthropic"})
 				return nil, s.streamErr
 			}
-			return nil, err
+			s.failStream(normalizeStreamReadError(err))
+			return nil, s.streamErr
 		}
 
 		gollemEvent, ok := s.processSSEEvent(event)
@@ -71,6 +72,13 @@ func (s *streamedResponse) Next() (core.ModelResponseStreamEvent, error) {
 		}
 		// Some SSE events (message_start, message_stop) don't produce gollem events.
 	}
+}
+
+func normalizeStreamReadError(err error) error {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+	return &core.StreamTransportError{Provider: "anthropic"}
 }
 
 // readSSEEvent reads one SSE event from the stream.
@@ -287,18 +295,7 @@ func (s *streamedResponse) processSSEEvent(event *sseEvent) (core.ModelResponseS
 	case "error":
 		s.done = true
 		s.finalizeAll()
-		// Parse error event data to propagate a meaningful error.
-		var errData struct {
-			Error struct {
-				Type    string `json:"type"`
-				Message string `json:"message"`
-			} `json:"error"`
-		}
-		if err := json.Unmarshal([]byte(event.Data), &errData); err == nil && errData.Error.Message != "" {
-			s.streamErr = fmt.Errorf("anthropic stream error (%s): %s", errData.Error.Type, errData.Error.Message)
-		} else {
-			s.streamErr = fmt.Errorf("anthropic stream error: %s", event.Data)
-		}
+		s.streamErr = errors.New("anthropic stream error (" + classifyProviderErrorBody(event.Data) + ")")
 		return nil, false
 
 	default:

--- a/provider/anthropic/stream_thinking_test.go
+++ b/provider/anthropic/stream_thinking_test.go
@@ -264,11 +264,11 @@ data: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}
 	if err == nil {
 		t.Fatal("expected error after error event")
 	}
-	if !strings.Contains(err.Error(), "Overloaded") {
-		t.Errorf("error = %v, want to contain 'Overloaded'", err)
+	if strings.Contains(err.Error(), "Overloaded") {
+		t.Errorf("error leaked provider message: %v", err)
 	}
-	if !strings.Contains(err.Error(), "overloaded_error") {
-		t.Errorf("error = %v, want to contain 'overloaded_error'", err)
+	if !strings.Contains(err.Error(), "overloaded") {
+		t.Errorf("error = %v, want sanitized overloaded classification", err)
 	}
 }
 

--- a/provider/openai/openai_test.go
+++ b/provider/openai/openai_test.go
@@ -2542,6 +2542,36 @@ func TestParseSSEStreamRejectsMalformedJSONEvent(t *testing.T) {
 	}
 }
 
+func TestParseSSEStreamNormalizesReadFailure(t *testing.T) {
+	stream := newStreamedResponse(io.NopCloser(streamReadFailure{err: io.ErrUnexpectedEOF}), "gpt-4o")
+
+	_, err := stream.Next()
+	var transport *core.StreamTransportError
+	if !errors.As(err, &transport) {
+		t.Fatalf("Next() error = %v, want StreamTransportError", err)
+	}
+	if strings.Contains(err.Error(), "unexpected EOF") {
+		t.Fatalf("transport error leaked raw read failure: %v", err)
+	}
+}
+
+func TestParseSSEStreamPreservesContextCancellation(t *testing.T) {
+	stream := newStreamedResponse(io.NopCloser(streamReadFailure{err: context.Canceled}), "gpt-4o")
+
+	_, err := stream.Next()
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Next() error = %v, want context canceled", err)
+	}
+}
+
+type streamReadFailure struct {
+	err error
+}
+
+func (r streamReadFailure) Read(_ []byte) (int, error) {
+	return 0, r.err
+}
+
 // --- Stream: empty tool call args get "{}" in finalization ---
 
 func TestParseSSEStreamEmptyToolCallArgs(t *testing.T) {

--- a/provider/openai/responses_stream.go
+++ b/provider/openai/responses_stream.go
@@ -115,9 +115,7 @@ func (s *responsesStreamedResponse) Next() (core.ModelResponseStreamEvent, error
 
 		if !s.scanner.Scan() {
 			if err := s.scanner.Err(); err != nil {
-				s.instrumentation.recordError(err)
-				s.instrumentation.finish()
-				return nil, fmt.Errorf("openai: SSE read error: %w", err)
+				return s.failStream(normalizeStreamReadError(err))
 			}
 			return s.failIncompleteStream()
 		}

--- a/provider/openai/responses_stream_test.go
+++ b/provider/openai/responses_stream_test.go
@@ -233,6 +233,19 @@ func TestResponsesStreamedResponse_RejectsMalformedJSONEvent(t *testing.T) {
 	}
 }
 
+func TestResponsesStreamedResponse_NormalizesReadFailure(t *testing.T) {
+	s := newResponsesStreamedResponse(io.NopCloser(streamReadFailure{err: io.ErrUnexpectedEOF}), "gpt-5")
+
+	_, err := s.Next()
+	var transport *core.StreamTransportError
+	if !errors.As(err, &transport) {
+		t.Fatalf("Next() error = %v, want StreamTransportError", err)
+	}
+	if strings.Contains(err.Error(), "unexpected EOF") {
+		t.Fatalf("transport error leaked raw read failure: %v", err)
+	}
+}
+
 func TestResponsesStreamedResponse_TextAndToolCall(t *testing.T) {
 	sse := `data: {"type":"response.output_text.delta","delta":"Thinking..."}
 

--- a/provider/openai/stream.go
+++ b/provider/openai/stream.go
@@ -2,6 +2,7 @@ package openai
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -143,9 +144,7 @@ func (s *streamedResponse) Next() (core.ModelResponseStreamEvent, error) {
 				}
 				// Data received with EOF; process this line, finalize on next read.
 			} else {
-				s.instrumentation.recordError(err)
-				s.instrumentation.finish()
-				return nil, err
+				return s.failStream(normalizeStreamReadError(err))
 			}
 		}
 
@@ -249,6 +248,13 @@ func (s *streamedResponse) Next() (core.ModelResponseStreamEvent, error) {
 			return events[0], nil
 		}
 	}
+}
+
+func normalizeStreamReadError(err error) error {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+	return &core.StreamTransportError{Provider: "openai"}
 }
 
 func (s *streamedResponse) failStream(err error) (core.ModelResponseStreamEvent, error) {


### PR DESCRIPTION
## Summary
- return source-free typed transport errors for non-context OpenAI and Anthropic SSE read failures
- preserve `context.Canceled` and `context.DeadlineExceeded` semantics
- redact native Anthropic HTTP and in-band SSE error payloads while preserving status and `Retry-After`
- document and test the completed peer-read-failure contract

## Verification
- `go test $(go list ./... | grep -v '^github.com/fugue-labs/gollem/ext/monty$')`\n- `go test -race ./provider/openai ./provider/anthropic ./provider/conformance`\n- `go vet $(go list ./... | grep -v '^github.com/fugue-labs/gollem/ext/monty$')`\n- `golangci-lint run ./...`\n- local pre-push gate (race excluding Monty, lint, vet, tidy)