### PR TITLE
Align dynamic tool call with source contract

### DIFF
--- a/appserver/interactions.go
+++ b/appserver/interactions.go
@@ -150,18 +150,14 @@ func (s *InteractionService) RequestToolCall(ctx context.Context, req DynamicToo
 	params := map[string]any{
 		"callId":    strings.TrimSpace(req.CallID),
 		"namespace": req.Namespace,
-		"tool":      req.ToolName,
-		"toolName":  req.ToolName,
-		"name":      req.ToolName,
+		"tool":      strings.TrimSpace(req.ToolName),
 		"arguments": json.RawMessage(append([]byte(nil), req.Arguments...)),
-		"metadata":  cloneStringAnyMap(req.Metadata),
 	}
 	return s.Request(ctx, InteractionRequest{
 		Method:   InteractionToolCall,
 		ThreadID: req.ThreadID,
 		TurnID:   req.TurnID,
 		ItemID:   req.ItemID,
-		Reason:   req.ToolName,
 		Params:   params,
 	})
 }
@@ -257,7 +253,7 @@ func (s *InteractionService) Request(ctx context.Context, req InteractionRequest
 		ItemID:    itemID,
 	}
 	payload := cloneStringAnyMap(req.Params)
-	if method != InteractionRequestUserInput && method != InteractionMCPElicitation {
+	if method != InteractionRequestUserInput && method != InteractionToolCall && method != InteractionMCPElicitation {
 		payload["requestId"] = requestID
 	}
 	payload["threadId"] = meta.ThreadID
@@ -266,10 +262,10 @@ func (s *InteractionService) Request(ctx context.Context, req InteractionRequest
 	} else {
 		payload["turnId"] = meta.TurnID
 	}
-	if method != InteractionMCPElicitation {
+	if method != InteractionToolCall && method != InteractionMCPElicitation {
 		payload["itemId"] = meta.ItemID
 	}
-	if method != InteractionRequestUserInput && method != InteractionMCPElicitation {
+	if method != InteractionRequestUserInput && method != InteractionToolCall && method != InteractionMCPElicitation {
 		payload["startedAtMs"] = time.Now().UnixMilli()
 	}
 	if method == InteractionToolCall {
@@ -278,7 +274,7 @@ func (s *InteractionService) Request(ctx context.Context, req InteractionRequest
 			payload["callId"] = firstNonEmpty(meta.ItemID, requestID)
 		}
 	}
-	if method != InteractionRequestUserInput && method != InteractionMCPElicitation && strings.TrimSpace(req.Reason) != "" {
+	if method != InteractionRequestUserInput && method != InteractionToolCall && method != InteractionMCPElicitation && strings.TrimSpace(req.Reason) != "" {
 		payload["reason"] = strings.TrimSpace(req.Reason)
 	}
 

--- a/appserver/interactions_test.go
+++ b/appserver/interactions_test.go
@@ -159,8 +159,17 @@ func TestInteractionToolCallErrorResponse(t *testing.T) {
 		t.Fatalf("decode dynamic tool params: %v", err)
 	}
 	if params.ThreadID != "thread-2" || params.TurnID != "turn-2" || params.CallID != "call-2" ||
-		params.Namespace != nil || params.Tool != "client.search" || params.ToolName != params.Tool {
+		params.Namespace != nil || params.Tool != "client.search" {
 		t.Fatalf("dynamic tool params = %#v", params)
+	}
+	var rawParams map[string]json.RawMessage
+	if err := json.Unmarshal(req.Params, &rawParams); err != nil {
+		t.Fatalf("decode raw dynamic tool params: %v", err)
+	}
+	for _, forbidden := range []string{"requestId", "itemId", "startedAtMs", "toolName", "name", "metadata", "reason"} {
+		if _, exists := rawParams[forbidden]; exists {
+			t.Fatalf("dynamic tool params leak %s: %s", forbidden, req.Params)
+		}
 	}
 	if err := server.HandleResponse(ctx, protocol.Response{
 		ID:    req.ID,
@@ -184,8 +193,8 @@ func TestInteractionToolCallResponseUsesExactBoundedContract(t *testing.T) {
 		wantFail bool
 	}{
 		{
-			name:   "text and image",
-			result: `{"contentItems":[{"type":"inputText","text":"match"},{"type":"inputImage","imageUrl":"data:image/png;base64,AA=="}],"success":true}`,
+			name:   "text image and audio",
+			result: `{"contentItems":[{"type":"inputText","text":"match"},{"type":"inputImage","imageUrl":"data:image/png;base64,AA=="},{"type":"inputAudio","audioUrl":"data:audio/wav;base64,AA=="}],"success":true}`,
 		},
 		{name: "missing fields", result: `{}`, wantFail: true},
 		{name: "null content", result: `{"contentItems":null,"success":true}`, wantFail: true},

--- a/appserver/protocol/dynamic_tool_call_contract_test.go
+++ b/appserver/protocol/dynamic_tool_call_contract_test.go
@@ -15,27 +15,40 @@ func TestDynamicToolCallSchemaAndBindingAreExact(t *testing.T) {
 		}
 	}
 	params := defs["DynamicToolCallParams"].(Schema)
-	for _, name := range []string{"threadId", "turnId", "callId", "namespace", "tool", "arguments"} {
+	if params["title"] != "DynamicToolCallParams" || params["properties"].(Schema)["arguments"] != true ||
+		!reflect.DeepEqual(params["properties"].(Schema)["namespace"].(Schema)["type"], []any{"string", "null"}) {
+		t.Fatalf("DynamicToolCallParams source schema = %#v", params)
+	}
+	for _, name := range []string{"threadId", "turnId", "callId", "tool", "arguments"} {
 		assertSchemaRequired(t, params, name)
 	}
+	if _, required := params["additionalProperties"]; required {
+		t.Fatalf("DynamicToolCallParams unexpectedly closes the serde-open record: %#v", params)
+	}
 	response := defs["DynamicToolCallResponse"].(Schema)
+	if response["title"] != "DynamicToolCallResponse" {
+		t.Fatalf("DynamicToolCallResponse source schema = %#v", response)
+	}
 	assertSchemaRequired(t, response, "contentItems")
 	assertSchemaRequired(t, response, "success")
 
 	content := defs["DynamicToolCallOutputContentItem"].(Schema)
 	variants, ok := content["oneOf"].([]any)
-	if !ok || len(variants) != 2 {
+	if !ok || len(variants) != 3 {
 		t.Fatalf("content variants = %#v", content["oneOf"])
 	}
 	for index, want := range []struct {
 		contentType string
 		field       string
-	}{{"inputText", "text"}, {"inputImage", "imageUrl"}} {
+	}{{"inputText", "text"}, {"inputImage", "imageUrl"}, {"inputAudio", "audioUrl"}} {
 		variant := variants[index].(Schema)
-		if variant["additionalProperties"] != false {
-			t.Fatalf("variant %s allows extra fields", want.contentType)
+		if _, closed := variant["additionalProperties"]; closed {
+			t.Fatalf("variant %s unexpectedly closes the serde-open record: %#v", want.contentType, variant)
 		}
 		properties := variant["properties"].(Schema)
+		if variant["title"] != "Input"+strings.ToUpper(want.contentType[5:6])+want.contentType[6:]+"DynamicToolCallOutputContentItem" {
+			t.Fatalf("variant %s title = %#v", want.contentType, variant["title"])
+		}
 		if !reflect.DeepEqual(properties["type"].(Schema)["enum"], []any{want.contentType}) {
 			t.Fatalf("variant %d type = %#v", index, properties["type"])
 		}
@@ -45,6 +58,50 @@ func TestDynamicToolCallSchemaAndBindingAreExact(t *testing.T) {
 	bindings := WireTypeBindings()
 	assertBinding(t, bindings, "item/tool/call", SurfaceServerRequest, "DynamicToolCallParams")
 	assertBinding(t, bindings, "item/tool/call", SurfaceServerRequest, "DynamicToolCallResponse")
+	typescript, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	for _, declaration := range []string{
+		`export type DynamicToolCallParams = { "threadId": string; "turnId": string; "callId": string; "namespace": string | null; "tool": string; "arguments": JsonValue; };`,
+		`export type DynamicToolCallResponse = { "contentItems": Array<DynamicToolCallOutputContentItem>; "success": boolean; };`,
+		`export type DynamicToolCallOutputContentItem = { "type": "inputText"; "text": string; } | { "type": "inputImage"; "imageUrl": string; } | { "type": "inputAudio"; "audioUrl": string; };`,
+	} {
+		if !strings.Contains(string(typescript), declaration) {
+			t.Fatalf("generated TypeScript missing %q", declaration)
+		}
+	}
+}
+
+func TestDynamicToolCallParamsUseSourceSerdeSemantics(t *testing.T) {
+	var params DynamicToolCallParams
+	if err := json.Unmarshal([]byte(`{"threadId":"thread","turnId":"turn","callId":"call","tool":"client.search","arguments":null,"ignored":true}`), &params); err != nil {
+		t.Fatalf("Unmarshal source-open params: %v", err)
+	}
+	if params.Namespace != nil || string(params.Arguments) != "null" {
+		t.Fatalf("decoded params = %#v", params)
+	}
+	encoded, err := json.Marshal(params)
+	if err != nil {
+		t.Fatalf("Marshal canonical params: %v", err)
+	}
+	if string(encoded) != `{"threadId":"thread","turnId":"turn","callId":"call","namespace":null,"tool":"client.search","arguments":null}` {
+		t.Fatalf("canonical params = %s", encoded)
+	}
+	for _, input := range []string{
+		`{}`,
+		`{"threadId":"thread","turnId":"turn","callId":"call","tool":"client.search"}`,
+		`{"threadId":"thread","threadId":"duplicate","turnId":"turn","callId":"call","tool":"client.search","arguments":{}}`,
+		`{"threadId":"thread","turnId":"turn","callId":"call","tool":"client.search","arguments":{}} null`,
+	} {
+		if err := json.Unmarshal([]byte(input), &params); err == nil {
+			t.Errorf("Unmarshal(%s) succeeded", input)
+		}
+	}
+	var nilParams *DynamicToolCallParams
+	if err := nilParams.UnmarshalJSON([]byte(`{}`)); err == nil {
+		t.Error("nil params receiver succeeded")
+	}
 }
 
 func TestDynamicToolCallResponseWireValidation(t *testing.T) {
@@ -52,6 +109,8 @@ func TestDynamicToolCallResponseWireValidation(t *testing.T) {
 		`{"contentItems":[],"success":false}`,
 		`{"contentItems":[{"type":"inputText","text":""}],"success":true}`,
 		`{"contentItems":[{"type":"inputImage","imageUrl":"data:image/png;base64,AA=="}],"success":true}`,
+		`{"contentItems":[{"type":"inputAudio","audioUrl":"data:audio/wav;base64,AA=="}],"success":true}`,
+		`{"contentItems":[{"type":"inputText","text":"ok","imageUrl":"ignored","extra":true}],"success":true,"extra":true}`,
 	}
 	for _, input := range valid {
 		var response DynamicToolCallResponse
@@ -69,11 +128,12 @@ func TestDynamicToolCallResponseWireValidation(t *testing.T) {
 		`{"contentItems":[{"type":1,"text":"bad"}],"success":true}`,
 		`{"contentItems":[{"type":"inputText"}],"success":true}`,
 		`{"contentItems":[{"type":"inputText","text":1}],"success":true}`,
-		`{"contentItems":[{"type":"inputText","text":"ok","imageUrl":"bad"}],"success":true}`,
 		`{"contentItems":[{"type":"inputImage"}],"success":true}`,
+		`{"contentItems":[{"type":"inputAudio"}],"success":true}`,
 		`{"contentItems":[{"type":"video","url":"bad"}],"success":true}`,
-		`{"contentItems":[{"type":"inputText","text":"ok","extra":true}],"success":true}`,
-		`{"contentItems":[],"success":true,"extra":true}`,
+		`{"contentItems":[],"contentItems":[],"success":true}`,
+		`{"contentItems":[{"type":"inputText","text":"ok","text":"duplicate"}],"success":true}`,
+		`{"contentItems":[],"success":true} null`,
 	}
 	for _, input := range invalid {
 		var response DynamicToolCallResponse
@@ -95,12 +155,13 @@ func TestDynamicToolCallResponseMarshalUsesPublicVariants(t *testing.T) {
 	response := DynamicToolCallResponse{ContentItems: []DynamicToolCallOutputContentItem{
 		{Type: "inputText", Text: "match"},
 		{Type: "inputImage", ImageURL: "data:image/png;base64,AA=="},
+		{Type: "inputAudio", AudioURL: "data:audio/wav;base64,AA=="},
 	}, Success: true}
 	encoded, err := json.Marshal(response)
 	if err != nil {
 		t.Fatalf("Marshal: %v", err)
 	}
-	for _, want := range []string{`"type":"inputText","text":"match"`, `"type":"inputImage","imageUrl":"data:image/png;base64,AA=="`, `"success":true`} {
+	for _, want := range []string{`"type":"inputText","text":"match"`, `"type":"inputImage","imageUrl":"data:image/png;base64,AA=="`, `"type":"inputAudio","audioUrl":"data:audio/wav;base64,AA=="`, `"success":true`} {
 		if !strings.Contains(string(encoded), want) {
 			t.Fatalf("response = %s, want %s", encoded, want)
 		}
@@ -115,6 +176,7 @@ func TestDynamicToolCallResponseMarshalUsesPublicVariants(t *testing.T) {
 	invalid := []DynamicToolCallOutputContentItem{
 		{Type: "inputText", Text: "ok", ImageURL: "bad"},
 		{Type: "inputImage", ImageURL: "image", Text: "bad"},
+		{Type: "inputAudio", AudioURL: "audio", Text: "bad"},
 		{Type: "video"},
 	}
 	for _, item := range invalid {

--- a/appserver/protocol/dynamic_tool_call_types.go
+++ b/appserver/protocol/dynamic_tool_call_types.go
@@ -7,22 +7,73 @@ import (
 	"fmt"
 )
 
-// DynamicToolCallParams is the public client-tool request. The trailing fields
-// preserve Gollem's v1 request metadata for existing clients.
+// DynamicToolCallParams is the public client-tool request.
 type DynamicToolCallParams struct {
-	ThreadID    string          `json:"threadId"`
-	TurnID      string          `json:"turnId"`
-	CallID      string          `json:"callId"`
-	Namespace   *string         `json:"namespace"`
-	Tool        string          `json:"tool"`
-	Arguments   json.RawMessage `json:"arguments"`
-	RequestID   string          `json:"requestId,omitempty"`
-	ItemID      string          `json:"itemId,omitempty"`
-	StartedAtMS int64           `json:"startedAtMs,omitempty"`
-	ToolName    string          `json:"toolName,omitempty"`
-	Name        string          `json:"name,omitempty"`
-	Metadata    map[string]any  `json:"metadata,omitempty"`
-	Reason      string          `json:"reason,omitempty"`
+	ThreadID  string          `json:"threadId"`
+	TurnID    string          `json:"turnId"`
+	CallID    string          `json:"callId"`
+	Namespace *string         `json:"namespace"`
+	Tool      string          `json:"tool"`
+	Arguments json.RawMessage `json:"arguments"`
+}
+
+func (p DynamicToolCallParams) MarshalJSON() ([]byte, error) {
+	arguments := p.Arguments
+	if len(bytes.TrimSpace(arguments)) == 0 {
+		arguments = json.RawMessage("null")
+	}
+	if err := requireDynamicToolJSONValue(arguments, "arguments"); err != nil {
+		return nil, err
+	}
+	return json.Marshal(struct {
+		ThreadID  string          `json:"threadId"`
+		TurnID    string          `json:"turnId"`
+		CallID    string          `json:"callId"`
+		Namespace *string         `json:"namespace"`
+		Tool      string          `json:"tool"`
+		Arguments json.RawMessage `json:"arguments"`
+	}{p.ThreadID, p.TurnID, p.CallID, p.Namespace, p.Tool, arguments})
+}
+
+func (p *DynamicToolCallParams) UnmarshalJSON(data []byte) error {
+	if p == nil {
+		return errors.New("decode dynamic tool call params into nil receiver")
+	}
+	const objectName = "dynamic tool call params"
+	payload, err := decodeRustSerdeObject(
+		data, objectName, "threadId", "turnId", "callId", "namespace", "tool", "arguments",
+	)
+	if err != nil {
+		return err
+	}
+	threadID, err := decodeRequiredThreadItemValue[string](payload, objectName, "threadId")
+	if err != nil {
+		return err
+	}
+	turnID, err := decodeRequiredThreadItemValue[string](payload, objectName, "turnId")
+	if err != nil {
+		return err
+	}
+	callID, err := decodeRequiredThreadItemValue[string](payload, objectName, "callId")
+	if err != nil {
+		return err
+	}
+	namespace, err := decodeOptionalNullableConfigValue[string](payload, objectName, "namespace")
+	if err != nil {
+		return err
+	}
+	tool, err := decodeRequiredThreadItemValue[string](payload, objectName, "tool")
+	if err != nil {
+		return err
+	}
+	arguments, err := requiredDynamicToolJSONValue(payload, objectName, "arguments")
+	if err != nil {
+		return err
+	}
+	*p = DynamicToolCallParams{
+		ThreadID: threadID, TurnID: turnID, CallID: callID, Namespace: namespace, Tool: tool, Arguments: arguments,
+	}
+	return nil
 }
 
 type DynamicToolCallResponse struct {
@@ -45,32 +96,18 @@ func (r *DynamicToolCallResponse) UnmarshalJSON(data []byte) error {
 	if r == nil {
 		return errors.New("decode dynamic tool call response into nil receiver")
 	}
-	var payload map[string]json.RawMessage
-	if err := json.Unmarshal(data, &payload); err != nil {
+	const objectName = "dynamic tool call response"
+	payload, err := decodeRustSerdeObject(data, objectName, "contentItems", "success")
+	if err != nil {
 		return err
 	}
-	for name := range payload {
-		switch name {
-		case "contentItems", "success":
-		default:
-			return fmt.Errorf("unknown dynamic tool call response field %q", name)
-		}
+	contentItems, err := decodeRequiredThreadItemValue[[]DynamicToolCallOutputContentItem](payload, objectName, "contentItems")
+	if err != nil {
+		return err
 	}
-	contentItemsRaw := payload["contentItems"]
-	if len(contentItemsRaw) == 0 || bytes.Equal(bytes.TrimSpace(contentItemsRaw), []byte("null")) {
-		return errors.New("dynamic tool call response requires contentItems array")
-	}
-	successRaw := payload["success"]
-	if len(successRaw) == 0 || bytes.Equal(bytes.TrimSpace(successRaw), []byte("null")) {
-		return errors.New("dynamic tool call response requires success")
-	}
-	var contentItems []DynamicToolCallOutputContentItem
-	if err := json.Unmarshal(contentItemsRaw, &contentItems); err != nil {
-		return fmt.Errorf("decode dynamic tool call response contentItems: %w", err)
-	}
-	var success bool
-	if err := json.Unmarshal(successRaw, &success); err != nil {
-		return fmt.Errorf("decode dynamic tool call response success: %w", err)
+	success, err := decodeRequiredThreadItemValue[bool](payload, objectName, "success")
+	if err != nil {
+		return err
 	}
 	*r = DynamicToolCallResponse{ContentItems: contentItems, Success: success}
 	return nil
@@ -80,26 +117,35 @@ type DynamicToolCallOutputContentItem struct {
 	Type     string `json:"type"`
 	Text     string `json:"text,omitempty"`
 	ImageURL string `json:"imageUrl,omitempty"`
+	AudioURL string `json:"audioUrl,omitempty"`
 }
 
 func (i DynamicToolCallOutputContentItem) MarshalJSON() ([]byte, error) {
 	switch i.Type {
 	case "inputText":
-		if i.ImageURL != "" {
-			return nil, errors.New("inputText dynamic tool content cannot include imageUrl")
+		if i.ImageURL != "" || i.AudioURL != "" {
+			return nil, errors.New("inputText dynamic tool content cannot include imageUrl or audioUrl")
 		}
 		return json.Marshal(struct {
 			Type string `json:"type"`
 			Text string `json:"text"`
 		}{Type: i.Type, Text: i.Text})
 	case "inputImage":
-		if i.Text != "" {
-			return nil, errors.New("inputImage dynamic tool content cannot include text")
+		if i.Text != "" || i.AudioURL != "" {
+			return nil, errors.New("inputImage dynamic tool content cannot include text or audioUrl")
 		}
 		return json.Marshal(struct {
 			Type     string `json:"type"`
 			ImageURL string `json:"imageUrl"`
 		}{Type: i.Type, ImageURL: i.ImageURL})
+	case "inputAudio":
+		if i.Text != "" || i.ImageURL != "" {
+			return nil, errors.New("inputAudio dynamic tool content cannot include text or imageUrl")
+		}
+		return json.Marshal(struct {
+			Type     string `json:"type"`
+			AudioURL string `json:"audioUrl"`
+		}{Type: i.Type, AudioURL: i.AudioURL})
 	default:
 		return nil, fmt.Errorf("unknown dynamic tool content type %q", i.Type)
 	}
@@ -109,55 +155,75 @@ func (i *DynamicToolCallOutputContentItem) UnmarshalJSON(data []byte) error {
 	if i == nil {
 		return errors.New("decode dynamic tool content into nil receiver")
 	}
-	var payload map[string]json.RawMessage
-	if err := json.Unmarshal(data, &payload); err != nil {
+	const objectName = "dynamic tool call output content item"
+	tagPayload, err := decodeRustSerdeObject(data, objectName, "type")
+	if err != nil {
 		return err
 	}
-	for name := range payload {
-		switch name {
-		case "type", "text", "imageUrl":
-		default:
-			return fmt.Errorf("unknown dynamic tool content field %q", name)
-		}
-	}
-	contentType, err := decodeRequiredDynamicToolString(payload, "type")
+	contentType, err := decodeRequiredThreadItemValue[string](tagPayload, objectName, "type")
 	if err != nil {
 		return err
 	}
 	switch contentType {
 	case "inputText":
-		if _, exists := payload["imageUrl"]; exists {
-			return errors.New("inputText dynamic tool content cannot include imageUrl")
+		payload, err := decodeRustSerdeObject(data, objectName, "type", "text")
+		if err != nil {
+			return err
 		}
-		text, err := decodeRequiredDynamicToolString(payload, "text")
+		text, err := decodeRequiredThreadItemValue[string](payload, objectName, "text")
 		if err != nil {
 			return err
 		}
 		*i = DynamicToolCallOutputContentItem{Type: contentType, Text: text}
 		return nil
 	case "inputImage":
-		if _, exists := payload["text"]; exists {
-			return errors.New("inputImage dynamic tool content cannot include text")
+		payload, err := decodeRustSerdeObject(data, objectName, "type", "imageUrl")
+		if err != nil {
+			return err
 		}
-		imageURL, err := decodeRequiredDynamicToolString(payload, "imageUrl")
+		imageURL, err := decodeRequiredThreadItemValue[string](payload, objectName, "imageUrl")
 		if err != nil {
 			return err
 		}
 		*i = DynamicToolCallOutputContentItem{Type: contentType, ImageURL: imageURL}
+		return nil
+	case "inputAudio":
+		payload, err := decodeRustSerdeObject(data, objectName, "type", "audioUrl")
+		if err != nil {
+			return err
+		}
+		audioURL, err := decodeRequiredThreadItemValue[string](payload, objectName, "audioUrl")
+		if err != nil {
+			return err
+		}
+		*i = DynamicToolCallOutputContentItem{Type: contentType, AudioURL: audioURL}
 		return nil
 	default:
 		return fmt.Errorf("unknown dynamic tool content type %q", contentType)
 	}
 }
 
-func decodeRequiredDynamicToolString(payload map[string]json.RawMessage, name string) (string, error) {
-	raw, ok := payload[name]
+func requiredDynamicToolJSONValue(
+	payload map[string]json.RawMessage,
+	objectName, fieldName string,
+) (json.RawMessage, error) {
+	raw, ok := payload[fieldName]
 	if !ok {
-		return "", fmt.Errorf("dynamic tool content requires %s", name)
+		return nil, fmt.Errorf("%s requires %s", objectName, fieldName)
 	}
-	var value string
+	if err := requireDynamicToolJSONValue(raw, fieldName); err != nil {
+		return nil, fmt.Errorf("decode %s %s: %w", objectName, fieldName, err)
+	}
+	return append(json.RawMessage(nil), raw...), nil
+}
+
+func requireDynamicToolJSONValue(raw json.RawMessage, fieldName string) error {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return fmt.Errorf("dynamic tool call requires %s", fieldName)
+	}
+	var value any
 	if err := json.Unmarshal(raw, &value); err != nil {
-		return "", fmt.Errorf("decode dynamic tool content %s: %w", name, err)
+		return fmt.Errorf("dynamic tool call %s must be valid JSON: %w", fieldName, err)
 	}
-	return value, nil
+	return nil
 }

--- a/appserver/protocol/runtime_wire_fixture_test.go
+++ b/appserver/protocol/runtime_wire_fixture_test.go
@@ -102,7 +102,7 @@ func TestDynamicToolCallWireV1FixtureUsesExportedContracts(t *testing.T) {
 	if err := decodeRuntimeFixture(data, &fixture); err != nil {
 		t.Fatalf("decode dynamic tool fixture: %v", err)
 	}
-	if fixture.ProtocolVersion != ProtocolVersion || fixture.SchemaVersion != SchemaVersion || len(fixture.Cases) != 3 {
+	if fixture.ProtocolVersion != ProtocolVersion || fixture.SchemaVersion != SchemaVersion || len(fixture.Cases) != 4 {
 		t.Fatalf("dynamic tool fixture metadata = %s/%s/%d", fixture.ProtocolVersion, fixture.SchemaVersion, len(fixture.Cases))
 	}
 	bindings := WireTypeBindings()

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -1548,6 +1548,8 @@ func wireSchemaDefinitions() Schema {
 		string(PatchApplyStatusFailed), string(PatchApplyStatusDeclined),
 	)
 	schemas["PatchChangeKind"] = patchChangeKindSchema()
+	schemas["DynamicToolCallParams"] = dynamicToolCallParamsSchema()
+	schemas["DynamicToolCallResponse"] = dynamicToolCallResponseSchema()
 	schemas["DynamicToolCallOutputContentItem"] = dynamicToolCallOutputContentItemSchema()
 	schemas["McpElicitationArrayType"] = stringEnumSchema("array")
 	schemas["McpElicitationBooleanType"] = stringEnumSchema("boolean")
@@ -2807,18 +2809,57 @@ func dynamicToolCallOutputContentItemSchema() Schema {
 	return Schema{"oneOf": []any{
 		dynamicToolCallOutputContentItemVariantSchema("inputText", "text"),
 		dynamicToolCallOutputContentItemVariantSchema("inputImage", "imageUrl"),
+		dynamicToolCallOutputContentItemVariantSchema("inputAudio", "audioUrl"),
 	}}
 }
 
+func dynamicToolCallParamsSchema() Schema {
+	return Schema{
+		"type":  "object",
+		"title": "DynamicToolCallParams",
+		"properties": Schema{
+			"threadId":  Schema{"type": "string"},
+			"turnId":    Schema{"type": "string"},
+			"callId":    Schema{"type": "string"},
+			"namespace": Schema{"type": []any{"string", "null"}},
+			"tool":      Schema{"type": "string"},
+			"arguments": true,
+		},
+		"required": []string{"arguments", "callId", "threadId", "tool", "turnId"},
+	}
+}
+
+func dynamicToolCallResponseSchema() Schema {
+	return Schema{
+		"type":  "object",
+		"title": "DynamicToolCallResponse",
+		"properties": Schema{
+			"contentItems": Schema{"type": "array", "items": Schema{"$ref": "#/$defs/DynamicToolCallOutputContentItem"}},
+			"success":      Schema{"type": "boolean"},
+		},
+		"required": []string{"contentItems", "success"},
+	}
+}
+
 func dynamicToolCallOutputContentItemVariantSchema(contentType, valueField string) Schema {
+	variantName := ""
+	typeName := ""
+	switch contentType {
+	case "inputText":
+		variantName, typeName = "InputTextDynamicToolCallOutputContentItem", "InputTextDynamicToolCallOutputContentItemType"
+	case "inputImage":
+		variantName, typeName = "InputImageDynamicToolCallOutputContentItem", "InputImageDynamicToolCallOutputContentItemType"
+	case "inputAudio":
+		variantName, typeName = "InputAudioDynamicToolCallOutputContentItem", "InputAudioDynamicToolCallOutputContentItemType"
+	}
 	return Schema{
 		"type": "object",
 		"properties": Schema{
-			"type":     Schema{"type": "string", "enum": []any{contentType}},
+			"type":     Schema{"type": "string", "enum": []any{contentType}, "title": typeName},
 			valueField: Schema{"type": "string"},
 		},
-		"required":             []string{"type", valueField},
-		"additionalProperties": false,
+		"required": []string{valueField, "type"},
+		"title":    variantName,
 	}
 }
 

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -4698,7 +4698,6 @@
     "DynamicToolCallOutputContentItem": {
       "oneOf": [
         {
-          "additionalProperties": false,
           "properties": {
             "text": {
               "type": "string"
@@ -4707,17 +4706,18 @@
               "enum": [
                 "inputText"
               ],
+              "title": "InputTextDynamicToolCallOutputContentItemType",
               "type": "string"
             }
           },
           "required": [
-            "type",
-            "text"
+            "text",
+            "type"
           ],
+          "title": "InputTextDynamicToolCallOutputContentItem",
           "type": "object"
         },
         {
-          "additionalProperties": false,
           "properties": {
             "imageUrl": {
               "type": "string"
@@ -4726,59 +4726,50 @@
               "enum": [
                 "inputImage"
               ],
+              "title": "InputImageDynamicToolCallOutputContentItemType",
               "type": "string"
             }
           },
           "required": [
-            "type",
-            "imageUrl"
+            "imageUrl",
+            "type"
           ],
+          "title": "InputImageDynamicToolCallOutputContentItem",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "audioUrl": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "inputAudio"
+              ],
+              "title": "InputAudioDynamicToolCallOutputContentItemType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "audioUrl",
+            "type"
+          ],
+          "title": "InputAudioDynamicToolCallOutputContentItem",
           "type": "object"
         }
       ]
     },
     "DynamicToolCallParams": {
-      "additionalProperties": false,
       "properties": {
-        "arguments": {},
+        "arguments": true,
         "callId": {
           "type": "string"
         },
-        "itemId": {
-          "type": "string"
-        },
-        "metadata": {
-          "anyOf": [
-            {
-              "additionalProperties": {},
-              "type": "object"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "name": {
-          "type": "string"
-        },
         "namespace": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
+          "type": [
+            "string",
+            "null"
           ]
-        },
-        "reason": {
-          "type": "string"
-        },
-        "requestId": {
-          "type": "string"
-        },
-        "startedAtMs": {
-          "type": "integer"
         },
         "threadId": {
           "type": "string"
@@ -4786,25 +4777,21 @@
         "tool": {
           "type": "string"
         },
-        "toolName": {
-          "type": "string"
-        },
         "turnId": {
           "type": "string"
         }
       },
       "required": [
-        "threadId",
-        "turnId",
+        "arguments",
         "callId",
-        "namespace",
+        "threadId",
         "tool",
-        "arguments"
+        "turnId"
       ],
+      "title": "DynamicToolCallParams",
       "type": "object"
     },
     "DynamicToolCallResponse": {
-      "additionalProperties": false,
       "properties": {
         "contentItems": {
           "items": {
@@ -4820,6 +4807,7 @@
         "contentItems",
         "success"
       ],
+      "title": "DynamicToolCallResponse",
       "type": "object"
     },
     "DynamicToolCallStatus": {

--- a/appserver/protocol/testdata/dynamic_tool_call_wire_v1.json
+++ b/appserver/protocol/testdata/dynamic_tool_call_wire_v1.json
@@ -16,14 +16,7 @@
           "callId": "call-1",
           "namespace": null,
           "tool": "client.search",
-          "arguments": {"query": "gollem"},
-          "requestId": "interaction-1",
-          "itemId": "item-tool-1",
-          "startedAtMs": 1783715400000,
-          "toolName": "client.search",
-          "name": "client.search",
-          "metadata": {"source": "runtime"},
-          "reason": "client.search"
+          "arguments": {"query": "gollem"}
         }
       }
     },
@@ -54,6 +47,22 @@
             {"type": "inputImage", "imageUrl": "data:image/png;base64,AA=="}
           ],
           "success": false
+        }
+      }
+    },
+    {
+      "name": "dynamic-tool-call-audio-response",
+      "surface": "server-request",
+      "method": "item/tool/call",
+      "envelope": "response",
+      "resultType": "DynamicToolCallResponse",
+      "message": {
+        "id": "interaction-1",
+        "result": {
+          "contentItems": [
+            {"type": "inputAudio", "audioUrl": "data:audio/wav;base64,AA=="}
+          ],
+          "success": true
         }
       }
     }

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -874,6 +874,18 @@ func MarshalTypeScript() ([]byte, error) {
 			definition = Schema{
 				typeScriptRawTypeKeyword: `{ "action": McpServerElicitationAction; "content": JsonValue | null; "_meta": JsonValue | null; }`,
 			}
+		case "DynamicToolCallParams":
+			definition = Schema{
+				typeScriptRawTypeKeyword: `{ "threadId": string; "turnId": string; "callId": string; "namespace": string | null; "tool": string; "arguments": JsonValue; }`,
+			}
+		case "DynamicToolCallResponse":
+			definition = Schema{
+				typeScriptRawTypeKeyword: `{ "contentItems": Array<DynamicToolCallOutputContentItem>; "success": boolean; }`,
+			}
+		case "DynamicToolCallOutputContentItem":
+			definition = Schema{
+				typeScriptRawTypeKeyword: `{ "type": "inputText"; "text": string; } | { "type": "inputImage"; "imageUrl": string; } | { "type": "inputAudio"; "audioUrl": string; }`,
+			}
 		case "DynamicToolFunctionSpec", "DynamicToolNamespaceSpec":
 			schema, _ := typeScriptSchema(definition)
 			schema["x-gollem-typescript-ignore-additional-properties"] = true

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -1396,34 +1396,11 @@ export type DynamicToolCallItemStartedNotificationParams = {
   "turnId": string;
 };
 
-export type DynamicToolCallOutputContentItem = {
-  "text": string;
-  "type": "inputText";
-} | {
-  "imageUrl": string;
-  "type": "inputImage";
-};
+export type DynamicToolCallOutputContentItem = { "type": "inputText"; "text": string; } | { "type": "inputImage"; "imageUrl": string; } | { "type": "inputAudio"; "audioUrl": string; };
 
-export type DynamicToolCallParams = {
-  "arguments": unknown;
-  "callId": string;
-  "itemId"?: string;
-  "metadata"?: Record<string, unknown> | null;
-  "name"?: string;
-  "namespace": string | null;
-  "reason"?: string;
-  "requestId"?: string;
-  "startedAtMs"?: number;
-  "threadId": string;
-  "tool": string;
-  "toolName"?: string;
-  "turnId": string;
-};
+export type DynamicToolCallParams = { "threadId": string; "turnId": string; "callId": string; "namespace": string | null; "tool": string; "arguments": JsonValue; };
 
-export type DynamicToolCallResponse = {
-  "contentItems": Array<DynamicToolCallOutputContentItem>;
-  "success": boolean;
-};
+export type DynamicToolCallResponse = { "contentItems": Array<DynamicToolCallOutputContentItem>; "success": boolean; };
 
 export type DynamicToolCallStatus = "inProgress" | "completed" | "failed";
 

--- a/appserver/protocol/typescript/testdata/dynamic_tool_call_contract.ts
+++ b/appserver/protocol/typescript/testdata/dynamic_tool_call_contract.ts
@@ -12,8 +12,6 @@ export const params = {
   namespace: null,
   tool: "client.search",
   arguments: { query: "gollem" },
-  requestId: "interaction-1",
-  toolName: "client.search",
 } satisfies DynamicToolCallParams;
 
 export const text = { type: "inputText", text: "match" } satisfies DynamicToolCallOutputContentItem;
@@ -21,7 +19,11 @@ export const image = {
   type: "inputImage",
   imageUrl: "data:image/png;base64,AA==",
 } satisfies DynamicToolCallOutputContentItem;
-export const response = { contentItems: [text, image], success: true } satisfies DynamicToolCallResponse;
+export const audio = {
+  type: "inputAudio",
+  audioUrl: "data:audio/wav;base64,AA==",
+} satisfies DynamicToolCallOutputContentItem;
+export const response = { contentItems: [text, image, audio], success: true } satisfies DynamicToolCallResponse;
 response satisfies ResultFor<"item/tool/call">;
 
 // @ts-expect-error callId is required.

--- a/appserver/protocol/typescript/testdata/dynamic_tool_call_wire_v1.ts
+++ b/appserver/protocol/typescript/testdata/dynamic_tool_call_wire_v1.ts
@@ -22,16 +22,7 @@ export const dynamicToolCallRequest = {
     "tool": "client.search",
     "arguments": {
       "query": "gollem"
-    },
-    "requestId": "interaction-1",
-    "itemId": "item-tool-1",
-    "startedAtMs": 1783715400000,
-    "toolName": "client.search",
-    "name": "client.search",
-    "metadata": {
-      "source": "runtime"
-    },
-    "reason": "client.search"
+    }
   }
 } satisfies BoundRequest<"item/tool/call">;
 export const dynamicToolCallRequestParams = dynamicToolCallRequest.params satisfies DynamicToolCallParams;
@@ -63,6 +54,20 @@ export const dynamicToolCallImageResponse = {
   }
 } satisfies BoundResponse<"item/tool/call">;
 export const dynamicToolCallImageResponseResult = dynamicToolCallImageResponse.result satisfies DynamicToolCallResponse;
+
+export const dynamicToolCallAudioResponse = {
+  "id": "interaction-1",
+  "result": {
+    "contentItems": [
+      {
+        "type": "inputAudio",
+        "audioUrl": "data:audio/wav;base64,AA=="
+      }
+    ],
+    "success": true
+  }
+} satisfies BoundResponse<"item/tool/call">;
+export const dynamicToolCallAudioResponseResult = dynamicToolCallAudioResponse.result satisfies DynamicToolCallResponse;
 
 // @ts-expect-error request methods cannot use notification envelopes.
 export type RejectRequestAsNotification = BoundNotification<"daemon/status">;

--- a/appserver/runtime_interaction_tools_test.go
+++ b/appserver/runtime_interaction_tools_test.go
@@ -237,11 +237,13 @@ func TestServerRuntimeClientToolAndMCPElicitationUseDurableCorrelation(t *testin
 			if params["threadId"] != started.Thread.ID || params["turnId"] != started.Turn.ID {
 				t.Fatalf("server request correlation = %#v", params)
 			}
-			if tt.wantMethod != InteractionMCPElicitation && (itemID == "" || itemID == "call-runtime-interaction") {
+			if tt.wantMethod != InteractionToolCall && tt.wantMethod != InteractionMCPElicitation && (itemID == "" || itemID == "call-runtime-interaction") {
 				t.Fatalf("server request item correlation = %#v", params)
 			}
 			if tt.wantMethod == InteractionToolCall &&
-				(params["callId"] != "call-runtime-interaction" || params["tool"] != "client.search" || params["namespace"] != nil) {
+				(params["callId"] != "call-runtime-interaction" || params["tool"] != "client.search" || params["namespace"] != nil ||
+					params["requestId"] != nil || params["itemId"] != nil || params["startedAtMs"] != nil || params["reason"] != nil ||
+					params["toolName"] != nil || params["name"] != nil || params["metadata"] != nil) {
 				t.Fatalf("public dynamic tool correlation = %#v", params)
 			}
 			if tt.wantMethod == InteractionMCPElicitation {
@@ -264,7 +266,7 @@ func TestServerRuntimeClientToolAndMCPElicitationUseDurableCorrelation(t *testin
 				t.Fatalf("ListItems: %v", err)
 			}
 			toolItem := findRuntimeToolItem(t, items, tt.toolName, tt.argumentKey, tt.argumentValue)
-			if (tt.wantMethod != InteractionMCPElicitation && toolItem.Item.ID != itemID) || toolItem.Status != runtimeToolStatusCompleted {
+			if (tt.wantMethod != InteractionToolCall && tt.wantMethod != InteractionMCPElicitation && toolItem.Item.ID != itemID) || toolItem.Status != runtimeToolStatusCompleted {
 				t.Fatalf("durable interaction item = %#v, request item %q", toolItem, itemID)
 			}
 		})


### PR DESCRIPTION
## Summary
- make `item/tool/call` parameters match the Codex source serde contract and keep local correlation metadata internal
- add source-open decoding, canonical nullable namespace behavior, and the `inputAudio` output variant
- regenerate exact JSON Schema and TypeScript bindings with source-compatible fixtures

## Verification
- `go test ./appserver/protocol -count=1`
- `go test ./appserver -count=1`
- `go test -race ./appserver/protocol ./appserver -run 'TestDynamicToolCall|TestInteractionToolCall|TestInteractionRuntimeClientToolAndMCPElicitation|TestServeJSONLinesResolvesExactDynamicToolCall' -count=1`\n- non-Monty `go test ./...` and `go vet`\n- `go mod tidy`\n- `go generate ./appserver/protocol`\n- `golangci-lint run`\n- normal pre-push full race hook with `hooks.skipMontyRace=true`