### PR TITLE
Exercise provider disconnect conformance

### DIFF
--- a/docs/PROVIDER_DRIVER_CONFORMANCE.md
+++ b/docs/PROVIDER_DRIVER_CONFORMANCE.md
@@ -20,7 +20,7 @@ of behavior and must not enable a control solely on provider identity.
 | Prompt cache / Responses API | Catalog-supported where applicable | Unsupported | Catalog-supported where applicable | Provider-specific tests; no common conformance claim yet |
 | Malformed JSON stream event normalization | Proven | Proven | Proven | `provider/conformance` plus provider parser tests; returns `StreamProtocolError` without raw event data |
 | Abrupt EOF partial-stream result | Proven | Proven | Proven | `provider/conformance` plus provider parser tests; preserves partial response and returns `StreamIncompleteError` |
-| Read-error peer-disconnect classification | Proven | Proven | Proven | Provider parser tests; returns source-free `StreamTransportError`, while context cancellation remains intact |
+| Read-error peer-disconnect classification | Proven | Proven | Proven | `provider/conformance` plus provider parser tests; returns source-free `StreamTransportError`, while context cancellation remains intact |
 | Retryable 429 request recovery | Proven | Proven | Proven | `provider/conformance` exercises bounded `modelutil.RetryModel` recovery |
 | Request deadline propagation | Proven | Proven | Proven | `provider/conformance` confirms HTTP request cancellation and `context.DeadlineExceeded` normalization |
 | Post-output retry / replay | Not yet proven | Not yet proven | Not yet proven | A stream may have produced caller-visible output; recovery must not replay it without an explicit safe-resume contract |

--- a/provider/conformance/conformance.go
+++ b/provider/conformance/conformance.go
@@ -27,6 +27,7 @@ type Claims struct {
 	Cancellation        bool
 	PartialStream       bool
 	MalformedStream     bool
+	DisconnectStream    bool
 	Retryability        bool
 	RequestTimeout      bool
 	ReasoningVisibility bool
@@ -36,12 +37,13 @@ type Claims struct {
 // produces. ToolName is required when Claims.ToolCalls is true. StreamText is
 // required when Claims.Streaming is true.
 type Expectations struct {
-	ResponseText  string
-	ToolName      string
-	StreamText    string
-	PartialText   string
-	RetryText     string
-	ReasoningText string
+	ResponseText   string
+	ToolName       string
+	StreamText     string
+	PartialText    string
+	DisconnectText string
+	RetryText      string
+	ReasoningText  string
 }
 
 // Driver binds a provider model to the common capability claims and expected
@@ -76,6 +78,9 @@ func Verify(ctx context.Context, driver Driver) error {
 	}
 	if driver.Claims.PartialStream && strings.TrimSpace(driver.Expectations.PartialText) == "" {
 		return fmt.Errorf("provider conformance: %s partial-stream fixture must expect partial text", driver.Name)
+	}
+	if driver.Claims.DisconnectStream && strings.TrimSpace(driver.Expectations.DisconnectText) == "" {
+		return fmt.Errorf("provider conformance: %s disconnect-stream fixture must expect partial text", driver.Name)
 	}
 	if driver.Claims.Retryability && strings.TrimSpace(driver.Expectations.RetryText) == "" {
 		return fmt.Errorf("provider conformance: %s retry fixture must expect retry text", driver.Name)
@@ -162,6 +167,11 @@ func Verify(ctx context.Context, driver Driver) error {
 	}
 	if driver.Claims.MalformedStream {
 		if err := verifyMalformedStream(ctx, driver); err != nil {
+			return err
+		}
+	}
+	if driver.Claims.DisconnectStream {
+		if err := verifyDisconnectStream(ctx, driver); err != nil {
 			return err
 		}
 	}
@@ -265,6 +275,29 @@ func verifyMalformedStream(ctx context.Context, driver Driver) error {
 		}
 		return nil
 	}
+}
+
+func verifyDisconnectStream(ctx context.Context, driver Driver) error {
+	stream, err := driver.Model.RequestStream(ctx, disconnectStreamMessages(), nil, &core.ModelRequestParameters{AllowTextOutput: true})
+	if err != nil {
+		return fmt.Errorf("provider conformance: %s disconnect stream request: %w", driver.Name, err)
+	}
+	defer stream.Close()
+	for {
+		_, err := stream.Next()
+		if err == nil {
+			continue
+		}
+		var transport *core.StreamTransportError
+		if !errors.As(err, &transport) {
+			return fmt.Errorf("provider conformance: %s disconnect stream error = %w, want StreamTransportError", driver.Name, err)
+		}
+		break
+	}
+	if got := stream.Response().TextContent(); got != driver.Expectations.DisconnectText {
+		return fmt.Errorf("provider conformance: %s disconnect text = %q, want %q", driver.Name, got, driver.Expectations.DisconnectText)
+	}
+	return nil
 }
 
 func verifyRetryability(ctx context.Context, driver Driver) error {
@@ -384,6 +417,12 @@ func partialStreamMessages() []core.ModelMessage {
 func malformedStreamMessages() []core.ModelMessage {
 	return []core.ModelMessage{
 		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "malformed stream conformance"}}},
+	}
+}
+
+func disconnectStreamMessages() []core.ModelMessage {
+	return []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "disconnect stream conformance"}}},
 	}
 }
 

--- a/provider/conformance/conformance_test.go
+++ b/provider/conformance/conformance_test.go
@@ -39,16 +39,17 @@ func TestDeterministicProviderDriverConformance(t *testing.T) {
 					Name:                "native OpenAI",
 					Model:               openai.New(openai.WithAPIKey("test-openai-key"), openai.WithBaseURL(openAIServer.URL), openai.WithModel("gpt-4o")),
 					ReasoningModel:      openai.New(openai.WithAPIKey("test-openai-key"), openai.WithBaseURL(openAIServer.URL), openai.WithModel("gpt-5")),
-					Claims:              conformance.Claims{ToolCalls: true, Streaming: true, Usage: true, Cancellation: true, PartialStream: true, MalformedStream: true, Retryability: true, RequestTimeout: true, ReasoningVisibility: true},
+					Claims:              conformance.Claims{ToolCalls: true, Streaming: true, Usage: true, Cancellation: true, PartialStream: true, MalformedStream: true, DisconnectStream: true, Retryability: true, RequestTimeout: true, ReasoningVisibility: true},
 					CancellationReady:   openAICancellationReady,
 					RequestTimeoutReady: openAITimeout.readyFor("gpt-4o"),
 					Expectations: conformance.Expectations{
-						ResponseText:  "openai response",
-						ToolName:      "conformance_echo",
-						StreamText:    "openai stream",
-						PartialText:   "openai partial",
-						RetryText:     "openai retry",
-						ReasoningText: "openai reasoning",
+						ResponseText:   "openai response",
+						ToolName:       "conformance_echo",
+						StreamText:     "openai stream",
+						PartialText:    "openai partial",
+						DisconnectText: "openai disconnect",
+						RetryText:      "openai retry",
+						ReasoningText:  "openai reasoning",
 					},
 				}, nil
 			},
@@ -67,15 +68,16 @@ func TestDeterministicProviderDriverConformance(t *testing.T) {
 				return conformance.Driver{
 					Name:                "OpenAI-compatible local",
 					Model:               model,
-					Claims:              conformance.Claims{ToolCalls: true, Streaming: true, Usage: true, Cancellation: true, PartialStream: true, MalformedStream: true, Retryability: true, RequestTimeout: true},
+					Claims:              conformance.Claims{ToolCalls: true, Streaming: true, Usage: true, Cancellation: true, PartialStream: true, MalformedStream: true, DisconnectStream: true, Retryability: true, RequestTimeout: true},
 					CancellationReady:   openAICancellationReady,
 					RequestTimeoutReady: openAITimeout.readyFor("gpt-5.2-codex"),
 					Expectations: conformance.Expectations{
-						ResponseText: "openai response",
-						ToolName:     "conformance_echo",
-						StreamText:   "openai stream",
-						PartialText:  "openai partial",
-						RetryText:    "openai retry",
+						ResponseText:   "openai response",
+						ToolName:       "conformance_echo",
+						StreamText:     "openai stream",
+						PartialText:    "openai partial",
+						DisconnectText: "openai disconnect",
+						RetryText:      "openai retry",
 					},
 				}, nil
 			},
@@ -88,16 +90,17 @@ func TestDeterministicProviderDriverConformance(t *testing.T) {
 					Name:                "native Anthropic",
 					Model:               model,
 					ReasoningModel:      model,
-					Claims:              conformance.Claims{ToolCalls: true, Streaming: true, Usage: true, Cancellation: true, PartialStream: true, MalformedStream: true, Retryability: true, RequestTimeout: true, ReasoningVisibility: true},
+					Claims:              conformance.Claims{ToolCalls: true, Streaming: true, Usage: true, Cancellation: true, PartialStream: true, MalformedStream: true, DisconnectStream: true, Retryability: true, RequestTimeout: true, ReasoningVisibility: true},
 					CancellationReady:   anthropicCancellationReady,
 					RequestTimeoutReady: anthropicTimeout.readyFor(anthropic.ClaudeSonnet46),
 					Expectations: conformance.Expectations{
-						ResponseText:  "anthropic response",
-						ToolName:      "conformance_echo",
-						StreamText:    "anthropic stream",
-						PartialText:   "anthropic partial",
-						RetryText:     "anthropic retry",
-						ReasoningText: "anthropic reasoning",
+						ResponseText:   "anthropic response",
+						ToolName:       "conformance_echo",
+						StreamText:     "anthropic stream",
+						PartialText:    "anthropic partial",
+						DisconnectText: "anthropic disconnect",
+						RetryText:      "anthropic retry",
+						ReasoningText:  "anthropic reasoning",
 					},
 				}, nil
 			},
@@ -141,6 +144,14 @@ func TestVerifyRejectsUnprovenClaims(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("Verify accepted a partial stream claim without expected partial text")
+	}
+	err = conformance.Verify(context.Background(), conformance.Driver{
+		Name:   "missing disconnect stream fixture",
+		Model:  openai.New(openai.WithAPIKey("test-key")),
+		Claims: conformance.Claims{DisconnectStream: true},
+	})
+	if err == nil {
+		t.Fatal("Verify accepted a disconnect stream claim without expected partial text")
 	}
 	err = conformance.Verify(context.Background(), conformance.Driver{
 		Name:   "missing retry fixture",
@@ -213,6 +224,12 @@ func openAIConformanceFixture(t *testing.T, cancellationReady chan<- struct{}, r
 		if strings.Contains(string(body), "partial stream conformance") {
 			w.Header().Set("Content-Type", "text/event-stream")
 			_, _ = fmt.Fprint(w, "data: {\"id\":\"chatcmpl-partial\",\"object\":\"chat.completion.chunk\",\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"openai partial\"},\"finish_reason\":null}]}\n\n")
+			return
+		}
+		if strings.Contains(string(body), "disconnect stream conformance") {
+			writeTruncatedSSE(w, `data: {"id":"chatcmpl-disconnect","object":"chat.completion.chunk","model":"gpt-4o","choices":[{"index":0,"delta":{"content":"openai disconnect"},"finish_reason":null}]}
+
+`)
 			return
 		}
 		if strings.Contains(string(body), "malformed stream conformance") {
@@ -320,6 +337,16 @@ func anthropicConformanceFixture(t *testing.T, cancellationReady chan<- struct{}
 			_, _ = fmt.Fprint(w, "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"anthropic partial\"}}\n\n")
 			return
 		}
+		if strings.Contains(string(body), "disconnect stream conformance") {
+			writeTruncatedSSE(w, `event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"anthropic disconnect"}}
+
+`)
+			return
+		}
 		if strings.Contains(string(body), "malformed stream conformance") {
 			w.Header().Set("Content-Type", "text/event-stream")
 			_, _ = fmt.Fprint(w, "event: content_block_delta\ndata: {\"fixture_sensitive\":\n\n")
@@ -400,6 +427,15 @@ data: {"type":"message_stop"}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = fmt.Fprint(w, `{"id":"msg-conformance","role":"assistant","model":"claude-sonnet-4-6","content":[{"type":"text","text":"anthropic response"},{"type":"tool_use","id":"call_anthropic","name":"conformance_echo","input":{"value":"ok"}}],"stop_reason":"tool_use","usage":{"input_tokens":3,"output_tokens":2}}`)
 	})
+}
+
+func writeTruncatedSSE(w http.ResponseWriter, body string) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Content-Length", fmt.Sprintf("%d", len(body)+1))
+	_, _ = fmt.Fprint(w, body)
+	if flusher, ok := w.(http.Flusher); ok {
+		flusher.Flush()
+	}
 }
 
 func waitForCancellation(request *http.Request, ready chan<- struct{}) {


### PR DESCRIPTION
## Summary
- add a reusable `DisconnectStream` conformance claim for model drivers
- exercise native OpenAI, OpenAI-compatible local, and native Anthropic against valid partial SSE followed by a deliberately truncated HTTP body
- require retained partial text and a source-free `core.StreamTransportError`
- document the common harness as evidence for peer-disconnect classification

## Verification
- `go test ./provider/conformance ./provider/openai ./provider/anthropic`
- `go test -race ./provider/conformance ./provider/openai ./provider/anthropic`
- `go vet ./provider/conformance ./provider/openai ./provider/anthropic`
- non-Monty `go test ./...` and `go vet ./...`
- `go mod tidy -diff` and `go mod verify`
- pre-push full non-Monty race suite, lint, vet, and tidy verification

The scenario deliberately does not claim automatic post-output retry or replay. A partial model response is caller-visible evidence and remains unsafe to reissue without an explicit resume contract.