### PR TITLE
protocol: align legacy approval params with source schema

### DIFF
--- a/appserver/protocol/apply_patch_approval_params_contract_test.go
+++ b/appserver/protocol/apply_patch_approval_params_contract_test.go
@@ -13,7 +13,7 @@ func TestApplyPatchApprovalParamsSchemaIsExact(t *testing.T) {
 	if !ok {
 		t.Fatal("$defs missing ApplyPatchApprovalParams")
 	}
-	want := closedThreadSessionParamSchema(Schema{
+	want := sourceApprovalParamsSchema("ApplyPatchApprovalParams", Schema{
 		"conversationId": Schema{"$ref": "#/$defs/ThreadId"},
 		"callId": Schema{
 			"type": "string",
@@ -25,11 +25,11 @@ func TestApplyPatchApprovalParamsSchemaIsExact(t *testing.T) {
 			"additionalProperties": Schema{"$ref": "#/$defs/FileChange"},
 		},
 		"reason": Schema{
-			"anyOf":       []any{Schema{"type": "string"}, Schema{"type": "null"}},
+			"type":        []any{"string", "null"},
 			"description": "Optional explanatory reason (e.g. request for extra write access).",
 		},
 		"grantRoot": Schema{
-			"anyOf": []any{Schema{"type": "string"}, Schema{"type": "null"}},
+			"type": []any{"string", "null"},
 			"description": "When set, the agent is asking the user to allow writes under this root " +
 				"for the remainder of the session (unclear if this is honored today).",
 		},

--- a/appserver/protocol/exec_command_approval_params_contract_test.go
+++ b/appserver/protocol/exec_command_approval_params_contract_test.go
@@ -13,7 +13,7 @@ func TestExecCommandApprovalParamsSchemaIsExact(t *testing.T) {
 	if !ok {
 		t.Fatal("$defs missing ExecCommandApprovalParams")
 	}
-	want := closedThreadSessionParamSchema(Schema{
+	want := sourceApprovalParamsSchema("ExecCommandApprovalParams", Schema{
 		"conversationId": Schema{"$ref": "#/$defs/ThreadId"},
 		"callId": Schema{
 			"type": "string",
@@ -21,12 +21,12 @@ func TestExecCommandApprovalParamsSchemaIsExact(t *testing.T) {
 				"and [codex_protocol::protocol::ExecCommandEndEvent].",
 		},
 		"approvalId": Schema{
-			"anyOf":       []any{Schema{"type": "string"}, Schema{"type": "null"}},
+			"type":        []any{"string", "null"},
 			"description": "Identifier for this specific approval callback.",
 		},
 		"command": Schema{"type": "array", "items": Schema{"type": "string"}},
 		"cwd":     Schema{"type": "string"},
-		"reason":  nullableStringSchema(),
+		"reason":  Schema{"type": []any{"string", "null"}},
 		"parsedCmd": Schema{
 			"type":  "array",
 			"items": Schema{"$ref": "#/$defs/ParsedCommand"},

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -1159,6 +1159,24 @@ func wireSchemaDefinitions() Schema {
 			"items": Schema{"$ref": "#/$defs/ParsedCommand"},
 		},
 	}, []string{"callId", "command", "conversationId", "cwd", "parsedCmd"})
+	// Preserve the raw source schemas for standalone legacy approval records.
+	// Their closed TypeScript records are normalized only in the renderer.
+	schemas["ApplyPatchApprovalParams"] = sourceApprovalParamsSchema("ApplyPatchApprovalParams", Schema{
+		"conversationId": Schema{"$ref": "#/$defs/ThreadId"},
+		"callId":         Schema{"type": "string", "description": "Use to correlate this with [codex_protocol::protocol::PatchApplyBeginEvent] and [codex_protocol::protocol::PatchApplyEndEvent]."},
+		"fileChanges":    Schema{"type": "object", "additionalProperties": Schema{"$ref": "#/$defs/FileChange"}},
+		"reason":         Schema{"description": "Optional explanatory reason (e.g. request for extra write access).", "type": []any{"string", "null"}},
+		"grantRoot":      Schema{"description": "When set, the agent is asking the user to allow writes under this root for the remainder of the session (unclear if this is honored today).", "type": []any{"string", "null"}},
+	}, []string{"callId", "conversationId", "fileChanges"})
+	schemas["ExecCommandApprovalParams"] = sourceApprovalParamsSchema("ExecCommandApprovalParams", Schema{
+		"conversationId": Schema{"$ref": "#/$defs/ThreadId"},
+		"callId":         Schema{"type": "string", "description": "Use to correlate this with [codex_protocol::protocol::ExecCommandBeginEvent] and [codex_protocol::protocol::ExecCommandEndEvent]."},
+		"approvalId":     Schema{"description": "Identifier for this specific approval callback.", "type": []any{"string", "null"}},
+		"command":        Schema{"type": "array", "items": Schema{"type": "string"}},
+		"cwd":            Schema{"type": "string"},
+		"reason":         Schema{"type": []any{"string", "null"}},
+		"parsedCmd":      Schema{"type": "array", "items": Schema{"$ref": "#/$defs/ParsedCommand"}},
+	}, []string{"callId", "command", "conversationId", "cwd", "parsedCmd"})
 	schemas["NetworkApprovalContext"] = closedThreadSessionParamSchema(Schema{
 		"host":     Schema{"type": "string"},
 		"protocol": Schema{"$ref": "#/$defs/NetworkApprovalProtocol"},
@@ -3083,6 +3101,10 @@ func closedThreadSessionParamSchema(properties Schema, required []string) Schema
 		schema["required"] = required
 	}
 	return schema
+}
+
+func sourceApprovalParamsSchema(title string, properties Schema, required []string) Schema {
+	return Schema{"$schema": "http://json-schema.org/draft-07/schema#", "properties": properties, "required": required, "title": title, "type": "object"}
 }
 
 func nullableThreadSessionParamSchema(value Schema) Schema {

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -1085,7 +1085,7 @@
       "type": "object"
     },
     "ApplyPatchApprovalParams": {
-      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#",
       "properties": {
         "callId": {
           "description": "Use to correlate this with [codex_protocol::protocol::PatchApplyBeginEvent] and [codex_protocol::protocol::PatchApplyEndEvent].",
@@ -1101,26 +1101,18 @@
           "type": "object"
         },
         "grantRoot": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "When set, the agent is asking the user to allow writes under this root for the remainder of the session (unclear if this is honored today)."
+          "description": "When set, the agent is asking the user to allow writes under this root for the remainder of the session (unclear if this is honored today).",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "reason": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "Optional explanatory reason (e.g. request for extra write access)."
+          "description": "Optional explanatory reason (e.g. request for extra write access).",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
@@ -1128,6 +1120,7 @@
         "conversationId",
         "fileChanges"
       ],
+      "title": "ApplyPatchApprovalParams",
       "type": "object"
     },
     "ApplyPatchApprovalResponse": {
@@ -5019,18 +5012,14 @@
       "type": "object"
     },
     "ExecCommandApprovalParams": {
-      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#",
       "properties": {
         "approvalId": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "Identifier for this specific approval callback."
+          "description": "Identifier for this specific approval callback.",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "callId": {
           "description": "Use to correlate this with [codex_protocol::protocol::ExecCommandBeginEvent] and [codex_protocol::protocol::ExecCommandEndEvent].",
@@ -5055,13 +5044,9 @@
           "type": "array"
         },
         "reason": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
+          "type": [
+            "string",
+            "null"
           ]
         }
       },
@@ -5072,6 +5057,7 @@
         "cwd",
         "parsedCmd"
       ],
+      "title": "ExecCommandApprovalParams",
       "type": "object"
     },
     "ExecCommandApprovalResponse": {

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -159,6 +159,7 @@ func MarshalTypeScript() ([]byte, error) {
 				schema["required"] = []string{
 					"conversationId", "callId", "fileChanges", "reason", "grantRoot",
 				}
+				schema["x-gollem-typescript-ignore-additional-properties"] = true
 			case "AttestationGenerateParams":
 				// The source JSON Schema is open for serde compatibility while ts-rs
 				// exports the exact empty Rust record.
@@ -206,6 +207,7 @@ func MarshalTypeScript() ([]byte, error) {
 				schema["required"] = []string{
 					"conversationId", "callId", "approvalId", "command", "cwd", "reason", "parsedCmd",
 				}
+				schema["x-gollem-typescript-ignore-additional-properties"] = true
 			case "ExperimentalFeature":
 				schema["required"] = []string{
 					"announcement", "defaultEnabled", "description", "displayName", "enabled", "name", "stage",
@@ -433,6 +435,18 @@ func MarshalTypeScript() ([]byte, error) {
 			definition = typeScriptDefinitionWithPropertySchemas(schema, Schema{
 				"previousAccountId": nullableStringSchema(),
 			})
+		}
+		if name == "ApplyPatchApprovalParams" {
+			schema, _ := typeScriptSchema(definition)
+			schema["required"] = []string{"conversationId", "callId", "fileChanges", "reason", "grantRoot"}
+			schema["x-gollem-typescript-ignore-additional-properties"] = true
+			definition = typeScriptDefinitionWithPropertySchemas(schema, Schema{"grantRoot": nullableStringSchema(), "reason": nullableStringSchema()})
+		}
+		if name == "ExecCommandApprovalParams" {
+			schema, _ := typeScriptSchema(definition)
+			schema["required"] = []string{"conversationId", "callId", "approvalId", "command", "cwd", "reason", "parsedCmd"}
+			schema["x-gollem-typescript-ignore-additional-properties"] = true
+			definition = typeScriptDefinitionWithPropertySchemas(schema, Schema{"approvalId": nullableStringSchema(), "reason": nullableStringSchema()})
 		}
 		if name == "CommandExecParams" {
 			// The source schema allows forward-compatible fields while ts-rs emits


### PR DESCRIPTION
## Summary
- align standalone `ApplyPatchApprovalParams` and `ExecCommandApprovalParams` with current source-open JSON Schemas
- retain source TypeScript record shapes through renderer-only closure and nullable normalization
- preserve source-compatible serializers, decoder behavior, and all method/item bindings

## Verification
- direct source-schema comparison for both records
- focused normal and race protocol tests
- full non-Monty `go test -count=1` and `go vet`
- module tidy, generation, lint, and normal pre-push non-Monty race hook