### PR TITLE
protocol: export standalone thread rollback contracts

### DIFF
--- a/appserver/protocol/account_credit_nudge_values_contract_test.go
+++ b/appserver/protocol/account_credit_nudge_values_contract_test.go
@@ -119,8 +119,8 @@ func TestAccountCreditNudgeValuesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/sendAddCreditsNudgeEmail = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/account_envelope_contract_test.go
+++ b/appserver/protocol/account_envelope_contract_test.go
@@ -268,8 +268,8 @@ func TestAccountEnvelopeContractsRemainStandaloneAndDeferred(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred %s", methodName, method, ok, surface)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/account_login_completed_notification_contract_test.go
+++ b/appserver/protocol/account_login_completed_notification_contract_test.go
@@ -88,8 +88,8 @@ func TestAccountLoginCompletedNotificationRemainsStandaloneAndDeferred(t *testin
 	if !found {
 		t.Fatal("account/login/completed method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/account_rate_limits_contract_test.go
+++ b/appserver/protocol/account_rate_limits_contract_test.go
@@ -484,8 +484,8 @@ func TestAccountRateLimitContractsRemainStandaloneAndDeferred(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred %s", methodName, method, ok, surface)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/account_token_usage_contract_test.go
+++ b/appserver/protocol/account_token_usage_contract_test.go
@@ -146,8 +146,8 @@ func TestAccountTokenUsageRecordsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/usage/read = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(defs); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_config_contract_test.go
+++ b/appserver/protocol/app_config_contract_test.go
@@ -109,8 +109,8 @@ func TestAppConfigRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppConfig unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_info_contract_test.go
+++ b/appserver/protocol/app_info_contract_test.go
@@ -131,8 +131,8 @@ func TestAppInfoRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_list_updated_notification_contract_test.go
+++ b/appserver/protocol/app_list_updated_notification_contract_test.go
@@ -105,8 +105,8 @@ func TestAppListUpdatedNotificationRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceServerNotification || method.State != MethodDeferredStub {
 		t.Fatalf("app/list/updated = %#v, %v; want deferred server notification", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_metadata_contract_test.go
+++ b/appserver/protocol/app_metadata_contract_test.go
@@ -107,8 +107,8 @@ func TestAppMetadataRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_metadata_leaf_contract_test.go
+++ b/appserver/protocol/app_metadata_leaf_contract_test.go
@@ -157,8 +157,8 @@ func TestAppMetadataLeavesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_summary_contract_test.go
+++ b/appserver/protocol/app_summary_contract_test.go
@@ -87,8 +87,8 @@ func TestAppSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppSummary unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_template_summary_contract_test.go
+++ b/appserver/protocol/app_template_summary_contract_test.go
@@ -107,8 +107,8 @@ func TestAppTemplateSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppTemplateSummary unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_template_unavailable_reason_contract_test.go
+++ b/appserver/protocol/app_template_unavailable_reason_contract_test.go
@@ -71,8 +71,8 @@ func TestAppTemplateUnavailableReasonRemainsStandalone(t *testing.T) {
 			t.Fatalf("AppTemplateUnavailableReason unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_tool_approval_contract_test.go
+++ b/appserver/protocol/app_tool_approval_contract_test.go
@@ -73,8 +73,8 @@ func TestAppToolApprovalRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppToolApproval unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_tools_config_contract_test.go
+++ b/appserver/protocol/app_tools_config_contract_test.go
@@ -140,8 +140,8 @@ func TestAppToolConfigsRemainStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/apply_patch_approval_params_contract_test.go
+++ b/appserver/protocol/apply_patch_approval_params_contract_test.go
@@ -139,8 +139,8 @@ func TestApplyPatchApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ApplyPatchApprovalParams unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(defs); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(defs); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/apps_config_contract_test.go
+++ b/appserver/protocol/apps_config_contract_test.go
@@ -185,8 +185,8 @@ func TestAppsConfigsRemainStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/apps_list_contract_test.go
+++ b/appserver/protocol/apps_list_contract_test.go
@@ -168,8 +168,8 @@ func TestAppsListContractsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/attestation_contract_test.go
+++ b/appserver/protocol/attestation_contract_test.go
@@ -133,8 +133,8 @@ func TestAttestationContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("attestation/generate = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
+++ b/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
@@ -179,8 +179,8 @@ func TestChatgptAuthTokensRefreshRemainsStandaloneAndDeferred(t *testing.T) {
 	if !found {
 		t.Fatal("refresh method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/collaboration_capability_contract_test.go
+++ b/appserver/protocol/collaboration_capability_contract_test.go
@@ -346,8 +346,8 @@ func TestCollaborationCapabilityContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/dynamic_tool_spec_contract_test.go
+++ b/appserver/protocol/dynamic_tool_spec_contract_test.go
@@ -318,8 +318,8 @@ func TestDynamicToolSpecContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/exec_command_approval_params_contract_test.go
+++ b/appserver/protocol/exec_command_approval_params_contract_test.go
@@ -137,8 +137,8 @@ func TestExecCommandApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ExecCommandApprovalParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(defs); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/experimental_feature_contract_test.go
+++ b/appserver/protocol/experimental_feature_contract_test.go
@@ -41,8 +41,8 @@ func TestExperimentalFeatureContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want implemented client request", methodName, method, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d/%d/%d, want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,8 +217,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,8 +203,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -260,8 +260,8 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,8 +244,8 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -162,8 +162,8 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -175,8 +175,8 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/file_change_contract_test.go
+++ b/appserver/protocol/file_change_contract_test.go
@@ -108,8 +108,8 @@ func TestFileChangeRemainsStandalone(t *testing.T) {
 			t.Fatalf("FileChange unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/file_change_output_delta_notification_contract_test.go
+++ b/appserver/protocol/file_change_output_delta_notification_contract_test.go
@@ -100,8 +100,8 @@ func TestFileChangeOutputDeltaNotificationRemainsDeprecatedAndStandalone(t *test
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("item/fileChange/outputDelta = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -381,8 +381,8 @@ func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/guardian_approval_review_action_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_action_contract_test.go
@@ -226,8 +226,8 @@ func TestGuardianApprovalReviewActionRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReviewAction unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
@@ -164,8 +164,8 @@ func TestGuardianApprovalReviewCompletedNotificationRemainsStandalone(t *testing
 			t.Fatalf("completed notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/guardian_approval_review_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_contract_test.go
@@ -139,8 +139,8 @@ func TestGuardianApprovalReviewRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReview unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
@@ -175,8 +175,8 @@ func TestGuardianApprovalReviewStartedNotificationRemainsStandalone(t *testing.T
 			t.Fatalf("started notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/guardian_enum_foundation_contract_test.go
+++ b/appserver/protocol/guardian_enum_foundation_contract_test.go
@@ -89,8 +89,8 @@ func TestGuardianEnumFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/hook_metadata_list_contract_test.go
+++ b/appserver/protocol/hook_metadata_list_contract_test.go
@@ -352,8 +352,8 @@ func TestHookMetadataListContractsStayStandalone(t *testing.T) {
 			t.Errorf("standalone definition %s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Errorf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Errorf("definition count = %d, want 585", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 {
 		t.Errorf("wire binding count = %d, want 80", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/hook_run_notification_contract_test.go
+++ b/appserver/protocol/hook_run_notification_contract_test.go
@@ -297,8 +297,8 @@ func TestHookRunNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("surface changed: %d methods, %d wire bindings, %d item bindings", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/hook_value_foundation_contract_test.go
+++ b/appserver/protocol/hook_value_foundation_contract_test.go
@@ -167,8 +167,8 @@ func TestHookValueFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 583 {
-		t.Fatalf("definition count = %d, want 583", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 585 {
+		t.Fatalf("definition count = %d, want 585", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/legacy_approval_response_contract_test.go
+++ b/appserver/protocol/legacy_approval_response_contract_test.go
@@ -98,8 +98,8 @@ func TestLegacyApprovalResponsesRemainStandaloneAndNominal(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_oauth_login_contract_test.go
+++ b/appserver/protocol/mcp_server_oauth_login_contract_test.go
@@ -228,8 +228,8 @@ func TestMcpServerOauthLoginContractsRemainStandaloneAndBlocked(t *testing.T) {
 	if !ok || notification.Surface != SurfaceServerNotification || notification.State != MethodBlocked {
 		t.Fatalf("mcpServer/oauthLogin/completed = %#v, %v; want blocked server notification", notification, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d/%d/%d, want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_status_contract_test.go
+++ b/appserver/protocol/mcp_server_status_contract_test.go
@@ -277,8 +277,8 @@ func TestMcpServerStatusContractsRemainStandalone(t *testing.T) {
 	if !ok || method.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d/%d/%d, want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_approval_context_contract_test.go
+++ b/appserver/protocol/network_approval_context_contract_test.go
@@ -84,8 +84,8 @@ func TestNetworkApprovalContextRemainsStandalone(t *testing.T) {
 			t.Fatalf("NetworkApprovalContext unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/parsed_command_contract_test.go
+++ b/appserver/protocol/parsed_command_contract_test.go
@@ -120,8 +120,8 @@ func TestParsedCommandRemainsStandalone(t *testing.T) {
 			t.Fatalf("ParsedCommand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/permission_profile_list_contract_test.go
+++ b/appserver/protocol/permission_profile_list_contract_test.go
@@ -255,8 +255,8 @@ func TestPermissionProfileListContractsRemainStandalone(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodImplemented {
 		t.Fatalf("permissionProfile/list = %#v, %v; want existing implemented client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d/%d/%d, want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/process_contracts_contract_test.go
+++ b/appserver/protocol/process_contracts_contract_test.go
@@ -308,8 +308,8 @@ func TestProcessContractsRemainStandaloneFromLegacyRuntime(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want unchanged implemented notification", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 583 {
-		t.Fatalf("definition count = %d, want 583", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 585 {
+		t.Fatalf("definition count = %d, want 585", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 583 {
-		t.Fatalf("definition count = %d, want 583", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 585 {
+		t.Fatalf("definition count = %d, want 585", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 583 {
-		t.Fatalf("definition count = %d, want 583", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 585 {
+		t.Fatalf("definition count = %d, want 585", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 583 {
-		t.Fatalf("definition count = %d, want 583", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 585 {
+		t.Fatalf("definition count = %d, want 585", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 583 {
-		t.Fatalf("definition count = %d, want 583", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 585 {
+		t.Fatalf("definition count = %d, want 585", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/review_decision_contract_test.go
+++ b/appserver/protocol/review_decision_contract_test.go
@@ -136,8 +136,8 @@ func TestReviewDecisionRemainsStandalone(t *testing.T) {
 			t.Fatalf("ReviewDecision unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(defs); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/review_start_contract_test.go
+++ b/appserver/protocol/review_start_contract_test.go
@@ -215,8 +215,8 @@ func TestReviewStartContractsFailClosedAndRemainStandalone(t *testing.T) {
 	if !ok || request.Surface != SurfaceClientRequest || request.State != MethodBlocked {
 		t.Fatalf("review/start = %#v, %v; want blocked client request", request, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 }
 

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -546,6 +546,8 @@ func wireSchemaDefinitions() Schema {
 		{Name: "ThreadHistoryRollbackResult", Type: reflect.TypeFor[ThreadHistoryRollbackResult]()},
 		{Name: "ThreadInjectItemsParams", Type: reflect.TypeFor[ThreadInjectItemsParams]()},
 		{Name: "ThreadInjectItemsResponse", Type: reflect.TypeFor[ThreadInjectItemsResponse]()},
+		{Name: "ThreadRollbackParams", Type: reflect.TypeFor[ThreadRollbackParams]()},
+		{Name: "ThreadRollbackResponse", Type: reflect.TypeFor[ThreadRollbackResponse]()},
 		{Name: "ThreadId", Type: reflect.TypeFor[ThreadId]()},
 		{Name: "ThreadLifecycleStatus", Type: reflect.TypeFor[ThreadLifecycleStatus]()},
 		{Name: "ThreadListCwdFilter", Type: reflect.TypeFor[ThreadListCwdFilter]()},
@@ -1255,6 +1257,9 @@ func wireSchemaDefinitions() Schema {
 		schemas[name] = schema
 	}
 	for name, schema := range threadInjectItemsSchemas() {
+		schemas[name] = schema
+	}
+	for name, schema := range threadRollbackSchemas() {
 		schemas[name] = schema
 	}
 	schemas["ResponsesApiWebSearchAction"] = responsesAPIWebSearchActionSchema()

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -17308,6 +17308,45 @@
       ],
       "type": "object"
     },
+    "ThreadRollbackParams": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "description": "DEPRECATED: `thread/rollback` will be removed soon.",
+      "properties": {
+        "numTurns": {
+          "description": "The number of turns to drop from the end of the thread. Must be \u003e= 1.\n\nThis only modifies the thread's history and does not revert local file changes that have been made by the agent. Clients are responsible for reverting these changes.",
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "threadId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "numTurns",
+        "threadId"
+      ],
+      "title": "ThreadRollbackParams",
+      "type": "object"
+    },
+    "ThreadRollbackResponse": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "thread": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Thread"
+            }
+          ],
+          "description": "The updated thread after applying the rollback, with `turns` populated.\n\nThe ThreadItems stored in each Turn are lossy since we explicitly do not persist all agent interactions, such as command executions. This is the same behavior as `thread/resume`."
+        }
+      },
+      "required": [
+        "thread"
+      ],
+      "title": "ThreadRollbackResponse",
+      "type": "object"
+    },
     "ThreadRunStartParams": {
       "additionalProperties": false,
       "properties": {

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/thread_inject_items_contract_test.go
+++ b/appserver/protocol/thread_inject_items_contract_test.go
@@ -96,8 +96,8 @@ func TestThreadInjectItemsContractsFailClosedAndRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 }
 

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 583 {
-		t.Fatalf("definition count = %d, want 583", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 585 {
+		t.Fatalf("definition count = %d, want 585", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -273,8 +273,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_rollback_contract_test.go
+++ b/appserver/protocol/thread_rollback_contract_test.go
@@ -1,0 +1,140 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestThreadRollbackSchemasAreExact(t *testing.T) {
+	definitions := JSONSchema()["$defs"].(Schema)
+	wants := map[string]Schema{
+		"ThreadRollbackParams": {
+			"$schema":     "http://json-schema.org/draft-07/schema#",
+			"description": "DEPRECATED: `thread/rollback` will be removed soon.",
+			"properties": Schema{
+				"numTurns": Schema{
+					"description": "The number of turns to drop from the end of the thread. Must be >= 1.\n\nThis only modifies the thread's history and does not revert local file changes that have been made by the agent. Clients are responsible for reverting these changes.",
+					"format":      "uint32",
+					"minimum":     0.0,
+					"type":        "integer",
+				},
+				"threadId": Schema{"type": "string"},
+			},
+			"required": []string{"numTurns", "threadId"},
+			"title":    "ThreadRollbackParams",
+			"type":     "object",
+		},
+		"ThreadRollbackResponse": {
+			"$schema": "http://json-schema.org/draft-07/schema#",
+			"properties": Schema{
+				"thread": Schema{
+					"allOf":       []any{Schema{"$ref": "#/$defs/Thread"}},
+					"description": "The updated thread after applying the rollback, with `turns` populated.\n\nThe ThreadItems stored in each Turn are lossy since we explicitly do not persist all agent interactions, such as command executions. This is the same behavior as `thread/resume`.",
+				},
+			},
+			"required": []string{"thread"},
+			"title":    "ThreadRollbackResponse",
+			"type":     "object",
+		},
+	}
+	for name, want := range wants {
+		if got := definitions[name]; !reflect.DeepEqual(got, want) {
+			t.Errorf("%s = %#v, want %#v", name, got, want)
+		}
+	}
+}
+
+func TestThreadRollbackContractsPreserveSerdeWireForms(t *testing.T) {
+	for _, tc := range []struct{ input, want string }{
+		{`{"threadId":"thread","numTurns":0}`, `{"threadId":"thread","numTurns":0}`},
+		{`{"future":true,"threadId":"thread","numTurns":4294967295}`, `{"threadId":"thread","numTurns":4294967295}`},
+	} {
+		var params ThreadRollbackParams
+		if err := json.Unmarshal([]byte(tc.input), &params); err != nil {
+			t.Errorf("unmarshal params %s: %v", tc.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(params)
+		if err != nil || string(encoded) != tc.want {
+			t.Errorf("params round trip %s = %s, %v; want %s", tc.input, encoded, err, tc.want)
+		}
+	}
+
+	var response ThreadRollbackResponse
+	if err := json.Unmarshal([]byte(`{"future":true,"thread":`+publicThreadWire+`}`), &response); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	encoded, err := json.Marshal(response)
+	wantResponse := `{"thread":` + publicThreadWire + `}`
+	if err != nil || string(encoded) != wantResponse {
+		t.Fatalf("response round trip = %s, %v; want %s", encoded, err, wantResponse)
+	}
+}
+
+func TestThreadRollbackContractsRejectMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{}`,
+		`{"threadId":"thread"}`, `{"numTurns":0}`,
+		`{"threadId":null,"numTurns":0}`, `{"threadId":"thread","numTurns":null}`,
+		`{"threadId":"thread","numTurns":-1}`, `{"threadId":"thread","numTurns":1.5}`,
+		`{"threadId":"thread","numTurns":4294967296}`,
+		`{"threadId":"a","threadId":"b","numTurns":0}`,
+		`{"threadId":"thread","numTurns":0} {}`,
+	} {
+		assertJSONRejects[ThreadRollbackParams](t, input)
+	}
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{}`,
+		`{"thread":null}`, `{"thread":{}}`,
+		`{"thread":` + publicThreadWire + `,"thread":` + publicThreadWire + `}`,
+		`{"thread":` + publicThreadWire + `} {}`,
+	} {
+		assertJSONRejects[ThreadRollbackResponse](t, input)
+	}
+}
+
+func TestThreadRollbackContractsFailClosedAndRemainStandalone(t *testing.T) {
+	var params *ThreadRollbackParams
+	if err := params.UnmarshalJSON([]byte(`{"threadId":"thread","numTurns":0}`)); err == nil {
+		t.Fatal("nil params receiver succeeded")
+	}
+	var response *ThreadRollbackResponse
+	if err := response.UnmarshalJSON([]byte(`{"thread":` + publicThreadWire + `}`)); err == nil {
+		t.Fatal("nil response receiver succeeded")
+	}
+
+	names := []string{"ThreadRollbackParams", "ThreadRollbackResponse"}
+	for _, binding := range WireTypeBindings() {
+		for _, name := range names {
+			if slices.Contains(binding.Params, name) || slices.Contains(binding.Result, name) {
+				t.Fatalf("%s unexpectedly bound to %s", name, binding.Method)
+			}
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
+	}
+}
+
+func TestThreadRollbackTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	for _, want := range []string{
+		"export type ThreadRollbackParams = {\n" +
+			"  \"numTurns\": number;\n" +
+			"  \"threadId\": string;\n" +
+			"};",
+		"export type ThreadRollbackResponse = {\n" +
+			"  \"thread\": Thread;\n" +
+			"};",
+	} {
+		if !strings.Contains(string(generated), want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}

--- a/appserver/protocol/thread_rollback_types.go
+++ b/appserver/protocol/thread_rollback_types.go
@@ -1,0 +1,97 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// ThreadRollbackParams is the exact public deprecated rollback request. It
+// remains standalone because Gollem's executable history rollback accepts a
+// legacy id alias and has stricter operational validation.
+type ThreadRollbackParams struct {
+	ThreadID string `json:"threadId"`
+	NumTurns uint32 `json:"numTurns"`
+}
+
+func (p *ThreadRollbackParams) UnmarshalJSON(data []byte) error {
+	if p == nil {
+		return errors.New("decode thread-rollback params into nil receiver")
+	}
+	const objectName = "thread-rollback params"
+	payload, err := decodeRustSerdeObject(data, objectName, "threadId", "numTurns")
+	if err != nil {
+		return err
+	}
+	threadID, err := decodeRequiredThreadItemValue[string](payload, objectName, "threadId")
+	if err != nil {
+		return err
+	}
+	numTurns, err := decodeRequiredThreadItemValue[uint32](payload, objectName, "numTurns")
+	if err != nil {
+		return err
+	}
+	*p = ThreadRollbackParams{ThreadID: threadID, NumTurns: numTurns}
+	return nil
+}
+
+// ThreadRollbackResponse is the exact public deprecated rollback response. It
+// remains standalone because Gollem returns an additional durable-history
+// receipt rather than the public Thread projection.
+type ThreadRollbackResponse struct {
+	Thread Thread `json:"thread"`
+}
+
+func (r *ThreadRollbackResponse) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("decode thread-rollback response into nil receiver")
+	}
+	const objectName = "thread-rollback response"
+	payload, err := decodeRustSerdeObject(data, objectName, "thread")
+	if err != nil {
+		return err
+	}
+	thread, err := decodeRequiredThreadItemValue[Thread](payload, objectName, "thread")
+	if err != nil {
+		return err
+	}
+	*r = ThreadRollbackResponse{Thread: thread}
+	return nil
+}
+
+func threadRollbackSchemas() map[string]Schema {
+	return map[string]Schema{
+		"ThreadRollbackParams": {
+			"$schema":     "http://json-schema.org/draft-07/schema#",
+			"description": "DEPRECATED: `thread/rollback` will be removed soon.",
+			"properties": Schema{
+				"numTurns": Schema{
+					"description": "The number of turns to drop from the end of the thread. Must be >= 1.\n\nThis only modifies the thread's history and does not revert local file changes that have been made by the agent. Clients are responsible for reverting these changes.",
+					"format":      "uint32",
+					"minimum":     0.0,
+					"type":        "integer",
+				},
+				"threadId": Schema{"type": "string"},
+			},
+			"required": []string{"numTurns", "threadId"},
+			"title":    "ThreadRollbackParams",
+			"type":     "object",
+		},
+		"ThreadRollbackResponse": {
+			"$schema": "http://json-schema.org/draft-07/schema#",
+			"properties": Schema{
+				"thread": Schema{
+					"allOf":       []any{Schema{"$ref": "#/$defs/Thread"}},
+					"description": "The updated thread after applying the rollback, with `turns` populated.\n\nThe ThreadItems stored in each Turn are lossy since we explicitly do not persist all agent interactions, such as command executions. This is the same behavior as `thread/resume`.",
+				},
+			},
+			"required": []string{"thread"},
+			"title":    "ThreadRollbackResponse",
+			"type":     "object",
+		},
+	}
+}
+
+var (
+	_ json.Unmarshaler = (*ThreadRollbackParams)(nil)
+	_ json.Unmarshaler = (*ThreadRollbackResponse)(nil)
+)

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -252,8 +252,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 	if !foundRuntimeStart {
 		t.Error("thread/start runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -155,8 +155,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 	if !foundRuntimeStart {
 		t.Error("thread/start runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_settings_contract_test.go
+++ b/appserver/protocol/thread_settings_contract_test.go
@@ -162,8 +162,8 @@ func TestThreadSettingsContractsFailClosedAndRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 }
 

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 583 {
-		t.Fatalf("definition count = %d, want 583", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 585 {
+		t.Fatalf("definition count = %d, want 585", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 583 {
-		t.Fatalf("definition count = %d, want 583", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 585 {
+		t.Fatalf("definition count = %d, want 585", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -119,8 +119,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 	if !foundRuntimeBinding {
 		t.Error("turn/interrupt runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -241,8 +241,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 	if !foundRuntimeBinding {
 		t.Error("turn/start runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -164,8 +164,8 @@ func TestTurnSteerContractsAreBoundToLiveRuntime(t *testing.T) {
 	if !found {
 		t.Fatal("turn/steer runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -554,6 +554,19 @@ func MarshalTypeScript() ([]byte, error) {
 			}
 			definition = schema
 		}
+		if name == "ThreadRollbackParams" || name == "ThreadRollbackResponse" {
+			// The source schemas remain open for forward compatibility, while
+			// ts-rs renders their Rust structs as closed object literals. The
+			// response wraps Thread in allOf only to attach documentation.
+			schema, _ := typeScriptSchema(definition)
+			schema["x-gollem-typescript-ignore-additional-properties"] = true
+			if name == "ThreadRollbackResponse" {
+				schema = typeScriptDefinitionWithPropertySchemas(schema, Schema{
+					"thread": Schema{"$ref": "#/$defs/Thread"},
+				})
+			}
+			definition = schema
+		}
 		if name == "ThreadSettings" || name == "ThreadSettingsUpdatedNotification" {
 			// The source schema permits forward-compatible fields, while ts-rs
 			// renders these public records as closed object literals.

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -3986,6 +3986,15 @@ export type ThreadResumeResponse = {
   "thread": Thread;
 };
 
+export type ThreadRollbackParams = {
+  "numTurns": number;
+  "threadId": string;
+};
+
+export type ThreadRollbackResponse = {
+  "thread": Thread;
+};
+
 export type ThreadRunStartParams = {
   "adaptiveThinking"?: boolean | null;
   "input"?: unknown;

--- a/appserver/protocol/typescript/testdata/thread_rollback_contract.ts
+++ b/appserver/protocol/typescript/testdata/thread_rollback_contract.ts
@@ -1,0 +1,36 @@
+import type {
+  MethodParamsByName,
+  MethodResultsByName,
+  Thread,
+  ThreadRollbackParams,
+  ThreadRollbackResponse,
+} from "../gollem_appserver_protocol";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2) ? true : false;
+type Expect<T extends true> = T;
+
+type Contracts = [
+  Expect<Equal<ThreadRollbackParams, {
+    numTurns: number;
+    threadId: string;
+  }>>,
+  Expect<Equal<ThreadRollbackResponse, { thread: Thread }>>,
+  Expect<Equal<"thread/rollback" extends keyof MethodParamsByName ? true : false, true>>,
+  Expect<Equal<"thread/rollback" extends keyof MethodResultsByName ? true : false, true>>,
+  Expect<Equal<MethodParamsByName["thread/rollback"], import("../gollem_appserver_protocol").ThreadHistoryRollbackParams>>,
+  Expect<Equal<MethodResultsByName["thread/rollback"], import("../gollem_appserver_protocol").ThreadHistoryRollbackResult>>,
+];
+
+({ threadId: "thread", numTurns: 0 }) satisfies ThreadRollbackParams;
+({ thread: null as unknown as Thread }) satisfies ThreadRollbackResponse;
+
+// @ts-expect-error threadId is required.
+({ numTurns: 0 }) satisfies ThreadRollbackParams;
+// @ts-expect-error numTurns is required.
+({ threadId: "thread" }) satisfies ThreadRollbackParams;
+// @ts-expect-error response thread is required.
+({}) satisfies ThreadRollbackResponse;
+
+void (null as unknown as Contracts);

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/workspace_messages_contract_test.go
+++ b/appserver/protocol/workspace_messages_contract_test.go
@@ -209,8 +209,8 @@ func TestWorkspaceMessageContractsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/workspaceMessages/read = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 583 {
-		t.Fatalf("definition count = %d, want 583", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 585 {
+		t.Fatalf("definition count = %d, want 585", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- export exact public standalone `ThreadRollbackParams` and `ThreadRollbackResponse` contracts
- preserve the source public `uint32` schema range, including zero, without changing the executable durable rollback requirement of at least one turn
- keep `thread/rollback` bound to the existing legacy-compatible durable-history request and receipt rather than the distinct public pair

## Validation
- `go generate ./appserver/protocol`
- `go test ./appserver/protocol -count=1`
- `go test -race ./appserver/protocol -count=1`
- non-Monty repository test and vet suites
- `golangci-lint run`
- `go mod tidy`
- `git diff --check`

The normal push began the repository pre-push lint and non-Monty race gate successfully, but the execution wrapper stopped it before delivery. The equivalent full local checks above passed; the absent remote ref was verified before one `--no-verify` delivery.