### PR TITLE
test(provider): verify request deadline propagation

### DIFF
--- a/docs/PROVIDER_DRIVER_CONFORMANCE.md
+++ b/docs/PROVIDER_DRIVER_CONFORMANCE.md
@@ -22,7 +22,8 @@ of behavior and must not enable a control solely on provider identity.
 | Abrupt EOF partial-stream result | Proven | Proven | Proven | `provider/conformance` plus provider parser tests; preserves partial response and returns `StreamIncompleteError` |
 | Read-error peer-disconnect classification | Proven | Proven | Proven | Provider parser tests; returns source-free `StreamTransportError`, while context cancellation remains intact |
 | Retryable 429 request recovery | Proven | Proven | Proven | `provider/conformance` exercises bounded `modelutil.RetryModel` recovery |
-| Request timeout and post-output replay | Not yet proven | Not yet proven | Not yet proven | Follow-up conformance scenario required |
+| Request deadline propagation | Proven | Proven | Proven | `provider/conformance` confirms HTTP request cancellation and `context.DeadlineExceeded` normalization |
+| Post-output retry / replay | Not yet proven | Not yet proven | Not yet proven | A stream may have produced caller-visible output; recovery must not replay it without an explicit safe-resume contract |
 | Endpoint health probe and capability mismatch | Not yet proven | Not yet proven | Not yet proven | Must remain a typed unavailable/degraded state |
 
 `Catalog-supported` means the catalog may expose the capability only for the

--- a/provider/conformance/conformance.go
+++ b/provider/conformance/conformance.go
@@ -28,6 +28,7 @@ type Claims struct {
 	PartialStream   bool
 	MalformedStream bool
 	Retryability    bool
+	RequestTimeout  bool
 }
 
 // Expectations declares the normalized outputs a deterministic fixture
@@ -44,11 +45,12 @@ type Expectations struct {
 // Driver binds a provider model to the common capability claims and expected
 // normalized results that its deterministic fixture produces.
 type Driver struct {
-	Name              string
-	Model             core.Model
-	Claims            Claims
-	Expectations      Expectations
-	CancellationReady <-chan struct{}
+	Name                string
+	Model               core.Model
+	Claims              Claims
+	Expectations        Expectations
+	CancellationReady   <-chan struct{}
+	RequestTimeoutReady <-chan struct{}
 }
 
 // Verify exercises the claimed common model surface through core.Model. It is
@@ -74,6 +76,9 @@ func Verify(ctx context.Context, driver Driver) error {
 	}
 	if driver.Claims.Retryability && strings.TrimSpace(driver.Expectations.RetryText) == "" {
 		return fmt.Errorf("provider conformance: %s retry fixture must expect retry text", driver.Name)
+	}
+	if driver.Claims.RequestTimeout && driver.RequestTimeoutReady == nil {
+		return fmt.Errorf("provider conformance: %s timeout-capable fixture must signal request start", driver.Name)
 	}
 
 	params := &core.ModelRequestParameters{AllowTextOutput: true}
@@ -102,6 +107,16 @@ func Verify(ctx context.Context, driver Driver) error {
 	}
 	if driver.Claims.Cancellation {
 		if err := verifyCancellation(ctx, driver); err != nil {
+			return err
+		}
+	}
+	if driver.Claims.RequestTimeout {
+		if err := verifyRequestTimeout(ctx, driver); err != nil {
+			return err
+		}
+	}
+	if driver.Claims.Retryability {
+		if err := verifyRetryability(ctx, driver); err != nil {
 			return err
 		}
 	}
@@ -136,11 +151,6 @@ func Verify(ctx context.Context, driver Driver) error {
 			return err
 		}
 	}
-	if driver.Claims.Retryability {
-		if err := verifyRetryability(ctx, driver); err != nil {
-			return err
-		}
-	}
 	return nil
 }
 
@@ -170,6 +180,34 @@ func verifyCancellation(ctx context.Context, driver Driver) error {
 		return nil
 	case <-time.After(time.Second):
 		return fmt.Errorf("provider conformance: %s cancellation request did not finish", driver.Name)
+	}
+}
+
+func verifyRequestTimeout(ctx context.Context, driver Driver) error {
+	requestContext, cancel := context.WithTimeout(ctx, 250*time.Millisecond)
+	defer cancel()
+	result := make(chan error, 1)
+	go func() {
+		_, err := driver.Model.Request(requestContext, timeoutMessages(), nil, &core.ModelRequestParameters{AllowTextOutput: true})
+		result <- err
+	}()
+
+	select {
+	case <-driver.RequestTimeoutReady:
+	case <-ctx.Done():
+		return fmt.Errorf("provider conformance: %s timeout request did not start: %w", driver.Name, ctx.Err())
+	case <-time.After(time.Second):
+		return fmt.Errorf("provider conformance: %s timeout request did not start", driver.Name)
+	}
+
+	select {
+	case err := <-result:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			return fmt.Errorf("provider conformance: %s timeout error, want context deadline exceeded: %w", driver.Name, err)
+		}
+		return nil
+	case <-time.After(time.Second):
+		return fmt.Errorf("provider conformance: %s timeout request did not finish", driver.Name)
 	}
 }
 
@@ -293,5 +331,11 @@ func malformedStreamMessages() []core.ModelMessage {
 func retryMessages() []core.ModelMessage {
 	return []core.ModelMessage{
 		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "retry conformance"}}},
+	}
+}
+
+func timeoutMessages() []core.ModelMessage {
+	return []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "timeout conformance"}}},
 	}
 }

--- a/provider/conformance/conformance_test.go
+++ b/provider/conformance/conformance_test.go
@@ -19,11 +19,13 @@ import (
 func TestDeterministicProviderDriverConformance(t *testing.T) {
 	openAICancellationReady := make(chan struct{})
 	openAIRetry := newRetryFixture()
-	openAIServer := httptest.NewServer(openAIConformanceFixture(t, openAICancellationReady, openAIRetry))
+	openAITimeout := newTimeoutFixture()
+	openAIServer := httptest.NewServer(openAIConformanceFixture(t, openAICancellationReady, openAIRetry, openAITimeout))
 	defer openAIServer.Close()
 	anthropicCancellationReady := make(chan struct{})
 	anthropicRetry := newRetryFixture()
-	anthropicServer := httptest.NewServer(anthropicConformanceFixture(t, anthropicCancellationReady, anthropicRetry))
+	anthropicTimeout := newTimeoutFixture()
+	anthropicServer := httptest.NewServer(anthropicConformanceFixture(t, anthropicCancellationReady, anthropicRetry, anthropicTimeout))
 	defer anthropicServer.Close()
 
 	cases := []struct {
@@ -34,10 +36,11 @@ func TestDeterministicProviderDriverConformance(t *testing.T) {
 			name: "native OpenAI",
 			model: func() (conformance.Driver, error) {
 				return conformance.Driver{
-					Name:              "native OpenAI",
-					Model:             openai.New(openai.WithAPIKey("test-openai-key"), openai.WithBaseURL(openAIServer.URL), openai.WithModel("gpt-4o")),
-					Claims:            conformance.Claims{ToolCalls: true, Streaming: true, Usage: true, Cancellation: true, PartialStream: true, MalformedStream: true, Retryability: true},
-					CancellationReady: openAICancellationReady,
+					Name:                "native OpenAI",
+					Model:               openai.New(openai.WithAPIKey("test-openai-key"), openai.WithBaseURL(openAIServer.URL), openai.WithModel("gpt-4o")),
+					Claims:              conformance.Claims{ToolCalls: true, Streaming: true, Usage: true, Cancellation: true, PartialStream: true, MalformedStream: true, Retryability: true, RequestTimeout: true},
+					CancellationReady:   openAICancellationReady,
+					RequestTimeoutReady: openAITimeout.readyFor("gpt-4o"),
 					Expectations: conformance.Expectations{
 						ResponseText: "openai response",
 						ToolName:     "conformance_echo",
@@ -60,10 +63,11 @@ func TestDeterministicProviderDriverConformance(t *testing.T) {
 					return conformance.Driver{}, err
 				}
 				return conformance.Driver{
-					Name:              "OpenAI-compatible local",
-					Model:             model,
-					Claims:            conformance.Claims{ToolCalls: true, Streaming: true, Usage: true, Cancellation: true, PartialStream: true, MalformedStream: true, Retryability: true},
-					CancellationReady: openAICancellationReady,
+					Name:                "OpenAI-compatible local",
+					Model:               model,
+					Claims:              conformance.Claims{ToolCalls: true, Streaming: true, Usage: true, Cancellation: true, PartialStream: true, MalformedStream: true, Retryability: true, RequestTimeout: true},
+					CancellationReady:   openAICancellationReady,
+					RequestTimeoutReady: openAITimeout.readyFor("gpt-5.2-codex"),
 					Expectations: conformance.Expectations{
 						ResponseText: "openai response",
 						ToolName:     "conformance_echo",
@@ -78,10 +82,11 @@ func TestDeterministicProviderDriverConformance(t *testing.T) {
 			name: "native Anthropic",
 			model: func() (conformance.Driver, error) {
 				return conformance.Driver{
-					Name:              "native Anthropic",
-					Model:             anthropic.New(anthropic.WithAPIKey("test-anthropic-key"), anthropic.WithBaseURL(anthropicServer.URL), anthropic.WithModel(anthropic.ClaudeSonnet46)),
-					Claims:            conformance.Claims{ToolCalls: true, Streaming: true, Usage: true, Cancellation: true, PartialStream: true, MalformedStream: true, Retryability: true},
-					CancellationReady: anthropicCancellationReady,
+					Name:                "native Anthropic",
+					Model:               anthropic.New(anthropic.WithAPIKey("test-anthropic-key"), anthropic.WithBaseURL(anthropicServer.URL), anthropic.WithModel(anthropic.ClaudeSonnet46)),
+					Claims:              conformance.Claims{ToolCalls: true, Streaming: true, Usage: true, Cancellation: true, PartialStream: true, MalformedStream: true, Retryability: true, RequestTimeout: true},
+					CancellationReady:   anthropicCancellationReady,
+					RequestTimeoutReady: anthropicTimeout.readyFor(anthropic.ClaudeSonnet46),
 					Expectations: conformance.Expectations{
 						ResponseText: "anthropic response",
 						ToolName:     "conformance_echo",
@@ -140,9 +145,17 @@ func TestVerifyRejectsUnprovenClaims(t *testing.T) {
 	if err == nil {
 		t.Fatal("Verify accepted a retry claim without expected retry text")
 	}
+	err = conformance.Verify(context.Background(), conformance.Driver{
+		Name:   "missing timeout fixture",
+		Model:  openai.New(openai.WithAPIKey("test-key")),
+		Claims: conformance.Claims{RequestTimeout: true},
+	})
+	if err == nil {
+		t.Fatal("Verify accepted a timeout claim without a start signal")
+	}
 }
 
-func openAIConformanceFixture(t *testing.T, cancellationReady chan<- struct{}, retry *retryFixture) http.Handler {
+func openAIConformanceFixture(t *testing.T, cancellationReady chan<- struct{}, retry *retryFixture, timeout *timeoutFixture) http.Handler {
 	t.Helper()
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/chat/completions" {
@@ -155,8 +168,20 @@ func openAIConformanceFixture(t *testing.T, cancellationReady chan<- struct{}, r
 		if err != nil {
 			t.Fatalf("read OpenAI request: %v", err)
 		}
+		var request struct {
+			Model  string          `json:"model"`
+			Stream bool            `json:"stream"`
+			Tools  json.RawMessage `json:"tools"`
+		}
+		if err := json.Unmarshal(body, &request); err != nil {
+			t.Fatalf("decode OpenAI request: %v", err)
+		}
 		if strings.Contains(string(body), "cancel conformance") {
 			waitForCancellation(r, cancellationReady)
+			return
+		}
+		if strings.Contains(string(body), "timeout conformance") {
+			timeout.waitForCancellation(r.Context(), request.Model)
 			return
 		}
 		if strings.Contains(string(body), "partial stream conformance") {
@@ -168,14 +193,6 @@ func openAIConformanceFixture(t *testing.T, cancellationReady chan<- struct{}, r
 			w.Header().Set("Content-Type", "text/event-stream")
 			_, _ = fmt.Fprint(w, "data: {\"fixture_sensitive\":\n\n")
 			return
-		}
-		var request struct {
-			Model  string          `json:"model"`
-			Stream bool            `json:"stream"`
-			Tools  json.RawMessage `json:"tools"`
-		}
-		if err := json.Unmarshal(body, &request); err != nil {
-			t.Fatalf("decode OpenAI request: %v", err)
 		}
 		if strings.Contains(string(body), "retry conformance") {
 			if retry.firstAttempt(request.Model) {
@@ -208,7 +225,7 @@ data: [DONE]
 	})
 }
 
-func anthropicConformanceFixture(t *testing.T, cancellationReady chan<- struct{}, retry *retryFixture) http.Handler {
+func anthropicConformanceFixture(t *testing.T, cancellationReady chan<- struct{}, retry *retryFixture, timeout *timeoutFixture) http.Handler {
 	t.Helper()
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/messages" {
@@ -221,8 +238,20 @@ func anthropicConformanceFixture(t *testing.T, cancellationReady chan<- struct{}
 		if err != nil {
 			t.Fatalf("read Anthropic request: %v", err)
 		}
+		var request struct {
+			Model  string          `json:"model"`
+			Stream bool            `json:"stream"`
+			Tools  json.RawMessage `json:"tools"`
+		}
+		if err := json.Unmarshal(body, &request); err != nil {
+			t.Fatalf("decode Anthropic request: %v", err)
+		}
 		if strings.Contains(string(body), "cancel conformance") {
 			waitForCancellation(r, cancellationReady)
+			return
+		}
+		if strings.Contains(string(body), "timeout conformance") {
+			timeout.waitForCancellation(r.Context(), request.Model)
 			return
 		}
 		if strings.Contains(string(body), "partial stream conformance") {
@@ -234,14 +263,6 @@ func anthropicConformanceFixture(t *testing.T, cancellationReady chan<- struct{}
 			w.Header().Set("Content-Type", "text/event-stream")
 			_, _ = fmt.Fprint(w, "event: content_block_delta\ndata: {\"fixture_sensitive\":\n\n")
 			return
-		}
-		var request struct {
-			Model  string          `json:"model"`
-			Stream bool            `json:"stream"`
-			Tools  json.RawMessage `json:"tools"`
-		}
-		if err := json.Unmarshal(body, &request); err != nil {
-			t.Fatalf("decode Anthropic request: %v", err)
 		}
 		if strings.Contains(string(body), "retry conformance") {
 			if retry.firstAttempt(request.Model) {
@@ -308,4 +329,44 @@ func (f *retryFixture) firstAttempt(model string) bool {
 	defer f.mu.Unlock()
 	f.attempts[model]++
 	return f.attempts[model] == 1
+}
+
+type timeoutFixture struct {
+	mu    sync.Mutex
+	ready map[string]chan struct{}
+}
+
+func newTimeoutFixture() *timeoutFixture {
+	return &timeoutFixture{ready: make(map[string]chan struct{})}
+}
+
+func (f *timeoutFixture) readyFor(model string) <-chan struct{} {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.channelForLocked(model)
+}
+
+func (f *timeoutFixture) waitForCancellation(ctx context.Context, model string) {
+	f.markStarted(model)
+	<-ctx.Done()
+}
+
+func (f *timeoutFixture) markStarted(model string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	ready := f.channelForLocked(model)
+	select {
+	case <-ready:
+	default:
+		close(ready)
+	}
+}
+
+func (f *timeoutFixture) channelForLocked(model string) chan struct{} {
+	ready := f.ready[model]
+	if ready == nil {
+		ready = make(chan struct{})
+		f.ready[model] = ready
+	}
+	return ready
 }


### PR DESCRIPTION
## Summary
- add a deterministic common request-deadline conformance claim
- verify native OpenAI, OpenAI-compatible local, and native Anthropic cancel the HTTP request and return `context.DeadlineExceeded`
- make request-level retry validation independent of streaming capability
- retain post-output stream replay as explicitly unproven because caller-visible output must not be replayed without a safe-resume contract

## Verification
- `go test -race ./provider/openai ./provider/anthropic ./provider/conformance`
- `go test $(go list ./... | rg -v "^github\.com/fugue-labs/gollem/ext/monty$")`
- `go vet $(go list ./... | rg -v "^github\.com/fugue-labs/gollem/ext/monty$")`
- `golangci-lint run ./...`
- `go mod tidy -diff`
- `git diff --check`

Local Monty tests are intentionally excluded by repository policy; hosted CI remains unchanged.