### PR TITLE
protocol: align auth refresh params with source schema

### DIFF
--- a/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
+++ b/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
@@ -10,19 +10,34 @@ import (
 
 func TestChatgptAuthTokensRefreshSchemasAreExact(t *testing.T) {
 	defs := JSONSchema()["$defs"].(Schema)
-	assertStringEnum(t, defs["ChatgptAuthTokensRefreshReason"], "unauthorized")
+	reason := Schema{
+		"oneOf": []any{Schema{
+			"description": "Codex attempted a backend request and received `401 Unauthorized`.",
+			"enum":        []any{"unauthorized"},
+			"type":        "string",
+		}},
+	}
+	if !reflect.DeepEqual(defs["ChatgptAuthTokensRefreshReason"], reason) {
+		t.Fatalf("ChatgptAuthTokensRefreshReason = %#v, want %#v", defs["ChatgptAuthTokensRefreshReason"], reason)
+	}
 
-	params := closedThreadSessionParamSchema(Schema{
-		"reason": Schema{"$ref": "#/$defs/ChatgptAuthTokensRefreshReason"},
-		"previousAccountId": Schema{
-			"anyOf": []any{Schema{"type": "string"}, Schema{"type": "null"}},
-			"description": "Workspace/account identifier that Codex was previously using.\n\n" +
-				"Clients that manage multiple accounts/workspaces can use this as a hint to " +
-				"refresh the token for the correct workspace.\n\n" +
-				"This may be `null` when the prior auth state did not include a workspace " +
-				"identifier (`chatgpt_account_id`).",
+	params := Schema{
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"properties": Schema{
+			"reason": Schema{"$ref": "#/$defs/ChatgptAuthTokensRefreshReason"},
+			"previousAccountId": Schema{
+				"description": "Workspace/account identifier that Codex was previously using.\n\n" +
+					"Clients that manage multiple accounts/workspaces can use this as a hint to " +
+					"refresh the token for the correct workspace.\n\n" +
+					"This may be `null` when the prior auth state did not include a workspace " +
+					"identifier (`chatgpt_account_id`).",
+				"type": []any{"string", "null"},
+			},
 		},
-	}, []string{"reason"})
+		"required": []string{"reason"},
+		"title":    "ChatgptAuthTokensRefreshParams",
+		"type":     "object",
+	}
 	if !reflect.DeepEqual(defs["ChatgptAuthTokensRefreshParams"], params) {
 		t.Fatalf("ChatgptAuthTokensRefreshParams = %#v, want %#v", defs["ChatgptAuthTokensRefreshParams"], params)
 	}
@@ -56,10 +71,10 @@ func TestChatgptAuthTokensRefreshRecordsAcceptSerdeWireForms(t *testing.T) {
 		input string
 		want  string
 	}{
-		{`{"reason":"unauthorized"}`, `{"previousAccountId":null,"reason":"unauthorized"}`},
-		{`{"reason":"unauthorized","previousAccountId":null}`, `{"previousAccountId":null,"reason":"unauthorized"}`},
-		{`{"reason":"unauthorized","previousAccountId":""}`, `{"previousAccountId":"","reason":"unauthorized"}`},
-		{`{"unknown":"ignored","reason":"unauthorized","previousAccountId":" workspace "}`, `{"previousAccountId":" workspace ","reason":"unauthorized"}`},
+		{`{"reason":"unauthorized"}`, `{"reason":"unauthorized","previousAccountId":null}`},
+		{`{"reason":"unauthorized","previousAccountId":null}`, `{"reason":"unauthorized","previousAccountId":null}`},
+		{`{"reason":"unauthorized","previousAccountId":""}`, `{"reason":"unauthorized","previousAccountId":""}`},
+		{`{"unknown":"ignored","reason":"unauthorized","previousAccountId":" workspace "}`, `{"reason":"unauthorized","previousAccountId":" workspace "}`},
 	} {
 		var params ChatgptAuthTokensRefreshParams
 		if err := json.Unmarshal([]byte(tc.input), &params); err != nil {

--- a/appserver/protocol/chatgpt_auth_tokens_refresh_types.go
+++ b/appserver/protocol/chatgpt_auth_tokens_refresh_types.go
@@ -33,10 +33,10 @@ type ChatgptAuthTokensRefreshParams struct {
 }
 
 func (p ChatgptAuthTokensRefreshParams) MarshalJSON() ([]byte, error) {
-	return json.Marshal(map[string]any{
-		"reason":            p.Reason,
-		"previousAccountId": p.PreviousAccountID,
-	})
+	return json.Marshal(struct {
+		Reason            ChatgptAuthTokensRefreshReason `json:"reason"`
+		PreviousAccountID *string                        `json:"previousAccountId"`
+	}{Reason: p.Reason, PreviousAccountID: p.PreviousAccountID})
 }
 
 func (p *ChatgptAuthTokensRefreshParams) UnmarshalJSON(data []byte) error {

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -948,20 +948,30 @@ func wireSchemaDefinitions() Schema {
 		string(CancelLoginAccountStatusCanceled),
 		string(CancelLoginAccountStatusNotFound),
 	)
-	schemas["ChatgptAuthTokensRefreshReason"] = stringEnumSchema(
-		string(ChatgptAuthTokensRefreshReasonUnauthorized),
-	)
-	schemas["ChatgptAuthTokensRefreshParams"] = closedThreadSessionParamSchema(Schema{
-		"reason": Schema{"$ref": "#/$defs/ChatgptAuthTokensRefreshReason"},
-		"previousAccountId": Schema{
-			"anyOf": []any{Schema{"type": "string"}, Schema{"type": "null"}},
-			"description": "Workspace/account identifier that Codex was previously using.\n\n" +
-				"Clients that manage multiple accounts/workspaces can use this as a hint to " +
-				"refresh the token for the correct workspace.\n\n" +
-				"This may be `null` when the prior auth state did not include a workspace " +
-				"identifier (`chatgpt_account_id`).",
+	schemas["ChatgptAuthTokensRefreshReason"] = Schema{
+		"oneOf": []any{Schema{
+			"description": "Codex attempted a backend request and received `401 Unauthorized`.",
+			"enum":        []any{string(ChatgptAuthTokensRefreshReasonUnauthorized)},
+			"type":        "string",
+		}},
+	}
+	schemas["ChatgptAuthTokensRefreshParams"] = Schema{
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"properties": Schema{
+			"reason": Schema{"$ref": "#/$defs/ChatgptAuthTokensRefreshReason"},
+			"previousAccountId": Schema{
+				"description": "Workspace/account identifier that Codex was previously using.\n\n" +
+					"Clients that manage multiple accounts/workspaces can use this as a hint to " +
+					"refresh the token for the correct workspace.\n\n" +
+					"This may be `null` when the prior auth state did not include a workspace " +
+					"identifier (`chatgpt_account_id`).",
+				"type": []any{"string", "null"},
+			},
 		},
-	}, []string{"reason"})
+		"required": []string{"reason"},
+		"title":    "ChatgptAuthTokensRefreshParams",
+		"type":     "object",
+	}
 	schemas["ChatgptAuthTokensRefreshResponse"] = closedThreadSessionParamSchema(Schema{
 		"accessToken":      Schema{"type": "string"},
 		"chatgptAccountId": Schema{"type": "string"},

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -1745,18 +1745,14 @@
       ]
     },
     "ChatgptAuthTokensRefreshParams": {
-      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#",
       "properties": {
         "previousAccountId": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "Workspace/account identifier that Codex was previously using.\n\nClients that manage multiple accounts/workspaces can use this as a hint to refresh the token for the correct workspace.\n\nThis may be `null` when the prior auth state did not include a workspace identifier (`chatgpt_account_id`)."
+          "description": "Workspace/account identifier that Codex was previously using.\n\nClients that manage multiple accounts/workspaces can use this as a hint to refresh the token for the correct workspace.\n\nThis may be `null` when the prior auth state did not include a workspace identifier (`chatgpt_account_id`).",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "reason": {
           "$ref": "#/$defs/ChatgptAuthTokensRefreshReason"
@@ -1765,13 +1761,19 @@
       "required": [
         "reason"
       ],
+      "title": "ChatgptAuthTokensRefreshParams",
       "type": "object"
     },
     "ChatgptAuthTokensRefreshReason": {
-      "enum": [
-        "unauthorized"
-      ],
-      "type": "string"
+      "oneOf": [
+        {
+          "description": "Codex attempted a backend request and received `401 Unauthorized`.",
+          "enum": [
+            "unauthorized"
+          ],
+          "type": "string"
+        }
+      ]
     },
     "ChatgptAuthTokensRefreshResponse": {
       "additionalProperties": false,

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -163,6 +163,8 @@ func MarshalTypeScript() ([]byte, error) {
 				schema["x-gollem-typescript-ignore-additional-properties"] = true
 			case "FileChangeRequestApprovalParams":
 				schema["x-gollem-typescript-ignore-additional-properties"] = true
+			case "ChatgptAuthTokensRefreshParams":
+				schema["x-gollem-typescript-ignore-additional-properties"] = true
 			case "ChatgptAuthTokensRefreshResponse":
 				schema["required"] = []string{
 					"accessToken", "chatgptAccountId", "chatgptPlanType",
@@ -418,6 +420,13 @@ func MarshalTypeScript() ([]byte, error) {
 			definition = typeScriptDefinitionWithPropertySchemas(schema, Schema{
 				"grantRoot": nullableStringSchema(),
 				"reason":    nullableStringSchema(),
+			})
+		}
+		if name == "ChatgptAuthTokensRefreshParams" {
+			schema, _ := typeScriptSchema(definition)
+			schema["x-gollem-typescript-ignore-additional-properties"] = true
+			definition = typeScriptDefinitionWithPropertySchemas(schema, Schema{
+				"previousAccountId": nullableStringSchema(),
 			})
 		}
 		if name == "CommandExecParams" {


### PR DESCRIPTION
## Summary
- align the standalone ChatGPT auth-refresh reason and params schemas with the current source contract
- preserve source-open forward fields and nullable `previousAccountId`, while maintaining strict known-field decoding
- serialize the params record in source field order (`reason`, then `previousAccountId`)
- preserve the generated TypeScript surface and all method/item bindings

## Verification
- direct source-schema comparison for the params and enum
- focused race coverage and full `appserver/protocol` suite
- full non-Monty `go test -count=1` and `go vet`
- `go mod tidy`, protocol generation, lint, and normal pre-push non-Monty race hook