### PR TITLE
protocol: align tool user input request with source

### DIFF
--- a/appserver/interactions.go
+++ b/appserver/interactions.go
@@ -134,18 +134,14 @@ func (s *InteractionService) RequestUserInput(ctx context.Context, req UserInput
 			Options:  publicOptions,
 		}},
 		"autoResolutionMs": req.AutoResolutionMS,
-		"prompt":           req.Prompt,
-		"placeholder":      req.Placeholder,
-		"required":         req.Required,
-		"options":          append([]string(nil), req.Options...),
-		"metadata":         cloneStringAnyMap(req.Metadata),
+		// Gollem waits synchronously for every runtime user-input response.
+		"isBlocking": true,
 	}
 	return s.Request(ctx, InteractionRequest{
 		Method:   InteractionRequestUserInput,
 		ThreadID: req.ThreadID,
 		TurnID:   req.TurnID,
 		ItemID:   req.ItemID,
-		Reason:   req.Prompt,
 		Params:   params,
 	})
 }
@@ -265,7 +261,9 @@ func (s *InteractionService) Request(ctx context.Context, req InteractionRequest
 		ItemID:    itemID,
 	}
 	payload := cloneStringAnyMap(req.Params)
-	payload["requestId"] = requestID
+	if method != InteractionRequestUserInput {
+		payload["requestId"] = requestID
+	}
 	payload["threadId"] = meta.ThreadID
 	if method == InteractionMCPElicitation && meta.TurnID == "" {
 		payload["turnId"] = nil
@@ -273,14 +271,16 @@ func (s *InteractionService) Request(ctx context.Context, req InteractionRequest
 		payload["turnId"] = meta.TurnID
 	}
 	payload["itemId"] = meta.ItemID
-	payload["startedAtMs"] = time.Now().UnixMilli()
+	if method != InteractionRequestUserInput {
+		payload["startedAtMs"] = time.Now().UnixMilli()
+	}
 	if method == InteractionToolCall {
 		callID, _ := payload["callId"].(string)
 		if strings.TrimSpace(callID) == "" {
 			payload["callId"] = firstNonEmpty(meta.ItemID, requestID)
 		}
 	}
-	if strings.TrimSpace(req.Reason) != "" {
+	if method != InteractionRequestUserInput && strings.TrimSpace(req.Reason) != "" {
 		payload["reason"] = strings.TrimSpace(req.Reason)
 	}
 

--- a/appserver/interactions_test.go
+++ b/appserver/interactions_test.go
@@ -34,11 +34,25 @@ func TestInteractionUserInputRequestResolvesFromJSONRPCResponse(t *testing.T) {
 	if req.Method != InteractionRequestUserInput {
 		t.Fatalf("request method = %q, want %s", req.Method, InteractionRequestUserInput)
 	}
+	var rawParams map[string]json.RawMessage
+	if err := json.Unmarshal(req.Params, &rawParams); err != nil {
+		t.Fatalf("decode raw request params: %v", err)
+	}
+	for name := range rawParams {
+		switch name {
+		case "threadId", "turnId", "itemId", "questions", "isBlocking", "autoResolutionMs":
+		default:
+			t.Fatalf("user input request retained legacy field %q: %s", name, req.Params)
+		}
+	}
+	if len(rawParams) != 6 {
+		t.Fatalf("user input request fields = %v, want source shape", rawParams)
+	}
 	var params protocol.ToolRequestUserInputParams
 	if err := json.Unmarshal(req.Params, &params); err != nil {
 		t.Fatalf("decode request params: %v", err)
 	}
-	if params.Prompt != "Need a value" || params.ThreadID != "thread-1" || params.TurnID != "turn-1" ||
+	if !params.IsBlocking || params.ThreadID != "thread-1" || params.TurnID != "turn-1" ||
 		params.ItemID == "" || params.AutoResolutionMS != nil || len(params.Questions) != 1 ||
 		params.Questions[0].ID != "input" || params.Questions[0].Header != "Input" ||
 		len(params.Questions[0].Options) != 2 || params.Questions[0].Options[0].Label != "one" {
@@ -69,7 +83,7 @@ func TestInteractionUserInputRequestResolvesFromJSONRPCResponse(t *testing.T) {
 	}
 }
 
-func TestInteractionUserInputResponseUsesExactBoundedContract(t *testing.T) {
+func TestInteractionUserInputResponseUsesSourceCompatibleContract(t *testing.T) {
 	tests := []struct {
 		name     string
 		result   string
@@ -80,8 +94,8 @@ func TestInteractionUserInputResponseUsesExactBoundedContract(t *testing.T) {
 		{name: "missing answers", result: `{}`, wantFail: true},
 		{name: "null answers", result: `{"answers":null}`, wantFail: true},
 		{name: "null answer list", result: `{"answers":{"question-1":{"answers":null}}}`, wantFail: true},
-		{name: "unknown answer field", result: `{"answers":{"question-1":{"answers":[],"extra":true}}}`, wantFail: true},
-		{name: "unknown response field", result: `{"answers":{},"extra":true}`, wantFail: true},
+		{name: "unknown answer field", result: `{"answers":{"question-1":{"answers":[],"extra":true}}}`},
+		{name: "unknown response field", result: `{"answers":{},"extra":true}`},
 		{
 			name:     "oversized",
 			result:   `{"answers":{"question-1":{"answers":["` + strings.Repeat("x", runtimeInteractionPayloadMaxBytes) + `"]}}}`,
@@ -566,7 +580,7 @@ func TestServeJSONLinesResolvesExactUserInput(t *testing.T) {
 	question := params.Questions[0]
 	if question.ID != "question-input-jsonl" || question.Header != "Target" || question.Question != "Choose a target" ||
 		!question.IsOther || question.IsSecret || len(question.Options) != 2 || question.Options[0].Label != "staging" ||
-		question.Options[0].Description != "" || params.Prompt != "Choose a target" || !params.Required {
+		question.Options[0].Description != "" || !params.IsBlocking {
 		t.Fatalf("user input question = %#v, params = %#v", question, params)
 	}
 	responseLine, err := json.Marshal(protocol.Response{

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -1191,6 +1191,68 @@ func wireSchemaDefinitions() Schema {
 		"threadId": Schema{"type": "string"},
 		"turnId":   Schema{"type": "string"},
 	}, []string{"cwd", "itemId", "permissions", "startedAtMs", "threadId", "turnId"})
+	// Preserve the raw source schemas for request_user_input. TypeScript closes
+	// these serde-open records in the renderer only.
+	schemas["ToolRequestUserInputOption"] = Schema{
+		"description": "EXPERIMENTAL. Defines a single selectable option for request_user_input.",
+		"properties": Schema{
+			"description": Schema{"type": "string"},
+			"label":       Schema{"type": "string"},
+		},
+		"required": []string{"description", "label"},
+		"type":     "object",
+	}
+	schemas["ToolRequestUserInputQuestion"] = Schema{
+		"description": "EXPERIMENTAL. Represents one request_user_input question and its required options.",
+		"properties": Schema{
+			"header":   Schema{"type": "string"},
+			"id":       Schema{"type": "string"},
+			"isOther":  Schema{"default": false, "type": "boolean"},
+			"isSecret": Schema{"default": false, "type": "boolean"},
+			"options": Schema{
+				"items": Schema{"$ref": "#/$defs/ToolRequestUserInputOption"},
+				"type":  []any{"array", "null"},
+			},
+			"question": Schema{"type": "string"},
+		},
+		"required": []string{"header", "id", "question"},
+		"type":     "object",
+	}
+	schemas["ToolRequestUserInputParams"] = Schema{
+		"$schema":     "http://json-schema.org/draft-07/schema#",
+		"description": "EXPERIMENTAL. Params sent with a request_user_input event.",
+		"properties": Schema{
+			"autoResolutionMs": Schema{
+				"default":     nil,
+				"description": "@deprecated Use `isBlocking` to decide whether the request should block.",
+				"format":      "uint64",
+				"minimum":     json.Number("0.0"),
+				"type":        []any{"integer", "null"},
+			},
+			"isBlocking": Schema{"type": "boolean"},
+			"itemId":     Schema{"type": "string"},
+			"questions":  Schema{"items": Schema{"$ref": "#/$defs/ToolRequestUserInputQuestion"}, "type": "array"},
+			"threadId":   Schema{"type": "string"},
+			"turnId":     Schema{"type": "string"},
+		},
+		"required": []string{"isBlocking", "itemId", "questions", "threadId", "turnId"},
+		"title":    "ToolRequestUserInputParams",
+		"type":     "object",
+	}
+	schemas["ToolRequestUserInputAnswer"] = Schema{
+		"description": "EXPERIMENTAL. Captures a user's answer to a request_user_input question.",
+		"properties":  Schema{"answers": Schema{"items": Schema{"type": "string"}, "type": "array"}},
+		"required":    []string{"answers"},
+		"type":        "object",
+	}
+	schemas["ToolRequestUserInputResponse"] = Schema{
+		"$schema":     "http://json-schema.org/draft-07/schema#",
+		"description": "EXPERIMENTAL. Response payload mapping question ids to answers.",
+		"properties":  Schema{"answers": Schema{"additionalProperties": Schema{"$ref": "#/$defs/ToolRequestUserInputAnswer"}, "type": "object"}},
+		"required":    []string{"answers"},
+		"title":       "ToolRequestUserInputResponse",
+		"type":        "object",
+	}
 	schemas["NetworkApprovalContext"] = closedThreadSessionParamSchema(Schema{
 		"host":     Schema{"type": "string"},
 		"protocol": Schema{"$ref": "#/$defs/NetworkApprovalProtocol"},

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -18802,7 +18802,7 @@
       "type": "object"
     },
     "ToolRequestUserInputAnswer": {
-      "additionalProperties": false,
+      "description": "EXPERIMENTAL. Captures a user's answer to a request_user_input question.",
       "properties": {
         "answers": {
           "items": {
@@ -18817,7 +18817,7 @@
       "type": "object"
     },
     "ToolRequestUserInputOption": {
-      "additionalProperties": false,
+      "description": "EXPERIMENTAL. Defines a single selectable option for request_user_input.",
       "properties": {
         "description": {
           "type": "string"
@@ -18827,55 +18827,29 @@
         }
       },
       "required": [
-        "label",
-        "description"
+        "description",
+        "label"
       ],
       "type": "object"
     },
     "ToolRequestUserInputParams": {
-      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "description": "EXPERIMENTAL. Params sent with a request_user_input event.",
       "properties": {
         "autoResolutionMs": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
+          "default": null,
+          "description": "@deprecated Use `isBlocking` to decide whether the request should block.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
           ]
+        },
+        "isBlocking": {
+          "type": "boolean"
         },
         "itemId": {
-          "type": "string"
-        },
-        "metadata": {
-          "anyOf": [
-            {
-              "additionalProperties": {},
-              "type": "object"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "options": {
-          "anyOf": [
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "placeholder": {
-          "type": "string"
-        },
-        "prompt": {
           "type": "string"
         },
         "questions": {
@@ -18883,18 +18857,6 @@
             "$ref": "#/$defs/ToolRequestUserInputQuestion"
           },
           "type": "array"
-        },
-        "reason": {
-          "type": "string"
-        },
-        "requestId": {
-          "type": "string"
-        },
-        "required": {
-          "type": "boolean"
-        },
-        "startedAtMs": {
-          "type": "integer"
         },
         "threadId": {
           "type": "string"
@@ -18904,16 +18866,17 @@
         }
       },
       "required": [
-        "threadId",
-        "turnId",
+        "isBlocking",
         "itemId",
         "questions",
-        "autoResolutionMs"
+        "threadId",
+        "turnId"
       ],
+      "title": "ToolRequestUserInputParams",
       "type": "object"
     },
     "ToolRequestUserInputQuestion": {
-      "additionalProperties": false,
+      "description": "EXPERIMENTAL. Represents one request_user_input question and its required options.",
       "properties": {
         "header": {
           "type": "string"
@@ -18922,22 +18885,20 @@
           "type": "string"
         },
         "isOther": {
+          "default": false,
           "type": "boolean"
         },
         "isSecret": {
+          "default": false,
           "type": "boolean"
         },
         "options": {
-          "anyOf": [
-            {
-              "items": {
-                "$ref": "#/$defs/ToolRequestUserInputOption"
-              },
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
+          "items": {
+            "$ref": "#/$defs/ToolRequestUserInputOption"
+          },
+          "type": [
+            "array",
+            "null"
           ]
         },
         "question": {
@@ -18945,17 +18906,15 @@
         }
       },
       "required": [
-        "id",
         "header",
-        "question",
-        "isOther",
-        "isSecret",
-        "options"
+        "id",
+        "question"
       ],
       "type": "object"
     },
     "ToolRequestUserInputResponse": {
-      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "description": "EXPERIMENTAL. Response payload mapping question ids to answers.",
       "properties": {
         "answers": {
           "additionalProperties": {
@@ -18967,6 +18926,7 @@
       "required": [
         "answers"
       ],
+      "title": "ToolRequestUserInputResponse",
       "type": "object"
     },
     "ToolsV2": {

--- a/appserver/protocol/testdata/user_input_wire_v1.json
+++ b/appserver/protocol/testdata/user_input_wire_v1.json
@@ -27,15 +27,8 @@
               ]
             }
           ],
-          "autoResolutionMs": null,
-          "requestId": "interaction-1",
-          "startedAtMs": 1783715400000,
-          "prompt": "Choose a mode",
-          "placeholder": "safe",
-          "required": true,
-          "options": ["safe", "fast"],
-          "metadata": {"source": "runtime"},
-          "reason": "Choose a mode"
+          "isBlocking": true,
+          "autoResolutionMs": null
         }
       }
     },

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -448,6 +448,31 @@ func MarshalTypeScript() ([]byte, error) {
 				"reason":        nullableStringSchema(),
 			})
 		}
+		if name == "ToolRequestUserInputParams" {
+			// The source schema expresses the deprecated optional timeout as a
+			// type array, while ts-rs exports a required nullable number.
+			schema, _ := typeScriptSchema(definition)
+			schema["required"] = []string{"threadId", "turnId", "itemId", "questions", "isBlocking", "autoResolutionMs"}
+			schema["x-gollem-typescript-ignore-additional-properties"] = true
+			definition = typeScriptDefinitionWithPropertySchemas(schema, Schema{
+				"autoResolutionMs": nullableIntegerSchema(),
+			})
+		}
+		if name == "ToolRequestUserInputQuestion" {
+			// serde defaults these fields, while ts-rs requires their canonical
+			// serialized values. Preserve that distinction in the render copy.
+			schema, _ := typeScriptSchema(definition)
+			schema["required"] = []string{"id", "header", "question", "isOther", "isSecret", "options"}
+			schema["x-gollem-typescript-ignore-additional-properties"] = true
+			definition = typeScriptDefinitionWithPropertySchemas(schema, Schema{
+				"options": nullableArrayRef("ToolRequestUserInputOption"),
+			})
+		}
+		if name == "ToolRequestUserInputOption" || name == "ToolRequestUserInputAnswer" || name == "ToolRequestUserInputResponse" {
+			schema, _ := typeScriptSchema(definition)
+			schema["x-gollem-typescript-ignore-additional-properties"] = true
+			definition = schema
+		}
 		if name == "ChatgptAuthTokensRefreshParams" {
 			schema, _ := typeScriptSchema(definition)
 			schema["x-gollem-typescript-ignore-additional-properties"] = true

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -4320,16 +4320,9 @@ export type ToolRequestUserInputOption = {
 
 export type ToolRequestUserInputParams = {
   "autoResolutionMs": number | null;
+  "isBlocking": boolean;
   "itemId": string;
-  "metadata"?: Record<string, unknown> | null;
-  "options"?: Array<string> | null;
-  "placeholder"?: string;
-  "prompt"?: string;
   "questions": Array<ToolRequestUserInputQuestion>;
-  "reason"?: string;
-  "requestId"?: string;
-  "required"?: boolean;
-  "startedAtMs"?: number;
   "threadId": string;
   "turnId": string;
 };

--- a/appserver/protocol/typescript/testdata/user_input_contract.ts
+++ b/appserver/protocol/typescript/testdata/user_input_contract.ts
@@ -21,8 +21,8 @@ export const params = {
   turnId: "turn-1",
   itemId: "item-1",
   questions: [question],
+  isBlocking: true,
   autoResolutionMs: null,
-  prompt: "Choose a mode",
 } satisfies ToolRequestUserInputParams;
 export const answer = { answers: ["safe"] } satisfies ToolRequestUserInputAnswer;
 export const response = { answers: { "call-1": answer } } satisfies ToolRequestUserInputResponse;

--- a/appserver/protocol/typescript/testdata/user_input_wire_v1.ts
+++ b/appserver/protocol/typescript/testdata/user_input_wire_v1.ts
@@ -37,20 +37,8 @@ export const userInputRequest = {
         ]
       }
     ],
-    "autoResolutionMs": null,
-    "requestId": "interaction-1",
-    "startedAtMs": 1783715400000,
-    "prompt": "Choose a mode",
-    "placeholder": "safe",
-    "required": true,
-    "options": [
-      "safe",
-      "fast"
-    ],
-    "metadata": {
-      "source": "runtime"
-    },
-    "reason": "Choose a mode"
+    "isBlocking": true,
+    "autoResolutionMs": null
   }
 } satisfies BoundRequest<"item/tool/requestUserInput">;
 export const userInputRequestParams = userInputRequest.params satisfies ToolRequestUserInputParams;

--- a/appserver/protocol/user_input_contract_test.go
+++ b/appserver/protocol/user_input_contract_test.go
@@ -2,6 +2,7 @@ package protocol
 
 import (
 	"encoding/json"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -20,12 +21,12 @@ func TestUserInputSchemaAndBindingAreExact(t *testing.T) {
 		}
 	}
 	params := defs["ToolRequestUserInputParams"].(Schema)
-	for _, name := range []string{"threadId", "turnId", "itemId", "questions", "autoResolutionMs"} {
-		assertSchemaRequired(t, params, name)
+	if got, want := schemaRequiredNames(params), []string{"isBlocking", "itemId", "questions", "threadId", "turnId"}; !slices.Equal(got, want) {
+		t.Fatalf("request params required = %v, want %v", got, want)
 	}
 	question := defs["ToolRequestUserInputQuestion"].(Schema)
-	for _, name := range []string{"id", "header", "question", "isOther", "isSecret", "options"} {
-		assertSchemaRequired(t, question, name)
+	if got, want := schemaRequiredNames(question), []string{"header", "id", "question"}; !slices.Equal(got, want) {
+		t.Fatalf("request question required = %v, want %v", got, want)
 	}
 	answer := defs["ToolRequestUserInputAnswer"].(Schema)
 	assertSchemaRequired(t, answer, "answers")
@@ -41,6 +42,7 @@ func TestUserInputResponseWireValidation(t *testing.T) {
 		`{"answers":{}}`,
 		`{"answers":{"question-1":{"answers":[]}}}`,
 		`{"answers":{"question-1":{"answers":["safe","other"]}}}`,
+		`{"answers":{"question-1":{"answers":[],"extra":true}},"extra":true}`,
 	}
 	for _, input := range valid {
 		var response ToolRequestUserInputResponse
@@ -57,8 +59,9 @@ func TestUserInputResponseWireValidation(t *testing.T) {
 		`{"answers":{"question-1":{}}}`,
 		`{"answers":{"question-1":{"answers":null}}}`,
 		`{"answers":{"question-1":{"answers":[1]}}}`,
-		`{"answers":{"question-1":{"answers":[],"extra":true}}}`,
-		`{"answers":{},"extra":true}`,
+		`{"answers":{"question-1":{"answers":[],"answers":[]}}}`,
+		`{"answers":{},"answers":{}}`,
+		`{"answers":{}} {}`,
 	}
 	for _, input := range invalid {
 		var response ToolRequestUserInputResponse
@@ -73,6 +76,14 @@ func TestUserInputResponseWireValidation(t *testing.T) {
 	var answer *ToolRequestUserInputAnswer
 	if err := answer.UnmarshalJSON([]byte(`{"answers":[]}`)); err == nil {
 		t.Error("nil answer receiver succeeded")
+	}
+	var option *ToolRequestUserInputOption
+	if err := option.UnmarshalJSON([]byte(`{"label":"safe","description":""}`)); err == nil {
+		t.Error("nil option receiver succeeded")
+	}
+	var question *ToolRequestUserInputQuestion
+	if err := question.UnmarshalJSON([]byte(`{"id":"q","header":"Header","question":"Choose"}`)); err == nil {
+		t.Error("nil question receiver succeeded")
 	}
 }
 

--- a/appserver/protocol/user_input_source_contract_test.go
+++ b/appserver/protocol/user_input_source_contract_test.go
@@ -1,0 +1,152 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestToolRequestUserInputSourceSchemasAreExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	wants := map[string]Schema{
+		"ToolRequestUserInputOption": {
+			"description": "EXPERIMENTAL. Defines a single selectable option for request_user_input.",
+			"properties":  Schema{"description": Schema{"type": "string"}, "label": Schema{"type": "string"}},
+			"required":    []string{"description", "label"},
+			"type":        "object",
+		},
+		"ToolRequestUserInputQuestion": {
+			"description": "EXPERIMENTAL. Represents one request_user_input question and its required options.",
+			"properties": Schema{
+				"header":   Schema{"type": "string"},
+				"id":       Schema{"type": "string"},
+				"isOther":  Schema{"default": false, "type": "boolean"},
+				"isSecret": Schema{"default": false, "type": "boolean"},
+				"options":  Schema{"items": Schema{"$ref": "#/$defs/ToolRequestUserInputOption"}, "type": []any{"array", "null"}},
+				"question": Schema{"type": "string"},
+			},
+			"required": []string{"header", "id", "question"},
+			"type":     "object",
+		},
+		"ToolRequestUserInputParams": {
+			"$schema":     "http://json-schema.org/draft-07/schema#",
+			"description": "EXPERIMENTAL. Params sent with a request_user_input event.",
+			"properties": Schema{
+				"autoResolutionMs": Schema{
+					"default":     nil,
+					"description": "@deprecated Use `isBlocking` to decide whether the request should block.",
+					"format":      "uint64",
+					"minimum":     json.Number("0.0"),
+					"type":        []any{"integer", "null"},
+				},
+				"isBlocking": Schema{"type": "boolean"},
+				"itemId":     Schema{"type": "string"},
+				"questions":  Schema{"items": Schema{"$ref": "#/$defs/ToolRequestUserInputQuestion"}, "type": "array"},
+				"threadId":   Schema{"type": "string"},
+				"turnId":     Schema{"type": "string"},
+			},
+			"required": []string{"isBlocking", "itemId", "questions", "threadId", "turnId"},
+			"title":    "ToolRequestUserInputParams",
+			"type":     "object",
+		},
+		"ToolRequestUserInputAnswer": {
+			"description": "EXPERIMENTAL. Captures a user's answer to a request_user_input question.",
+			"properties":  Schema{"answers": Schema{"items": Schema{"type": "string"}, "type": "array"}},
+			"required":    []string{"answers"},
+			"type":        "object",
+		},
+		"ToolRequestUserInputResponse": {
+			"$schema":     "http://json-schema.org/draft-07/schema#",
+			"description": "EXPERIMENTAL. Response payload mapping question ids to answers.",
+			"properties":  Schema{"answers": Schema{"additionalProperties": Schema{"$ref": "#/$defs/ToolRequestUserInputAnswer"}, "type": "object"}},
+			"required":    []string{"answers"},
+			"title":       "ToolRequestUserInputResponse",
+			"type":        "object",
+		},
+	}
+	for name, want := range wants {
+		if got := defs[name]; !reflect.DeepEqual(got, want) {
+			t.Errorf("%s = %#v, want %#v", name, got, want)
+		}
+	}
+}
+
+func TestToolRequestUserInputParamsMatchSerdeWireForms(t *testing.T) {
+	for _, test := range []struct {
+		input string
+		want  string
+	}{
+		{
+			input: `{"threadId":"thread","turnId":"turn","itemId":"item","questions":[{"id":"question","header":"Header","question":"Choose","future":true}],"future":1}`,
+			want:  `{"threadId":"thread","turnId":"turn","itemId":"item","questions":[{"id":"question","header":"Header","question":"Choose","isOther":false,"isSecret":false,"options":null}],"isBlocking":true,"autoResolutionMs":null}`,
+		},
+		{
+			input: `{"threadId":"thread","turnId":"turn","itemId":"item","questions":[],"isBlocking":null,"autoResolutionMs":null}`,
+			want:  `{"threadId":"thread","turnId":"turn","itemId":"item","questions":[],"isBlocking":true,"autoResolutionMs":null}`,
+		},
+		{
+			input: `{"threadId":"thread","turnId":"turn","itemId":"item","questions":[{"id":"question","header":"Header","question":"Choose","isOther":true,"isSecret":true,"options":[{"label":"yes","description":"Continue","future":"ignored"}]}],"isBlocking":false,"autoResolutionMs":5,"future":2}`,
+			want:  `{"threadId":"thread","turnId":"turn","itemId":"item","questions":[{"id":"question","header":"Header","question":"Choose","isOther":true,"isSecret":true,"options":[{"label":"yes","description":"Continue"}]}],"isBlocking":false,"autoResolutionMs":5}`,
+		},
+	} {
+		var params ToolRequestUserInputParams
+		if err := json.Unmarshal([]byte(test.input), &params); err != nil {
+			t.Errorf("Unmarshal(%s): %v", test.input, err)
+			continue
+		}
+		encoded, err := json.Marshal(params)
+		if err != nil || string(encoded) != test.want {
+			t.Errorf("round trip %s = %s, %v; want %s", test.input, encoded, err, test.want)
+		}
+	}
+}
+
+func TestToolRequestUserInputParamsRejectMalformedSerdeWire(t *testing.T) {
+	valid := `"threadId":"thread","turnId":"turn","itemId":"item","questions":[]`
+	for _, input := range []string{
+		``, `null`, `[]`, `{`, `{}`,
+		`{"turnId":"turn","itemId":"item","questions":[]}`,
+		`{"threadId":"thread","itemId":"item","questions":[]}`,
+		`{"threadId":"thread","turnId":"turn","questions":[]}`,
+		`{"threadId":"thread","turnId":"turn","itemId":"item"}`,
+		`{"threadId":null,"turnId":"turn","itemId":"item","questions":[]}`,
+		`{"threadId":"thread","turnId":"turn","itemId":"item","questions":null}`,
+		`{"threadId":"thread","turnId":"turn","itemId":"item","questions":[{}]}`,
+		`{"threadId":"thread","turnId":"turn","itemId":"item","questions":[{"id":"question","header":"Header","question":"Choose","isOther":null}]}`,
+		`{"threadId":"thread","turnId":"turn","itemId":"item","questions":[{"id":"question","header":"Header","question":"Choose","options":[{"label":"yes"}]}]}`,
+		`{"threadId":"thread","turnId":"turn","itemId":"item","questions":[],"isBlocking":1}`,
+		`{"threadId":"thread","turnId":"turn","itemId":"item","questions":[],"autoResolutionMs":-1}`,
+		`{"threadId":"one","threadId":"two","turnId":"turn","itemId":"item","questions":[]}`,
+		`{"threadId":"thread","turnId":"turn","itemId":"item","questions":[],"isBlocking":true,"isBlocking":false}`,
+		`{"threadId":"thread","turnId":"turn","itemId":"item","questions":[{"id":"question","id":"duplicate","header":"Header","question":"Choose"}]}`,
+		`{"threadId":"thread","turnId":"turn","itemId":"item","questions":[{"id":"question","header":"Header","question":"Choose","options":[{"label":"one","label":"two","description":"Continue"}]}]}`,
+		`{` + valid + `} {}`,
+		`{` + valid + `} x`,
+	} {
+		assertJSONRejects[ToolRequestUserInputParams](t, input)
+	}
+
+	var params *ToolRequestUserInputParams
+	if err := params.UnmarshalJSON([]byte(`{` + valid + `}`)); err == nil {
+		t.Fatal("nil ToolRequestUserInputParams receiver succeeded")
+	}
+}
+
+func TestToolRequestUserInputTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	want := "export type ToolRequestUserInputParams = {\n" +
+		"  \"autoResolutionMs\": number | null;\n" +
+		"  \"isBlocking\": boolean;\n" +
+		"  \"itemId\": string;\n" +
+		"  \"questions\": Array<ToolRequestUserInputQuestion>;\n" +
+		"  \"threadId\": string;\n" +
+		"  \"turnId\": string;\n" +
+		"};"
+	if !strings.Contains(string(generated), want) {
+		t.Fatalf("generated TypeScript missing %q", want)
+	}
+}

--- a/appserver/protocol/user_input_types.go
+++ b/appserver/protocol/user_input_types.go
@@ -1,15 +1,34 @@
 package protocol
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
-	"fmt"
 )
 
 type ToolRequestUserInputOption struct {
 	Label       string `json:"label"`
 	Description string `json:"description"`
+}
+
+func (o *ToolRequestUserInputOption) UnmarshalJSON(data []byte) error {
+	if o == nil {
+		return errors.New("decode tool request user input option into nil receiver")
+	}
+	const objectName = "tool request user input option"
+	payload, err := decodeRustSerdeObject(data, objectName, "label", "description")
+	if err != nil {
+		return err
+	}
+	label, err := decodeRequiredThreadItemValue[string](payload, objectName, "label")
+	if err != nil {
+		return err
+	}
+	description, err := decodeRequiredThreadItemValue[string](payload, objectName, "description")
+	if err != nil {
+		return err
+	}
+	*o = ToolRequestUserInputOption{Label: label, Description: description}
+	return nil
 }
 
 type ToolRequestUserInputQuestion struct {
@@ -21,22 +40,112 @@ type ToolRequestUserInputQuestion struct {
 	Options  []ToolRequestUserInputOption `json:"options"`
 }
 
-// ToolRequestUserInputParams is the public structured request. The trailing
-// fields preserve Gollem's v1 single-prompt request for existing clients.
+func (q *ToolRequestUserInputQuestion) UnmarshalJSON(data []byte) error {
+	if q == nil {
+		return errors.New("decode tool request user input question into nil receiver")
+	}
+	const objectName = "tool request user input question"
+	payload, err := decodeRustSerdeObject(data, objectName, "id", "header", "question", "isOther", "isSecret", "options")
+	if err != nil {
+		return err
+	}
+	id, err := decodeRequiredThreadItemValue[string](payload, objectName, "id")
+	if err != nil {
+		return err
+	}
+	header, err := decodeRequiredThreadItemValue[string](payload, objectName, "header")
+	if err != nil {
+		return err
+	}
+	question, err := decodeRequiredThreadItemValue[string](payload, objectName, "question")
+	if err != nil {
+		return err
+	}
+	isOther, err := decodeOptionalConfigBool(payload, objectName, "isOther")
+	if err != nil {
+		return err
+	}
+	isSecret, err := decodeOptionalConfigBool(payload, objectName, "isSecret")
+	if err != nil {
+		return err
+	}
+	options, err := decodeOptionalNullableConfigValue[[]ToolRequestUserInputOption](payload, objectName, "options")
+	if err != nil {
+		return err
+	}
+	*q = ToolRequestUserInputQuestion{
+		ID:       id,
+		Header:   header,
+		Question: question,
+		IsOther:  isOther,
+		IsSecret: isSecret,
+	}
+	if options != nil {
+		q.Options = *options
+	}
+	return nil
+}
+
+// ToolRequestUserInputParams is the public structured request.
 type ToolRequestUserInputParams struct {
 	ThreadID         string                         `json:"threadId"`
 	TurnID           string                         `json:"turnId"`
 	ItemID           string                         `json:"itemId"`
 	Questions        []ToolRequestUserInputQuestion `json:"questions" jsonschema:"nonnullable=true"`
+	IsBlocking       bool                           `json:"isBlocking"`
 	AutoResolutionMS *uint64                        `json:"autoResolutionMs"`
-	RequestID        string                         `json:"requestId,omitempty"`
-	StartedAtMS      int64                          `json:"startedAtMs,omitempty"`
-	Prompt           string                         `json:"prompt,omitempty"`
-	Placeholder      string                         `json:"placeholder,omitempty"`
-	Required         bool                           `json:"required,omitempty"`
-	Options          []string                       `json:"options,omitempty"`
-	Metadata         map[string]any                 `json:"metadata,omitempty"`
-	Reason           string                         `json:"reason,omitempty"`
+}
+
+func (p *ToolRequestUserInputParams) UnmarshalJSON(data []byte) error {
+	if p == nil {
+		return errors.New("decode tool request user input params into nil receiver")
+	}
+	const objectName = "tool request user input params"
+	payload, err := decodeRustSerdeObject(
+		data,
+		objectName,
+		"threadId", "turnId", "itemId", "questions", "isBlocking", "autoResolutionMs",
+	)
+	if err != nil {
+		return err
+	}
+	threadID, err := decodeRequiredThreadItemValue[string](payload, objectName, "threadId")
+	if err != nil {
+		return err
+	}
+	turnID, err := decodeRequiredThreadItemValue[string](payload, objectName, "turnId")
+	if err != nil {
+		return err
+	}
+	itemID, err := decodeRequiredThreadItemValue[string](payload, objectName, "itemId")
+	if err != nil {
+		return err
+	}
+	questions, err := decodeRequiredThreadItemValue[[]ToolRequestUserInputQuestion](payload, objectName, "questions")
+	if err != nil {
+		return err
+	}
+	isBlocking, err := decodeOptionalNullableConfigValue[bool](payload, objectName, "isBlocking")
+	if err != nil {
+		return err
+	}
+	autoResolutionMS, err := decodeOptionalNullableConfigValue[uint64](payload, objectName, "autoResolutionMs")
+	if err != nil {
+		return err
+	}
+	blocking := true
+	if isBlocking != nil {
+		blocking = *isBlocking
+	}
+	*p = ToolRequestUserInputParams{
+		ThreadID:         threadID,
+		TurnID:           turnID,
+		ItemID:           itemID,
+		Questions:        questions,
+		IsBlocking:       blocking,
+		AutoResolutionMS: autoResolutionMS,
+	}
+	return nil
 }
 
 type ToolRequestUserInputAnswer struct {
@@ -57,22 +166,14 @@ func (a *ToolRequestUserInputAnswer) UnmarshalJSON(data []byte) error {
 	if a == nil {
 		return errors.New("decode user input answer into nil receiver")
 	}
-	var payload map[string]json.RawMessage
-	if err := json.Unmarshal(data, &payload); err != nil {
+	const objectName = "tool request user input answer"
+	payload, err := decodeRustSerdeObject(data, objectName, "answers")
+	if err != nil {
 		return err
 	}
-	for name := range payload {
-		if name != "answers" {
-			return fmt.Errorf("unknown user input answer field %q", name)
-		}
-	}
-	answersRaw := payload["answers"]
-	if len(answersRaw) == 0 || bytes.Equal(bytes.TrimSpace(answersRaw), []byte("null")) {
-		return errors.New("user input answer requires answers array")
-	}
-	var answers []string
-	if err := json.Unmarshal(answersRaw, &answers); err != nil {
-		return fmt.Errorf("decode user input answers: %w", err)
+	answers, err := decodeRequiredThreadItemValue[[]string](payload, objectName, "answers")
+	if err != nil {
+		return err
 	}
 	*a = ToolRequestUserInputAnswer{Answers: answers}
 	return nil
@@ -96,22 +197,14 @@ func (r *ToolRequestUserInputResponse) UnmarshalJSON(data []byte) error {
 	if r == nil {
 		return errors.New("decode user input response into nil receiver")
 	}
-	var payload map[string]json.RawMessage
-	if err := json.Unmarshal(data, &payload); err != nil {
+	const objectName = "tool request user input response"
+	payload, err := decodeRustSerdeObject(data, objectName, "answers")
+	if err != nil {
 		return err
 	}
-	for name := range payload {
-		if name != "answers" {
-			return fmt.Errorf("unknown user input response field %q", name)
-		}
-	}
-	answersRaw := payload["answers"]
-	if len(answersRaw) == 0 || bytes.Equal(bytes.TrimSpace(answersRaw), []byte("null")) {
-		return errors.New("user input response requires answers object")
-	}
-	var answers map[string]ToolRequestUserInputAnswer
-	if err := json.Unmarshal(answersRaw, &answers); err != nil {
-		return fmt.Errorf("decode user input response answers: %w", err)
+	answers, err := decodeRequiredThreadItemValue[map[string]ToolRequestUserInputAnswer](payload, objectName, "answers")
+	if err != nil {
+		return err
 	}
 	*r = ToolRequestUserInputResponse{Answers: answers}
 	return nil


### PR DESCRIPTION
## Summary
- align the live `item/tool/requestUserInput` payload with the current Codex structured request contract
- serialize canonical `isBlocking: true`, remove legacy request metadata from the public wire payload, and preserve legacy missing-isBlocking decode semantics
- align user-input schemas, serde decode behavior, generated TypeScript, and fixtures with the source contract

## Verification
- `go test -race ./appserver/protocol ./appserver -run 'UserInput|InteractionUserInput|ServerRuntimeUserInput' -count=1`\n- `go test ./appserver/protocol -count=1`\n- non-Monty `go test ./...` and `go vet`\n- `go mod tidy`\n- `go generate ./appserver/protocol`\n- `golangci-lint run`\n- source schema exact comparisons for params, question, option, response, and answer