### PR TITLE
Verify tool call identities in provider conformance

### DIFF
--- a/docs/PROVIDER_DRIVER_CONFORMANCE.md
+++ b/docs/PROVIDER_DRIVER_CONFORMANCE.md
@@ -11,7 +11,7 @@ of behavior and must not enable a control solely on provider identity.
 | Behavior | Native OpenAI | OpenAI-compatible local | Native Anthropic | Evidence |
 | --- | --- | --- | --- | --- |
 | Non-stream text response | Proven | Proven | Proven | `provider/conformance` |
-| Function-tool request and normalized tool call | Proven | Proven | Proven | `provider/conformance` |
+| Function-tool request and normalized tool-call name, ID, and argument JSON | Proven | Proven | Proven | `provider/conformance` |
 | Streaming text and terminal usage | Proven | Proven | Proven | `provider/conformance` |
 | In-flight request cancellation | Proven | Proven | Proven | `provider/conformance` |
 | Structured output | Catalog-supported | Unsupported | Catalog-supported | Provider-specific tests; no common conformance claim yet |

--- a/provider/conformance/conformance.go
+++ b/provider/conformance/conformance.go
@@ -35,11 +35,14 @@ type Claims struct {
 }
 
 // Expectations declares the normalized outputs a deterministic fixture
-// produces. ToolName is required when Claims.ToolCalls is true. StreamText is
-// required when Claims.Streaming is true.
+// produces. ToolName, ToolCallID, and ToolArgumentsJSON are required when
+// Claims.ToolCalls is true. StreamText is required when Claims.Streaming is
+// true.
 type Expectations struct {
 	ResponseText      string
 	ToolName          string
+	ToolCallID        string
+	ToolArgumentsJSON string
 	StreamText        string
 	PartialText       string
 	DisconnectText    string
@@ -71,6 +74,12 @@ func Verify(ctx context.Context, driver Driver) error {
 	}
 	if driver.Claims.ToolCalls && strings.TrimSpace(driver.Expectations.ToolName) == "" {
 		return fmt.Errorf("provider conformance: %s tool-capable fixture must expect a tool call", driver.Name)
+	}
+	if driver.Claims.ToolCalls && strings.TrimSpace(driver.Expectations.ToolCallID) == "" {
+		return fmt.Errorf("provider conformance: %s tool-capable fixture must expect a tool call ID", driver.Name)
+	}
+	if driver.Claims.ToolCalls && strings.TrimSpace(driver.Expectations.ToolArgumentsJSON) == "" {
+		return fmt.Errorf("provider conformance: %s tool-capable fixture must expect tool arguments", driver.Name)
 	}
 	if driver.Claims.Streaming && strings.TrimSpace(driver.Expectations.StreamText) == "" {
 		return fmt.Errorf("provider conformance: %s streaming fixture must expect stream text", driver.Name)
@@ -412,8 +421,10 @@ func verifyResponse(driver Driver, response *core.ModelResponse, streaming bool)
 	if got := response.TextContent(); got != wantText {
 		return fmt.Errorf("provider conformance: %s text = %q, want %q", driver.Name, got, wantText)
 	}
-	if driver.Claims.ToolCalls && !streaming && !hasToolCall(response.Parts, driver.Expectations.ToolName) {
-		return fmt.Errorf("provider conformance: %s response did not contain tool %q", driver.Name, driver.Expectations.ToolName)
+	if driver.Claims.ToolCalls && !streaming {
+		if err := verifyToolCall(driver, response.Parts); err != nil {
+			return err
+		}
 	}
 	if driver.Claims.Usage && response.Usage.InputTokens+response.Usage.OutputTokens == 0 {
 		return fmt.Errorf("provider conformance: %s response did not report usage", driver.Name)
@@ -421,13 +432,45 @@ func verifyResponse(driver Driver, response *core.ModelResponse, streaming bool)
 	return nil
 }
 
-func hasToolCall(parts []core.ModelResponsePart, name string) bool {
+func verifyToolCall(driver Driver, parts []core.ModelResponsePart) error {
+	foundName := false
+	foundCallID := false
 	for _, part := range parts {
-		if call, ok := part.(core.ToolCallPart); ok && call.ToolName == name {
-			return true
+		call, ok := part.(core.ToolCallPart)
+		if !ok || call.ToolName != driver.Expectations.ToolName {
+			continue
+		}
+		foundName = true
+		if call.ToolCallID != driver.Expectations.ToolCallID {
+			continue
+		}
+		foundCallID = true
+		if call.ArgsJSON == driver.Expectations.ToolArgumentsJSON {
+			return nil
 		}
 	}
-	return false
+	if !foundName {
+		return fmt.Errorf(
+			"provider conformance: %s response did not contain tool %q",
+			driver.Name,
+			driver.Expectations.ToolName,
+		)
+	}
+	if !foundCallID {
+		return fmt.Errorf(
+			"provider conformance: %s response did not contain tool %q call ID %q",
+			driver.Name,
+			driver.Expectations.ToolName,
+			driver.Expectations.ToolCallID,
+		)
+	}
+	return fmt.Errorf(
+		"provider conformance: %s response did not contain tool %q arguments %q for call ID %q",
+		driver.Name,
+		driver.Expectations.ToolName,
+		driver.Expectations.ToolArgumentsJSON,
+		driver.Expectations.ToolCallID,
+	)
 }
 
 func conformanceMessages() []core.ModelMessage {

--- a/provider/conformance/conformance_test.go
+++ b/provider/conformance/conformance_test.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/fugue-labs/gollem/core"
 	"github.com/fugue-labs/gollem/provider/anthropic"
 	"github.com/fugue-labs/gollem/provider/conformance"
 	"github.com/fugue-labs/gollem/provider/openai"
@@ -45,6 +46,8 @@ func TestDeterministicProviderDriverConformance(t *testing.T) {
 					Expectations: conformance.Expectations{
 						ResponseText:      "openai response",
 						ToolName:          "conformance_echo",
+						ToolCallID:        "call_openai",
+						ToolArgumentsJSON: `{"value":"ok"}`,
 						StreamText:        "openai stream",
 						PartialText:       "openai partial",
 						DisconnectText:    "openai disconnect",
@@ -75,6 +78,8 @@ func TestDeterministicProviderDriverConformance(t *testing.T) {
 					Expectations: conformance.Expectations{
 						ResponseText:      "openai response",
 						ToolName:          "conformance_echo",
+						ToolCallID:        "call_openai",
+						ToolArgumentsJSON: `{"value":"ok"}`,
 						StreamText:        "openai stream",
 						PartialText:       "openai partial",
 						DisconnectText:    "openai disconnect",
@@ -98,6 +103,8 @@ func TestDeterministicProviderDriverConformance(t *testing.T) {
 					Expectations: conformance.Expectations{
 						ResponseText:      "anthropic response",
 						ToolName:          "conformance_echo",
+						ToolCallID:        "call_anthropic",
+						ToolArgumentsJSON: `{"value":"ok"}`,
 						StreamText:        "anthropic stream",
 						PartialText:       "anthropic partial",
 						DisconnectText:    "anthropic disconnect",
@@ -131,6 +138,30 @@ func TestVerifyRejectsUnprovenClaims(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("Verify accepted a tool claim without an expected tool")
+	}
+	err = conformance.Verify(context.Background(), conformance.Driver{
+		Name:   "missing tool call ID",
+		Model:  openai.New(openai.WithAPIKey("test-key")),
+		Claims: conformance.Claims{ToolCalls: true},
+		Expectations: conformance.Expectations{
+			ToolName:          "conformance_echo",
+			ToolArgumentsJSON: `{"value":"ok"}`,
+		},
+	})
+	if err == nil {
+		t.Fatal("Verify accepted a tool claim without an expected tool call ID")
+	}
+	err = conformance.Verify(context.Background(), conformance.Driver{
+		Name:   "missing tool arguments",
+		Model:  openai.New(openai.WithAPIKey("test-key")),
+		Claims: conformance.Claims{ToolCalls: true},
+		Expectations: conformance.Expectations{
+			ToolName:   "conformance_echo",
+			ToolCallID: "call_conformance",
+		},
+	})
+	if err == nil {
+		t.Fatal("Verify accepted a tool claim without expected tool arguments")
 	}
 	err = conformance.Verify(context.Background(), conformance.Driver{
 		Name:   "missing cancellation fixture",
@@ -196,6 +227,76 @@ func TestVerifyRejectsUnprovenClaims(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("Verify accepted a reasoning claim without expected reasoning text")
+	}
+}
+
+func TestVerifyRejectsToolCallFieldMismatch(t *testing.T) {
+	for _, tt := range []struct {
+		name          string
+		toolCallID    string
+		argumentsJSON string
+		want          string
+	}{
+		{
+			name:          "call ID",
+			toolCallID:    "call_other",
+			argumentsJSON: `{"value":"ok"}`,
+			want:          "call ID",
+		},
+		{
+			name:          "arguments",
+			toolCallID:    "call_conformance",
+			argumentsJSON: `{"value":"other"}`,
+			want:          "arguments",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			driver := conformance.Driver{
+				Name: "mismatched tool call",
+				Model: core.NewTestModel(core.ToolCallResponseWithID(
+					"conformance_echo",
+					`{"value":"ok"}`,
+					"call_conformance",
+				)),
+				Claims: conformance.Claims{ToolCalls: true},
+				Expectations: conformance.Expectations{
+					ToolName:          "conformance_echo",
+					ToolCallID:        tt.toolCallID,
+					ToolArgumentsJSON: tt.argumentsJSON,
+				},
+			}
+			err := conformance.Verify(context.Background(), driver)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Verify tool mismatch error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestVerifyMatchesTheExpectedToolCallAmongSameNamedCalls(t *testing.T) {
+	driver := conformance.Driver{
+		Name: "multiple tool calls",
+		Model: core.NewTestModel(core.MultiToolCallResponse(
+			core.ToolCallPart{
+				ToolName:   "conformance_echo",
+				ToolCallID: "call_first",
+				ArgsJSON:   `{"value":"first"}`,
+			},
+			core.ToolCallPart{
+				ToolName:   "conformance_echo",
+				ToolCallID: "call_expected",
+				ArgsJSON:   `{"value":"expected"}`,
+			},
+		)),
+		Claims: conformance.Claims{ToolCalls: true},
+		Expectations: conformance.Expectations{
+			ToolName:          "conformance_echo",
+			ToolCallID:        "call_expected",
+			ToolArgumentsJSON: `{"value":"expected"}`,
+		},
+	}
+	if err := conformance.Verify(context.Background(), driver); err != nil {
+		t.Fatalf("Verify multiple tool calls: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- require tool-call IDs and argument JSON in claimed tool-call conformance fixtures
- verify exact normalized tool-call identity across native OpenAI, local OpenAI-compatible, and native Anthropic drivers
- document the stronger common-driver guarantee

## Verification
- `go test ./provider/conformance`
- `go test -race ./provider/conformance`
- all Go tests and vet excluding `github.com/fugue-labs/gollem/ext/monty`
- `golangci-lint run`