### PR TITLE
protocol: align permissions approval params with source contract

### DIFF
--- a/appserver/protocol/permission_profile_contract_test.go
+++ b/appserver/protocol/permission_profile_contract_test.go
@@ -71,14 +71,10 @@ func TestPermissionProfileSchemasMatchPublicWire(t *testing.T) {
 	assertSchemaRequired(t, defs["AdditionalPermissionProfile"].(Schema), "fileSystem")
 	assertSchemaRequired(t, defs["RequestPermissionProfile"].(Schema), "network")
 	assertSchemaRequired(t, defs["RequestPermissionProfile"].(Schema), "fileSystem")
-	assertSchemaRequired(t, defs["PermissionsRequestApprovalParams"].(Schema), "threadId")
-	assertSchemaRequired(t, defs["PermissionsRequestApprovalParams"].(Schema), "turnId")
-	assertSchemaRequired(t, defs["PermissionsRequestApprovalParams"].(Schema), "itemId")
-	assertSchemaRequired(t, defs["PermissionsRequestApprovalParams"].(Schema), "startedAtMs")
-	assertSchemaRequired(t, defs["PermissionsRequestApprovalParams"].(Schema), "cwd")
-	assertSchemaRequired(t, defs["PermissionsRequestApprovalParams"].(Schema), "permissions")
-	assertSchemaRequired(t, defs["PermissionsRequestApprovalParams"].(Schema), "environmentId")
-	assertSchemaRequired(t, defs["PermissionsRequestApprovalParams"].(Schema), "reason")
+	requestApprovalParams := defs["PermissionsRequestApprovalParams"].(Schema)
+	if got, want := schemaRequiredNames(requestApprovalParams), []string{"cwd", "itemId", "permissions", "startedAtMs", "threadId", "turnId"}; !slices.Equal(got, want) {
+		t.Fatalf("permission request required = %v, want %v", got, want)
+	}
 	assertSchemaRequired(t, defs["PermissionsRequestApprovalResponse"].(Schema), "permissions")
 	assertSchemaRequired(t, defs["PermissionsRequestApprovalResponse"].(Schema), "scope")
 
@@ -269,7 +265,6 @@ func TestPermissionProfilePublicValuesRejectMalformedInput(t *testing.T) {
 		{"absolute path wrong type", `1`, func() any { return new(AbsolutePathBuf) }},
 		{"relative cwd", `{"threadId":"t","turnId":"u","itemId":"i","startedAtMs":1,"cwd":"relative","permissions":{}}`, func() any { return new(PermissionsRequestApprovalParams) }},
 		{"missing cwd", `{"threadId":"t","turnId":"u","itemId":"i","startedAtMs":1,"permissions":{}}`, func() any { return new(PermissionsRequestApprovalParams) }},
-		{"request unknown", `{"threadId":"t","turnId":"u","itemId":"i","startedAtMs":1,"cwd":"/workspace","permissions":{},"extra":true}`, func() any { return new(PermissionsRequestApprovalParams) }},
 		{"profile unknown", `{"network":null,"extra":true}`, func() any { return new(RequestPermissionProfile) }},
 		{"zero depth", `{"globScanMaxDepth":0}`, func() any { return new(AdditionalFileSystemPermissions) }},
 		{"missing entry path", `{"access":"read"}`, func() any { return new(FileSystemSandboxEntry) }},

--- a/appserver/protocol/permission_profile_types.go
+++ b/appserver/protocol/permission_profile_types.go
@@ -328,14 +328,57 @@ func (p *PermissionsRequestApprovalParams) UnmarshalJSON(data []byte) error {
 	if p == nil {
 		return errors.New("cannot unmarshal PermissionsRequestApprovalParams into nil receiver")
 	}
-	type wire PermissionsRequestApprovalParams
-	var value wire
-	if err := decodePermissionObject(data, &value,
-		"threadId", "turnId", "itemId", "startedAtMs", "cwd", "permissions",
-	); err != nil {
+	const objectName = "permissions request approval params"
+	payload, err := decodeRustSerdeObject(
+		data,
+		objectName,
+		"threadId", "turnId", "itemId", "environmentId", "startedAtMs", "cwd", "reason", "permissions",
+	)
+	if err != nil {
 		return err
 	}
-	*p = PermissionsRequestApprovalParams(value)
+	threadID, err := decodeRequiredThreadItemValue[string](payload, objectName, "threadId")
+	if err != nil {
+		return err
+	}
+	turnID, err := decodeRequiredThreadItemValue[string](payload, objectName, "turnId")
+	if err != nil {
+		return err
+	}
+	itemID, err := decodeRequiredThreadItemValue[string](payload, objectName, "itemId")
+	if err != nil {
+		return err
+	}
+	environmentID, err := decodeOptionalNullableConfigValue[string](payload, objectName, "environmentId")
+	if err != nil {
+		return err
+	}
+	startedAtMS, err := decodeRequiredThreadItemValue[int64](payload, objectName, "startedAtMs")
+	if err != nil {
+		return err
+	}
+	cwd, err := decodeRequiredThreadItemValue[AbsolutePathBuf](payload, objectName, "cwd")
+	if err != nil {
+		return err
+	}
+	reason, err := decodeOptionalNullableConfigValue[string](payload, objectName, "reason")
+	if err != nil {
+		return err
+	}
+	permissions, err := decodeRequiredThreadItemValue[RequestPermissionProfile](payload, objectName, "permissions")
+	if err != nil {
+		return err
+	}
+	*p = PermissionsRequestApprovalParams{
+		ThreadID:      threadID,
+		TurnID:        turnID,
+		ItemID:        itemID,
+		EnvironmentID: environmentID,
+		StartedAtMS:   startedAtMS,
+		CWD:           cwd,
+		Reason:        reason,
+		Permissions:   permissions,
+	}
 	return nil
 }
 

--- a/appserver/protocol/permissions_request_approval_params_contract_test.go
+++ b/appserver/protocol/permissions_request_approval_params_contract_test.go
@@ -1,0 +1,133 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestPermissionsRequestApprovalParamsSchemaIsExact(t *testing.T) {
+	definition, ok := JSONSchema()["$defs"].(Schema)["PermissionsRequestApprovalParams"].(Schema)
+	if !ok {
+		t.Fatal("$defs missing PermissionsRequestApprovalParams")
+	}
+	want := sourceApprovalParamsSchema("PermissionsRequestApprovalParams", Schema{
+		"cwd":           Schema{"$ref": "#/$defs/AbsolutePathBuf"},
+		"environmentId": Schema{"default": nil, "type": []any{"string", "null"}},
+		"itemId":        Schema{"type": "string"},
+		"permissions":   Schema{"$ref": "#/$defs/RequestPermissionProfile"},
+		"reason":        Schema{"type": []any{"string", "null"}},
+		"startedAtMs": Schema{
+			"description": "Unix timestamp (in milliseconds) when this approval request started.",
+			"format":      "int64",
+			"type":        "integer",
+		},
+		"threadId": Schema{"type": "string"},
+		"turnId":   Schema{"type": "string"},
+	}, []string{"cwd", "itemId", "permissions", "startedAtMs", "threadId", "turnId"})
+	if !reflect.DeepEqual(definition, want) {
+		t.Fatalf("PermissionsRequestApprovalParams = %#v, want %#v", definition, want)
+	}
+}
+
+func TestPermissionsRequestApprovalParamsAcceptsSerdeWireForms(t *testing.T) {
+	for _, test := range []struct {
+		input string
+		want  string
+	}{
+		{
+			input: `{"threadId":"thread","turnId":"turn","itemId":"item","startedAtMs":1,"cwd":"/workspace","permissions":{}}`,
+			want:  `{"threadId":"thread","turnId":"turn","itemId":"item","environmentId":null,"startedAtMs":1,"cwd":"/workspace","reason":null,"permissions":{"network":null,"fileSystem":null}}`,
+		},
+		{
+			input: `{"future":1,"future":2,"threadId":"thread","turnId":"turn","itemId":"item","environmentId":"env","startedAtMs":2,"cwd":"/workspace/../workspace/project","reason":"review","permissions":{"network":null,"fileSystem":null},"other":{"ignored":true}}`,
+			want:  `{"threadId":"thread","turnId":"turn","itemId":"item","environmentId":"env","startedAtMs":2,"cwd":"/workspace/project","reason":"review","permissions":{"network":null,"fileSystem":null}}`,
+		},
+	} {
+		var params PermissionsRequestApprovalParams
+		if err := json.Unmarshal([]byte(test.input), &params); err != nil {
+			t.Errorf("Unmarshal(%s): %v", test.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(params)
+		if err != nil || string(encoded) != test.want {
+			t.Errorf("round trip %s = %s, %v; want %s", test.input, encoded, err, test.want)
+		}
+	}
+}
+
+func TestPermissionsRequestApprovalParamsRejectsMalformedWireForms(t *testing.T) {
+	valid := `"threadId":"thread","turnId":"turn","itemId":"item","startedAtMs":1,"cwd":"/workspace","permissions":{}`
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`, `{}`,
+		`{"turnId":"turn","itemId":"item","startedAtMs":1,"cwd":"/workspace","permissions":{}}`,
+		`{"threadId":"thread","itemId":"item","startedAtMs":1,"cwd":"/workspace","permissions":{}}`,
+		`{"threadId":"thread","turnId":"turn","startedAtMs":1,"cwd":"/workspace","permissions":{}}`,
+		`{"threadId":"thread","turnId":"turn","itemId":"item","cwd":"/workspace","permissions":{}}`,
+		`{"threadId":"thread","turnId":"turn","itemId":"item","startedAtMs":1,"permissions":{}}`,
+		`{"threadId":null,"turnId":"turn","itemId":"item","startedAtMs":1,"cwd":"/workspace","permissions":{}}`,
+		`{"threadId":"thread","turnId":null,"itemId":"item","startedAtMs":1,"cwd":"/workspace","permissions":{}}`,
+		`{"threadId":"thread","turnId":"turn","itemId":null,"startedAtMs":1,"cwd":"/workspace","permissions":{}}`,
+		`{"threadId":"thread","turnId":"turn","itemId":"item","startedAtMs":null,"cwd":"/workspace","permissions":{}}`,
+		`{"threadId":"thread","turnId":"turn","itemId":"item","startedAtMs":1,"cwd":null,"permissions":{}}`,
+		`{"threadId":"thread","turnId":"turn","itemId":"item","startedAtMs":1,"cwd":"relative","permissions":{}}`,
+		`{"threadId":"thread","turnId":"turn","itemId":"item","startedAtMs":1,"cwd":"/workspace","permissions":null}`,
+		`{"threadId":"thread","turnId":"turn","itemId":"item","environmentId":1,"startedAtMs":1,"cwd":"/workspace","permissions":{}}`,
+		`{"threadId":"thread","turnId":"turn","itemId":"item","startedAtMs":1,"cwd":"/workspace","reason":1,"permissions":{}}`,
+		`{"threadId":"one","threadId":"two","turnId":"turn","itemId":"item","startedAtMs":1,"cwd":"/workspace","permissions":{}}`,
+		`{"threadId":"thread","turnId":"one","turnId":"two","itemId":"item","startedAtMs":1,"cwd":"/workspace","permissions":{}}`,
+		`{"threadId":"thread","turnId":"turn","itemId":"one","itemId":"two","startedAtMs":1,"cwd":"/workspace","permissions":{}}`,
+		`{"threadId":"thread","turnId":"turn","itemId":"item","environmentId":null,"environmentId":"env","startedAtMs":1,"cwd":"/workspace","permissions":{}}`,
+		`{"threadId":"thread","turnId":"turn","itemId":"item","startedAtMs":1,"startedAtMs":2,"cwd":"/workspace","permissions":{}}`,
+		`{"threadId":"thread","turnId":"turn","itemId":"item","startedAtMs":1,"cwd":"/workspace","cwd":"/other","permissions":{}}`,
+		`{"threadId":"thread","turnId":"turn","itemId":"item","startedAtMs":1,"cwd":"/workspace","reason":null,"reason":"review","permissions":{}}`,
+		`{"threadId":"thread","turnId":"turn","itemId":"item","startedAtMs":1,"cwd":"/workspace","permissions":{},"permissions":{}}`,
+		`{` + valid + `} {}`,
+		`{` + valid + `} x`,
+	} {
+		assertJSONRejects[PermissionsRequestApprovalParams](t, input)
+	}
+
+	var params *PermissionsRequestApprovalParams
+	if err := params.UnmarshalJSON([]byte(`{` + valid + `}`)); err == nil {
+		t.Fatal("nil PermissionsRequestApprovalParams receiver succeeded")
+	}
+}
+
+func TestPermissionsRequestApprovalParamsRemainsStandalone(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	if _, ok := defs["PermissionsRequestApprovalParams"]; !ok {
+		t.Fatal("PermissionsRequestApprovalParams missing")
+	}
+	for _, binding := range WireTypeBindings() {
+		if slices.Contains(binding.Params, "PermissionsRequestApprovalParams") ||
+			slices.Contains(binding.Result, "PermissionsRequestApprovalParams") {
+			t.Fatalf("PermissionsRequestApprovalParams unexpectedly bound to %s", binding.Method)
+		}
+	}
+	if got := len(defs); got != 605 {
+		t.Fatalf("definition count = %d, want 605", got)
+	}
+}
+
+func TestPermissionsRequestApprovalParamsTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	want := "export type PermissionsRequestApprovalParams = {\n" +
+		"  \"cwd\": AbsolutePathBuf;\n" +
+		"  \"environmentId\": string | null;\n" +
+		"  \"itemId\": string;\n" +
+		"  \"permissions\": RequestPermissionProfile;\n" +
+		"  \"reason\": string | null;\n" +
+		"  \"startedAtMs\": number;\n" +
+		"  \"threadId\": string;\n" +
+		"  \"turnId\": string;\n" +
+		"};"
+	if !strings.Contains(string(generated), want) {
+		t.Fatalf("generated TypeScript missing %q", want)
+	}
+}

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -1177,6 +1177,20 @@ func wireSchemaDefinitions() Schema {
 		"reason":         Schema{"type": []any{"string", "null"}},
 		"parsedCmd":      Schema{"type": "array", "items": Schema{"$ref": "#/$defs/ParsedCommand"}},
 	}, []string{"callId", "command", "conversationId", "cwd", "parsedCmd"})
+	schemas["PermissionsRequestApprovalParams"] = sourceApprovalParamsSchema("PermissionsRequestApprovalParams", Schema{
+		"cwd":           Schema{"$ref": "#/$defs/AbsolutePathBuf"},
+		"environmentId": Schema{"default": nil, "type": []any{"string", "null"}},
+		"itemId":        Schema{"type": "string"},
+		"permissions":   Schema{"$ref": "#/$defs/RequestPermissionProfile"},
+		"reason":        Schema{"type": []any{"string", "null"}},
+		"startedAtMs": Schema{
+			"description": "Unix timestamp (in milliseconds) when this approval request started.",
+			"format":      "int64",
+			"type":        "integer",
+		},
+		"threadId": Schema{"type": "string"},
+		"turnId":   Schema{"type": "string"},
+	}, []string{"cwd", "itemId", "permissions", "startedAtMs", "threadId", "turnId"})
 	schemas["NetworkApprovalContext"] = closedThreadSessionParamSchema(Schema{
 		"host":     Schema{"type": "string"},
 		"protocol": Schema{"$ref": "#/$defs/NetworkApprovalProtocol"},

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -12018,19 +12018,16 @@
       "type": "object"
     },
     "PermissionsRequestApprovalParams": {
-      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#",
       "properties": {
         "cwd": {
           "$ref": "#/$defs/AbsolutePathBuf"
         },
         "environmentId": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
+          "default": null,
+          "type": [
+            "string",
+            "null"
           ]
         },
         "itemId": {
@@ -12040,16 +12037,14 @@
           "$ref": "#/$defs/RequestPermissionProfile"
         },
         "reason": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
+          "type": [
+            "string",
+            "null"
           ]
         },
         "startedAtMs": {
+          "description": "Unix timestamp (in milliseconds) when this approval request started.",
+          "format": "int64",
           "type": "integer"
         },
         "threadId": {
@@ -12060,15 +12055,14 @@
         }
       },
       "required": [
-        "threadId",
-        "turnId",
-        "itemId",
-        "environmentId",
-        "startedAtMs",
         "cwd",
-        "reason",
-        "permissions"
+        "itemId",
+        "permissions",
+        "startedAtMs",
+        "threadId",
+        "turnId"
       ],
+      "title": "PermissionsRequestApprovalParams",
       "type": "object"
     },
     "PermissionsRequestApprovalResponse": {

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -68,6 +68,7 @@ func MarshalTypeScript() ([]byte, error) {
 			name == "GuardianApprovalReview" || name == "ParsedCommand" ||
 			name == "ProcessExitedNotification" || name == "ProcessOutputDeltaNotification" ||
 			name == "ProcessTerminalSize" ||
+			name == "PermissionsRequestApprovalParams" ||
 			name == "RateLimitResetCredit" || name == "RateLimitResetCreditsSummary" ||
 			name == "RateLimitSnapshot" || name == "RateLimitWindow" ||
 			name == "SendAddCreditsNudgeEmailParams" || name == "SendAddCreditsNudgeEmailResponse" ||
@@ -168,6 +169,11 @@ func MarshalTypeScript() ([]byte, error) {
 				schema["required"] = []string{"threadId", "turnId", "itemId", "startedAtMs", "environmentId"}
 				schema["x-gollem-typescript-ignore-additional-properties"] = true
 			case "FileChangeRequestApprovalParams":
+				schema["x-gollem-typescript-ignore-additional-properties"] = true
+			case "PermissionsRequestApprovalParams":
+				schema["required"] = []string{
+					"threadId", "turnId", "itemId", "environmentId", "startedAtMs", "cwd", "reason", "permissions",
+				}
 				schema["x-gollem-typescript-ignore-additional-properties"] = true
 			case "ChatgptAuthTokensRefreshParams":
 				schema["x-gollem-typescript-ignore-additional-properties"] = true
@@ -427,6 +433,19 @@ func MarshalTypeScript() ([]byte, error) {
 			definition = typeScriptDefinitionWithPropertySchemas(schema, Schema{
 				"grantRoot": nullableStringSchema(),
 				"reason":    nullableStringSchema(),
+			})
+		}
+		if name == "PermissionsRequestApprovalParams" {
+			// The source schema expresses nullable Options as JSON Schema type
+			// arrays. Normalize only the renderer copy to the ts-rs union shape.
+			schema, _ := typeScriptSchema(definition)
+			schema["required"] = []string{
+				"threadId", "turnId", "itemId", "environmentId", "startedAtMs", "cwd", "reason", "permissions",
+			}
+			schema["x-gollem-typescript-ignore-additional-properties"] = true
+			definition = typeScriptDefinitionWithPropertySchemas(schema, Schema{
+				"environmentId": nullableStringSchema(),
+				"reason":        nullableStringSchema(),
 			})
 		}
 		if name == "ChatgptAuthTokensRefreshParams" {


### PR DESCRIPTION
## Summary
- align `PermissionsRequestApprovalParams` raw Draft 7 schema with the current Codex source contract
- accept omitted nullable `environmentId` and `reason`, preserve canonical null output, and match serde unknown/duplicate/trailing behavior
- retain the existing closed source-compatible TypeScript record through renderer-only normalization

## Verification
- `go test ./appserver/protocol -count=1`
- `go test -race ./appserver/protocol -run 'PermissionsRequestApprovalParams|PermissionProfile' -count=1`\n- non-Monty `go test ./...` and `go vet`\n- `go mod tidy`\n- `go generate ./appserver/protocol`\n- `golangci-lint run`\n- source schema exact comparison\n- generated TypeScript artifact byte-identical