### PR TITLE
Exercise streaming deadline conformance

### DIFF
--- a/docs/PROVIDER_DRIVER_CONFORMANCE.md
+++ b/docs/PROVIDER_DRIVER_CONFORMANCE.md
@@ -22,7 +22,7 @@ of behavior and must not enable a control solely on provider identity.
 | Abrupt EOF partial-stream result | Proven | Proven | Proven | `provider/conformance` plus provider parser tests; preserves partial response and returns `StreamIncompleteError` |
 | Read-error peer-disconnect classification | Proven | Proven | Proven | `provider/conformance` plus provider parser tests; returns source-free `StreamTransportError`, while context cancellation remains intact |
 | Retryable 429 request recovery | Proven | Proven | Proven | `provider/conformance` exercises bounded `modelutil.RetryModel` recovery |
-| Request deadline propagation | Proven | Proven | Proven | `provider/conformance` confirms HTTP request cancellation and `context.DeadlineExceeded` normalization |
+| Request deadline propagation | Proven | Proven | Proven | `provider/conformance` confirms initial-request and post-header streaming cancellation with `context.DeadlineExceeded` normalization |
 | Post-output retry / replay | Not yet proven | Not yet proven | Not yet proven | A stream may have produced caller-visible output; recovery must not replay it without an explicit safe-resume contract |
 | Endpoint health probe | Unsupported | Proven | Unsupported | `provider/health/probe` performs a loopback-only `GET /v1/models`; it returns only a typed status and never starts a model turn |
 | Capability mismatch | Catalog/daemon proven | Catalog/daemon proven | Catalog/daemon proven | `ValidateAgentRuntimeSelection` rejects unconfigured, unknown, cross-provider, and non-streaming/non-tool-capable selections before the daemon persists a thread or turn; Slang continues to render the same condition as unavailable |

--- a/provider/conformance/conformance.go
+++ b/provider/conformance/conformance.go
@@ -30,6 +30,7 @@ type Claims struct {
 	DisconnectStream    bool
 	Retryability        bool
 	RequestTimeout      bool
+	StreamTimeout       bool
 	ReasoningVisibility bool
 }
 
@@ -37,13 +38,14 @@ type Claims struct {
 // produces. ToolName is required when Claims.ToolCalls is true. StreamText is
 // required when Claims.Streaming is true.
 type Expectations struct {
-	ResponseText   string
-	ToolName       string
-	StreamText     string
-	PartialText    string
-	DisconnectText string
-	RetryText      string
-	ReasoningText  string
+	ResponseText      string
+	ToolName          string
+	StreamText        string
+	PartialText       string
+	DisconnectText    string
+	RetryText         string
+	StreamTimeoutText string
+	ReasoningText     string
 }
 
 // Driver binds a provider model to the common capability claims and expected
@@ -88,6 +90,9 @@ func Verify(ctx context.Context, driver Driver) error {
 	if driver.Claims.RequestTimeout && driver.RequestTimeoutReady == nil {
 		return fmt.Errorf("provider conformance: %s timeout-capable fixture must signal request start", driver.Name)
 	}
+	if driver.Claims.StreamTimeout && strings.TrimSpace(driver.Expectations.StreamTimeoutText) == "" {
+		return fmt.Errorf("provider conformance: %s stream-timeout fixture must expect partial text", driver.Name)
+	}
 	if driver.Claims.ReasoningVisibility && driver.ReasoningModel == nil {
 		return fmt.Errorf("provider conformance: %s reasoning-capable fixture must supply a reasoning model", driver.Name)
 	}
@@ -126,6 +131,11 @@ func Verify(ctx context.Context, driver Driver) error {
 	}
 	if driver.Claims.RequestTimeout {
 		if err := verifyRequestTimeout(ctx, driver); err != nil {
+			return err
+		}
+	}
+	if driver.Claims.StreamTimeout {
+		if err := verifyStreamTimeout(ctx, driver); err != nil {
 			return err
 		}
 	}
@@ -233,6 +243,30 @@ func verifyRequestTimeout(ctx context.Context, driver Driver) error {
 	case <-time.After(time.Second):
 		return fmt.Errorf("provider conformance: %s timeout request did not finish", driver.Name)
 	}
+}
+
+func verifyStreamTimeout(ctx context.Context, driver Driver) error {
+	requestContext, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	defer cancel()
+	stream, err := driver.Model.RequestStream(requestContext, streamTimeoutMessages(), nil, &core.ModelRequestParameters{AllowTextOutput: true})
+	if err != nil {
+		return fmt.Errorf("provider conformance: %s stream-timeout request: %w", driver.Name, err)
+	}
+	defer stream.Close()
+	for {
+		_, err := stream.Next()
+		if err == nil {
+			continue
+		}
+		if !errors.Is(err, context.DeadlineExceeded) {
+			return fmt.Errorf("provider conformance: %s stream-timeout error, want context deadline exceeded: %w", driver.Name, err)
+		}
+		break
+	}
+	if got := stream.Response().TextContent(); got != driver.Expectations.StreamTimeoutText {
+		return fmt.Errorf("provider conformance: %s stream-timeout text = %q, want %q", driver.Name, got, driver.Expectations.StreamTimeoutText)
+	}
+	return nil
 }
 
 func verifyPartialStream(ctx context.Context, driver Driver) error {
@@ -435,6 +469,12 @@ func retryMessages() []core.ModelMessage {
 func timeoutMessages() []core.ModelMessage {
 	return []core.ModelMessage{
 		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "timeout conformance"}}},
+	}
+}
+
+func streamTimeoutMessages() []core.ModelMessage {
+	return []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "stream timeout conformance"}}},
 	}
 }
 

--- a/provider/conformance/conformance_test.go
+++ b/provider/conformance/conformance_test.go
@@ -39,17 +39,18 @@ func TestDeterministicProviderDriverConformance(t *testing.T) {
 					Name:                "native OpenAI",
 					Model:               openai.New(openai.WithAPIKey("test-openai-key"), openai.WithBaseURL(openAIServer.URL), openai.WithModel("gpt-4o")),
 					ReasoningModel:      openai.New(openai.WithAPIKey("test-openai-key"), openai.WithBaseURL(openAIServer.URL), openai.WithModel("gpt-5")),
-					Claims:              conformance.Claims{ToolCalls: true, Streaming: true, Usage: true, Cancellation: true, PartialStream: true, MalformedStream: true, DisconnectStream: true, Retryability: true, RequestTimeout: true, ReasoningVisibility: true},
+					Claims:              conformance.Claims{ToolCalls: true, Streaming: true, Usage: true, Cancellation: true, PartialStream: true, MalformedStream: true, DisconnectStream: true, Retryability: true, RequestTimeout: true, StreamTimeout: true, ReasoningVisibility: true},
 					CancellationReady:   openAICancellationReady,
 					RequestTimeoutReady: openAITimeout.readyFor("gpt-4o"),
 					Expectations: conformance.Expectations{
-						ResponseText:   "openai response",
-						ToolName:       "conformance_echo",
-						StreamText:     "openai stream",
-						PartialText:    "openai partial",
-						DisconnectText: "openai disconnect",
-						RetryText:      "openai retry",
-						ReasoningText:  "openai reasoning",
+						ResponseText:      "openai response",
+						ToolName:          "conformance_echo",
+						StreamText:        "openai stream",
+						PartialText:       "openai partial",
+						DisconnectText:    "openai disconnect",
+						RetryText:         "openai retry",
+						StreamTimeoutText: "openai deadline",
+						ReasoningText:     "openai reasoning",
 					},
 				}, nil
 			},
@@ -68,16 +69,17 @@ func TestDeterministicProviderDriverConformance(t *testing.T) {
 				return conformance.Driver{
 					Name:                "OpenAI-compatible local",
 					Model:               model,
-					Claims:              conformance.Claims{ToolCalls: true, Streaming: true, Usage: true, Cancellation: true, PartialStream: true, MalformedStream: true, DisconnectStream: true, Retryability: true, RequestTimeout: true},
+					Claims:              conformance.Claims{ToolCalls: true, Streaming: true, Usage: true, Cancellation: true, PartialStream: true, MalformedStream: true, DisconnectStream: true, Retryability: true, RequestTimeout: true, StreamTimeout: true},
 					CancellationReady:   openAICancellationReady,
 					RequestTimeoutReady: openAITimeout.readyFor("gpt-5.2-codex"),
 					Expectations: conformance.Expectations{
-						ResponseText:   "openai response",
-						ToolName:       "conformance_echo",
-						StreamText:     "openai stream",
-						PartialText:    "openai partial",
-						DisconnectText: "openai disconnect",
-						RetryText:      "openai retry",
+						ResponseText:      "openai response",
+						ToolName:          "conformance_echo",
+						StreamText:        "openai stream",
+						PartialText:       "openai partial",
+						DisconnectText:    "openai disconnect",
+						RetryText:         "openai retry",
+						StreamTimeoutText: "openai deadline",
 					},
 				}, nil
 			},
@@ -90,17 +92,18 @@ func TestDeterministicProviderDriverConformance(t *testing.T) {
 					Name:                "native Anthropic",
 					Model:               model,
 					ReasoningModel:      model,
-					Claims:              conformance.Claims{ToolCalls: true, Streaming: true, Usage: true, Cancellation: true, PartialStream: true, MalformedStream: true, DisconnectStream: true, Retryability: true, RequestTimeout: true, ReasoningVisibility: true},
+					Claims:              conformance.Claims{ToolCalls: true, Streaming: true, Usage: true, Cancellation: true, PartialStream: true, MalformedStream: true, DisconnectStream: true, Retryability: true, RequestTimeout: true, StreamTimeout: true, ReasoningVisibility: true},
 					CancellationReady:   anthropicCancellationReady,
 					RequestTimeoutReady: anthropicTimeout.readyFor(anthropic.ClaudeSonnet46),
 					Expectations: conformance.Expectations{
-						ResponseText:   "anthropic response",
-						ToolName:       "conformance_echo",
-						StreamText:     "anthropic stream",
-						PartialText:    "anthropic partial",
-						DisconnectText: "anthropic disconnect",
-						RetryText:      "anthropic retry",
-						ReasoningText:  "anthropic reasoning",
+						ResponseText:      "anthropic response",
+						ToolName:          "conformance_echo",
+						StreamText:        "anthropic stream",
+						PartialText:       "anthropic partial",
+						DisconnectText:    "anthropic disconnect",
+						RetryText:         "anthropic retry",
+						StreamTimeoutText: "anthropic deadline",
+						ReasoningText:     "anthropic reasoning",
 					},
 				}, nil
 			},
@@ -170,6 +173,14 @@ func TestVerifyRejectsUnprovenClaims(t *testing.T) {
 		t.Fatal("Verify accepted a timeout claim without a start signal")
 	}
 	err = conformance.Verify(context.Background(), conformance.Driver{
+		Name:   "missing stream timeout fixture",
+		Model:  openai.New(openai.WithAPIKey("test-key")),
+		Claims: conformance.Claims{StreamTimeout: true},
+	})
+	if err == nil {
+		t.Fatal("Verify accepted a stream timeout claim without expected partial text")
+	}
+	err = conformance.Verify(context.Background(), conformance.Driver{
 		Name:   "missing reasoning model",
 		Model:  openai.New(openai.WithAPIKey("test-key")),
 		Claims: conformance.Claims{ReasoningVisibility: true},
@@ -215,6 +226,12 @@ func openAIConformanceFixture(t *testing.T, cancellationReady chan<- struct{}, r
 		}
 		if strings.Contains(string(body), "cancel conformance") {
 			waitForCancellation(r, cancellationReady)
+			return
+		}
+		if strings.Contains(string(body), "stream timeout conformance") {
+			writeDeadlineBoundSSE(w, r, `data: {"id":"chatcmpl-deadline","object":"chat.completion.chunk","model":"gpt-4o","choices":[{"index":0,"delta":{"content":"openai deadline"},"finish_reason":null}]}
+
+`)
 			return
 		}
 		if strings.Contains(string(body), "timeout conformance") {
@@ -328,6 +345,16 @@ func anthropicConformanceFixture(t *testing.T, cancellationReady chan<- struct{}
 			waitForCancellation(r, cancellationReady)
 			return
 		}
+		if strings.Contains(string(body), "stream timeout conformance") {
+			writeDeadlineBoundSSE(w, r, `event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"anthropic deadline"}}
+
+`)
+			return
+		}
 		if strings.Contains(string(body), "timeout conformance") {
 			timeout.waitForCancellation(r.Context(), request.Model)
 			return
@@ -436,6 +463,15 @@ func writeTruncatedSSE(w http.ResponseWriter, body string) {
 	if flusher, ok := w.(http.Flusher); ok {
 		flusher.Flush()
 	}
+}
+
+func writeDeadlineBoundSSE(w http.ResponseWriter, request *http.Request, body string) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	_, _ = fmt.Fprint(w, body)
+	if flusher, ok := w.(http.Flusher); ok {
+		flusher.Flush()
+	}
+	<-request.Context().Done()
 }
 
 func waitForCancellation(request *http.Request, ready chan<- struct{}) {


### PR DESCRIPTION
## Summary
- add a reusable `StreamTimeout` conformance claim for a live SSE response
- verify native OpenAI, OpenAI-compatible local, and native Anthropic retain partial text when their request context expires after response headers
- require the terminal stream error to remain `context.DeadlineExceeded`, not `StreamTransportError`
- clarify that the deadline matrix row covers both initial request and post-header stream reads

## Verification
- `go test -count=1 ./provider/conformance ./provider/openai ./provider/anthropic`
- `go test -race -count=1 ./provider/conformance ./provider/openai ./provider/anthropic`
- `go vet ./provider/conformance ./provider/openai ./provider/anthropic`
- non-Monty `go test ./...` and `go vet ./...`
- `go mod tidy -diff`, `go mod verify`, and focused `golangci-lint`
- pre-push full non-Monty race suite, lint, vet, and tidy verification

The fixture handles `stream timeout conformance` before the existing request-timeout branch, sends a valid partial SSE payload, flushes headers, and waits for the request context to expire. It does not add retry or replay behavior.