### PR TITLE
protocol: align attestation params with source schema

### DIFF
--- a/appserver/protocol/attestation_contract_test.go
+++ b/appserver/protocol/attestation_contract_test.go
@@ -11,8 +11,9 @@ import (
 func TestAttestationContractsSchemaIsExact(t *testing.T) {
 	defs := JSONSchema()["$defs"].(Schema)
 	wantParams := Schema{
-		"type":                 "object",
-		"additionalProperties": false,
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"title":   "AttestationGenerateParams",
+		"type":    "object",
 	}
 	if got := defs["AttestationGenerateParams"]; !reflect.DeepEqual(got, wantParams) {
 		t.Fatalf("AttestationGenerateParams = %#v, want %#v", got, wantParams)

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -928,6 +928,11 @@ func wireSchemaDefinitions() Schema {
 		string(AddCreditsNudgeEmailStatusCooldownActive),
 	)
 	schemas["AgentPath"] = Schema{"type": "string"}
+	schemas["AttestationGenerateParams"] = Schema{
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"title":   "AttestationGenerateParams",
+		"type":    "object",
+	}
 	schemas["AmazonBedrockCredentialSource"] = stringEnumSchema(
 		string(AmazonBedrockCredentialSourceCodexManaged),
 		string(AmazonBedrockCredentialSourceAWSManaged),

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -1387,7 +1387,8 @@
       ]
     },
     "AttestationGenerateParams": {
-      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "AttestationGenerateParams",
       "type": "object"
     },
     "AttestationGenerateResponse": {

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -48,6 +48,7 @@ func MarshalTypeScript() ([]byte, error) {
 			name == "AppsListParams" || name == "AppsListResponse" ||
 			name == "AppToolConfig" ||
 			name == "ApplyPatchApprovalParams" ||
+			name == "AttestationGenerateParams" ||
 			name == "ChatgptAuthTokensRefreshResponse" ||
 			name == "ConsumeAccountRateLimitResetCreditParams" ||
 			name == "ConsumeAccountRateLimitResetCreditResponse" || name == "CreditsSnapshot" ||
@@ -158,6 +159,10 @@ func MarshalTypeScript() ([]byte, error) {
 				schema["required"] = []string{
 					"conversationId", "callId", "fileChanges", "reason", "grantRoot",
 				}
+			case "AttestationGenerateParams":
+				// The source JSON Schema is open for serde compatibility while ts-rs
+				// exports the exact empty Rust record.
+				schema["additionalProperties"] = false
 			case "CommandExecutionRequestApprovalParams":
 				schema["required"] = []string{"threadId", "turnId", "itemId", "startedAtMs", "environmentId"}
 				schema["x-gollem-typescript-ignore-additional-properties"] = true


### PR DESCRIPTION
## Summary
- align `AttestationGenerateParams` with the current source-open empty-record JSON Schema
- retain the source `Record<string, never>` TypeScript surface with a renderer-only closure
- preserve serde-compatible unknown-field discard and all method/item bindings

## Verification
- direct source-schema comparison
- focused race and full protocol tests
- full non-Monty `go test -count=1` and `go vet`
- generation, lint, and normal pre-push non-Monty race hook