### PR TITLE
Add local provider health probe

### DIFF
--- a/appserver/catalog/catalog.go
+++ b/appserver/catalog/catalog.go
@@ -1,12 +1,15 @@
 package catalog
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/fugue-labs/gollem/appserver/protocol"
 	anthropicprovider "github.com/fugue-labs/gollem/provider/anthropic"
@@ -25,6 +28,8 @@ const (
 
 var ErrProviderNotFound = errors.New("provider not found")
 
+const localEndpointProbeTimeout = 5 * time.Second
+
 type EnvLookup func(string) (string, bool)
 
 type Option func(*Catalog)
@@ -37,14 +42,26 @@ func WithEnvLookup(lookup EnvLookup) Option {
 	}
 }
 
+// WithHTTPClient configures the process-owned client used for bounded local
+// endpoint health probes. It is primarily useful for deterministic tests.
+func WithHTTPClient(client *http.Client) Option {
+	return func(c *Catalog) {
+		if client != nil {
+			c.httpClient = client
+		}
+	}
+}
+
 type Catalog struct {
-	env       EnvLookup
-	providers []Provider
+	env        EnvLookup
+	httpClient *http.Client
+	providers  []Provider
 }
 
 func NewDefault(opts ...Option) *Catalog {
 	c := &Catalog{
-		env: os.LookupEnv,
+		env:        os.LookupEnv,
+		httpClient: &http.Client{Timeout: localEndpointProbeTimeout},
 	}
 	for _, opt := range opts {
 		opt(c)
@@ -65,6 +82,16 @@ type ModelListParams = protocol.ModelCatalogListParams
 type ModelListResponse = protocol.ModelCatalogListResponse
 type ProviderListParams = protocol.ProviderListParams
 type ProviderListResponse = protocol.ProviderListResponse
+type ProviderHealthProbeParams = protocol.ProviderHealthProbeParams
+type ProviderHealthProbeResponse = protocol.ProviderHealthProbeResponse
+type ProviderHealthProbeStatus = protocol.ProviderHealthProbeStatus
+
+const (
+	ProviderHealthAvailable     = protocol.ProviderHealthAvailable
+	ProviderHealthUnavailable   = protocol.ProviderHealthUnavailable
+	ProviderHealthNotConfigured = protocol.ProviderHealthNotConfigured
+	ProviderHealthUnsupported   = protocol.ProviderHealthUnsupported
+)
 
 type CapabilitiesReadParams struct {
 	ProviderID    string `json:"providerId,omitempty"`
@@ -224,6 +251,33 @@ func (c *Catalog) ProviderCapabilities(providerID string) (ProviderCapabilities,
 	return aggregate, nil
 }
 
+// ProbeProvider reports bounded health for the selected provider. The only
+// network operation permitted here is a discovery request to an explicitly
+// configured loopback OpenAI-compatible endpoint.
+func (c *Catalog) ProbeProvider(ctx context.Context, params ProviderHealthProbeParams) (ProviderHealthProbeResponse, error) {
+	c = ensureCatalog(c)
+	providerID := normalizeProviderID(params.ProviderID)
+	if !c.hasProvider(providerID) {
+		return ProviderHealthProbeResponse{}, fmt.Errorf("%w: %s", ErrProviderNotFound, providerID)
+	}
+	response := ProviderHealthProbeResponse{ProviderID: providerID}
+	if providerID != ProviderOpenAICompatibleLocal {
+		response.Status = protocol.ProviderHealthUnsupported
+		return response, nil
+	}
+
+	config, configured := c.localEndpointConfig()
+	if !configured {
+		response.Status = protocol.ProviderHealthNotConfigured
+		return response, nil
+	}
+	response.Status = protocol.ProviderHealthAvailable
+	if openaiprovider.ProbeLocalEndpoint(ctx, config, c.httpClient) != nil {
+		response.Status = protocol.ProviderHealthUnavailable
+	}
+	return response, nil
+}
+
 func ListTools(params ToolListParams, services ToolServices) ToolListResponse {
 	tools := builtinTools(services)
 	filtered := make([]Tool, 0, len(tools))
@@ -249,14 +303,7 @@ func (c *Catalog) defaultProviders() []Provider {
 	openaiConfigured := envConfigured(c.env, "OPENAI_API_KEY") || envConfigured(c.env, "CHATGPT_ACCESS_TOKEN")
 	anthropicConfigured := envConfigured(c.env, "ANTHROPIC_API_KEY")
 	vertexConfigured := envConfigured(c.env, "GOOGLE_CLOUD_PROJECT") || envConfigured(c.env, "GOOGLE_APPLICATION_CREDENTIALS")
-	localConfig, localConfigErr := openaiprovider.LocalEndpointConfigFromLookup(c.env)
-	// Merely having a safe default is not evidence that a local server exists.
-	// Require an explicit local-profile setting before offering it as runnable.
-	localConfigured := localConfigErr == nil && envConfigured(c.env,
-		openaiprovider.LocalEndpointBaseURLEnv,
-		openaiprovider.LocalEndpointModelEnv,
-		openaiprovider.LocalEndpointAPIKeyEnv,
-	)
+	localConfig, localConfigured := c.localEndpointConfig()
 	localModel := "llama3"
 	if localConfigured {
 		localModel = localConfig.Model
@@ -416,6 +463,27 @@ func (c *Catalog) defaultProviders() []Provider {
 	}
 }
 
+func (c *Catalog) localEndpointConfig() (openaiprovider.LocalEndpointConfig, bool) {
+	config, err := openaiprovider.LocalEndpointConfigFromLookup(c.env)
+	// Merely having a safe default is not evidence that a local server exists.
+	// Require an explicit local-profile setting before offering it as runnable.
+	configured := err == nil && envConfigured(c.env,
+		openaiprovider.LocalEndpointBaseURLEnv,
+		openaiprovider.LocalEndpointModelEnv,
+		openaiprovider.LocalEndpointAPIKeyEnv,
+	)
+	return config, configured
+}
+
+func (c *Catalog) hasProvider(providerID string) bool {
+	for _, provider := range c.providers {
+		if provider.ID == providerID {
+			return true
+		}
+	}
+	return false
+}
+
 func builtinTools(services ToolServices) []Tool {
 	return []Tool{
 		tool("fs", "Filesystem", "Read, write, copy, remove, inspect, and watch files under the configured workspace root.", "workspace", []string{"fs/readFile", "fs/writeFile", "fs/createDirectory", "fs/readDirectory", "fs/getMetadata", "fs/remove", "fs/copy", "fs/watch", "fs/unwatch"}, services.Filesystem, true, true, "fs/changed", true, false),
@@ -425,7 +493,7 @@ func builtinTools(services ToolServices) []Tool {
 		tool("file-change-revert", "File change revert", "Restore one exact workspace file state from durable private recovery evidence.", "workspace", []string{"item/fileChange/revert"}, services.Filesystem && services.FileRecovery, true, true, "fs/changed", true, false),
 		tool("turn-runtime", "Turn runtime", "Start, resume, interrupt, steer, and retry provider-neutral Gollem app-server turns.", "runtime", []string{"thread/start", "thread/resume", "turn/start", "turn/interrupt", "turn/steer", "turn/retry"}, services.Runtime, true, false, "turn/started", true, true),
 		tool("interactions", "Interactions", "Request user input, dynamic tool calls, and MCP elicitation from the connected Slang client.", "runtime", []string{"item/tool/requestUserInput", "item/tool/call", "mcpServer/elicitation/request"}, services.Interactions, false, false, "serverRequest/resolved", true, false),
-		tool("provider-catalog", "Provider catalog", "List provider, model, capability, and app-server tool metadata for Slang controls.", "configuration", []string{"provider/list", "model/list", "modelProvider/capabilities/read", "provider/capabilities/read", "tool/list"}, true, false, false, "", true, true),
+		tool("provider-catalog", "Provider catalog", "List provider, model, capability, and app-server tool metadata for Slang controls.", "configuration", []string{"provider/list", "provider/health/probe", "model/list", "modelProvider/capabilities/read", "provider/capabilities/read", "tool/list"}, true, false, false, "", true, true),
 		tool("config", "Configuration", "Read and update app-server config, environment metadata, permission profiles, collaboration modes, and feature flags.", "configuration", []string{"config/read", "config/value/write", "config/batchWrite", "configRequirements/read", "config/mcpServer/reload", "environment/info", "environment/add", "permissionProfile/list", "collaborationMode/list", "experimentalFeature/list", "experimentalFeature/enablement/set"}, services.Config, true, false, "", true, false),
 		tool("mcp", "MCP servers", "List MCP server startup status, read MCP resources, and call MCP tools through registered Gollem MCP clients.", "runtime", []string{"mcpServerStatus/list", "mcpServer/resource/read", "mcpServer/tool/call"}, services.MCP, true, true, "", true, false),
 		tool("skills", "Skills and plugins", "List workspace-scoped skills and read plugin manifests and skill content from configured roots.", "configuration", []string{"skills/list", "plugin/list", "plugin/installed", "plugin/read", "plugin/skill/read"}, services.Skills, false, false, "", true, false),

--- a/appserver/catalog/catalog_test.go
+++ b/appserver/catalog/catalog_test.go
@@ -1,8 +1,11 @@
 package catalog
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -162,6 +165,89 @@ func TestLocalOpenAICompatibleProviderRequiresExplicitValidConfiguration(t *test
 	}
 }
 
+func TestProbeProviderReportsBoundedLocalHealth(t *testing.T) {
+	const token = "local-probe-secret"
+	var authorization string
+	available := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/models" {
+			t.Fatalf("probe request = %s %s, want GET /v1/models", r.Method, r.URL.Path)
+		}
+		authorization = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	defer available.Close()
+
+	configuredEnv := map[string]string{
+		openaiprovider.LocalEndpointBaseURLEnv: available.URL,
+		openaiprovider.LocalEndpointModelEnv:   "local-tool-model",
+		openaiprovider.LocalEndpointAPIKeyEnv:  token,
+	}
+	c := NewDefault(WithEnvLookup(mapEnv(configuredEnv)))
+	response, err := c.ProbeProvider(context.Background(), ProviderHealthProbeParams{ProviderID: ProviderOpenAICompatibleLocal})
+	if err != nil {
+		t.Fatalf("ProbeProvider: %v", err)
+	}
+	if response.ProviderID != ProviderOpenAICompatibleLocal || response.Status != ProviderHealthAvailable {
+		t.Fatalf("available probe = %#v", response)
+	}
+	if authorization != "Bearer "+token {
+		t.Fatalf("Authorization = %q, want local token", authorization)
+	}
+	encoded, err := json.Marshal(response)
+	if err != nil {
+		t.Fatalf("marshal response: %v", err)
+	}
+	for _, secret := range []string{available.URL, token} {
+		if strings.Contains(string(encoded), secret) {
+			t.Fatalf("probe response leaked local configuration %q: %s", secret, encoded)
+		}
+	}
+
+	notConfigured := NewDefault(WithEnvLookup(mapEnv(nil)))
+	response, err = notConfigured.ProbeProvider(context.Background(), ProviderHealthProbeParams{ProviderID: ProviderOpenAICompatibleLocal})
+	if err != nil || response.Status != ProviderHealthNotConfigured {
+		t.Fatalf("not-configured probe = %#v, %v", response, err)
+	}
+
+	unsupported, err := c.ProbeProvider(context.Background(), ProviderHealthProbeParams{ProviderID: ProviderOpenAI})
+	if err != nil || unsupported.Status != ProviderHealthUnsupported {
+		t.Fatalf("unsupported probe = %#v, %v", unsupported, err)
+	}
+
+	_, err = c.ProbeProvider(context.Background(), ProviderHealthProbeParams{ProviderID: "unknown-provider"})
+	if !errors.Is(err, ErrProviderNotFound) {
+		t.Fatalf("unknown provider error = %v, want ErrProviderNotFound", err)
+	}
+}
+
+func TestProbeProviderReportsUnavailableWithoutEndpointDetails(t *testing.T) {
+	const token = "unavailable-local-probe-secret"
+	unavailable := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte("endpoint unavailable"))
+	}))
+	defer unavailable.Close()
+	c := NewDefault(WithEnvLookup(mapEnv(map[string]string{
+		openaiprovider.LocalEndpointBaseURLEnv: unavailable.URL,
+		openaiprovider.LocalEndpointModelEnv:   "local-tool-model",
+		openaiprovider.LocalEndpointAPIKeyEnv:  token,
+	})))
+
+	response, err := c.ProbeProvider(context.Background(), ProviderHealthProbeParams{ProviderID: ProviderOpenAICompatibleLocal})
+	if err != nil || response.Status != ProviderHealthUnavailable {
+		t.Fatalf("unavailable probe = %#v, %v", response, err)
+	}
+	encoded, err := json.Marshal(response)
+	if err != nil {
+		t.Fatalf("marshal response: %v", err)
+	}
+	for _, secret := range []string{unavailable.URL, token} {
+		if strings.Contains(string(encoded), secret) {
+			t.Fatalf("probe response leaked local configuration %q: %s", secret, encoded)
+		}
+	}
+}
+
 func TestToolListAvailability(t *testing.T) {
 	resp := ListTools(ToolListParams{}, ToolServices{Filesystem: true})
 	if len(resp.Data) == 0 {
@@ -193,6 +279,10 @@ func TestToolListAvailability(t *testing.T) {
 	cacheTool := findTool(ListTools(ToolListParams{}, ToolServices{Cache: true}).Data, "cache")
 	if cacheTool == nil || !cacheTool.Available || !cacheTool.GollemExtension {
 		t.Fatalf("cache tool metadata = %#v", cacheTool)
+	}
+	providerCatalogTool := findTool(ListTools(ToolListParams{}, ToolServices{}).Data, "provider-catalog")
+	if providerCatalogTool == nil || !providerCatalogTool.GollemExtension || !containsMethod(providerCatalogTool.Methods, "provider/health/probe") {
+		t.Fatalf("provider catalog tool metadata = %#v", providerCatalogTool)
 	}
 	memoryTool := findTool(ListTools(ToolListParams{}, ToolServices{Memory: true}).Data, "memory")
 	if memoryTool == nil || !memoryTool.Available || memoryTool.GollemExtension || !memoryTool.CodexCompatible || !memoryTool.Mutation {

--- a/appserver/protocol/README.md
+++ b/appserver/protocol/README.md
@@ -351,12 +351,12 @@ result after process exit.
 
 Generated clients can discover providers and models, start, steer, and
 interrupt live runs, and consume the current streaming lifecycle without an
-untyped JSON escape hatch. `provider/list` and `model/list` bind the
-provider-aware catalog records; `thread/start`, `turn/start`, `turn/steer`,
-`turn/retry`, and `turn/interrupt` bind durable thread/turn results; and
+untyped JSON escape hatch. `provider/list`, `provider/health/probe`, and
+`model/list` bind the provider-aware catalog records; `thread/start`,
+`turn/start`, `turn/steer`, `turn/retry`, and `turn/interrupt` bind durable thread/turn results; and
 `thread/started`, `turn/started`, `turn/completed`,
 `item/agentMessage/delta`, and `item/reasoning/textDelta` bind the live
-notification records. The registry now contains 79 method bindings and five
+notification records. The registry now contains 80 method bindings and five
 durable item bindings.
 
 The live names are intentionally explicit: `ModelCatalog*`, `ThreadRun*`,
@@ -366,7 +366,10 @@ types remain separate and retain their stricter Codex shapes. This exposes the
 implemented Gollem wire truthfully without weakening or falsely claiming those
 public contracts. Catalog responses expose configuration state and required
 environment-variable names, never credential values; runtime requests contain
-selection and model settings but no credential-bearing fields.
+selection and model settings but no credential-bearing fields. Local endpoint
+health is an explicit bounded extension: it returns only one of `available`,
+`unavailable`, `not-configured`, or `unsupported`, and only checks a configured
+loopback endpoint without starting a turn.
 
 An explicit `reasoningEffort` is accepted only when the selected catalog model
 advertises reasoning and that exact effort. Validation happens before

--- a/appserver/protocol/account_credit_nudge_values_contract_test.go
+++ b/appserver/protocol/account_credit_nudge_values_contract_test.go
@@ -119,14 +119,14 @@ func TestAccountCreditNudgeValuesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/sendAddCreditsNudgeEmail = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/account_envelope_contract_test.go
+++ b/appserver/protocol/account_envelope_contract_test.go
@@ -268,11 +268,11 @@ func TestAccountEnvelopeContractsRemainStandaloneAndDeferred(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred %s", methodName, method, ok, surface)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if len(Methods()) != 225 || len(WireTypeBindings()) != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 225/79/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/account_login_completed_notification_contract_test.go
+++ b/appserver/protocol/account_login_completed_notification_contract_test.go
@@ -88,14 +88,14 @@ func TestAccountLoginCompletedNotificationRemainsStandaloneAndDeferred(t *testin
 	if !found {
 		t.Fatal("account/login/completed method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/account_rate_limits_contract_test.go
+++ b/appserver/protocol/account_rate_limits_contract_test.go
@@ -484,14 +484,14 @@ func TestAccountRateLimitContractsRemainStandaloneAndDeferred(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred %s", methodName, method, ok, surface)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/account_token_usage_contract_test.go
+++ b/appserver/protocol/account_token_usage_contract_test.go
@@ -146,14 +146,14 @@ func TestAccountTokenUsageRecordsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/usage/read = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,14 +148,14 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(defs); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,14 +54,14 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_config_contract_test.go
+++ b/appserver/protocol/app_config_contract_test.go
@@ -109,14 +109,14 @@ func TestAppConfigRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppConfig unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_info_contract_test.go
+++ b/appserver/protocol/app_info_contract_test.go
@@ -131,14 +131,14 @@ func TestAppInfoRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_list_updated_notification_contract_test.go
+++ b/appserver/protocol/app_list_updated_notification_contract_test.go
@@ -105,14 +105,14 @@ func TestAppListUpdatedNotificationRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceServerNotification || method.State != MethodDeferredStub {
 		t.Fatalf("app/list/updated = %#v, %v; want deferred server notification", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_metadata_contract_test.go
+++ b/appserver/protocol/app_metadata_contract_test.go
@@ -107,14 +107,14 @@ func TestAppMetadataRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_metadata_leaf_contract_test.go
+++ b/appserver/protocol/app_metadata_leaf_contract_test.go
@@ -157,14 +157,14 @@ func TestAppMetadataLeavesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_summary_contract_test.go
+++ b/appserver/protocol/app_summary_contract_test.go
@@ -87,14 +87,14 @@ func TestAppSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppSummary unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_template_summary_contract_test.go
+++ b/appserver/protocol/app_template_summary_contract_test.go
@@ -107,14 +107,14 @@ func TestAppTemplateSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppTemplateSummary unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_template_unavailable_reason_contract_test.go
+++ b/appserver/protocol/app_template_unavailable_reason_contract_test.go
@@ -71,14 +71,14 @@ func TestAppTemplateUnavailableReasonRemainsStandalone(t *testing.T) {
 			t.Fatalf("AppTemplateUnavailableReason unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_tool_approval_contract_test.go
+++ b/appserver/protocol/app_tool_approval_contract_test.go
@@ -73,14 +73,14 @@ func TestAppToolApprovalRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppToolApproval unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_tools_config_contract_test.go
+++ b/appserver/protocol/app_tools_config_contract_test.go
@@ -140,14 +140,14 @@ func TestAppToolConfigsRemainStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/apply_patch_approval_params_contract_test.go
+++ b/appserver/protocol/apply_patch_approval_params_contract_test.go
@@ -139,14 +139,14 @@ func TestApplyPatchApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ApplyPatchApprovalParams unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(defs); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(defs); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/apps_config_contract_test.go
+++ b/appserver/protocol/apps_config_contract_test.go
@@ -185,14 +185,14 @@ func TestAppsConfigsRemainStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/apps_list_contract_test.go
+++ b/appserver/protocol/apps_list_contract_test.go
@@ -168,14 +168,14 @@ func TestAppsListContractsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/attestation_contract_test.go
+++ b/appserver/protocol/attestation_contract_test.go
@@ -133,14 +133,14 @@ func TestAttestationContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("attestation/generate = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,14 +74,14 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,14 +52,14 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/bindings.go
+++ b/appserver/protocol/bindings.go
@@ -57,6 +57,7 @@ var wireTypeBindings = []WireTypeBinding{
 	{Method: "item/tool/requestUserInput", Surface: SurfaceServerRequest, Params: []string{"ToolRequestUserInputParams"}, Result: []string{"ToolRequestUserInputResponse"}},
 	{Method: "mcpServer/elicitation/request", Surface: SurfaceServerRequest, Params: []string{"McpServerElicitationRequestParams"}, Result: []string{"McpServerElicitationRequestResponse"}},
 	{Method: "model/list", Surface: SurfaceClientRequest, Params: []string{"ModelCatalogListParams"}, Result: []string{"ModelCatalogListResponse"}},
+	{Method: "provider/health/probe", Surface: SurfaceGollemExtension, Params: []string{"ProviderHealthProbeParams"}, Result: []string{"ProviderHealthProbeResponse"}},
 	{Method: "provider/list", Surface: SurfaceGollemExtension, Params: []string{"ProviderListParams"}, Result: []string{"ProviderListResponse"}},
 	{Method: "serverRequest/resolved", Surface: SurfaceServerNotification, Params: []string{"ServerRequestResolvedNotification"}},
 	{Method: "thread/archive", Surface: SurfaceClientRequest, Params: []string{"ThreadArchiveParams"}, Result: []string{"ThreadArchiveResponse"}},

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,14 +148,14 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
+++ b/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
@@ -179,14 +179,14 @@ func TestChatgptAuthTokensRefreshRemainsStandaloneAndDeferred(t *testing.T) {
 	if !found {
 		t.Fatal("refresh method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/collaboration_capability_contract_test.go
+++ b/appserver/protocol/collaboration_capability_contract_test.go
@@ -346,14 +346,14 @@ func TestCollaborationCapabilityContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,14 +102,14 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,14 +217,14 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,14 +146,14 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,14 +321,14 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,14 +67,14 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,14 +200,14 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,14 +228,14 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,11 +169,11 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,14 +332,14 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/dynamic_tool_spec_contract_test.go
+++ b/appserver/protocol/dynamic_tool_spec_contract_test.go
@@ -318,14 +318,14 @@ func TestDynamicToolSpecContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/exec_command_approval_params_contract_test.go
+++ b/appserver/protocol/exec_command_approval_params_contract_test.go
@@ -137,14 +137,14 @@ func TestExecCommandApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ExecCommandApprovalParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(defs); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/experimental_feature_contract_test.go
+++ b/appserver/protocol/experimental_feature_contract_test.go
@@ -41,11 +41,11 @@ func TestExperimentalFeatureContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want implemented client request", methodName, method, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if len(Methods()) != 225 || len(WireTypeBindings()) != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("counts = %d/%d/%d, want 225/79/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("counts = %d/%d/%d, want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,14 +217,14 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,14 +203,14 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -260,14 +260,14 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,14 +244,14 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -162,14 +162,14 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -175,14 +175,14 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,14 +186,14 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,14 +84,14 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/file_change_contract_test.go
+++ b/appserver/protocol/file_change_contract_test.go
@@ -108,14 +108,14 @@ func TestFileChangeRemainsStandalone(t *testing.T) {
 			t.Fatalf("FileChange unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/file_change_output_delta_notification_contract_test.go
+++ b/appserver/protocol/file_change_output_delta_notification_contract_test.go
@@ -100,14 +100,14 @@ func TestFileChangeOutputDeltaNotificationRemainsDeprecatedAndStandalone(t *test
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("item/fileChange/outputDelta = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -381,14 +381,14 @@ func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/guardian_approval_review_action_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_action_contract_test.go
@@ -226,14 +226,14 @@ func TestGuardianApprovalReviewActionRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReviewAction unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
@@ -164,14 +164,14 @@ func TestGuardianApprovalReviewCompletedNotificationRemainsStandalone(t *testing
 			t.Fatalf("completed notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 	for _, method := range Methods() {
 		if (method.Method == "item/autoApprovalReview/started" ||

--- a/appserver/protocol/guardian_approval_review_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_contract_test.go
@@ -139,14 +139,14 @@ func TestGuardianApprovalReviewRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReview unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
@@ -175,14 +175,14 @@ func TestGuardianApprovalReviewStartedNotificationRemainsStandalone(t *testing.T
 			t.Fatalf("started notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 	for _, method := range Methods() {
 		if method.Method == "item/autoApprovalReview/started" && method.State != MethodBlocked {

--- a/appserver/protocol/guardian_enum_foundation_contract_test.go
+++ b/appserver/protocol/guardian_enum_foundation_contract_test.go
@@ -89,14 +89,14 @@ func TestGuardianEnumFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/hook_metadata_list_contract_test.go
+++ b/appserver/protocol/hook_metadata_list_contract_test.go
@@ -352,11 +352,11 @@ func TestHookMetadataListContractsStayStandalone(t *testing.T) {
 			t.Errorf("standalone definition %s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Errorf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Errorf("definition count = %d, want 573", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 {
-		t.Errorf("wire binding count = %d, want 79", got)
+	if got := len(WireTypeBindings()); got != 80 {
+		t.Errorf("wire binding count = %d, want 80", got)
 	}
 	if got := len(ItemPayloadBindings()); got != 5 {
 		t.Errorf("item binding count = %d, want 5", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,14 +102,14 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/hook_run_notification_contract_test.go
+++ b/appserver/protocol/hook_run_notification_contract_test.go
@@ -297,10 +297,10 @@ func TestHookRunNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if len(Methods()) != 225 || len(WireTypeBindings()) != 79 || len(ItemPayloadBindings()) != 5 {
+	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("surface changed: %d methods, %d wire bindings, %d item bindings", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 }

--- a/appserver/protocol/hook_value_foundation_contract_test.go
+++ b/appserver/protocol/hook_value_foundation_contract_test.go
@@ -167,14 +167,14 @@ func TestHookValueFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,11 +223,11 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,11 +159,11 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 570 {
-		t.Fatalf("definition count = %d, want 570", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 573 {
+		t.Fatalf("definition count = %d, want 573", len(JSONSchema()["$defs"].(Schema)))
 	}
-	if len(WireTypeBindings()) != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 
 	generated, err := MarshalTypeScript()

--- a/appserver/protocol/legacy_approval_response_contract_test.go
+++ b/appserver/protocol/legacy_approval_response_contract_test.go
@@ -98,14 +98,14 @@ func TestLegacyApprovalResponsesRemainStandaloneAndNominal(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,14 +127,14 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,14 +276,14 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,14 +57,14 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,14 +70,14 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,14 +227,14 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,14 +74,14 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,14 +114,14 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,14 +130,14 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,14 +148,14 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,14 +102,14 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_oauth_login_contract_test.go
+++ b/appserver/protocol/mcp_server_oauth_login_contract_test.go
@@ -228,11 +228,11 @@ func TestMcpServerOauthLoginContractsRemainStandaloneAndBlocked(t *testing.T) {
 	if !ok || notification.Surface != SurfaceServerNotification || notification.State != MethodBlocked {
 		t.Fatalf("mcpServer/oauthLogin/completed = %#v, %v; want blocked server notification", notification, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if len(Methods()) != 225 || len(WireTypeBindings()) != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("counts = %d/%d/%d, want 225/79/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("counts = %d/%d/%d, want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,14 +70,14 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,14 +116,14 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_status_contract_test.go
+++ b/appserver/protocol/mcp_server_status_contract_test.go
@@ -277,11 +277,11 @@ func TestMcpServerStatusContractsRemainStandalone(t *testing.T) {
 	if !ok || method.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if len(Methods()) != 225 || len(WireTypeBindings()) != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("counts = %d/%d/%d, want 225/79/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("counts = %d/%d/%d, want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,14 +69,14 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,14 +125,14 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,14 +140,14 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,14 +134,14 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/methods_gen.go
+++ b/appserver/protocol/methods_gen.go
@@ -224,6 +224,7 @@ var methodRegistry = []MethodInfo{
 	{Method: "git/worktree/list", Surface: SurfaceGollemExtension, State: MethodImplemented, Source: "goal.txt"},
 	{Method: "item/fileChange/revert", Surface: SurfaceGollemExtension, State: MethodImplemented, Source: "goal.txt"},
 	{Method: "provider/capabilities/read", Surface: SurfaceGollemExtension, State: MethodImplemented, Source: "goal.txt"},
+	{Method: "provider/health/probe", Surface: SurfaceGollemExtension, State: MethodImplemented, Source: "goal.txt"},
 	{Method: "provider/list", Surface: SurfaceGollemExtension, State: MethodImplemented, Source: "goal.txt"},
 	{Method: "tool/list", Surface: SurfaceGollemExtension, State: MethodImplemented, Source: "goal.txt"},
 	{Method: "turn/retry", Surface: SurfaceGollemExtension, State: MethodImplemented, Source: "goal.txt"},

--- a/appserver/protocol/methods_test.go
+++ b/appserver/protocol/methods_test.go
@@ -4,8 +4,8 @@ import "testing"
 
 func TestMethodRegistryCountsAndKeyMethods(t *testing.T) {
 	methods := Methods()
-	if len(methods) != 225 {
-		t.Fatalf("Methods() returned %d entries, want 225", len(methods))
+	if len(methods) != 226 {
+		t.Fatalf("Methods() returned %d entries, want 226", len(methods))
 	}
 
 	counts := map[Surface]int{}
@@ -17,7 +17,7 @@ func TestMethodRegistryCountsAndKeyMethods(t *testing.T) {
 		SurfaceServerNotification: 70,
 		SurfaceServerRequest:      11,
 		SurfaceClientNotification: 1,
-		SurfaceGollemExtension:    18,
+		SurfaceGollemExtension:    19,
 	}
 	for surface, want := range wantCounts {
 		if got := counts[surface]; got != want {
@@ -77,6 +77,7 @@ func TestMethodRegistryCountsAndKeyMethods(t *testing.T) {
 	assertMethod(t, "turn/retry", SurfaceGollemExtension, MethodImplemented)
 	assertMethod(t, "provider/list", SurfaceGollemExtension, MethodImplemented)
 	assertMethod(t, "provider/capabilities/read", SurfaceGollemExtension, MethodImplemented)
+	assertMethod(t, "provider/health/probe", SurfaceGollemExtension, MethodImplemented)
 	assertMethod(t, "tool/list", SurfaceGollemExtension, MethodImplemented)
 	assertMethod(t, "cache/stats", SurfaceGollemExtension, MethodImplemented)
 	assertMethod(t, "cache/benchmark", SurfaceGollemExtension, MethodImplemented)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,14 +168,14 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,14 +184,14 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,14 +235,14 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,11 +201,11 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,14 +140,14 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,14 +159,14 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,11 +248,11 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/network_approval_context_contract_test.go
+++ b/appserver/protocol/network_approval_context_contract_test.go
@@ -84,14 +84,14 @@ func TestNetworkApprovalContextRemainsStandalone(t *testing.T) {
 			t.Fatalf("NetworkApprovalContext unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,14 +163,14 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/parsed_command_contract_test.go
+++ b/appserver/protocol/parsed_command_contract_test.go
@@ -120,14 +120,14 @@ func TestParsedCommandRemainsStandalone(t *testing.T) {
 			t.Fatalf("ParsedCommand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/permission_profile_list_contract_test.go
+++ b/appserver/protocol/permission_profile_list_contract_test.go
@@ -255,11 +255,11 @@ func TestPermissionProfileListContractsRemainStandalone(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodImplemented {
 		t.Fatalf("permissionProfile/list = %#v, %v; want existing implemented client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if len(Methods()) != 225 || len(WireTypeBindings()) != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("counts = %d/%d/%d, want 225/79/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("counts = %d/%d/%d, want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,14 +127,14 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/process_contracts_contract_test.go
+++ b/appserver/protocol/process_contracts_contract_test.go
@@ -308,14 +308,14 @@ func TestProcessContractsRemainStandaloneFromLegacyRuntime(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want unchanged implemented notification", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,14 +258,14 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,11 +197,11 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 570 {
-		t.Fatalf("definition count = %d, want 570", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 573 {
+		t.Fatalf("definition count = %d, want 573", len(JSONSchema()["$defs"].(Schema)))
 	}
-	if len(WireTypeBindings()) != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 	names := []string{
 		"ThreadStartedNotification", "ThreadStatusChangedNotification",

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,11 +204,11 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 570 {
-		t.Fatalf("definition count = %d, want 570", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 573 {
+		t.Fatalf("definition count = %d, want 573", len(JSONSchema()["$defs"].(Schema)))
 	}
-	if len(WireTypeBindings()) != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 	for _, binding := range WireTypeBindings() {
 		if slices.Contains(binding.Params, "Thread") || slices.Contains(binding.Result, "Thread") {

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,11 +197,11 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 570 {
-		t.Fatalf("definition count = %d, want 570", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 573 {
+		t.Fatalf("definition count = %d, want 573", len(JSONSchema()["$defs"].(Schema)))
 	}
-	if len(bindings) != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", len(bindings), len(ItemPayloadBindings()))
+	if len(bindings) != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(bindings), len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,11 +146,11 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 570 {
-		t.Fatalf("definition count = %d, want 570", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 573 {
+		t.Fatalf("definition count = %d, want 573", len(JSONSchema()["$defs"].(Schema)))
 	}
-	if len(WireTypeBindings()) != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 	for _, binding := range WireTypeBindings() {
 		if slices.Contains(binding.Params, "Turn") || slices.Contains(binding.Result, "Turn") {

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,11 +94,11 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 570 {
-		t.Fatalf("definition count = %d, want 570", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 573 {
+		t.Fatalf("definition count = %d, want 573", len(JSONSchema()["$defs"].(Schema)))
 	}
-	if len(WireTypeBindings()) != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 
 	generated, err := MarshalTypeScript()

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,14 +159,14 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/review_decision_contract_test.go
+++ b/appserver/protocol/review_decision_contract_test.go
@@ -136,14 +136,14 @@ func TestReviewDecisionRemainsStandalone(t *testing.T) {
 			t.Fatalf("ReviewDecision unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(defs); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/runtime_client_types.go
+++ b/appserver/protocol/runtime_client_types.go
@@ -110,6 +110,58 @@ type ProviderListResponse struct {
 	Providers []ProviderCatalogEntry `json:"providers"`
 }
 
+// ProviderHealthProbeStatus is the bounded health outcome for a configured
+// provider. It deliberately carries no endpoint, credential, or upstream
+// failure detail.
+type ProviderHealthProbeStatus string
+
+const (
+	ProviderHealthAvailable     ProviderHealthProbeStatus = "available"
+	ProviderHealthUnavailable   ProviderHealthProbeStatus = "unavailable"
+	ProviderHealthNotConfigured ProviderHealthProbeStatus = "not-configured"
+	ProviderHealthUnsupported   ProviderHealthProbeStatus = "unsupported"
+)
+
+// ProviderHealthProbeParams selects the provider whose bounded health should
+// be checked. Only the local OpenAI-compatible provider supports probing.
+type ProviderHealthProbeParams struct {
+	ProviderID string `json:"providerId"`
+}
+
+// ProviderHealthProbeResponse reports a source-free provider health outcome.
+type ProviderHealthProbeResponse struct {
+	ProviderID string                    `json:"providerId"`
+	Status     ProviderHealthProbeStatus `json:"status"`
+}
+
+func providerHealthProbeSchemas() map[string]Schema {
+	return map[string]Schema{
+		"ProviderHealthProbeParams": {
+			"additionalProperties": false,
+			"properties": Schema{
+				"providerId": Schema{"type": "string"},
+			},
+			"required": []string{"providerId"},
+			"type":     "object",
+		},
+		"ProviderHealthProbeResponse": {
+			"additionalProperties": false,
+			"properties": Schema{
+				"providerId": Schema{"type": "string"},
+				"status":     Schema{"$ref": "#/$defs/ProviderHealthProbeStatus"},
+			},
+			"required": []string{"providerId", "status"},
+			"type":     "object",
+		},
+		"ProviderHealthProbeStatus": stringEnumSchema(
+			string(ProviderHealthAvailable),
+			string(ProviderHealthUnavailable),
+			string(ProviderHealthNotConfigured),
+			string(ProviderHealthUnsupported),
+		),
+	}
+}
+
 type ModelCatalogListParams struct {
 	Cursor        *string  `json:"cursor,omitempty"`
 	Limit         *uint32  `json:"limit,omitempty"`

--- a/appserver/protocol/runtime_client_types_contract_test.go
+++ b/appserver/protocol/runtime_client_types_contract_test.go
@@ -24,6 +24,10 @@ func TestRuntimeClientBindingsAreExact(t *testing.T) {
 			Method: "provider/list", Surface: SurfaceGollemExtension,
 			Params: []string{"ProviderListParams"}, Result: []string{"ProviderListResponse"},
 		},
+		"provider/health/probe": {
+			Method: "provider/health/probe", Surface: SurfaceGollemExtension,
+			Params: []string{"ProviderHealthProbeParams"}, Result: []string{"ProviderHealthProbeResponse"},
+		},
 		"thread/start": {
 			Method: "thread/start", Surface: SurfaceClientRequest,
 			Params: []string{"ThreadRunStartParams"}, Result: []string{"ThreadRunStartResult"},
@@ -82,6 +86,8 @@ func TestRuntimeClientSchemasAreClosedAndCredentialFree(t *testing.T) {
 		"ModelCatalogUpgradeInfo",
 		"ProviderCatalogCapabilities",
 		"ProviderCatalogEntry",
+		"ProviderHealthProbeParams",
+		"ProviderHealthProbeResponse",
 		"ProviderListParams",
 		"ProviderListResponse",
 		"RuntimeDeltaNotification",
@@ -110,9 +116,11 @@ func TestRuntimeClientSchemasAreClosedAndCredentialFree(t *testing.T) {
 	}
 
 	required := map[string][]string{
-		"ModelCatalogListResponse": {"data", "nextCursor"},
-		"ProviderListResponse":     {"data", "providers"},
-		"ThreadRunStartResult":     {"thread", "turn"},
+		"ModelCatalogListResponse":    {"data", "nextCursor"},
+		"ProviderListResponse":        {"data", "providers"},
+		"ProviderHealthProbeParams":   {"providerId"},
+		"ProviderHealthProbeResponse": {"providerId", "status"},
+		"ThreadRunStartResult":        {"thread", "turn"},
 		"ThreadHistoryRollbackResult": {
 			"thread", "removedTurnIds", "marker", "workspaceEffectsReverted",
 		},
@@ -129,10 +137,14 @@ func TestRuntimeClientSchemasAreClosedAndCredentialFree(t *testing.T) {
 			t.Errorf("%s required = %v, want %v", name, got, fields)
 		}
 	}
+	assertSchemaEnum(t, defs, "ProviderHealthProbeStatus", []any{
+		"available", "unavailable", "not-configured", "unsupported",
+	})
 
 	for _, name := range []string{
 		"ModelCatalogListParams",
 		"ProviderListParams",
+		"ProviderHealthProbeParams",
 		"RuntimeModelParams",
 		"ThreadHistoryRollbackParams",
 		"ThreadRunStartParams",

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -469,6 +469,9 @@ func wireSchemaDefinitions() Schema {
 		{Name: "PermissionsRequestApprovalResponse", Type: reflect.TypeFor[PermissionsRequestApprovalResponse]()},
 		{Name: "ProviderCatalogCapabilities", Type: reflect.TypeFor[ProviderCatalogCapabilities]()},
 		{Name: "ProviderCatalogEntry", Type: reflect.TypeFor[ProviderCatalogEntry]()},
+		{Name: "ProviderHealthProbeParams", Type: reflect.TypeFor[ProviderHealthProbeParams]()},
+		{Name: "ProviderHealthProbeResponse", Type: reflect.TypeFor[ProviderHealthProbeResponse]()},
+		{Name: "ProviderHealthProbeStatus", Type: reflect.TypeFor[ProviderHealthProbeStatus]()},
 		{Name: "ProviderListParams", Type: reflect.TypeFor[ProviderListParams]()},
 		{Name: "ProviderListResponse", Type: reflect.TypeFor[ProviderListResponse]()},
 		{Name: "RequestPermissionProfile", Type: reflect.TypeFor[RequestPermissionProfile]()},
@@ -1114,6 +1117,9 @@ func wireSchemaDefinitions() Schema {
 		schemas[name] = schema
 	}
 	for name, schema := range collaborationCapabilitySchemas() {
+		schemas[name] = schema
+	}
+	for name, schema := range providerHealthProbeSchemas() {
 		schemas[name] = schema
 	}
 	schemas["ProcessExitedNotification"] = processExitedNotificationSchema()

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -12038,6 +12038,43 @@
       ],
       "type": "object"
     },
+    "ProviderHealthProbeParams": {
+      "additionalProperties": false,
+      "properties": {
+        "providerId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "providerId"
+      ],
+      "type": "object"
+    },
+    "ProviderHealthProbeResponse": {
+      "additionalProperties": false,
+      "properties": {
+        "providerId": {
+          "type": "string"
+        },
+        "status": {
+          "$ref": "#/$defs/ProviderHealthProbeStatus"
+        }
+      },
+      "required": [
+        "providerId",
+        "status"
+      ],
+      "type": "object"
+    },
+    "ProviderHealthProbeStatus": {
+      "enum": [
+        "available",
+        "unavailable",
+        "not-configured",
+        "unsupported"
+      ],
+      "type": "string"
+    },
     "ProviderListParams": {
       "additionalProperties": false,
       "properties": {
@@ -12634,6 +12671,7 @@
             "git/worktree/list",
             "item/fileChange/revert",
             "provider/capabilities/read",
+            "provider/health/probe",
             "provider/list",
             "tool/list",
             "turn/retry"
@@ -20893,6 +20931,12 @@
       "source": "goal.txt"
     },
     {
+      "method": "provider/health/probe",
+      "surface": "gollem-extension",
+      "state": "implemented",
+      "source": "goal.txt"
+    },
+    {
       "method": "provider/list",
       "surface": "gollem-extension",
       "state": "implemented",
@@ -21275,6 +21319,16 @@
       ],
       "result": [
         "ModelCatalogListResponse"
+      ]
+    },
+    {
+      "method": "provider/health/probe",
+      "surface": "gollem-extension",
+      "params": [
+        "ProviderHealthProbeParams"
+      ],
+      "result": [
+        "ProviderHealthProbeResponse"
       ]
     },
     {

--- a/appserver/protocol/schema_test.go
+++ b/appserver/protocol/schema_test.go
@@ -27,8 +27,8 @@ func TestJSONSchemaContainsEnvelopeAndMethodInventory(t *testing.T) {
 	if !ok {
 		t.Fatalf("x-gollem-methods = %T", schema["x-gollem-methods"])
 	}
-	if len(methods) != 225 {
-		t.Fatalf("schema method inventory has %d rows, want 225", len(methods))
+	if len(methods) != 226 {
+		t.Fatalf("schema method inventory has %d rows, want 226", len(methods))
 	}
 
 	defs := schema["$defs"].(Schema)

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,14 +128,14 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,14 +102,14 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,14 +102,14 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(Methods()); got != 225 {
-		t.Fatalf("methods = %d, want 225", got)
+	if got := len(Methods()); got != 226 {
+		t.Fatalf("methods = %d, want 226", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,11 +387,11 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 570 {
-		t.Fatalf("definition count = %d, want 570", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 573 {
+		t.Fatalf("definition count = %d, want 573", len(JSONSchema()["$defs"].(Schema)))
 	}
-	if len(WireTypeBindings()) != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 	for _, binding := range WireTypeBindings() {
 		if slices.Contains(binding.Params, "ThreadItem") || slices.Contains(binding.Result, "ThreadItem") {

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,11 +94,11 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,11 +273,11 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,11 +194,11 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -252,11 +252,11 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 	if !foundRuntimeStart {
 		t.Error("thread/start runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -155,11 +155,11 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 	if !foundRuntimeStart {
 		t.Error("thread/start runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,11 +311,11 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 570 {
-		t.Fatalf("definition count = %d, want 570", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 573 {
+		t.Fatalf("definition count = %d, want 573", len(JSONSchema()["$defs"].(Schema)))
 	}
-	if len(WireTypeBindings()) != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 
 	generated, err := MarshalTypeScript()

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,11 +220,11 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 570 {
-		t.Fatalf("definition count = %d, want 570", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 573 {
+		t.Fatalf("definition count = %d, want 573", len(JSONSchema()["$defs"].(Schema)))
 	}
-	if len(WireTypeBindings()) != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 
 	generated, err := MarshalTypeScript()

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -119,11 +119,11 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 	if !foundRuntimeBinding {
 		t.Error("turn/interrupt runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,11 +209,11 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -241,11 +241,11 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 	if !foundRuntimeBinding {
 		t.Error("turn/start runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -164,11 +164,11 @@ func TestTurnSteerContractsAreBoundToLiveRuntime(t *testing.T) {
 	if !found {
 		t.Fatal("turn/steer runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -247,6 +247,7 @@ export const protocolMethods = [
   { "method": "git/worktree/list", "surface": "gollem-extension", "state": "implemented", "source": "goal.txt" },
   { "method": "item/fileChange/revert", "surface": "gollem-extension", "state": "implemented", "source": "goal.txt" },
   { "method": "provider/capabilities/read", "surface": "gollem-extension", "state": "implemented", "source": "goal.txt" },
+  { "method": "provider/health/probe", "surface": "gollem-extension", "state": "implemented", "source": "goal.txt" },
   { "method": "provider/list", "surface": "gollem-extension", "state": "implemented", "source": "goal.txt" },
   { "method": "tool/list", "surface": "gollem-extension", "state": "implemented", "source": "goal.txt" },
   { "method": "turn/retry", "surface": "gollem-extension", "state": "implemented", "source": "goal.txt" },
@@ -483,6 +484,7 @@ export type GollemExtensionMethod =
   | "git/worktree/list"
   | "item/fileChange/revert"
   | "provider/capabilities/read"
+  | "provider/health/probe"
   | "provider/list"
   | "tool/list"
   | "turn/retry";
@@ -2984,6 +2986,17 @@ export type ProviderCatalogEntry = {
   "requiredEnvVars"?: Array<string> | null;
 };
 
+export type ProviderHealthProbeParams = {
+  "providerId": string;
+};
+
+export type ProviderHealthProbeResponse = {
+  "providerId": string;
+  "status": ProviderHealthProbeStatus;
+};
+
+export type ProviderHealthProbeStatus = "available" | "unavailable" | "not-configured" | "unsupported";
+
 export type ProviderListParams = {
   "configuredOnly"?: boolean;
   "includeHidden"?: boolean | null;
@@ -3085,7 +3098,7 @@ export type ReasoningTextDeltaNotification = {
 
 export type Request = {
   "id": RequestID;
-  "method": "account/login/cancel" | "account/login/start" | "account/logout" | "account/rateLimitResetCredit/consume" | "account/rateLimits/read" | "account/read" | "account/sendAddCreditsNudgeEmail" | "account/usage/read" | "account/workspaceMessages/read" | "app/list" | "collaborationMode/list" | "command/exec" | "command/exec/resize" | "command/exec/terminate" | "command/exec/write" | "config/batchWrite" | "config/mcpServer/reload" | "config/read" | "config/value/write" | "configRequirements/read" | "environment/add" | "environment/info" | "experimentalFeature/enablement/set" | "experimentalFeature/list" | "externalAgentConfig/detect" | "externalAgentConfig/import" | "externalAgentConfig/import/readHistories" | "feedback/upload" | "fs/copy" | "fs/createDirectory" | "fs/getMetadata" | "fs/readDirectory" | "fs/readFile" | "fs/remove" | "fs/unwatch" | "fs/watch" | "fs/writeFile" | "fuzzyFileSearch" | "fuzzyFileSearch/sessionStart" | "fuzzyFileSearch/sessionStop" | "fuzzyFileSearch/sessionUpdate" | "getAuthStatus" | "getConversationSummary" | "gitDiffToRemote" | "hooks/list" | "initialize" | "marketplace/add" | "marketplace/remove" | "marketplace/upgrade" | "mcpServer/oauth/login" | "mcpServer/resource/read" | "mcpServer/tool/call" | "mcpServerStatus/list" | "memory/reset" | "mock/experimentalMethod" | "model/list" | "modelProvider/capabilities/read" | "permissionProfile/list" | "plugin/install" | "plugin/installed" | "plugin/list" | "plugin/read" | "plugin/share/checkout" | "plugin/share/delete" | "plugin/share/list" | "plugin/share/save" | "plugin/share/updateTargets" | "plugin/skill/read" | "plugin/uninstall" | "process/kill" | "process/resizePty" | "process/spawn" | "process/writeStdin" | "remoteControl/client/list" | "remoteControl/client/revoke" | "remoteControl/disable" | "remoteControl/enable" | "remoteControl/pairing/start" | "remoteControl/pairing/status" | "remoteControl/status/read" | "review/start" | "skills/config/write" | "skills/extraRoots/set" | "skills/list" | "thread/approveGuardianDeniedAction" | "thread/archive" | "thread/backgroundTerminals/clean" | "thread/backgroundTerminals/list" | "thread/backgroundTerminals/terminate" | "thread/compact/start" | "thread/decrement_elicitation" | "thread/delete" | "thread/fork" | "thread/goal/clear" | "thread/goal/get" | "thread/goal/set" | "thread/increment_elicitation" | "thread/inject_items" | "thread/items/list" | "thread/list" | "thread/loaded/list" | "thread/memoryMode/set" | "thread/metadata/update" | "thread/name/set" | "thread/read" | "thread/realtime/appendAudio" | "thread/realtime/appendSpeech" | "thread/realtime/appendText" | "thread/realtime/listVoices" | "thread/realtime/start" | "thread/realtime/stop" | "thread/resume" | "thread/rollback" | "thread/search" | "thread/settings/update" | "thread/shellCommand" | "thread/start" | "thread/turns/list" | "thread/unarchive" | "thread/unsubscribe" | "turn/interrupt" | "turn/start" | "turn/steer" | "windowsSandbox/readiness" | "windowsSandbox/setupStart" | "approval/respond" | "cache/benchmark" | "cache/stats" | "daemon/restart" | "daemon/start" | "daemon/status" | "daemon/stop" | "daemon/version" | "git/commit" | "git/diff" | "git/status" | "git/worktree/create" | "git/worktree/list" | "item/fileChange/revert" | "provider/capabilities/read" | "provider/list" | "tool/list" | "turn/retry";
+  "method": "account/login/cancel" | "account/login/start" | "account/logout" | "account/rateLimitResetCredit/consume" | "account/rateLimits/read" | "account/read" | "account/sendAddCreditsNudgeEmail" | "account/usage/read" | "account/workspaceMessages/read" | "app/list" | "collaborationMode/list" | "command/exec" | "command/exec/resize" | "command/exec/terminate" | "command/exec/write" | "config/batchWrite" | "config/mcpServer/reload" | "config/read" | "config/value/write" | "configRequirements/read" | "environment/add" | "environment/info" | "experimentalFeature/enablement/set" | "experimentalFeature/list" | "externalAgentConfig/detect" | "externalAgentConfig/import" | "externalAgentConfig/import/readHistories" | "feedback/upload" | "fs/copy" | "fs/createDirectory" | "fs/getMetadata" | "fs/readDirectory" | "fs/readFile" | "fs/remove" | "fs/unwatch" | "fs/watch" | "fs/writeFile" | "fuzzyFileSearch" | "fuzzyFileSearch/sessionStart" | "fuzzyFileSearch/sessionStop" | "fuzzyFileSearch/sessionUpdate" | "getAuthStatus" | "getConversationSummary" | "gitDiffToRemote" | "hooks/list" | "initialize" | "marketplace/add" | "marketplace/remove" | "marketplace/upgrade" | "mcpServer/oauth/login" | "mcpServer/resource/read" | "mcpServer/tool/call" | "mcpServerStatus/list" | "memory/reset" | "mock/experimentalMethod" | "model/list" | "modelProvider/capabilities/read" | "permissionProfile/list" | "plugin/install" | "plugin/installed" | "plugin/list" | "plugin/read" | "plugin/share/checkout" | "plugin/share/delete" | "plugin/share/list" | "plugin/share/save" | "plugin/share/updateTargets" | "plugin/skill/read" | "plugin/uninstall" | "process/kill" | "process/resizePty" | "process/spawn" | "process/writeStdin" | "remoteControl/client/list" | "remoteControl/client/revoke" | "remoteControl/disable" | "remoteControl/enable" | "remoteControl/pairing/start" | "remoteControl/pairing/status" | "remoteControl/status/read" | "review/start" | "skills/config/write" | "skills/extraRoots/set" | "skills/list" | "thread/approveGuardianDeniedAction" | "thread/archive" | "thread/backgroundTerminals/clean" | "thread/backgroundTerminals/list" | "thread/backgroundTerminals/terminate" | "thread/compact/start" | "thread/decrement_elicitation" | "thread/delete" | "thread/fork" | "thread/goal/clear" | "thread/goal/get" | "thread/goal/set" | "thread/increment_elicitation" | "thread/inject_items" | "thread/items/list" | "thread/list" | "thread/loaded/list" | "thread/memoryMode/set" | "thread/metadata/update" | "thread/name/set" | "thread/read" | "thread/realtime/appendAudio" | "thread/realtime/appendSpeech" | "thread/realtime/appendText" | "thread/realtime/listVoices" | "thread/realtime/start" | "thread/realtime/stop" | "thread/resume" | "thread/rollback" | "thread/search" | "thread/settings/update" | "thread/shellCommand" | "thread/start" | "thread/turns/list" | "thread/unarchive" | "thread/unsubscribe" | "turn/interrupt" | "turn/start" | "turn/steer" | "windowsSandbox/readiness" | "windowsSandbox/setupStart" | "approval/respond" | "cache/benchmark" | "cache/stats" | "daemon/restart" | "daemon/start" | "daemon/status" | "daemon/stop" | "daemon/version" | "git/commit" | "git/diff" | "git/status" | "git/worktree/create" | "git/worktree/list" | "item/fileChange/revert" | "provider/capabilities/read" | "provider/health/probe" | "provider/list" | "tool/list" | "turn/retry";
   "params"?: unknown;
 };
 
@@ -4477,6 +4490,7 @@ export const wireTypeBindings = [
   { "method": "item/tool/requestUserInput", "surface": "server-request", "params": ["ToolRequestUserInputParams"], "result": ["ToolRequestUserInputResponse"] },
   { "method": "mcpServer/elicitation/request", "surface": "server-request", "params": ["McpServerElicitationRequestParams"], "result": ["McpServerElicitationRequestResponse"] },
   { "method": "model/list", "surface": "client-request", "params": ["ModelCatalogListParams"], "result": ["ModelCatalogListResponse"] },
+  { "method": "provider/health/probe", "surface": "gollem-extension", "params": ["ProviderHealthProbeParams"], "result": ["ProviderHealthProbeResponse"] },
   { "method": "provider/list", "surface": "gollem-extension", "params": ["ProviderListParams"], "result": ["ProviderListResponse"] },
   { "method": "serverRequest/resolved", "surface": "server-notification", "params": ["ServerRequestResolvedNotification"] },
   { "method": "thread/archive", "surface": "client-request", "params": ["ThreadArchiveParams"], "result": ["ThreadArchiveResponse"] },
@@ -4559,6 +4573,7 @@ export interface MethodParamsByName {
   "item/tool/requestUserInput": ToolRequestUserInputParams;
   "mcpServer/elicitation/request": McpServerElicitationRequestParams;
   "model/list": ModelCatalogListParams;
+  "provider/health/probe": ProviderHealthProbeParams;
   "provider/list": ProviderListParams;
   "serverRequest/resolved": ServerRequestResolvedNotification;
   "thread/archive": ThreadArchiveParams;
@@ -4629,6 +4644,7 @@ export interface MethodResultsByName {
   "item/tool/requestUserInput": ToolRequestUserInputResponse;
   "mcpServer/elicitation/request": McpServerElicitationRequestResponse;
   "model/list": ModelCatalogListResponse;
+  "provider/health/probe": ProviderHealthProbeResponse;
   "provider/list": ProviderListResponse;
   "thread/archive": ThreadArchiveResponse;
   "thread/backgroundTerminals/clean": BackgroundTerminalCleanResponse;

--- a/appserver/protocol/typescript/testdata/collaboration_capability_contract.ts
+++ b/appserver/protocol/typescript/testdata/collaboration_capability_contract.ts
@@ -73,8 +73,8 @@ type Contracts = [
   Expect<Equal<ExactMembers<MethodParamsByName[keyof MethodParamsByName], CollaborationCapabilityContracts>, never>>,
   Expect<Equal<ExactMembers<MethodResultsByName[keyof MethodResultsByName], CollaborationCapabilityContracts>, never>>,
   Expect<Equal<ExactMembers<ItemPayloadByKind[keyof ItemPayloadByKind], CollaborationCapabilityContracts>, never>>,
-  Expect<Equal<typeof protocolMethods["length"], 225>>,
-  Expect<Equal<typeof wireTypeBindings["length"], 79>>,
+  Expect<Equal<typeof protocolMethods["length"], 226>>,
+  Expect<Equal<typeof wireTypeBindings["length"], 80>>,
   Expect<Equal<typeof itemPayloadBindings["length"], 5>>,
 ];
 

--- a/appserver/protocol/typescript/testdata/dynamic_tool_spec_contract.ts
+++ b/appserver/protocol/typescript/testdata/dynamic_tool_spec_contract.ts
@@ -57,8 +57,8 @@ type Contracts = [
   Expect<Equal<ExactMembers<MethodParamsByName[keyof MethodParamsByName], DynamicToolSpecContracts>, never>>,
   Expect<Equal<ExactMembers<MethodResultsByName[keyof MethodResultsByName], DynamicToolSpecContracts>, never>>,
   Expect<Equal<ExactMembers<ItemPayloadByKind[keyof ItemPayloadByKind], DynamicToolSpecContracts>, never>>,
-  Expect<Equal<typeof protocolMethods["length"], 225>>,
-  Expect<Equal<typeof wireTypeBindings["length"], 79>>,
+  Expect<Equal<typeof protocolMethods["length"], 226>>,
+  Expect<Equal<typeof wireTypeBindings["length"], 80>>,
   Expect<Equal<typeof itemPayloadBindings["length"], 5>>,
 ];
 

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,11 +163,11 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if got := len(WireTypeBindings()); got != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 79/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/workspace_messages_contract_test.go
+++ b/appserver/protocol/workspace_messages_contract_test.go
@@ -209,11 +209,11 @@ func TestWorkspaceMessageContractsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/workspaceMessages/read = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 570 {
-		t.Fatalf("definition count = %d, want 570", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 573 {
+		t.Fatalf("definition count = %d, want 573", got)
 	}
-	if len(Methods()) != 225 || len(WireTypeBindings()) != 79 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 225/79/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/scheduler.go
+++ b/appserver/scheduler.go
@@ -126,7 +126,7 @@ func RequestScheduleFor(method string, params json.RawMessage) RequestSchedule {
 		return RequestSchedule{Scope: "skills", Serial: true}
 	case "daemon/start", "daemon/stop", "daemon/restart", "daemon/status", "daemon/version":
 		return RequestSchedule{Scope: "daemon", Serial: true}
-	case "model/list", "modelProvider/capabilities/read", "provider/capabilities/read", "provider/list", "tool/list",
+	case "model/list", "modelProvider/capabilities/read", "provider/capabilities/read", "provider/health/probe", "provider/list", "tool/list",
 		"config/read", "config/value/write", "config/batchWrite", "configRequirements/read", "config/mcpServer/reload",
 		"environment/add", "environment/info", "collaborationMode/list", "permissionProfile/list",
 		"experimentalFeature/list", "experimentalFeature/enablement/set":

--- a/appserver/scheduler_test.go
+++ b/appserver/scheduler_test.go
@@ -188,3 +188,10 @@ func TestRequestScheduleForMemoryReset(t *testing.T) {
 		t.Fatalf("schedule = %#v, want serial memory scope", schedule)
 	}
 }
+
+func TestRequestScheduleForProviderHealthProbe(t *testing.T) {
+	schedule := RequestScheduleFor("provider/health/probe", nil)
+	if schedule.Scope != "catalog" || !schedule.Serial {
+		t.Fatalf("schedule = %#v, want serial catalog scope", schedule)
+	}
+}

--- a/appserver/server.go
+++ b/appserver/server.go
@@ -623,6 +623,8 @@ func (s *Server) dispatch(ctx context.Context, method string, params json.RawMes
 		return s.handleProviderCapabilities(params)
 	case "provider/list":
 		return s.handleProviderList(params)
+	case "provider/health/probe":
+		return s.handleProviderHealthProbe(ctx, params)
 	case "tool/list":
 		return s.handleToolList(params)
 	case "collaborationMode/list":
@@ -1612,6 +1614,18 @@ func (s *Server) handleProviderList(raw json.RawMessage) (any, *protocol.Error) 
 		return nil, rpcErr
 	}
 	return s.requireCatalog().ListProviders(params), nil
+}
+
+func (s *Server) handleProviderHealthProbe(ctx context.Context, raw json.RawMessage) (any, *protocol.Error) {
+	var params catalog.ProviderHealthProbeParams
+	if rpcErr := decodeParams(raw, &params); rpcErr != nil {
+		return nil, rpcErr
+	}
+	result, err := s.requireCatalog().ProbeProvider(ctx, params)
+	if err != nil {
+		return nil, invalidParams("invalid provider health probe params", err)
+	}
+	return result, nil
 }
 
 func (s *Server) handleProviderCapabilities(raw json.RawMessage) (any, *protocol.Error) {

--- a/appserver/server_test.go
+++ b/appserver/server_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1441,6 +1443,52 @@ func TestServerCatalogHandlers(t *testing.T) {
 	}
 	if !toolAvailable(tools.Data, "memory") {
 		t.Fatalf("tool/list did not report memory available: %#v", tools.Data)
+	}
+}
+
+func TestServerProviderHealthProbeIsTypedAndCredentialFree(t *testing.T) {
+	const token = "server-local-probe-secret"
+	endpoint := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/models" {
+			t.Fatalf("probe request = %s %s, want GET /v1/models", r.Method, r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer "+token {
+			t.Fatalf("Authorization = %q, want local token", got)
+		}
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	defer endpoint.Close()
+	env := map[string]string{
+		"GOLLEM_LOCAL_OPENAI_BASE_URL": endpoint.URL,
+		"GOLLEM_LOCAL_OPENAI_MODEL":    "local-tool-model",
+		"GOLLEM_LOCAL_OPENAI_API_KEY":  token,
+	}
+	catalogSvc := catalog.NewDefault(catalog.WithEnvLookup(func(key string) (string, bool) {
+		value, ok := env[key]
+		return value, ok
+	}))
+	server := readyServer(WithCatalog(catalogSvc))
+
+	resp := server.HandleRequest(context.Background(), request("provider/health/probe", map[string]any{
+		"providerId": catalog.ProviderOpenAICompatibleLocal,
+	}))
+	if resp.Error != nil {
+		t.Fatalf("provider/health/probe error: %v", resp.Error)
+	}
+	var probe catalog.ProviderHealthProbeResponse
+	decodeResult(t, resp, &probe)
+	if probe.ProviderID != catalog.ProviderOpenAICompatibleLocal || probe.Status != catalog.ProviderHealthAvailable {
+		t.Fatalf("provider/health/probe = %#v", probe)
+	}
+	for _, secret := range []string{endpoint.URL, token} {
+		if strings.Contains(string(resp.Result), secret) {
+			t.Fatalf("provider/health/probe leaked %q: %s", secret, resp.Result)
+		}
+	}
+
+	unknown := server.HandleRequest(context.Background(), request("provider/health/probe", map[string]any{"providerId": "unknown"}))
+	if unknown.Error == nil || unknown.Error.Code != protocol.CodeInvalidParams {
+		t.Fatalf("unknown provider probe error = %#v, want invalid params", unknown.Error)
 	}
 }
 

--- a/docs/PROVIDER_DRIVER_CONFORMANCE.md
+++ b/docs/PROVIDER_DRIVER_CONFORMANCE.md
@@ -24,7 +24,8 @@ of behavior and must not enable a control solely on provider identity.
 | Retryable 429 request recovery | Proven | Proven | Proven | `provider/conformance` exercises bounded `modelutil.RetryModel` recovery |
 | Request deadline propagation | Proven | Proven | Proven | `provider/conformance` confirms HTTP request cancellation and `context.DeadlineExceeded` normalization |
 | Post-output retry / replay | Not yet proven | Not yet proven | Not yet proven | A stream may have produced caller-visible output; recovery must not replay it without an explicit safe-resume contract |
-| Endpoint health probe and capability mismatch | Not yet proven | Not yet proven | Not yet proven | Must remain a typed unavailable/degraded state |
+| Endpoint health probe | Unsupported | Proven | Unsupported | `provider/health/probe` performs a loopback-only `GET /v1/models`; it returns only a typed status and never starts a model turn |
+| Capability mismatch | Not yet proven | Not yet proven | Not yet proven | Must remain a typed unavailable/degraded state |
 
 `Catalog-supported` means the catalog may expose the capability only for the
 listed provider/model profile. It does not make that behavior part of the common
@@ -41,6 +42,9 @@ driver contract until a deterministic conformance scenario covers it.
 - A local endpoint connection failure is a bounded `local endpoint unavailable`
   error. It must not reveal the endpoint or local token through app-server,
   catalog, or renderer diagnostics.
+- `provider/health/probe` is available only for the explicitly configured local
+  profile. It returns `available`, `unavailable`, `not-configured`, or
+  `unsupported`; the probe reads `/v1/models` and does not invoke a model.
 
 ## Adding Or Expanding A Claim
 

--- a/provider/openai/local_endpoint.go
+++ b/provider/openai/local_endpoint.go
@@ -1,9 +1,12 @@
 package openai
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net"
+	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -28,6 +31,10 @@ const (
 	defaultLocalEndpointModel   = "llama3"
 	defaultLocalEndpointAPIKey  = "local"
 )
+
+// ErrLocalEndpointUnavailable is intentionally source-free so callers can
+// report local endpoint availability without projecting its address or error.
+var ErrLocalEndpointUnavailable = errors.New("openai: local endpoint unavailable")
 
 // LocalEndpointConfig is the process-owned configuration for a trusted local
 // OpenAI-compatible Chat Completions endpoint. It contains no renderer-facing
@@ -94,6 +101,37 @@ func NewLocalEndpoint(config LocalEndpointConfig, opts ...Option) (*Provider, er
 		withLocalEndpointConstraints(),
 	)
 	return New(options...), nil
+}
+
+// ProbeLocalEndpoint verifies that a normalized local endpoint accepts a
+// lightweight OpenAI-compatible discovery request. It never creates a model
+// completion and returns only ErrLocalEndpointUnavailable for probe failures.
+func ProbeLocalEndpoint(ctx context.Context, config LocalEndpointConfig, client *http.Client) error {
+	config, err := NormalizeLocalEndpointConfig(config)
+	if err != nil {
+		return ErrLocalEndpointUnavailable
+	}
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, config.BaseURL+"/v1/models", nil)
+	if err != nil {
+		return ErrLocalEndpointUnavailable
+	}
+	req.Header.Set("Authorization", "Bearer "+config.Token)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return ErrLocalEndpointUnavailable
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 64<<10))
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return ErrLocalEndpointUnavailable
+	}
+	return nil
 }
 
 func withLocalEndpointConstraints() Option {

--- a/provider/openai/local_endpoint_test.go
+++ b/provider/openai/local_endpoint_test.go
@@ -3,6 +3,7 @@ package openai
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -127,6 +128,48 @@ func TestLocalEndpointRedactsUnavailableEndpoint(t *testing.T) {
 	}
 	if got := err.Error(); got != "openai: local endpoint unavailable" {
 		t.Fatalf("error = %q, want redacted local endpoint error", got)
+	}
+}
+
+func TestProbeLocalEndpointUsesDiscoveryAndRedactsFailure(t *testing.T) {
+	const token = "local-probe-token"
+	var authorization string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/models" {
+			t.Fatalf("probe request = %s %s, want GET /v1/models", r.Method, r.URL.Path)
+		}
+		authorization = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	defer server.Close()
+
+	if err := ProbeLocalEndpoint(context.Background(), LocalEndpointConfig{
+		BaseURL: server.URL,
+		Model:   "local-tool-model",
+		Token:   token,
+	}, nil); err != nil {
+		t.Fatalf("ProbeLocalEndpoint: %v", err)
+	}
+	if authorization != "Bearer "+token {
+		t.Fatalf("Authorization = %q, want local token", authorization)
+	}
+
+	unavailable := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte("unavailable at /private/path"))
+	}))
+	defer unavailable.Close()
+	err := ProbeLocalEndpoint(context.Background(), LocalEndpointConfig{
+		BaseURL: unavailable.URL,
+		Model:   "local-tool-model",
+		Token:   token,
+	}, nil)
+	if !errors.Is(err, ErrLocalEndpointUnavailable) {
+		t.Fatalf("unavailable probe error = %v, want ErrLocalEndpointUnavailable", err)
+	}
+	if strings.Contains(err.Error(), unavailable.URL) || strings.Contains(err.Error(), token) {
+		t.Fatalf("unavailable probe leaked local details: %v", err)
 	}
 }
 

--- a/provider/openai/openai.go
+++ b/provider/openai/openai.go
@@ -584,7 +584,7 @@ func (p *Provider) doRequest(ctx context.Context, endpoint string, body []byte, 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+endpoint, bytes.NewReader(body))
 	if err != nil {
 		if p.redactEndpointErrors {
-			return nil, errors.New("openai: local endpoint unavailable")
+			return nil, ErrLocalEndpointUnavailable
 		}
 		return nil, fmt.Errorf("openai: failed to create HTTP request: %w", err)
 	}
@@ -597,7 +597,7 @@ func (p *Provider) doRequest(ctx context.Context, endpoint string, body []byte, 
 	if err != nil {
 		ri.recordError(err)
 		if p.redactEndpointErrors && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
-			return nil, errors.New("openai: local endpoint unavailable")
+			return nil, ErrLocalEndpointUnavailable
 		}
 		return nil, fmt.Errorf("openai: HTTP request failed: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Add a loopback-only `provider/health/probe` extension for explicitly configured local OpenAI-compatible endpoints.
- Return only typed `available`, `unavailable`, `not-configured`, or `unsupported` status, without endpoint, token, upstream body, or model invocation.
- Generate app-server JSON Schema and TypeScript bindings; cover provider, catalog, server, scheduler, and protocol behavior.

## Verification
- Full non-Monty Go test suite
- Targeted race coverage for OpenAI and app-server packages
- Non-Monty `go vet`
- `golangci-lint run ./...`
- `go mod tidy -diff`, `go mod verify`, and `git diff --check`

## Note
Local `govulncheck ./...` reports existing upstream dependency and Go 1.25.1 standard-library advisories; this PR does not modify `go.mod` or `go.sum`. Hosted Vulncheck is the merge gate.