### PR TITLE
test(provider): verify retryable request recovery

### DIFF
--- a/docs/PROVIDER_DRIVER_CONFORMANCE.md
+++ b/docs/PROVIDER_DRIVER_CONFORMANCE.md
@@ -21,7 +21,8 @@ of behavior and must not enable a control solely on provider identity.
 | Malformed JSON stream event normalization | Proven | Proven | Proven | `provider/conformance` plus provider parser tests; returns `StreamProtocolError` without raw event data |
 | Abrupt EOF partial-stream result | Proven | Proven | Proven | `provider/conformance` plus provider parser tests; preserves partial response and returns `StreamIncompleteError` |
 | Read-error peer-disconnect classification | Proven | Proven | Proven | Provider parser tests; returns source-free `StreamTransportError`, while context cancellation remains intact |
-| Timeout and retryability classification | Not yet proven | Not yet proven | Not yet proven | Follow-up conformance scenario required |
+| Retryable 429 request recovery | Proven | Proven | Proven | `provider/conformance` exercises bounded `modelutil.RetryModel` recovery |
+| Request timeout and post-output replay | Not yet proven | Not yet proven | Not yet proven | Follow-up conformance scenario required |
 | Endpoint health probe and capability mismatch | Not yet proven | Not yet proven | Not yet proven | Must remain a typed unavailable/degraded state |
 
 `Catalog-supported` means the catalog may expose the capability only for the

--- a/provider/conformance/conformance.go
+++ b/provider/conformance/conformance.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/fugue-labs/gollem/core"
+	"github.com/fugue-labs/gollem/modelutil"
 )
 
 // Claims are the capabilities covered by a deterministic conformance fixture.
@@ -26,6 +27,7 @@ type Claims struct {
 	Cancellation    bool
 	PartialStream   bool
 	MalformedStream bool
+	Retryability    bool
 }
 
 // Expectations declares the normalized outputs a deterministic fixture
@@ -36,6 +38,7 @@ type Expectations struct {
 	ToolName     string
 	StreamText   string
 	PartialText  string
+	RetryText    string
 }
 
 // Driver binds a provider model to the common capability claims and expected
@@ -68,6 +71,9 @@ func Verify(ctx context.Context, driver Driver) error {
 	}
 	if driver.Claims.PartialStream && strings.TrimSpace(driver.Expectations.PartialText) == "" {
 		return fmt.Errorf("provider conformance: %s partial-stream fixture must expect partial text", driver.Name)
+	}
+	if driver.Claims.Retryability && strings.TrimSpace(driver.Expectations.RetryText) == "" {
+		return fmt.Errorf("provider conformance: %s retry fixture must expect retry text", driver.Name)
 	}
 
 	params := &core.ModelRequestParameters{AllowTextOutput: true}
@@ -127,6 +133,11 @@ func Verify(ctx context.Context, driver Driver) error {
 	}
 	if driver.Claims.MalformedStream {
 		if err := verifyMalformedStream(ctx, driver); err != nil {
+			return err
+		}
+	}
+	if driver.Claims.Retryability {
+		if err := verifyRetryability(ctx, driver); err != nil {
 			return err
 		}
 	}
@@ -204,6 +215,28 @@ func verifyMalformedStream(ctx context.Context, driver Driver) error {
 	}
 }
 
+func verifyRetryability(ctx context.Context, driver Driver) error {
+	retryingModel := modelutil.NewRetryModel(driver.Model, modelutil.RetryConfig{
+		MaxRetries:     1,
+		InitialBackoff: time.Millisecond,
+		MaxBackoff:     time.Millisecond,
+		BackoffFactor:  1,
+		Jitter:         false,
+		MinRemaining:   0,
+	})
+	response, err := retryingModel.Request(ctx, retryMessages(), nil, &core.ModelRequestParameters{AllowTextOutput: true})
+	if err != nil {
+		return fmt.Errorf("provider conformance: %s retry request: %w", driver.Name, err)
+	}
+	if response == nil {
+		return fmt.Errorf("provider conformance: %s retry request returned a nil response", driver.Name)
+	}
+	if got := response.TextContent(); got != driver.Expectations.RetryText {
+		return fmt.Errorf("provider conformance: %s retry text = %q, want %q", driver.Name, got, driver.Expectations.RetryText)
+	}
+	return nil
+}
+
 func verifyResponse(driver Driver, response *core.ModelResponse, streaming bool) error {
 	if response == nil {
 		return fmt.Errorf("provider conformance: %s returned a nil response", driver.Name)
@@ -254,5 +287,11 @@ func partialStreamMessages() []core.ModelMessage {
 func malformedStreamMessages() []core.ModelMessage {
 	return []core.ModelMessage{
 		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "malformed stream conformance"}}},
+	}
+}
+
+func retryMessages() []core.ModelMessage {
+	return []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "retry conformance"}}},
 	}
 }

--- a/provider/conformance/conformance_test.go
+++ b/provider/conformance/conformance_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/fugue-labs/gollem/provider/anthropic"
@@ -17,10 +18,12 @@ import (
 
 func TestDeterministicProviderDriverConformance(t *testing.T) {
 	openAICancellationReady := make(chan struct{})
-	openAIServer := httptest.NewServer(openAIConformanceFixture(t, openAICancellationReady))
+	openAIRetry := newRetryFixture()
+	openAIServer := httptest.NewServer(openAIConformanceFixture(t, openAICancellationReady, openAIRetry))
 	defer openAIServer.Close()
 	anthropicCancellationReady := make(chan struct{})
-	anthropicServer := httptest.NewServer(anthropicConformanceFixture(t, anthropicCancellationReady))
+	anthropicRetry := newRetryFixture()
+	anthropicServer := httptest.NewServer(anthropicConformanceFixture(t, anthropicCancellationReady, anthropicRetry))
 	defer anthropicServer.Close()
 
 	cases := []struct {
@@ -33,13 +36,14 @@ func TestDeterministicProviderDriverConformance(t *testing.T) {
 				return conformance.Driver{
 					Name:              "native OpenAI",
 					Model:             openai.New(openai.WithAPIKey("test-openai-key"), openai.WithBaseURL(openAIServer.URL), openai.WithModel("gpt-4o")),
-					Claims:            conformance.Claims{ToolCalls: true, Streaming: true, Usage: true, Cancellation: true, PartialStream: true, MalformedStream: true},
+					Claims:            conformance.Claims{ToolCalls: true, Streaming: true, Usage: true, Cancellation: true, PartialStream: true, MalformedStream: true, Retryability: true},
 					CancellationReady: openAICancellationReady,
 					Expectations: conformance.Expectations{
 						ResponseText: "openai response",
 						ToolName:     "conformance_echo",
 						StreamText:   "openai stream",
 						PartialText:  "openai partial",
+						RetryText:    "openai retry",
 					},
 				}, nil
 			},
@@ -58,13 +62,14 @@ func TestDeterministicProviderDriverConformance(t *testing.T) {
 				return conformance.Driver{
 					Name:              "OpenAI-compatible local",
 					Model:             model,
-					Claims:            conformance.Claims{ToolCalls: true, Streaming: true, Usage: true, Cancellation: true, PartialStream: true, MalformedStream: true},
+					Claims:            conformance.Claims{ToolCalls: true, Streaming: true, Usage: true, Cancellation: true, PartialStream: true, MalformedStream: true, Retryability: true},
 					CancellationReady: openAICancellationReady,
 					Expectations: conformance.Expectations{
 						ResponseText: "openai response",
 						ToolName:     "conformance_echo",
 						StreamText:   "openai stream",
 						PartialText:  "openai partial",
+						RetryText:    "openai retry",
 					},
 				}, nil
 			},
@@ -75,13 +80,14 @@ func TestDeterministicProviderDriverConformance(t *testing.T) {
 				return conformance.Driver{
 					Name:              "native Anthropic",
 					Model:             anthropic.New(anthropic.WithAPIKey("test-anthropic-key"), anthropic.WithBaseURL(anthropicServer.URL), anthropic.WithModel(anthropic.ClaudeSonnet46)),
-					Claims:            conformance.Claims{ToolCalls: true, Streaming: true, Usage: true, Cancellation: true, PartialStream: true, MalformedStream: true},
+					Claims:            conformance.Claims{ToolCalls: true, Streaming: true, Usage: true, Cancellation: true, PartialStream: true, MalformedStream: true, Retryability: true},
 					CancellationReady: anthropicCancellationReady,
 					Expectations: conformance.Expectations{
 						ResponseText: "anthropic response",
 						ToolName:     "conformance_echo",
 						StreamText:   "anthropic stream",
 						PartialText:  "anthropic partial",
+						RetryText:    "anthropic retry",
 					},
 				}, nil
 			},
@@ -126,9 +132,17 @@ func TestVerifyRejectsUnprovenClaims(t *testing.T) {
 	if err == nil {
 		t.Fatal("Verify accepted a partial stream claim without expected partial text")
 	}
+	err = conformance.Verify(context.Background(), conformance.Driver{
+		Name:   "missing retry fixture",
+		Model:  openai.New(openai.WithAPIKey("test-key")),
+		Claims: conformance.Claims{Retryability: true},
+	})
+	if err == nil {
+		t.Fatal("Verify accepted a retry claim without expected retry text")
+	}
 }
 
-func openAIConformanceFixture(t *testing.T, cancellationReady chan<- struct{}) http.Handler {
+func openAIConformanceFixture(t *testing.T, cancellationReady chan<- struct{}, retry *retryFixture) http.Handler {
 	t.Helper()
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/chat/completions" {
@@ -156,11 +170,23 @@ func openAIConformanceFixture(t *testing.T, cancellationReady chan<- struct{}) h
 			return
 		}
 		var request struct {
+			Model  string          `json:"model"`
 			Stream bool            `json:"stream"`
 			Tools  json.RawMessage `json:"tools"`
 		}
 		if err := json.Unmarshal(body, &request); err != nil {
 			t.Fatalf("decode OpenAI request: %v", err)
+		}
+		if strings.Contains(string(body), "retry conformance") {
+			if retry.firstAttempt(request.Model) {
+				w.Header().Set("Retry-After", "0")
+				w.WriteHeader(http.StatusTooManyRequests)
+				_, _ = fmt.Fprint(w, `{"error":{"type":"rate_limit_error"}}`)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `{"id":"chatcmpl-retry","object":"chat.completion","model":"gpt-4o","choices":[{"message":{"role":"assistant","content":"openai retry"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":2}}`)
+			return
 		}
 		if request.Stream {
 			if len(request.Tools) != 0 && string(request.Tools) != "null" {
@@ -182,7 +208,7 @@ data: [DONE]
 	})
 }
 
-func anthropicConformanceFixture(t *testing.T, cancellationReady chan<- struct{}) http.Handler {
+func anthropicConformanceFixture(t *testing.T, cancellationReady chan<- struct{}, retry *retryFixture) http.Handler {
 	t.Helper()
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/messages" {
@@ -210,11 +236,23 @@ func anthropicConformanceFixture(t *testing.T, cancellationReady chan<- struct{}
 			return
 		}
 		var request struct {
+			Model  string          `json:"model"`
 			Stream bool            `json:"stream"`
 			Tools  json.RawMessage `json:"tools"`
 		}
 		if err := json.Unmarshal(body, &request); err != nil {
 			t.Fatalf("decode Anthropic request: %v", err)
+		}
+		if strings.Contains(string(body), "retry conformance") {
+			if retry.firstAttempt(request.Model) {
+				w.Header().Set("Retry-After", "0")
+				w.WriteHeader(http.StatusTooManyRequests)
+				_, _ = fmt.Fprint(w, `{"error":{"type":"rate_limit_error"}}`)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `{"id":"msg-retry","role":"assistant","model":"claude-sonnet-4-6","content":[{"type":"text","text":"anthropic retry"}],"stop_reason":"end_turn","usage":{"input_tokens":3,"output_tokens":2}}`)
+			return
 		}
 		if request.Stream {
 			w.Header().Set("Content-Type", "text/event-stream")
@@ -254,4 +292,20 @@ func waitForCancellation(request *http.Request, ready chan<- struct{}) {
 		return
 	}
 	<-request.Context().Done()
+}
+
+type retryFixture struct {
+	mu       sync.Mutex
+	attempts map[string]int
+}
+
+func newRetryFixture() *retryFixture {
+	return &retryFixture{attempts: make(map[string]int)}
+}
+
+func (f *retryFixture) firstAttempt(model string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.attempts[model]++
+	return f.attempts[model] == 1
 }


### PR DESCRIPTION
## Summary
- add deterministic retryability claims to the common provider conformance harness
- prove one bounded 429 recovery for native OpenAI, OpenAI-compatible local, and native Anthropic drivers
- record retry recovery separately from still-unproven timeout and post-output replay behavior

## Verification
- `go test -race ./provider/openai ./provider/anthropic ./provider/conformance`
- `go test $(go list ./... | rg -v "^github\.com/fugue-labs/gollem/ext/monty$")`
- `go vet $(go list ./... | rg -v "^github\.com/fugue-labs/gollem/ext/monty$")`
- `golangci-lint run ./...`
- `go mod tidy -diff`
- `git diff --check`

Local Monty tests are intentionally excluded by repository policy; hosted CI remains unchanged.