### PR TITLE
test(provider): verify native reasoning visibility

### DIFF
--- a/docs/PROVIDER_DRIVER_CONFORMANCE.md
+++ b/docs/PROVIDER_DRIVER_CONFORMANCE.md
@@ -16,7 +16,7 @@ of behavior and must not enable a control solely on provider identity.
 | In-flight request cancellation | Proven | Proven | Proven | `provider/conformance` |
 | Structured output | Catalog-supported | Unsupported | Catalog-supported | Provider-specific tests; no common conformance claim yet |
 | Vision | Catalog-supported | Unsupported | Catalog-supported | Provider-specific tests; no common conformance claim yet |
-| Reasoning visibility | Catalog-supported where applicable | Unsupported | Catalog-supported where applicable | Provider-specific tests; no common conformance claim yet |
+| Reasoning visibility | Proven where catalog-supported | Unsupported | Proven where catalog-supported | `provider/conformance` verifies native `ThinkingPart` start/delta events and final retention; local Chat Completions remains unsupported |
 | Prompt cache / Responses API | Catalog-supported where applicable | Unsupported | Catalog-supported where applicable | Provider-specific tests; no common conformance claim yet |
 | Malformed JSON stream event normalization | Proven | Proven | Proven | `provider/conformance` plus provider parser tests; returns `StreamProtocolError` without raw event data |
 | Abrupt EOF partial-stream result | Proven | Proven | Proven | `provider/conformance` plus provider parser tests; preserves partial response and returns `StreamIncompleteError` |

--- a/provider/conformance/conformance.go
+++ b/provider/conformance/conformance.go
@@ -21,25 +21,27 @@ import (
 // A driver must not advertise one of these capabilities in Slang unless it has
 // a matching deterministic fixture and this verification passes.
 type Claims struct {
-	ToolCalls       bool
-	Streaming       bool
-	Usage           bool
-	Cancellation    bool
-	PartialStream   bool
-	MalformedStream bool
-	Retryability    bool
-	RequestTimeout  bool
+	ToolCalls           bool
+	Streaming           bool
+	Usage               bool
+	Cancellation        bool
+	PartialStream       bool
+	MalformedStream     bool
+	Retryability        bool
+	RequestTimeout      bool
+	ReasoningVisibility bool
 }
 
 // Expectations declares the normalized outputs a deterministic fixture
 // produces. ToolName is required when Claims.ToolCalls is true. StreamText is
 // required when Claims.Streaming is true.
 type Expectations struct {
-	ResponseText string
-	ToolName     string
-	StreamText   string
-	PartialText  string
-	RetryText    string
+	ResponseText  string
+	ToolName      string
+	StreamText    string
+	PartialText   string
+	RetryText     string
+	ReasoningText string
 }
 
 // Driver binds a provider model to the common capability claims and expected
@@ -51,6 +53,7 @@ type Driver struct {
 	Expectations        Expectations
 	CancellationReady   <-chan struct{}
 	RequestTimeoutReady <-chan struct{}
+	ReasoningModel      core.Model
 }
 
 // Verify exercises the claimed common model surface through core.Model. It is
@@ -79,6 +82,12 @@ func Verify(ctx context.Context, driver Driver) error {
 	}
 	if driver.Claims.RequestTimeout && driver.RequestTimeoutReady == nil {
 		return fmt.Errorf("provider conformance: %s timeout-capable fixture must signal request start", driver.Name)
+	}
+	if driver.Claims.ReasoningVisibility && driver.ReasoningModel == nil {
+		return fmt.Errorf("provider conformance: %s reasoning-capable fixture must supply a reasoning model", driver.Name)
+	}
+	if driver.Claims.ReasoningVisibility && strings.TrimSpace(driver.Expectations.ReasoningText) == "" {
+		return fmt.Errorf("provider conformance: %s reasoning fixture must expect reasoning text", driver.Name)
 	}
 
 	params := &core.ModelRequestParameters{AllowTextOutput: true}
@@ -117,6 +126,11 @@ func Verify(ctx context.Context, driver Driver) error {
 	}
 	if driver.Claims.Retryability {
 		if err := verifyRetryability(ctx, driver); err != nil {
+			return err
+		}
+	}
+	if driver.Claims.ReasoningVisibility {
+		if err := verifyReasoningVisibility(ctx, driver); err != nil {
 			return err
 		}
 	}
@@ -275,6 +289,51 @@ func verifyRetryability(ctx context.Context, driver Driver) error {
 	return nil
 }
 
+func verifyReasoningVisibility(ctx context.Context, driver Driver) error {
+	stream, err := driver.ReasoningModel.RequestStream(ctx, reasoningMessages(), nil, &core.ModelRequestParameters{AllowTextOutput: true})
+	if err != nil {
+		return fmt.Errorf("provider conformance: %s reasoning stream request: %w", driver.Name, err)
+	}
+	defer stream.Close()
+
+	var (
+		started bool
+		deltas  strings.Builder
+	)
+	for {
+		event, err := stream.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("provider conformance: %s reasoning stream: %w", driver.Name, err)
+		}
+		switch value := event.(type) {
+		case core.PartStartEvent:
+			if part, ok := value.Part.(core.ThinkingPart); ok {
+				started = true
+				deltas.WriteString(part.Content)
+			}
+		case core.PartDeltaEvent:
+			if delta, ok := value.Delta.(core.ThinkingPartDelta); ok {
+				deltas.WriteString(delta.ContentDelta)
+			}
+		}
+	}
+	if !started {
+		return fmt.Errorf("provider conformance: %s reasoning stream did not emit a ThinkingPart start", driver.Name)
+	}
+	if got := deltas.String(); got != driver.Expectations.ReasoningText {
+		return fmt.Errorf("provider conformance: %s reasoning deltas = %q, want %q", driver.Name, got, driver.Expectations.ReasoningText)
+	}
+	for _, part := range stream.Response().Parts {
+		if thinking, ok := part.(core.ThinkingPart); ok && thinking.Content == driver.Expectations.ReasoningText {
+			return nil
+		}
+	}
+	return fmt.Errorf("provider conformance: %s final response did not retain reasoning text", driver.Name)
+}
+
 func verifyResponse(driver Driver, response *core.ModelResponse, streaming bool) error {
 	if response == nil {
 		return fmt.Errorf("provider conformance: %s returned a nil response", driver.Name)
@@ -337,5 +396,11 @@ func retryMessages() []core.ModelMessage {
 func timeoutMessages() []core.ModelMessage {
 	return []core.ModelMessage{
 		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "timeout conformance"}}},
+	}
+}
+
+func reasoningMessages() []core.ModelMessage {
+	return []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "reasoning conformance"}}},
 	}
 }

--- a/provider/conformance/conformance_test.go
+++ b/provider/conformance/conformance_test.go
@@ -38,15 +38,17 @@ func TestDeterministicProviderDriverConformance(t *testing.T) {
 				return conformance.Driver{
 					Name:                "native OpenAI",
 					Model:               openai.New(openai.WithAPIKey("test-openai-key"), openai.WithBaseURL(openAIServer.URL), openai.WithModel("gpt-4o")),
-					Claims:              conformance.Claims{ToolCalls: true, Streaming: true, Usage: true, Cancellation: true, PartialStream: true, MalformedStream: true, Retryability: true, RequestTimeout: true},
+					ReasoningModel:      openai.New(openai.WithAPIKey("test-openai-key"), openai.WithBaseURL(openAIServer.URL), openai.WithModel("gpt-5")),
+					Claims:              conformance.Claims{ToolCalls: true, Streaming: true, Usage: true, Cancellation: true, PartialStream: true, MalformedStream: true, Retryability: true, RequestTimeout: true, ReasoningVisibility: true},
 					CancellationReady:   openAICancellationReady,
 					RequestTimeoutReady: openAITimeout.readyFor("gpt-4o"),
 					Expectations: conformance.Expectations{
-						ResponseText: "openai response",
-						ToolName:     "conformance_echo",
-						StreamText:   "openai stream",
-						PartialText:  "openai partial",
-						RetryText:    "openai retry",
+						ResponseText:  "openai response",
+						ToolName:      "conformance_echo",
+						StreamText:    "openai stream",
+						PartialText:   "openai partial",
+						RetryText:     "openai retry",
+						ReasoningText: "openai reasoning",
 					},
 				}, nil
 			},
@@ -81,18 +83,21 @@ func TestDeterministicProviderDriverConformance(t *testing.T) {
 		{
 			name: "native Anthropic",
 			model: func() (conformance.Driver, error) {
+				model := anthropic.New(anthropic.WithAPIKey("test-anthropic-key"), anthropic.WithBaseURL(anthropicServer.URL), anthropic.WithModel(anthropic.ClaudeSonnet46))
 				return conformance.Driver{
 					Name:                "native Anthropic",
-					Model:               anthropic.New(anthropic.WithAPIKey("test-anthropic-key"), anthropic.WithBaseURL(anthropicServer.URL), anthropic.WithModel(anthropic.ClaudeSonnet46)),
-					Claims:              conformance.Claims{ToolCalls: true, Streaming: true, Usage: true, Cancellation: true, PartialStream: true, MalformedStream: true, Retryability: true, RequestTimeout: true},
+					Model:               model,
+					ReasoningModel:      model,
+					Claims:              conformance.Claims{ToolCalls: true, Streaming: true, Usage: true, Cancellation: true, PartialStream: true, MalformedStream: true, Retryability: true, RequestTimeout: true, ReasoningVisibility: true},
 					CancellationReady:   anthropicCancellationReady,
 					RequestTimeoutReady: anthropicTimeout.readyFor(anthropic.ClaudeSonnet46),
 					Expectations: conformance.Expectations{
-						ResponseText: "anthropic response",
-						ToolName:     "conformance_echo",
-						StreamText:   "anthropic stream",
-						PartialText:  "anthropic partial",
-						RetryText:    "anthropic retry",
+						ResponseText:  "anthropic response",
+						ToolName:      "conformance_echo",
+						StreamText:    "anthropic stream",
+						PartialText:   "anthropic partial",
+						RetryText:     "anthropic retry",
+						ReasoningText: "anthropic reasoning",
 					},
 				}, nil
 			},
@@ -153,11 +158,32 @@ func TestVerifyRejectsUnprovenClaims(t *testing.T) {
 	if err == nil {
 		t.Fatal("Verify accepted a timeout claim without a start signal")
 	}
+	err = conformance.Verify(context.Background(), conformance.Driver{
+		Name:   "missing reasoning model",
+		Model:  openai.New(openai.WithAPIKey("test-key")),
+		Claims: conformance.Claims{ReasoningVisibility: true},
+	})
+	if err == nil {
+		t.Fatal("Verify accepted a reasoning claim without a reasoning model")
+	}
+	err = conformance.Verify(context.Background(), conformance.Driver{
+		Name:           "missing reasoning fixture",
+		Model:          openai.New(openai.WithAPIKey("test-key")),
+		ReasoningModel: openai.New(openai.WithAPIKey("test-key")),
+		Claims:         conformance.Claims{ReasoningVisibility: true},
+	})
+	if err == nil {
+		t.Fatal("Verify accepted a reasoning claim without expected reasoning text")
+	}
 }
 
 func openAIConformanceFixture(t *testing.T, cancellationReady chan<- struct{}, retry *retryFixture, timeout *timeoutFixture) http.Handler {
 	t.Helper()
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/responses" {
+			openAIReasoningConformanceFixture(t, w, r)
+			return
+		}
 		if r.URL.Path != "/v1/chat/completions" {
 			t.Fatalf("OpenAI path = %q, want /v1/chat/completions", r.URL.Path)
 		}
@@ -225,6 +251,41 @@ data: [DONE]
 	})
 }
 
+func openAIReasoningConformanceFixture(t *testing.T, w http.ResponseWriter, r *http.Request) {
+	t.Helper()
+	if r.Header.Get("Authorization") == "" {
+		t.Fatal("OpenAI reasoning fixture request had no authorization header")
+	}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Fatalf("read OpenAI reasoning request: %v", err)
+	}
+	var request struct {
+		Model  string `json:"model"`
+		Stream bool   `json:"stream"`
+	}
+	if err := json.Unmarshal(body, &request); err != nil {
+		t.Fatalf("decode OpenAI reasoning request: %v", err)
+	}
+	if request.Model != "gpt-5" || !request.Stream || !strings.Contains(string(body), "reasoning conformance") {
+		t.Fatalf("unexpected OpenAI reasoning request: model=%q stream=%t body=%s", request.Model, request.Stream, body)
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	_, _ = fmt.Fprint(w, `data: {"type":"response.output_item.added","output_index":0,"item":{"type":"reasoning","summary":[]}}
+
+data: {"type":"response.reasoning_summary_text.delta","output_index":0,"delta":"openai reasoning"}
+
+data: {"type":"response.output_item.done","output_index":0,"item":{"type":"reasoning","summary":[{"type":"summary_text","text":"openai reasoning"}]}}
+
+data: {"type":"response.output_text.delta","delta":"openai reasoning answer"}
+
+data: {"type":"response.completed","response":{"id":"resp-reasoning","model":"gpt-5","output":[{"type":"reasoning","summary":[{"type":"summary_text","text":"openai reasoning"}]},{"type":"message","role":"assistant","content":[{"type":"output_text","text":"openai reasoning answer"}]}],"usage":{"input_tokens":3,"output_tokens":2}}}
+
+data: [DONE]
+
+`)
+}
+
 func anthropicConformanceFixture(t *testing.T, cancellationReady chan<- struct{}, retry *retryFixture, timeout *timeoutFixture) http.Handler {
 	t.Helper()
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -273,6 +334,41 @@ func anthropicConformanceFixture(t *testing.T, cancellationReady chan<- struct{}
 			}
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = fmt.Fprint(w, `{"id":"msg-retry","role":"assistant","model":"claude-sonnet-4-6","content":[{"type":"text","text":"anthropic retry"}],"stop_reason":"end_turn","usage":{"input_tokens":3,"output_tokens":2}}`)
+			return
+		}
+		if strings.Contains(string(body), "reasoning conformance") {
+			if !request.Stream {
+				t.Fatal("Anthropic reasoning request was not streaming")
+			}
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = fmt.Fprint(w, `event: message_start
+data: {"type":"message_start","message":{"usage":{"input_tokens":3,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":"","signature":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"anthropic reasoning"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: content_block_start
+data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"anthropic reasoning answer"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":1}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":2}}
+
+event: message_stop
+data: {"type":"message_stop"}
+
+`)
 			return
 		}
 		if request.Stream {


### PR DESCRIPTION
## Summary
- add an optional common reasoning-visibility conformance claim
- verify native OpenAI Responses reasoning summaries and native Anthropic thinking blocks emit `ThinkingPart` start/delta events and retain final reasoning
- keep the OpenAI-compatible local Chat Completions profile explicitly unsupported for reasoning
- scope the matrix claim to catalog-supported native models only

## Verification
- `go test -race ./provider/openai ./provider/anthropic ./provider/conformance`
- `go test $(go list ./... | rg -v "^github\.com/fugue-labs/gollem/ext/monty$")`
- `go vet $(go list ./... | rg -v "^github\.com/fugue-labs/gollem/ext/monty$")`
- `golangci-lint run ./...`
- `go mod tidy -diff`
- `git diff --check`

This uses deterministic credential-free protocol fixtures. Local Monty tests are intentionally excluded by repository policy; hosted CI remains unchanged.