### PR TITLE
Gate runtime selections by catalog capabilities

### DIFF
--- a/appserver/catalog/catalog.go
+++ b/appserver/catalog/catalog.go
@@ -251,6 +251,55 @@ func (c *Catalog) ProviderCapabilities(providerID string) (ProviderCapabilities,
 	return aggregate, nil
 }
 
+// ValidateAgentRuntimeSelection proves that a catalog selection can support
+// Gollem's streaming, tool-capable agent runtime. It deliberately returns only
+// catalog identities and capability names, never configuration values.
+func (c *Catalog) ValidateAgentRuntimeSelection(providerID, modelName string) error {
+	c = ensureCatalog(c)
+	providerID = normalizeProviderID(providerID)
+	modelName = strings.TrimSpace(modelName)
+	if providerID == "" {
+		return errors.New("provider selection is unavailable")
+	}
+
+	var selectedProvider *Provider
+	for index := range c.providers {
+		provider := &c.providers[index]
+		if provider.ID == providerID {
+			selectedProvider = provider
+			break
+		}
+	}
+	if selectedProvider == nil {
+		return fmt.Errorf("provider selection is unavailable for %q", providerID)
+	}
+	if !selectedProvider.Configured {
+		return fmt.Errorf("provider %q is not configured", selectedProvider.ID)
+	}
+	if !selectedProvider.Capabilities.Streaming || !selectedProvider.Capabilities.ToolCalls {
+		return fmt.Errorf("provider %q does not advertise streaming agent tool use", selectedProvider.ID)
+	}
+
+	for index := range selectedProvider.Models {
+		model := &selectedProvider.Models[index]
+		if modelName == "" {
+			if !model.IsDefault && model.ID != selectedProvider.DefaultModelID {
+				continue
+			}
+		} else if model.ID != modelName && model.Model != modelName {
+			continue
+		}
+		if !model.Capabilities.Streaming || !model.Capabilities.ToolCalls {
+			return fmt.Errorf("model %q does not advertise streaming agent tool use", model.ID)
+		}
+		return nil
+	}
+	if modelName == "" {
+		return fmt.Errorf("provider %q has no available default model", selectedProvider.ID)
+	}
+	return fmt.Errorf("model selection is unavailable for %q", modelName)
+}
+
 // ProbeProvider reports bounded health for the selected provider. The only
 // network operation permitted here is a discovery request to an explicitly
 // configured loopback OpenAI-compatible endpoint.

--- a/appserver/catalog/catalog_test.go
+++ b/appserver/catalog/catalog_test.go
@@ -109,6 +109,73 @@ func TestProviderCapabilities(t *testing.T) {
 	}
 }
 
+func TestValidateAgentRuntimeSelection(t *testing.T) {
+	c := NewDefault(WithEnvLookup(mapEnv(map[string]string{
+		"OPENAI_API_KEY": "configured",
+	})))
+
+	if err := c.ValidateAgentRuntimeSelection(ProviderOpenAI, "gpt-5"); err != nil {
+		t.Fatalf("ValidateAgentRuntimeSelection configured model: %v", err)
+	}
+	mutatedToolCapability := false
+	for providerIndex := range c.providers {
+		provider := &c.providers[providerIndex]
+		if provider.ID != ProviderOpenAI {
+			continue
+		}
+		for modelIndex := range provider.Models {
+			model := &provider.Models[modelIndex]
+			if model.Model != "gpt-4o" {
+				continue
+			}
+			model.Capabilities.ToolCalls = false
+			mutatedToolCapability = true
+			err := c.ValidateAgentRuntimeSelection(ProviderOpenAI, model.Model)
+			if err == nil || !strings.Contains(err.Error(), "does not advertise streaming agent tool use") {
+				t.Fatalf("ValidateAgentRuntimeSelection missing tool capability error = %v", err)
+			}
+			break
+		}
+		break
+	}
+	if !mutatedToolCapability {
+		t.Fatal("OpenAI gpt-4o catalog fixture is missing")
+	}
+
+	for _, tc := range []struct {
+		name       string
+		providerID string
+		model      string
+		want       string
+	}{
+		{
+			name:       "unconfigured provider",
+			providerID: ProviderAnthropic,
+			model:      "claude-sonnet-4-6",
+			want:       "not configured",
+		},
+		{
+			name:       "unknown provider",
+			providerID: "unsupported-provider",
+			model:      "model",
+			want:       "provider selection is unavailable",
+		},
+		{
+			name:       "unknown model",
+			providerID: ProviderOpenAI,
+			model:      "unlisted-model",
+			want:       "model selection is unavailable",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := c.ValidateAgentRuntimeSelection(tc.providerID, tc.model)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("ValidateAgentRuntimeSelection(%q, %q) error = %v, want %q", tc.providerID, tc.model, err, tc.want)
+			}
+		})
+	}
+}
+
 func TestLocalOpenAICompatibleProviderUsesExplicitSafeConfiguration(t *testing.T) {
 	const baseURL = "http://127.0.0.1:8765/v1"
 	const model = "local-tool-model"

--- a/appserver/runtime_selection.go
+++ b/appserver/runtime_selection.go
@@ -1,0 +1,12 @@
+package appserver
+
+import "github.com/fugue-labs/gollem/core"
+
+func (s *Server) validateRuntimeSelection(selection RuntimeModelSelection, settings core.ModelSettings) error {
+	if s != nil && s.selectionValidator != nil {
+		if err := s.selectionValidator(selection); err != nil {
+			return err
+		}
+	}
+	return validateRuntimeReasoningSelection(s.catalog, selection, settings)
+}

--- a/appserver/runtime_test.go
+++ b/appserver/runtime_test.go
@@ -273,6 +273,45 @@ func TestServerRuntimeReasoningEffortFailsClosedAgainstModelCatalog(t *testing.T
 	}
 }
 
+func TestServerRuntimeSelectionValidatorFailsClosedBeforeThreadCreation(t *testing.T) {
+	ctx := context.Background()
+	st := newRuntimeTestStore(t)
+	factoryCalls := 0
+	server := readyServer(
+		WithStore(st),
+		WithRuntimeService(NewRuntimeService(WithRuntimeModelFactory(
+			func(context.Context, RuntimeModelSelection) (core.Model, RuntimeModelInfo, error) {
+				factoryCalls++
+				return core.NewTestModel(core.TextResponse("must not run")), RuntimeModelInfo{}, nil
+			},
+		))),
+		WithRuntimeSelectionValidator(func(RuntimeModelSelection) error {
+			return errors.New("selected model does not advertise streaming agent tool use")
+		}),
+	)
+
+	response := server.HandleRequest(ctx, request("thread/start", map[string]any{
+		"workspace":  t.TempDir(),
+		"prompt":     "do not persist",
+		"providerId": "openai",
+		"model":      "gpt-4o",
+	}))
+	if response.Error == nil || response.Error.Code != protocol.CodeInvalidParams ||
+		!strings.Contains(response.Error.Message, "does not advertise streaming agent tool use") {
+		t.Fatalf("thread/start error = %#v", response.Error)
+	}
+	threads, err := st.ListThreads(ctx, store.ThreadFilter{})
+	if err != nil {
+		t.Fatalf("ListThreads: %v", err)
+	}
+	if len(threads) != 0 {
+		t.Fatalf("rejected selection created threads: %#v", threads)
+	}
+	if factoryCalls != 0 {
+		t.Fatalf("rejected selection called runtime factory %d times", factoryCalls)
+	}
+}
+
 func TestServerThreadCompactStartFailureTerminalizesCreatedTurn(t *testing.T) {
 	for _, tc := range []struct {
 		name      string

--- a/appserver/server.go
+++ b/appserver/server.go
@@ -53,22 +53,23 @@ type Server struct {
 
 	workspaceCoordinator *WorkspaceMutationCoordinator
 
-	store     store.Store
-	fs        *toolfs.Service
-	process   *toolprocess.Service
-	git       *toolgit.Service
-	catalog   *catalog.Catalog
-	config    *appconfig.Service
-	cache     *appcache.Service
-	mcp       *appmcp.Service
-	skills    *appskills.Service
-	events    *EventQueue
-	requests  *RequestQueue
-	approvals *ApprovalService
-	interact  *InteractionService
-	daemon    *DaemonService
-	runtime   *RuntimeService
-	memory    *MemoryService
+	store              store.Store
+	fs                 *toolfs.Service
+	process            *toolprocess.Service
+	git                *toolgit.Service
+	catalog            *catalog.Catalog
+	config             *appconfig.Service
+	cache              *appcache.Service
+	mcp                *appmcp.Service
+	skills             *appskills.Service
+	events             *EventQueue
+	requests           *RequestQueue
+	approvals          *ApprovalService
+	interact           *InteractionService
+	daemon             *DaemonService
+	runtime            *RuntimeService
+	memory             *MemoryService
+	selectionValidator RuntimeSelectionValidator
 
 	requestSchedulerLimit int
 	threadIdleUnloadAfter time.Duration
@@ -76,6 +77,17 @@ type Server struct {
 
 // Option configures a Server.
 type Option func(*Server)
+
+// RuntimeSelectionValidator rejects a requested provider/model before the
+// server creates a durable thread or turn. It is optional so embedders that
+// supply their own non-catalog runtime can define their own authority.
+type RuntimeSelectionValidator func(RuntimeModelSelection) error
+
+func WithRuntimeSelectionValidator(validator RuntimeSelectionValidator) Option {
+	return func(s *Server) {
+		s.selectionValidator = validator
+	}
+}
 
 func WithImplementationInfo(info protocol.ImplementationInfo) Option {
 	return func(s *Server) {
@@ -755,7 +767,7 @@ func (s *Server) handleThreadStart(ctx context.Context, raw json.RawMessage) (an
 	selection := runtimeSelectionFromParams(params.ProviderID, params.Provider, params.Model)
 	modelSettings := runtimeModelSettingsFromParams(params.RuntimeModelParams)
 	settings = mergeRuntimeReasoningIntoSettings(settings, modelSettings.ReasoningEffort)
-	if err := validateRuntimeReasoningSelection(s.catalog, selection, modelSettings); err != nil {
+	if err := s.validateRuntimeSelection(selection, modelSettings); err != nil {
 		return nil, invalidParams(err.Error(), err)
 	}
 	ctx, releaseStart, err := runtimeSvc.acquireStartLease(ctx, s)
@@ -1498,7 +1510,7 @@ func (s *Server) handleTurnRetry(ctx context.Context, raw json.RawMessage) (any,
 	if modelSettings.ReasoningEffort == nil {
 		modelSettings = runtimeModelSettingsFromInput(source.Input)
 	}
-	if err := validateRuntimeReasoningSelection(s.catalog, selection, modelSettings); err != nil {
+	if err := s.validateRuntimeSelection(selection, modelSettings); err != nil {
 		return nil, invalidParams(err.Error(), err)
 	}
 	retry, err := runtimeSvc.Retry(ctx, st, s, RuntimeRetryRequest{
@@ -1548,7 +1560,7 @@ func (s *Server) startTurnWithParams(ctx context.Context, method string, params 
 	selection = runtimeSelectionWithThreadDefaults(selection, thread.Settings)
 	modelSettings := runtimeModelSettingsFromParams(params.RuntimeModelParams)
 	modelSettings = runtimeModelSettingsWithThreadDefaults(modelSettings, thread.Settings)
-	if err := validateRuntimeReasoningSelection(s.catalog, selection, modelSettings); err != nil {
+	if err := s.validateRuntimeSelection(selection, modelSettings); err != nil {
 		return nil, invalidParams(err.Error(), err)
 	}
 	turn, err := runtimeSvc.Start(ctx, st, s, RuntimeStartRequest{

--- a/cmd/gollem/app_server.go
+++ b/cmd/gollem/app_server.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	appserver "github.com/fugue-labs/gollem/appserver"
+	"github.com/fugue-labs/gollem/appserver/catalog"
 	appconfig "github.com/fugue-labs/gollem/appserver/config"
 	appmcp "github.com/fugue-labs/gollem/appserver/mcp"
 	"github.com/fugue-labs/gollem/appserver/protocol"
@@ -224,10 +225,24 @@ func newCLIAppServer(flags appServerFlags) (*appserver.Server, func(), error) {
 }
 
 func newCLIAppServerWithTransport(flags appServerFlags, transport string) (*appserver.Server, func(), error) {
-	return newCLIAppServerWithRuntimeFactory(flags, transport, appServerRuntimeModelFactory(flags))
+	return newCLIAppServerWithRuntimeFactoryAndSelectionValidation(
+		flags,
+		transport,
+		appServerRuntimeModelFactory(flags),
+		true,
+	)
 }
 
 func newCLIAppServerWithRuntimeFactory(flags appServerFlags, transport string, runtimeFactory appserver.RuntimeModelFactory) (*appserver.Server, func(), error) {
+	return newCLIAppServerWithRuntimeFactoryAndSelectionValidation(flags, transport, runtimeFactory, false)
+}
+
+func newCLIAppServerWithRuntimeFactoryAndSelectionValidation(
+	flags appServerFlags,
+	transport string,
+	runtimeFactory appserver.RuntimeModelFactory,
+	validateSelection bool,
+) (*appserver.Server, func(), error) {
 	workDir, err := filepath.Abs(flags.workDir)
 	if err != nil {
 		return nil, nil, fmt.Errorf("resolve workdir: %w", err)
@@ -326,6 +341,7 @@ func newCLIAppServerWithRuntimeFactory(flags appServerFlags, transport string, r
 	if version == "" {
 		version = "dev"
 	}
+	catalogSvc := catalog.NewDefault()
 	opts := []appserver.Option{
 		appserver.WithImplementationInfo(protocol.ImplementationInfo{Name: "gollem-appserver", Version: version}),
 		appserver.WithInitializeHome(filepath.Join(workDir, ".gollem")),
@@ -350,6 +366,12 @@ func newCLIAppServerWithRuntimeFactory(flags appServerFlags, transport string, r
 		appserver.WithApprovalService(approvals),
 		appserver.WithInteractionService(interactionSvc),
 		appserver.WithRuntimeService(runtimeSvc),
+		appserver.WithCatalog(catalogSvc),
+	}
+	if validateSelection {
+		opts = append(opts, appserver.WithRuntimeSelectionValidator(
+			appServerRuntimeSelectionValidator(flags, catalogSvc),
+		))
 	}
 	if flags.workspaceCoordinator != nil {
 		opts = append(opts, appserver.WithWorkspaceMutationCoordinator(flags.workspaceCoordinator))
@@ -681,6 +703,22 @@ func appServerRuntimeModelFactory(flags appServerFlags) appserver.RuntimeModelFa
 			Provider:   provider,
 			Model:      modelName,
 		}, nil
+	}
+}
+
+func appServerRuntimeSelectionValidator(flags appServerFlags, catalogSvc *catalog.Catalog) appserver.RuntimeSelectionValidator {
+	return func(selection appserver.RuntimeModelSelection) error {
+		provider := firstNonEmptyAppServer(selection.ProviderID, selection.Provider, flags.provider)
+		// The built-in deterministic model is a credential-free CLI fixture, not
+		// a catalog-backed external provider.
+		if strings.EqualFold(strings.TrimSpace(provider), "test") {
+			return nil
+		}
+		if provider == "" {
+			provider = detectProvider()
+		}
+		modelName := firstNonEmptyAppServer(selection.Model, flags.modelName)
+		return catalogSvc.ValidateAgentRuntimeSelection(provider, modelName)
 	}
 }
 

--- a/cmd/gollem/app_server_test.go
+++ b/cmd/gollem/app_server_test.go
@@ -922,6 +922,30 @@ func TestCLIAppServerThreadStartUsesRuntimeProviderFlag(t *testing.T) {
 	waitCLINotification(t, server, "turn/completed")
 }
 
+func TestCLIAppServerCapabilityGateRejectsUnconfiguredProvider(t *testing.T) {
+	server, cleanup, err := newCLIAppServer(appServerFlags{
+		workDir:   t.TempDir(),
+		storePath: ":memory:",
+		provider:  catalog.ProviderAnthropic,
+		stdio:     true,
+	})
+	if err != nil {
+		t.Fatalf("newCLIAppServer: %v", err)
+	}
+	defer cleanup()
+	readyCLIAppServer(t, server)
+
+	response := server.HandleRequest(context.Background(), protocol.Request{
+		ID:     protocol.NewStringID("rejected-capability"),
+		Method: "thread/start",
+		Params: json.RawMessage(`{"prompt":"do not create a thread"}`),
+	})
+	if response.Error == nil || response.Error.Code != protocol.CodeInvalidParams ||
+		!strings.Contains(response.Error.Message, "not configured") {
+		t.Fatalf("thread/start error = %#v", response.Error)
+	}
+}
+
 func TestCLIAppServerRuntimeFactoryUsesLocalOpenAICompatibleProfile(t *testing.T) {
 	var requests int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/docs/PROVIDER_DRIVER_CONFORMANCE.md
+++ b/docs/PROVIDER_DRIVER_CONFORMANCE.md
@@ -25,7 +25,7 @@ of behavior and must not enable a control solely on provider identity.
 | Request deadline propagation | Proven | Proven | Proven | `provider/conformance` confirms HTTP request cancellation and `context.DeadlineExceeded` normalization |
 | Post-output retry / replay | Not yet proven | Not yet proven | Not yet proven | A stream may have produced caller-visible output; recovery must not replay it without an explicit safe-resume contract |
 | Endpoint health probe | Unsupported | Proven | Unsupported | `provider/health/probe` performs a loopback-only `GET /v1/models`; it returns only a typed status and never starts a model turn |
-| Capability mismatch | Not yet proven | Not yet proven | Not yet proven | Must remain a typed unavailable/degraded state |
+| Capability mismatch | Catalog/daemon proven | Catalog/daemon proven | Catalog/daemon proven | `ValidateAgentRuntimeSelection` rejects unconfigured, unknown, cross-provider, and non-streaming/non-tool-capable selections before the daemon persists a thread or turn; Slang continues to render the same condition as unavailable |
 
 `Catalog-supported` means the catalog may expose the capability only for the
 listed provider/model profile. It does not make that behavior part of the common


### PR DESCRIPTION
## Summary
- reject unconfigured, unknown, cross-provider, and non-agent-capable catalog selections before threads or turns persist
- wire the real CLI app-server to one process-owned catalog validator while retaining the deterministic test provider
- record the bounded catalog/daemon capability-mismatch proof and add focused tests

## Verification
- `go test ./appserver/catalog ./appserver ./cmd/gollem`
- non-Monty `go test` suite
- non-Monty `go vet` suite
- `go mod tidy -diff` and `go mod verify`
- repository pre-push: `golangci-lint run ./...`, non-Monty `go test -race ./...`, `go vet`, tidy check