### PR TITLE
Align MCP elicitation contract with source

### DIFF
--- a/appserver/interactions.go
+++ b/appserver/interactions.go
@@ -209,9 +209,6 @@ func (s *InteractionService) RequestMCPElicitation(ctx context.Context, req MCPE
 		Meta:            meta,
 		Message:         req.Message,
 		RequestedSchema: requestedSchemaJSON,
-		ServerID:        strings.TrimSpace(req.ServerID),
-		Schema:          schema,
-		Metadata:        cloneStringAnyMap(req.Metadata),
 	}
 	paramsJSON, err := json.Marshal(typedParams)
 	if err != nil {
@@ -229,7 +226,6 @@ func (s *InteractionService) RequestMCPElicitation(ctx context.Context, req MCPE
 		ThreadID: req.ThreadID,
 		TurnID:   req.TurnID,
 		ItemID:   req.ItemID,
-		Reason:   req.Message,
 		Params:   params,
 	})
 }
@@ -261,7 +257,7 @@ func (s *InteractionService) Request(ctx context.Context, req InteractionRequest
 		ItemID:    itemID,
 	}
 	payload := cloneStringAnyMap(req.Params)
-	if method != InteractionRequestUserInput {
+	if method != InteractionRequestUserInput && method != InteractionMCPElicitation {
 		payload["requestId"] = requestID
 	}
 	payload["threadId"] = meta.ThreadID
@@ -270,8 +266,10 @@ func (s *InteractionService) Request(ctx context.Context, req InteractionRequest
 	} else {
 		payload["turnId"] = meta.TurnID
 	}
-	payload["itemId"] = meta.ItemID
-	if method != InteractionRequestUserInput {
+	if method != InteractionMCPElicitation {
+		payload["itemId"] = meta.ItemID
+	}
+	if method != InteractionRequestUserInput && method != InteractionMCPElicitation {
 		payload["startedAtMs"] = time.Now().UnixMilli()
 	}
 	if method == InteractionToolCall {
@@ -280,7 +278,7 @@ func (s *InteractionService) Request(ctx context.Context, req InteractionRequest
 			payload["callId"] = firstNonEmpty(meta.ItemID, requestID)
 		}
 	}
-	if method != InteractionRequestUserInput && strings.TrimSpace(req.Reason) != "" {
+	if method != InteractionRequestUserInput && method != InteractionMCPElicitation && strings.TrimSpace(req.Reason) != "" {
 		payload["reason"] = strings.TrimSpace(req.Reason)
 	}
 

--- a/appserver/interactions_test.go
+++ b/appserver/interactions_test.go
@@ -278,7 +278,7 @@ func TestInteractionMCPElicitationRequestUsesExactCanonicalForm(t *testing.T) {
 	}
 	if params.ThreadID != "thread-mcp" || params.TurnID == nil || *params.TurnID != "turn-mcp" ||
 		params.ServerName != "repo" || params.Mode != protocol.McpServerElicitationModeForm ||
-		params.ItemID != "item-mcp" || params.ServerID != "repo" || params.Message != "Choose access" ||
+		params.Message != "Choose access" ||
 		!strings.Contains(string(params.Meta), `"source":"runtime"`) ||
 		!strings.Contains(string(params.RequestedSchema), `"items":{"anyOf"`) {
 		t.Fatalf("MCP elicitation params = %#v, schema=%s", params, params.RequestedSchema)
@@ -311,7 +311,7 @@ func TestInteractionMCPElicitationRequestUsesExactCanonicalForm(t *testing.T) {
 	}
 }
 
-func TestInteractionMCPElicitationResponseUsesExactBoundedContract(t *testing.T) {
+func TestInteractionMCPElicitationResponseMatchesSourceSerde(t *testing.T) {
 	tests := []struct {
 		name     string
 		result   string
@@ -321,10 +321,10 @@ func TestInteractionMCPElicitationResponseUsesExactBoundedContract(t *testing.T)
 		{name: "decline", result: `{"action":"decline","content":null,"_meta":{"reason":"policy"}}`},
 		{name: "cancel", result: `{"action":"cancel","content":null,"_meta":null}`},
 		{name: "missing action", result: `{"content":null,"_meta":null}`, wantFail: true},
-		{name: "missing content", result: `{"action":"accept","_meta":null}`, wantFail: true},
-		{name: "missing meta", result: `{"action":"accept","content":null}`, wantFail: true},
+		{name: "missing content", result: `{"action":"accept","_meta":null}`},
+		{name: "missing meta", result: `{"action":"accept","content":null}`},
 		{name: "invalid action", result: `{"action":"approve","content":null,"_meta":null}`, wantFail: true},
-		{name: "unknown field", result: `{"action":"cancel","content":null,"_meta":null,"extra":true}`, wantFail: true},
+		{name: "unknown field", result: `{"action":"cancel","content":null,"_meta":null,"extra":true}`},
 		{
 			name:     "oversized",
 			result:   `{"action":"accept","content":{"value":"` + strings.Repeat("x", runtimeInteractionPayloadMaxBytes) + `"},"_meta":null}`,

--- a/appserver/protocol/mcp_elicitation_contract_test.go
+++ b/appserver/protocol/mcp_elicitation_contract_test.go
@@ -44,19 +44,39 @@ func TestMcpElicitationSchemaAndBindingAreExact(t *testing.T) {
 		assertSchemaRequired(t, schema, name)
 	}
 	params := defs["McpServerElicitationRequestParams"].(Schema)
+	for _, name := range []string{"threadId", "serverName"} {
+		assertSchemaRequired(t, params, name)
+	}
+	if _, required := params["additionalProperties"]; required {
+		t.Fatalf("McpServerElicitationRequestParams unexpectedly closes the serde-open record: %#v", params)
+	}
 	variants, ok := params["oneOf"].([]any)
 	if !ok || len(variants) != 3 {
 		t.Fatalf("McpServerElicitationRequestParams oneOf = %#v", params["oneOf"])
 	}
 	for _, variant := range variants {
 		item := variant.(Schema)
-		for _, name := range []string{"threadId", "turnId", "serverName", "mode", "_meta", "message"} {
+		for _, name := range []string{"mode", "message"} {
 			assertSchemaRequired(t, item, name)
 		}
+		if _, required := item["additionalProperties"]; required {
+			t.Fatalf("McpServerElicitationRequestParams variant unexpectedly closes the serde-open record: %#v", item)
+		}
+	}
+	formProperties := variants[0].(Schema)["properties"].(Schema)
+	openAIFormProperties := variants[1].(Schema)["properties"].(Schema)
+	if formProperties["_meta"] != true || openAIFormProperties["_meta"] != true ||
+		openAIFormProperties["requestedSchema"] != true {
+		t.Fatalf("McpServerElicitationRequestParams JSON-value fields = %#v / %#v", formProperties, openAIFormProperties)
+	}
+	urlRequired := variants[2].(Schema)["required"].([]string)
+	if got, want := strings.Join(urlRequired, ","), "elicitationId,message,mode,url"; got != want {
+		t.Fatalf("URL request required order = %q, want %q", got, want)
 	}
 	response := defs["McpServerElicitationRequestResponse"].(Schema)
-	for _, name := range []string{"action", "content", "_meta"} {
-		assertSchemaRequired(t, response, name)
+	assertSchemaRequired(t, response, "action")
+	if _, required := response["additionalProperties"]; required {
+		t.Fatalf("McpServerElicitationRequestResponse unexpectedly closes the serde-open record: %#v", response)
 	}
 	enumSchema := defs["McpElicitationEnumSchema"].(Schema)
 	if variants, ok := enumSchema["anyOf"].([]any); !ok || len(variants) != 3 {
@@ -73,6 +93,19 @@ func TestMcpElicitationSchemaAndBindingAreExact(t *testing.T) {
 	bindings := WireTypeBindings()
 	assertBinding(t, bindings, "mcpServer/elicitation/request", SurfaceServerRequest, "McpServerElicitationRequestParams")
 	assertBinding(t, bindings, "mcpServer/elicitation/request", SurfaceServerRequest, "McpServerElicitationRequestResponse")
+	typescript, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	for _, declaration := range []string{
+		`export type McpServerElicitationRequestParams = { "threadId": string; "turnId": string | null; "serverName": string; } &`,
+		`"requestedSchema": JsonValue;`,
+		`export type McpServerElicitationRequestResponse = { "action": McpServerElicitationAction; "content": JsonValue | null; "_meta": JsonValue | null; };`,
+	} {
+		if !strings.Contains(string(typescript), declaration) {
+			t.Fatalf("generated TypeScript missing %q", declaration)
+		}
+	}
 }
 
 func TestMcpElicitationSchemaAcceptsEveryPublicPrimitiveVariant(t *testing.T) {
@@ -228,8 +261,8 @@ func TestMcpElicitationUnionWrappersAreStrict(t *testing.T) {
 
 func TestMcpServerElicitationParamsValidateAllModes(t *testing.T) {
 	valid := []string{
-		`{"threadId":"thread-1","turnId":null,"serverName":"repo","mode":"form","_meta":null,"message":"Choose","requestedSchema":{"type":"object","properties":{"scopes":{"type":"array","items":{"oneOf":[{"const":"read","title":"Read"}]}}}}}`,
-		`{"threadId":"thread-1","turnId":"turn-1","serverName":"repo","mode":"openai/form","_meta":{"source":"test"},"message":"Choose","requestedSchema":{"type":"custom"},"itemId":"item-1","schema":null,"metadata":null}`,
+		`{"threadId":"thread-1","serverName":"repo","mode":"form","message":"Choose","requestedSchema":{"type":"object","properties":{"scopes":{"type":"array","items":{"oneOf":[{"const":"read","title":"Read"}]}}}},"ignored":true}`,
+		`{"threadId":"thread-1","turnId":"turn-1","serverName":"repo","mode":"openai/form","_meta":{"source":"test"},"message":"Choose","requestedSchema":{"type":"custom"},"itemId":"legacy-is-ignored"}`,
 		`{"threadId":"thread-1","turnId":null,"serverName":"repo","mode":"url","_meta":null,"message":"Open","url":"https://example.com","elicitationId":"elicit-1"}`,
 	}
 	for _, input := range valid {
@@ -251,18 +284,25 @@ func TestMcpServerElicitationParamsValidateAllModes(t *testing.T) {
 			t.Errorf("form params were not canonicalized: %s", encoded)
 		}
 	}
+	var canonical McpServerElicitationRequestParams
+	if err := json.Unmarshal([]byte(`{"threadId":"thread-1","serverName":"repo","mode":"url","message":"Open","url":"https://example.com","elicitationId":"elicit-1","requestId":"legacy","extra":true}`), &canonical); err != nil {
+		t.Fatalf("source-open params: %v", err)
+	}
+	encoded, err := json.Marshal(canonical)
+	if err != nil {
+		t.Fatalf("marshal source-open params: %v", err)
+	}
+	if strings.Contains(string(encoded), `"requestId"`) || strings.Contains(string(encoded), `"extra"`) ||
+		!strings.Contains(string(encoded), `"turnId":null`) || !strings.Contains(string(encoded), `"_meta":null`) {
+		t.Fatalf("source-open params canonicalized as %s", encoded)
+	}
 	invalid := []string{
 		`{}`,
-		`{"threadId":"thread-1","serverName":"repo","mode":"form","_meta":null,"message":"Choose","requestedSchema":{"type":"object","properties":{}}}`,
-		`{"threadId":"thread-1","turnId":null,"serverName":"repo","mode":"form","message":"Choose","requestedSchema":{"type":"object","properties":{}}}`,
 		`{"threadId":"thread-1","turnId":null,"serverName":"repo","mode":"form","_meta":null,"message":"Choose"}`,
 		`{"threadId":"thread-1","turnId":null,"serverName":"repo","mode":"form","_meta":null,"message":"Choose","requestedSchema":{"type":"object"}}`,
-		`{"threadId":"thread-1","turnId":null,"serverName":"repo","mode":"form","_meta":null,"message":"Choose","requestedSchema":{"type":"object","properties":{}},"url":"bad"}`,
 		`{"threadId":"thread-1","turnId":null,"serverName":"repo","mode":"url","_meta":null,"message":"Open","url":"https://example.com"}`,
 		`{"threadId":"thread-1","turnId":null,"serverName":"repo","mode":"other","_meta":null,"message":"Choose"}`,
-		`{"threadId":"thread-1","turnId":null,"serverName":"repo","mode":"url","_meta":null,"message":"Open","url":"https://example.com","elicitationId":"id","extra":true}`,
-		`{"threadId":"thread-1","turnId":null,"serverName":"repo","mode":"url","_meta":null,"message":"Open","url":"https://example.com","elicitationId":"id","metadata":[]}`,
-		`{"threadId":"thread-1","turnId":null,"serverName":"repo","mode":"url","_meta":null,"message":"Open","url":"https://example.com","elicitationId":"id","startedAtMs":null}`,
+		`{"threadId":"thread-1","serverName":"repo","mode":"url","message":"Open","url":"https://example.com","elicitationId":"id","threadId":"duplicate"}`,
 	}
 	for _, input := range invalid {
 		var params McpServerElicitationRequestParams
@@ -279,7 +319,7 @@ func TestMcpServerElicitationParamsValidateAllModes(t *testing.T) {
 	}
 }
 
-func TestMcpServerElicitationResponseIsStrictAndNonNullOnMarshal(t *testing.T) {
+func TestMcpServerElicitationResponseMatchesSourceSerde(t *testing.T) {
 	for _, input := range []string{
 		`{"action":"accept","content":{"choice":"safe"},"_meta":null}`,
 		`{"action":"decline","content":null,"_meta":{"reason":"policy"}}`,
@@ -291,13 +331,30 @@ func TestMcpServerElicitationResponseIsStrictAndNonNullOnMarshal(t *testing.T) {
 		}
 	}
 	for _, input := range []string{
+		`{"action":"accept"}`,
+		`{"action":"cancel","content":null,"_meta":null,"extra":true}`,
+	} {
+		var response McpServerElicitationRequestResponse
+		if err := json.Unmarshal([]byte(input), &response); err != nil {
+			t.Errorf("source-open Unmarshal(%s): %v", input, err)
+			continue
+		}
+		encoded, err := json.Marshal(response)
+		if err != nil {
+			t.Errorf("source-open Marshal(%s): %v", input, err)
+			continue
+		}
+		if string(encoded) != `{"action":"accept","content":null,"_meta":null}` &&
+			string(encoded) != `{"action":"cancel","content":null,"_meta":null}` {
+			t.Errorf("source-open response canonicalized as %s", encoded)
+		}
+	}
+	for _, input := range []string{
 		`[`,
 		`{}`,
-		`{"action":"accept","_meta":null}`,
-		`{"action":"accept","content":null}`,
 		`{"action":"approve","content":null,"_meta":null}`,
-		`{"action":"accept","content":null,"_meta":null,"extra":true}`,
 		`{"action":null,"content":null,"_meta":null}`,
+		`{"action":"accept","action":"cancel"}`,
 	} {
 		var response McpServerElicitationRequestResponse
 		if err := json.Unmarshal([]byte(input), &response); err == nil {

--- a/appserver/protocol/mcp_elicitation_types.go
+++ b/appserver/protocol/mcp_elicitation_types.go
@@ -21,6 +21,15 @@ const (
 	McpServerElicitationModeURL        = "url"
 )
 
+func validMcpServerElicitationAction(action McpServerElicitationAction) bool {
+	switch action {
+	case McpServerElicitationAccept, McpServerElicitationDecline, McpServerElicitationCancel:
+		return true
+	default:
+		return false
+	}
+}
+
 type McpElicitationObjectType string
 
 const McpElicitationObject McpElicitationObjectType = "object"
@@ -163,13 +172,6 @@ type McpServerElicitationRequestParams struct {
 	RequestedSchema json.RawMessage `json:"requestedSchema,omitempty"`
 	URL             string          `json:"url,omitempty"`
 	ElicitationID   string          `json:"elicitationId,omitempty"`
-	RequestID       string          `json:"requestId,omitempty"`
-	ItemID          string          `json:"itemId,omitempty"`
-	StartedAtMS     int64           `json:"startedAtMs,omitempty"`
-	ServerID        string          `json:"serverId,omitempty"`
-	Schema          map[string]any  `json:"schema,omitempty"`
-	Metadata        map[string]any  `json:"metadata,omitempty"`
-	Reason          string          `json:"reason,omitempty"`
 }
 
 type McpServerElicitationRequestResponse struct {
@@ -271,47 +273,127 @@ func (s *McpElicitationSchema) UnmarshalJSON(data []byte) error {
 }
 
 func (p McpServerElicitationRequestParams) MarshalJSON() ([]byte, error) {
-	type wire McpServerElicitationRequestParams
 	if len(p.Meta) == 0 {
 		p.Meta = json.RawMessage("null")
 	}
-	if p.Mode == McpServerElicitationModeForm {
+	switch p.Mode {
+	case McpServerElicitationModeForm:
 		canonical, err := canonicalMcpElicitationSchema(p.RequestedSchema)
 		if err != nil {
 			return nil, err
 		}
 		p.RequestedSchema = canonical
+		return json.Marshal(struct {
+			ThreadID        string          `json:"threadId"`
+			TurnID          *string         `json:"turnId"`
+			ServerName      string          `json:"serverName"`
+			Mode            string          `json:"mode"`
+			Meta            json.RawMessage `json:"_meta"`
+			Message         string          `json:"message"`
+			RequestedSchema json.RawMessage `json:"requestedSchema"`
+		}{p.ThreadID, p.TurnID, p.ServerName, p.Mode, p.Meta, p.Message, p.RequestedSchema})
+	case McpServerElicitationModeOpenAIForm:
+		if err := requireMcpElicitationJSONValue(p.RequestedSchema, "requestedSchema"); err != nil {
+			return nil, err
+		}
+		return json.Marshal(struct {
+			ThreadID        string          `json:"threadId"`
+			TurnID          *string         `json:"turnId"`
+			ServerName      string          `json:"serverName"`
+			Mode            string          `json:"mode"`
+			Meta            json.RawMessage `json:"_meta"`
+			Message         string          `json:"message"`
+			RequestedSchema json.RawMessage `json:"requestedSchema"`
+		}{p.ThreadID, p.TurnID, p.ServerName, p.Mode, p.Meta, p.Message, p.RequestedSchema})
+	case McpServerElicitationModeURL:
+		return json.Marshal(struct {
+			ThreadID      string          `json:"threadId"`
+			TurnID        *string         `json:"turnId"`
+			ServerName    string          `json:"serverName"`
+			Mode          string          `json:"mode"`
+			Meta          json.RawMessage `json:"_meta"`
+			Message       string          `json:"message"`
+			URL           string          `json:"url"`
+			ElicitationID string          `json:"elicitationId"`
+		}{p.ThreadID, p.TurnID, p.ServerName, p.Mode, p.Meta, p.Message, p.URL, p.ElicitationID})
+	default:
+		return nil, fmt.Errorf("unknown MCP elicitation mode %q", p.Mode)
 	}
-	data, err := json.Marshal(wire(p))
-	if err != nil {
-		return nil, err
-	}
-	if err := validateMcpServerElicitationParamsJSON(data); err != nil {
-		return nil, err
-	}
-	return data, nil
 }
 
 func (p *McpServerElicitationRequestParams) UnmarshalJSON(data []byte) error {
 	if p == nil {
 		return errors.New("decode MCP elicitation request params into nil receiver")
 	}
-	if err := validateMcpServerElicitationParamsJSON(data); err != nil {
+	const objectName = "MCP elicitation request params"
+	payload, err := decodeRustSerdeObject(
+		data, objectName,
+		"threadId", "turnId", "serverName", "mode", "_meta", "message", "requestedSchema", "url", "elicitationId",
+	)
+	if err != nil {
 		return err
 	}
-	type wire McpServerElicitationRequestParams
-	var decoded wire
-	if err := json.Unmarshal(data, &decoded); err != nil {
+	threadID, err := decodeRequiredThreadItemValue[string](payload, objectName, "threadId")
+	if err != nil {
 		return err
 	}
-	if decoded.Mode == McpServerElicitationModeForm {
-		canonical, err := canonicalMcpElicitationSchema(decoded.RequestedSchema)
+	turnID, err := decodeOptionalNullableConfigValue[string](payload, objectName, "turnId")
+	if err != nil {
+		return err
+	}
+	serverName, err := decodeRequiredThreadItemValue[string](payload, objectName, "serverName")
+	if err != nil {
+		return err
+	}
+	mode, err := decodeRequiredThreadItemValue[string](payload, objectName, "mode")
+	if err != nil {
+		return err
+	}
+	meta, err := decodeOptionalNullableConfigValue[json.RawMessage](payload, objectName, "_meta")
+	if err != nil {
+		return err
+	}
+	message, err := decodeRequiredThreadItemValue[string](payload, objectName, "message")
+	if err != nil {
+		return err
+	}
+	decoded := McpServerElicitationRequestParams{
+		ThreadID: threadID, TurnID: turnID, ServerName: serverName, Mode: mode, Message: message,
+	}
+	if meta != nil {
+		decoded.Meta = append(json.RawMessage(nil), (*meta)...)
+	}
+	switch mode {
+	case McpServerElicitationModeForm:
+		requestedSchema, err := requiredMcpElicitationJSONValue(payload, objectName, "requestedSchema")
+		if err != nil {
+			return err
+		}
+		canonical, err := canonicalMcpElicitationSchema(requestedSchema)
 		if err != nil {
 			return err
 		}
 		decoded.RequestedSchema = canonical
+	case McpServerElicitationModeOpenAIForm:
+		requestedSchema, err := requiredMcpElicitationJSONValue(payload, objectName, "requestedSchema")
+		if err != nil {
+			return err
+		}
+		decoded.RequestedSchema = requestedSchema
+	case McpServerElicitationModeURL:
+		url, err := decodeRequiredThreadItemValue[string](payload, objectName, "url")
+		if err != nil {
+			return err
+		}
+		elicitationID, err := decodeRequiredThreadItemValue[string](payload, objectName, "elicitationId")
+		if err != nil {
+			return err
+		}
+		decoded.URL, decoded.ElicitationID = url, elicitationID
+	default:
+		return fmt.Errorf("unknown MCP elicitation mode %q", mode)
 	}
-	*p = McpServerElicitationRequestParams(decoded)
+	*p = decoded
 	return nil
 }
 
@@ -337,15 +419,27 @@ func (r *McpServerElicitationRequestResponse) UnmarshalJSON(data []byte) error {
 	if r == nil {
 		return errors.New("decode MCP elicitation response into nil receiver")
 	}
-	if err := validateMcpServerElicitationResponseJSON(data); err != nil {
+	const objectName = "MCP elicitation response"
+	payload, err := decodeRustSerdeObject(data, objectName, "action", "content", "_meta")
+	if err != nil {
 		return err
 	}
-	type wire McpServerElicitationRequestResponse
-	var decoded wire
-	if err := json.Unmarshal(data, &decoded); err != nil {
+	action, err := decodeRequiredThreadItemValue[McpServerElicitationAction](payload, objectName, "action")
+	if err != nil {
 		return err
 	}
-	*r = McpServerElicitationRequestResponse(decoded)
+	if !validMcpServerElicitationAction(action) {
+		return fmt.Errorf("unknown MCP elicitation action %q", action)
+	}
+	content, err := decodeOptionalMcpElicitationJSONValue(payload, objectName, "content")
+	if err != nil {
+		return err
+	}
+	meta, err := decodeOptionalMcpElicitationJSONValue(payload, objectName, "_meta")
+	if err != nil {
+		return err
+	}
+	*r = McpServerElicitationRequestResponse{Action: action, Content: content, Meta: meta}
 	return nil
 }
 
@@ -669,70 +763,41 @@ func validateMcpElicitationMultiSelectObject(object map[string]json.RawMessage) 
 	return requiredMcpElicitationStringArray(items, "enum")
 }
 
-func validateMcpServerElicitationParamsJSON(data []byte) error {
-	object, err := decodeMcpElicitationObject(data)
-	if err != nil {
-		return fmt.Errorf("decode MCP elicitation request params: %w", err)
+func requiredMcpElicitationJSONValue(
+	payload map[string]json.RawMessage,
+	objectName, fieldName string,
+) (json.RawMessage, error) {
+	raw, ok := payload[fieldName]
+	if !ok {
+		return nil, fmt.Errorf("%s requires %s", objectName, fieldName)
 	}
-	for _, name := range []string{"threadId", "serverName", "mode", "message"} {
-		if _, err := requiredMcpElicitationString(object, name); err != nil {
-			return err
-		}
+	if err := requireMcpElicitationJSONValue(raw, fieldName); err != nil {
+		return nil, err
 	}
-	if raw, ok := object["turnId"]; !ok || (!isMcpElicitationNull(raw) && !isMcpElicitationString(raw)) {
-		return errors.New("MCP elicitation request requires nullable turnId")
+	return append(json.RawMessage(nil), raw...), nil
+}
+
+func decodeOptionalMcpElicitationJSONValue(
+	payload map[string]json.RawMessage,
+	objectName, fieldName string,
+) (json.RawMessage, error) {
+	raw, ok := payload[fieldName]
+	if !ok || isMcpElicitationNull(raw) {
+		return nil, nil
 	}
-	if _, ok := object["_meta"]; !ok {
-		return errors.New("MCP elicitation request requires _meta")
+	if err := requireMcpElicitationJSONValue(raw, fieldName); err != nil {
+		return nil, fmt.Errorf("decode %s %s: %w", objectName, fieldName, err)
 	}
-	mode, _ := requiredMcpElicitationString(object, "mode")
-	common := []string{"threadId", "turnId", "serverName", "mode", "_meta", "message", "requestId", "itemId", "startedAtMs", "serverId", "schema", "metadata", "reason"}
-	switch mode {
-	case "form":
-		if err := allowOnlyMcpElicitationFields(object, append(common, "requestedSchema")...); err != nil {
-			return err
-		}
-		raw, ok := object["requestedSchema"]
-		if !ok {
-			return errors.New("form MCP elicitation request requires requestedSchema")
-		}
-		if err := validateMcpElicitationSchemaJSON(raw); err != nil {
-			return err
-		}
-	case "openai/form":
-		if err := allowOnlyMcpElicitationFields(object, append(common, "requestedSchema")...); err != nil {
-			return err
-		}
-		if _, ok := object["requestedSchema"]; !ok {
-			return errors.New("openai/form MCP elicitation request requires requestedSchema")
-		}
-	case "url":
-		if err := allowOnlyMcpElicitationFields(object, append(common, "url", "elicitationId")...); err != nil {
-			return err
-		}
-		for _, name := range []string{"url", "elicitationId"} {
-			if _, err := requiredMcpElicitationString(object, name); err != nil {
-				return err
-			}
-		}
-	default:
-		return fmt.Errorf("unknown MCP elicitation mode %q", mode)
+	return append(json.RawMessage(nil), raw...), nil
+}
+
+func requireMcpElicitationJSONValue(raw json.RawMessage, fieldName string) error {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return fmt.Errorf("MCP elicitation requires %s", fieldName)
 	}
-	for _, name := range []string{"requestId", "itemId", "serverId", "reason"} {
-		if err := optionalMcpElicitationString(object, name); err != nil {
-			return err
-		}
-	}
-	if raw, ok := object["startedAtMs"]; ok && (isMcpElicitationNull(raw) || !isMcpElicitationInteger(raw)) {
-		return errors.New("MCP elicitation startedAtMs must be an integer")
-	}
-	for _, name := range []string{"schema", "metadata"} {
-		if raw, ok := object[name]; ok && !isMcpElicitationNull(raw) {
-			var value map[string]any
-			if err := json.Unmarshal(raw, &value); err != nil || value == nil {
-				return fmt.Errorf("MCP elicitation %s must be an object or null", name)
-			}
-		}
+	var value any
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return fmt.Errorf("MCP elicitation %s must be valid JSON: %w", fieldName, err)
 	}
 	return nil
 }
@@ -914,14 +979,4 @@ func decodeMcpElicitationString(raw json.RawMessage) (string, error) {
 
 func isMcpElicitationNull(raw json.RawMessage) bool {
 	return bytes.Equal(bytes.TrimSpace(raw), []byte("null"))
-}
-
-func isMcpElicitationString(raw json.RawMessage) bool {
-	_, err := decodeMcpElicitationString(raw)
-	return err == nil
-}
-
-func isMcpElicitationInteger(raw json.RawMessage) bool {
-	var value int64
-	return json.Unmarshal(raw, &value) == nil
 }

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -1579,6 +1579,7 @@ func wireSchemaDefinitions() Schema {
 	setSchemaIntegerMinimum(schemas["McpElicitationUntitledMultiSelectEnumSchema"].(Schema), 0, "minItems", "maxItems")
 	schemas["McpServerElicitationAction"] = stringEnumSchema("accept", "decline", "cancel")
 	schemas["McpServerElicitationRequestParams"] = mcpServerElicitationRequestParamsSchema()
+	schemas["McpServerElicitationRequestResponse"] = mcpServerElicitationRequestResponseSchema()
 	schemas["NetworkPolicyRuleAction"] = stringEnumSchema(
 		string(NetworkPolicyRuleAllow), string(NetworkPolicyRuleDeny),
 	)
@@ -3305,53 +3306,66 @@ func sandboxPolicySchema() Schema {
 }
 
 func mcpServerElicitationRequestParamsSchema() Schema {
-	return Schema{"oneOf": []any{
-		mcpServerElicitationRequestVariantSchema("form"),
-		mcpServerElicitationRequestVariantSchema("openai/form"),
-		mcpServerElicitationRequestVariantSchema("url"),
-	}}
+	return Schema{
+		"type":  "object",
+		"title": "McpServerElicitationRequestParams",
+		"properties": Schema{
+			"threadId": Schema{"type": "string"},
+			"turnId": Schema{
+				"description": "Active Codex turn when this elicitation was observed, if app-server could correlate one.\n\nThis is nullable because MCP models elicitation as a standalone server-to-client request identified by the MCP server request id. It may be triggered during a turn, but turn context is app-server correlation rather than part of the protocol identity of the elicitation itself.",
+				"type":        []any{"string", "null"},
+			},
+			"serverName": Schema{"type": "string"},
+		},
+		"required": []string{"serverName", "threadId"},
+		"oneOf": []any{
+			mcpServerElicitationRequestVariantSchema("form"),
+			mcpServerElicitationRequestVariantSchema("openai/form"),
+			mcpServerElicitationRequestVariantSchema("url"),
+		},
+	}
 }
 
 func mcpServerElicitationRequestVariantSchema(mode string) Schema {
 	properties := Schema{
-		"threadId":    Schema{"type": "string"},
-		"turnId":      Schema{"anyOf": []any{Schema{"type": "string"}, Schema{"type": "null"}}},
-		"serverName":  Schema{"type": "string"},
-		"mode":        Schema{"type": "string", "enum": []any{mode}},
-		"_meta":       Schema{},
-		"message":     Schema{"type": "string"},
-		"requestId":   Schema{"type": "string"},
-		"itemId":      Schema{"type": "string"},
-		"startedAtMs": Schema{"type": "integer"},
-		"serverId":    Schema{"type": "string"},
-		"schema": Schema{"anyOf": []any{
-			Schema{"type": "object", "additionalProperties": Schema{}},
-			Schema{"type": "null"},
-		}},
-		"metadata": Schema{"anyOf": []any{
-			Schema{"type": "object", "additionalProperties": Schema{}},
-			Schema{"type": "null"},
-		}},
-		"reason": Schema{"type": "string"},
+		"mode":    Schema{"type": "string", "enum": []any{mode}},
+		"_meta":   true,
+		"message": Schema{"type": "string"},
 	}
-	required := []string{"threadId", "turnId", "serverName", "mode", "_meta", "message"}
+	required := []string{"message", "mode"}
 	switch mode {
 	case "form":
 		properties["requestedSchema"] = Schema{"$ref": "#/$defs/McpElicitationSchema"}
 		required = append(required, "requestedSchema")
 	case "openai/form":
-		properties["requestedSchema"] = Schema{}
+		properties["requestedSchema"] = true
 		required = append(required, "requestedSchema")
 	case "url":
 		properties["url"] = Schema{"type": "string"}
 		properties["elicitationId"] = Schema{"type": "string"}
-		required = append(required, "url", "elicitationId")
+		required = []string{"elicitationId", "message", "mode", "url"}
 	}
 	return Schema{
-		"type":                 "object",
-		"properties":           properties,
-		"required":             required,
-		"additionalProperties": false,
+		"type":       "object",
+		"properties": properties,
+		"required":   required,
+	}
+}
+
+func mcpServerElicitationRequestResponseSchema() Schema {
+	return Schema{
+		"type":  "object",
+		"title": "McpServerElicitationRequestResponse",
+		"properties": Schema{
+			"action": Schema{"$ref": "#/$defs/McpServerElicitationAction"},
+			"content": Schema{
+				"description": "Structured user input for accepted elicitations, mirroring RMCP `CreateElicitationResult`.\n\nThis is nullable because decline/cancel responses have no content.",
+			},
+			"_meta": Schema{
+				"description": "Optional client metadata for form-mode action handling.",
+			},
+		},
+		"required": []string{"action"},
 	}
 }
 

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -9524,25 +9524,10 @@
     "McpServerElicitationRequestParams": {
       "oneOf": [
         {
-          "additionalProperties": false,
           "properties": {
-            "_meta": {},
-            "itemId": {
-              "type": "string"
-            },
+            "_meta": true,
             "message": {
               "type": "string"
-            },
-            "metadata": {
-              "anyOf": [
-                {
-                  "additionalProperties": {},
-                  "type": "object"
-                },
-                {
-                  "type": "null"
-                }
-              ]
             },
             "mode": {
               "enum": [
@@ -9550,80 +9535,22 @@
               ],
               "type": "string"
             },
-            "reason": {
-              "type": "string"
-            },
-            "requestId": {
-              "type": "string"
-            },
             "requestedSchema": {
               "$ref": "#/$defs/McpElicitationSchema"
-            },
-            "schema": {
-              "anyOf": [
-                {
-                  "additionalProperties": {},
-                  "type": "object"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "serverId": {
-              "type": "string"
-            },
-            "serverName": {
-              "type": "string"
-            },
-            "startedAtMs": {
-              "type": "integer"
-            },
-            "threadId": {
-              "type": "string"
-            },
-            "turnId": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ]
             }
           },
           "required": [
-            "threadId",
-            "turnId",
-            "serverName",
-            "mode",
-            "_meta",
             "message",
+            "mode",
             "requestedSchema"
           ],
           "type": "object"
         },
         {
-          "additionalProperties": false,
           "properties": {
-            "_meta": {},
-            "itemId": {
-              "type": "string"
-            },
+            "_meta": true,
             "message": {
               "type": "string"
-            },
-            "metadata": {
-              "anyOf": [
-                {
-                  "additionalProperties": {},
-                  "type": "object"
-                },
-                {
-                  "type": "null"
-                }
-              ]
             },
             "mode": {
               "enum": [
@@ -9631,81 +9558,23 @@
               ],
               "type": "string"
             },
-            "reason": {
-              "type": "string"
-            },
-            "requestId": {
-              "type": "string"
-            },
-            "requestedSchema": {},
-            "schema": {
-              "anyOf": [
-                {
-                  "additionalProperties": {},
-                  "type": "object"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "serverId": {
-              "type": "string"
-            },
-            "serverName": {
-              "type": "string"
-            },
-            "startedAtMs": {
-              "type": "integer"
-            },
-            "threadId": {
-              "type": "string"
-            },
-            "turnId": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            }
+            "requestedSchema": true
           },
           "required": [
-            "threadId",
-            "turnId",
-            "serverName",
-            "mode",
-            "_meta",
             "message",
+            "mode",
             "requestedSchema"
           ],
           "type": "object"
         },
         {
-          "additionalProperties": false,
           "properties": {
-            "_meta": {},
+            "_meta": true,
             "elicitationId": {
-              "type": "string"
-            },
-            "itemId": {
               "type": "string"
             },
             "message": {
               "type": "string"
-            },
-            "metadata": {
-              "anyOf": [
-                {
-                  "additionalProperties": {},
-                  "type": "object"
-                },
-                {
-                  "type": "null"
-                }
-              ]
             },
             "mode": {
               "enum": [
@@ -9713,77 +9582,57 @@
               ],
               "type": "string"
             },
-            "reason": {
-              "type": "string"
-            },
-            "requestId": {
-              "type": "string"
-            },
-            "schema": {
-              "anyOf": [
-                {
-                  "additionalProperties": {},
-                  "type": "object"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "serverId": {
-              "type": "string"
-            },
-            "serverName": {
-              "type": "string"
-            },
-            "startedAtMs": {
-              "type": "integer"
-            },
-            "threadId": {
-              "type": "string"
-            },
-            "turnId": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
             "url": {
               "type": "string"
             }
           },
           "required": [
-            "threadId",
-            "turnId",
-            "serverName",
-            "mode",
-            "_meta",
+            "elicitationId",
             "message",
-            "url",
-            "elicitationId"
+            "mode",
+            "url"
           ],
           "type": "object"
         }
-      ]
+      ],
+      "properties": {
+        "serverName": {
+          "type": "string"
+        },
+        "threadId": {
+          "type": "string"
+        },
+        "turnId": {
+          "description": "Active Codex turn when this elicitation was observed, if app-server could correlate one.\n\nThis is nullable because MCP models elicitation as a standalone server-to-client request identified by the MCP server request id. It may be triggered during a turn, but turn context is app-server correlation rather than part of the protocol identity of the elicitation itself.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "serverName",
+        "threadId"
+      ],
+      "title": "McpServerElicitationRequestParams",
+      "type": "object"
     },
     "McpServerElicitationRequestResponse": {
-      "additionalProperties": false,
       "properties": {
-        "_meta": {},
+        "_meta": {
+          "description": "Optional client metadata for form-mode action handling."
+        },
         "action": {
           "$ref": "#/$defs/McpServerElicitationAction"
         },
-        "content": {}
+        "content": {
+          "description": "Structured user input for accepted elicitations, mirroring RMCP `CreateElicitationResult`.\n\nThis is nullable because decline/cancel responses have no content."
+        }
       },
       "required": [
-        "action",
-        "content",
-        "_meta"
+        "action"
       ],
+      "title": "McpServerElicitationRequestResponse",
       "type": "object"
     },
     "McpServerInfo": {

--- a/appserver/protocol/testdata/mcp_elicitation_wire_v1.json
+++ b/appserver/protocol/testdata/mcp_elicitation_wire_v1.json
@@ -42,13 +42,7 @@
               }
             },
             "required": ["email", "enabled"]
-          },
-          "requestId": "interaction-1",
-          "itemId": "item-tool-1",
-          "startedAtMs": 1783715400000,
-          "serverId": "repo",
-          "metadata": {"source": "runtime"},
-          "reason": "Choose access"
+          }
         }
       }
     },

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -862,6 +862,18 @@ func MarshalTypeScript() ([]byte, error) {
 			definition = schema
 		}
 		switch name {
+		case "McpServerElicitationRequestParams":
+			// The raw schema mirrors serde's open, flattened record. ts-rs instead
+			// emits the exact closed intersection and makes Option fields nullable.
+			definition = Schema{
+				typeScriptRawTypeKeyword: `{ "threadId": string; "turnId": string | null; "serverName": string; } & ({ "mode": "form"; "_meta": JsonValue | null; "message": string; "requestedSchema": McpElicitationSchema; } | { "mode": "openai/form"; "_meta": JsonValue | null; "message": string; "requestedSchema": JsonValue; } | { "mode": "url"; "_meta": JsonValue | null; "message": string; "url": string; "elicitationId": string; })`,
+			}
+		case "McpServerElicitationRequestResponse":
+			// serde accepts omitted optional values, but ts-rs exposes their
+			// canonical nullable representation in the public TypeScript binding.
+			definition = Schema{
+				typeScriptRawTypeKeyword: `{ "action": McpServerElicitationAction; "content": JsonValue | null; "_meta": JsonValue | null; }`,
+			}
 		case "DynamicToolFunctionSpec", "DynamicToolNamespaceSpec":
 			schema, _ := typeScriptSchema(definition)
 			schema["x-gollem-typescript-ignore-additional-properties"] = true

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -2501,59 +2501,9 @@ export type McpResourceReadResponse = {
 
 export type McpServerElicitationAction = "accept" | "decline" | "cancel";
 
-export type McpServerElicitationRequestParams = {
-  "_meta": unknown;
-  "itemId"?: string;
-  "message": string;
-  "metadata"?: Record<string, unknown> | null;
-  "mode": "form";
-  "reason"?: string;
-  "requestId"?: string;
-  "requestedSchema": McpElicitationSchema;
-  "schema"?: Record<string, unknown> | null;
-  "serverId"?: string;
-  "serverName": string;
-  "startedAtMs"?: number;
-  "threadId": string;
-  "turnId": string | null;
-} | {
-  "_meta": unknown;
-  "itemId"?: string;
-  "message": string;
-  "metadata"?: Record<string, unknown> | null;
-  "mode": "openai/form";
-  "reason"?: string;
-  "requestId"?: string;
-  "requestedSchema": unknown;
-  "schema"?: Record<string, unknown> | null;
-  "serverId"?: string;
-  "serverName": string;
-  "startedAtMs"?: number;
-  "threadId": string;
-  "turnId": string | null;
-} | {
-  "_meta": unknown;
-  "elicitationId": string;
-  "itemId"?: string;
-  "message": string;
-  "metadata"?: Record<string, unknown> | null;
-  "mode": "url";
-  "reason"?: string;
-  "requestId"?: string;
-  "schema"?: Record<string, unknown> | null;
-  "serverId"?: string;
-  "serverName": string;
-  "startedAtMs"?: number;
-  "threadId": string;
-  "turnId": string | null;
-  "url": string;
-};
+export type McpServerElicitationRequestParams = { "threadId": string; "turnId": string | null; "serverName": string; } & ({ "mode": "form"; "_meta": JsonValue | null; "message": string; "requestedSchema": McpElicitationSchema; } | { "mode": "openai/form"; "_meta": JsonValue | null; "message": string; "requestedSchema": JsonValue; } | { "mode": "url"; "_meta": JsonValue | null; "message": string; "url": string; "elicitationId": string; });
 
-export type McpServerElicitationRequestResponse = {
-  "_meta": unknown;
-  "action": McpServerElicitationAction;
-  "content": unknown;
-};
+export type McpServerElicitationRequestResponse = { "action": McpServerElicitationAction; "content": JsonValue | null; "_meta": JsonValue | null; };
 
 export type McpServerInfo = {
   "description": string | null;

--- a/appserver/protocol/typescript/testdata/mcp_elicitation_wire_v1.ts
+++ b/appserver/protocol/typescript/testdata/mcp_elicitation_wire_v1.ts
@@ -73,15 +73,7 @@ export const mcpElicitationFormRequest = {
         "email",
         "enabled"
       ]
-    },
-    "requestId": "interaction-1",
-    "itemId": "item-tool-1",
-    "startedAtMs": 1783715400000,
-    "serverId": "repo",
-    "metadata": {
-      "source": "runtime"
-    },
-    "reason": "Choose access"
+    }
   }
 } satisfies BoundRequest<"mcpServer/elicitation/request">;
 export const mcpElicitationFormRequestParams = mcpElicitationFormRequest.params satisfies McpServerElicitationRequestParams;

--- a/appserver/runtime_interaction_tools_test.go
+++ b/appserver/runtime_interaction_tools_test.go
@@ -234,8 +234,11 @@ func TestServerRuntimeClientToolAndMCPElicitationUseDurableCorrelation(t *testin
 				t.Fatalf("decode server request: %v", err)
 			}
 			itemID, _ := params["itemId"].(string)
-			if itemID == "" || itemID == "call-runtime-interaction" || params["threadId"] != started.Thread.ID || params["turnId"] != started.Turn.ID {
+			if params["threadId"] != started.Thread.ID || params["turnId"] != started.Turn.ID {
 				t.Fatalf("server request correlation = %#v", params)
+			}
+			if tt.wantMethod != InteractionMCPElicitation && (itemID == "" || itemID == "call-runtime-interaction") {
+				t.Fatalf("server request item correlation = %#v", params)
 			}
 			if tt.wantMethod == InteractionToolCall &&
 				(params["callId"] != "call-runtime-interaction" || params["tool"] != "client.search" || params["namespace"] != nil) {
@@ -247,7 +250,8 @@ func TestServerRuntimeClientToolAndMCPElicitationUseDurableCorrelation(t *testin
 					t.Fatalf("decode MCP elicitation params: %v", err)
 				}
 				if typed.Mode != protocol.McpServerElicitationModeForm || typed.ServerName != "repo" ||
-					typed.TurnID == nil || *typed.TurnID != started.Turn.ID || typed.ItemID != itemID {
+					typed.TurnID == nil || *typed.TurnID != started.Turn.ID ||
+					params["requestId"] != nil || params["itemId"] != nil || params["startedAtMs"] != nil || params["reason"] != nil {
 					t.Fatalf("public MCP elicitation correlation = %#v", typed)
 				}
 			}
@@ -260,7 +264,7 @@ func TestServerRuntimeClientToolAndMCPElicitationUseDurableCorrelation(t *testin
 				t.Fatalf("ListItems: %v", err)
 			}
 			toolItem := findRuntimeToolItem(t, items, tt.toolName, tt.argumentKey, tt.argumentValue)
-			if toolItem.Item.ID != itemID || toolItem.Status != runtimeToolStatusCompleted {
+			if (tt.wantMethod != InteractionMCPElicitation && toolItem.Item.ID != itemID) || toolItem.Status != runtimeToolStatusCompleted {
 				t.Fatalf("durable interaction item = %#v, request item %q", toolItem, itemID)
 			}
 		})


### PR DESCRIPTION
## Summary
- align the public MCP elicitation request and response schema/serde behavior with the current Codex source contract
- remove Gollem-only correlation and metadata fields from the public MCP request while preserving envelope-based response correlation
- render the source-equivalent closed TypeScript types and update runtime fixtures

## Verification
- `go test ./appserver/protocol -count=1`
- `go test -race ./appserver/protocol ./appserver -run 'Mcp|MCP|Interaction' -count=1`\n- `go list ./... | rg -v '^github\\.com/fugue-labs/gollem/ext/monty(/|$)' | xargs go test -count=1`\n- `go list ./... | rg -v '^github\\.com/fugue-labs/gollem/ext/monty(/|$)' | xargs go vet`\n- `go mod tidy`\n- `go generate ./appserver/protocol`\n- `golangci-lint run`\n- normalized source-schema comparison for both MCP elicitation request and response contracts\n- normal pre-push lint and full race suite with `hooks.skipMontyRace=true`