### PR TITLE
feat(protocol): add standalone ServerRequest union

### DIFF
--- a/appserver/protocol/account_credit_nudge_values_contract_test.go
+++ b/appserver/protocol/account_credit_nudge_values_contract_test.go
@@ -119,8 +119,8 @@ func TestAccountCreditNudgeValuesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/sendAddCreditsNudgeEmail = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/account_envelope_contract_test.go
+++ b/appserver/protocol/account_envelope_contract_test.go
@@ -268,8 +268,8 @@ func TestAccountEnvelopeContractsRemainStandaloneAndDeferred(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred %s", methodName, method, ok, surface)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/account_login_completed_notification_contract_test.go
+++ b/appserver/protocol/account_login_completed_notification_contract_test.go
@@ -88,8 +88,8 @@ func TestAccountLoginCompletedNotificationRemainsStandaloneAndDeferred(t *testin
 	if !found {
 		t.Fatal("account/login/completed method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/account_rate_limits_contract_test.go
+++ b/appserver/protocol/account_rate_limits_contract_test.go
@@ -484,8 +484,8 @@ func TestAccountRateLimitContractsRemainStandaloneAndDeferred(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred %s", methodName, method, ok, surface)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/account_token_usage_contract_test.go
+++ b/appserver/protocol/account_token_usage_contract_test.go
@@ -146,8 +146,8 @@ func TestAccountTokenUsageRecordsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/usage/read = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(defs); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_config_contract_test.go
+++ b/appserver/protocol/app_config_contract_test.go
@@ -109,8 +109,8 @@ func TestAppConfigRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppConfig unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_info_contract_test.go
+++ b/appserver/protocol/app_info_contract_test.go
@@ -131,8 +131,8 @@ func TestAppInfoRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_list_updated_notification_contract_test.go
+++ b/appserver/protocol/app_list_updated_notification_contract_test.go
@@ -105,8 +105,8 @@ func TestAppListUpdatedNotificationRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceServerNotification || method.State != MethodDeferredStub {
 		t.Fatalf("app/list/updated = %#v, %v; want deferred server notification", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_metadata_contract_test.go
+++ b/appserver/protocol/app_metadata_contract_test.go
@@ -107,8 +107,8 @@ func TestAppMetadataRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_metadata_leaf_contract_test.go
+++ b/appserver/protocol/app_metadata_leaf_contract_test.go
@@ -157,8 +157,8 @@ func TestAppMetadataLeavesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_summary_contract_test.go
+++ b/appserver/protocol/app_summary_contract_test.go
@@ -87,8 +87,8 @@ func TestAppSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppSummary unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_template_summary_contract_test.go
+++ b/appserver/protocol/app_template_summary_contract_test.go
@@ -107,8 +107,8 @@ func TestAppTemplateSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppTemplateSummary unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_template_unavailable_reason_contract_test.go
+++ b/appserver/protocol/app_template_unavailable_reason_contract_test.go
@@ -71,8 +71,8 @@ func TestAppTemplateUnavailableReasonRemainsStandalone(t *testing.T) {
 			t.Fatalf("AppTemplateUnavailableReason unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_tool_approval_contract_test.go
+++ b/appserver/protocol/app_tool_approval_contract_test.go
@@ -73,8 +73,8 @@ func TestAppToolApprovalRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppToolApproval unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_tools_config_contract_test.go
+++ b/appserver/protocol/app_tools_config_contract_test.go
@@ -140,8 +140,8 @@ func TestAppToolConfigsRemainStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/apply_patch_approval_params_contract_test.go
+++ b/appserver/protocol/apply_patch_approval_params_contract_test.go
@@ -139,8 +139,8 @@ func TestApplyPatchApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ApplyPatchApprovalParams unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(defs); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(defs); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/apps_config_contract_test.go
+++ b/appserver/protocol/apps_config_contract_test.go
@@ -185,8 +185,8 @@ func TestAppsConfigsRemainStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/apps_list_contract_test.go
+++ b/appserver/protocol/apps_list_contract_test.go
@@ -168,8 +168,8 @@ func TestAppsListContractsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/attestation_contract_test.go
+++ b/appserver/protocol/attestation_contract_test.go
@@ -134,8 +134,8 @@ func TestAttestationContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("attestation/generate = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
+++ b/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
@@ -194,8 +194,8 @@ func TestChatgptAuthTokensRefreshRemainsStandaloneAndDeferred(t *testing.T) {
 	if !found {
 		t.Fatal("refresh method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/client_notification_contract_test.go
+++ b/appserver/protocol/client_notification_contract_test.go
@@ -58,8 +58,8 @@ func TestClientNotificationRemainsStandaloneFromInitializedBinding(t *testing.T)
 	if !ok || info.Surface != SurfaceClientNotification || info.State != MethodImplemented {
 		t.Fatalf("initialized method = %#v, %v; want implemented client notification", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 }
 

--- a/appserver/protocol/collaboration_capability_contract_test.go
+++ b/appserver/protocol/collaboration_capability_contract_test.go
@@ -346,8 +346,8 @@ func TestCollaborationCapabilityContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/command_exec_contract_test.go
+++ b/appserver/protocol/command_exec_contract_test.go
@@ -79,8 +79,8 @@ func TestCommandExecContractsFailClosedAndRemainStandalone(t *testing.T) {
 			t.Fatalf("public command-exec contract unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 }
 

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/conversation_text_role_contract_test.go
+++ b/appserver/protocol/conversation_text_role_contract_test.go
@@ -42,7 +42,7 @@ func TestConversationTextRoleContractIsExact(t *testing.T) {
 			t.Fatalf("standalone conversation role unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(definitions); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(definitions); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 }

--- a/appserver/protocol/dynamic_tool_spec_contract_test.go
+++ b/appserver/protocol/dynamic_tool_spec_contract_test.go
@@ -318,8 +318,8 @@ func TestDynamicToolSpecContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/exec_command_approval_params_contract_test.go
+++ b/appserver/protocol/exec_command_approval_params_contract_test.go
@@ -137,8 +137,8 @@ func TestExecCommandApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ExecCommandApprovalParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(defs); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/experimental_feature_contract_test.go
+++ b/appserver/protocol/experimental_feature_contract_test.go
@@ -41,8 +41,8 @@ func TestExperimentalFeatureContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want implemented client request", methodName, method, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d/%d/%d, want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,8 +217,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,8 +203,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -260,8 +260,8 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,8 +244,8 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -162,8 +162,8 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -175,8 +175,8 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/file_change_contract_test.go
+++ b/appserver/protocol/file_change_contract_test.go
@@ -108,8 +108,8 @@ func TestFileChangeRemainsStandalone(t *testing.T) {
 			t.Fatalf("FileChange unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/file_change_output_delta_notification_contract_test.go
+++ b/appserver/protocol/file_change_output_delta_notification_contract_test.go
@@ -100,8 +100,8 @@ func TestFileChangeOutputDeltaNotificationRemainsDeprecatedAndStandalone(t *test
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("item/fileChange/outputDelta = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -381,8 +381,8 @@ func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/guardian_approval_review_action_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_action_contract_test.go
@@ -226,8 +226,8 @@ func TestGuardianApprovalReviewActionRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReviewAction unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
@@ -164,8 +164,8 @@ func TestGuardianApprovalReviewCompletedNotificationRemainsStandalone(t *testing
 			t.Fatalf("completed notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/guardian_approval_review_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_contract_test.go
@@ -139,8 +139,8 @@ func TestGuardianApprovalReviewRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReview unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
@@ -175,8 +175,8 @@ func TestGuardianApprovalReviewStartedNotificationRemainsStandalone(t *testing.T
 			t.Fatalf("started notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/guardian_enum_foundation_contract_test.go
+++ b/appserver/protocol/guardian_enum_foundation_contract_test.go
@@ -89,8 +89,8 @@ func TestGuardianEnumFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/hook_metadata_list_contract_test.go
+++ b/appserver/protocol/hook_metadata_list_contract_test.go
@@ -352,8 +352,8 @@ func TestHookMetadataListContractsStayStandalone(t *testing.T) {
 			t.Errorf("standalone definition %s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Errorf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Errorf("definition count = %d, want 606", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 {
 		t.Errorf("wire binding count = %d, want 80", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/hook_run_notification_contract_test.go
+++ b/appserver/protocol/hook_run_notification_contract_test.go
@@ -297,8 +297,8 @@ func TestHookRunNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("surface changed: %d methods, %d wire bindings, %d item bindings", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/hook_value_foundation_contract_test.go
+++ b/appserver/protocol/hook_value_foundation_contract_test.go
@@ -167,8 +167,8 @@ func TestHookValueFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 605 {
-		t.Fatalf("definition count = %d, want 605", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 606 {
+		t.Fatalf("definition count = %d, want 606", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/jsonrpc_envelope_contract_test.go
+++ b/appserver/protocol/jsonrpc_envelope_contract_test.go
@@ -87,8 +87,8 @@ func TestJSONRPCEnvelopesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 }
 

--- a/appserver/protocol/jsonrpc_error_contract_test.go
+++ b/appserver/protocol/jsonrpc_error_contract_test.go
@@ -67,8 +67,8 @@ func TestJSONRPCErrorsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 }
 

--- a/appserver/protocol/jsonrpc_message_contract_test.go
+++ b/appserver/protocol/jsonrpc_message_contract_test.go
@@ -74,8 +74,8 @@ func TestJSONRPCMessageRemainsStandalone(t *testing.T) {
 			t.Fatalf("JSONRPCMessage unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 }
 

--- a/appserver/protocol/legacy_approval_response_contract_test.go
+++ b/appserver/protocol/legacy_approval_response_contract_test.go
@@ -98,8 +98,8 @@ func TestLegacyApprovalResponsesRemainStandaloneAndNominal(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_oauth_login_contract_test.go
+++ b/appserver/protocol/mcp_server_oauth_login_contract_test.go
@@ -228,8 +228,8 @@ func TestMcpServerOauthLoginContractsRemainStandaloneAndBlocked(t *testing.T) {
 	if !ok || notification.Surface != SurfaceServerNotification || notification.State != MethodBlocked {
 		t.Fatalf("mcpServer/oauthLogin/completed = %#v, %v; want blocked server notification", notification, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d/%d/%d, want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_status_contract_test.go
+++ b/appserver/protocol/mcp_server_status_contract_test.go
@@ -277,8 +277,8 @@ func TestMcpServerStatusContractsRemainStandalone(t *testing.T) {
 	if !ok || method.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d/%d/%d, want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_approval_context_contract_test.go
+++ b/appserver/protocol/network_approval_context_contract_test.go
@@ -84,8 +84,8 @@ func TestNetworkApprovalContextRemainsStandalone(t *testing.T) {
 			t.Fatalf("NetworkApprovalContext unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/parsed_command_contract_test.go
+++ b/appserver/protocol/parsed_command_contract_test.go
@@ -120,8 +120,8 @@ func TestParsedCommandRemainsStandalone(t *testing.T) {
 			t.Fatalf("ParsedCommand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/permission_profile_list_contract_test.go
+++ b/appserver/protocol/permission_profile_list_contract_test.go
@@ -255,8 +255,8 @@ func TestPermissionProfileListContractsRemainStandalone(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodImplemented {
 		t.Fatalf("permissionProfile/list = %#v, %v; want existing implemented client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d/%d/%d, want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/permissions_request_approval_params_contract_test.go
+++ b/appserver/protocol/permissions_request_approval_params_contract_test.go
@@ -107,8 +107,8 @@ func TestPermissionsRequestApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("PermissionsRequestApprovalParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(defs); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 }
 

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/process_contracts_contract_test.go
+++ b/appserver/protocol/process_contracts_contract_test.go
@@ -308,8 +308,8 @@ func TestProcessContractsRemainStandaloneFromLegacyRuntime(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want unchanged implemented notification", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 605 {
-		t.Fatalf("definition count = %d, want 605", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 606 {
+		t.Fatalf("definition count = %d, want 606", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 605 {
-		t.Fatalf("definition count = %d, want 605", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 606 {
+		t.Fatalf("definition count = %d, want 606", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 605 {
-		t.Fatalf("definition count = %d, want 605", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 606 {
+		t.Fatalf("definition count = %d, want 606", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 605 {
-		t.Fatalf("definition count = %d, want 605", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 606 {
+		t.Fatalf("definition count = %d, want 606", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 605 {
-		t.Fatalf("definition count = %d, want 605", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 606 {
+		t.Fatalf("definition count = %d, want 606", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/review_decision_contract_test.go
+++ b/appserver/protocol/review_decision_contract_test.go
@@ -136,8 +136,8 @@ func TestReviewDecisionRemainsStandalone(t *testing.T) {
 			t.Fatalf("ReviewDecision unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(defs); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/review_start_contract_test.go
+++ b/appserver/protocol/review_start_contract_test.go
@@ -215,8 +215,8 @@ func TestReviewStartContractsFailClosedAndRemainStandalone(t *testing.T) {
 	if !ok || request.Surface != SurfaceClientRequest || request.State != MethodBlocked {
 		t.Fatalf("review/start = %#v, %v; want blocked client request", request, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 }
 

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -517,6 +517,7 @@ func wireSchemaDefinitions() Schema {
 		{Name: "SelectedCapabilityRoot", Type: reflect.TypeFor[SelectedCapabilityRoot]()},
 		{Name: "SendAddCreditsNudgeEmailParams", Type: reflect.TypeFor[SendAddCreditsNudgeEmailParams]()},
 		{Name: "SendAddCreditsNudgeEmailResponse", Type: reflect.TypeFor[SendAddCreditsNudgeEmailResponse]()},
+		{Name: "ServerRequest", Type: reflect.TypeFor[ServerRequest]()},
 		{Name: "ServerRequestResolvedNotificationParams", Type: reflect.TypeFor[ServerRequestResolvedNotificationParams]()},
 		{Name: "ServerCapabilities", Type: reflect.TypeFor[ServerCapabilities]()},
 		{Name: "SessionSource", Type: reflect.TypeFor[SessionSource]()},
@@ -1498,6 +1499,7 @@ func wireSchemaDefinitions() Schema {
 		schemas[alias] = Schema{"$ref": "#/$defs/" + canonical}
 	}
 	schemas["RequestId"] = Schema{"$ref": "#/$defs/RequestID"}
+	schemas["ServerRequest"] = serverRequestSchema()
 	schemas["SandboxMode"] = stringEnumSchema(
 		string(SandboxModeReadOnly), string(SandboxModeWorkspaceWrite), string(SandboxModeDangerFullAccess),
 	)
@@ -2811,6 +2813,28 @@ func dynamicToolCallOutputContentItemSchema() Schema {
 		dynamicToolCallOutputContentItemVariantSchema("inputImage", "imageUrl"),
 		dynamicToolCallOutputContentItemVariantSchema("inputAudio", "audioUrl"),
 	}}
+}
+
+func serverRequestSchema() Schema {
+	variants := make([]any, 0, len(serverRequestVariants))
+	for _, variant := range serverRequestVariants {
+		properties := Schema{
+			"id":     Schema{"$ref": "#/$defs/RequestId"},
+			"method": Schema{"enum": []any{variant.Method}, "title": variant.Title + "Method", "type": "string"},
+			"params": Schema{"$ref": "#/$defs/" + variant.ParamType},
+		}
+		item := Schema{
+			"properties": properties,
+			"required":   []string{"id", "method", "params"},
+			"title":      variant.Title,
+			"type":       "object",
+		}
+		if variant.Description != "" {
+			item["description"] = variant.Description
+		}
+		variants = append(variants, item)
+	}
+	return Schema{"oneOf": variants, "title": "ServerRequest"}
 }
 
 func dynamicToolCallParamsSchema() Schema {

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -14371,6 +14371,260 @@
       ],
       "type": "object"
     },
+    "ServerRequest": {
+      "oneOf": [
+        {
+          "description": "NEW APIs Sent when approval is requested for a specific command execution. This request is used for Turns started via turn/start.",
+          "properties": {
+            "id": {
+              "$ref": "#/$defs/RequestId"
+            },
+            "method": {
+              "enum": [
+                "item/commandExecution/requestApproval"
+              ],
+              "title": "Item/commandExecution/requestApprovalRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/$defs/CommandExecutionRequestApprovalParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "Item/commandExecution/requestApprovalRequest",
+          "type": "object"
+        },
+        {
+          "description": "Sent when approval is requested for a specific file change. This request is used for Turns started via turn/start.",
+          "properties": {
+            "id": {
+              "$ref": "#/$defs/RequestId"
+            },
+            "method": {
+              "enum": [
+                "item/fileChange/requestApproval"
+              ],
+              "title": "Item/fileChange/requestApprovalRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/$defs/FileChangeRequestApprovalParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "Item/fileChange/requestApprovalRequest",
+          "type": "object"
+        },
+        {
+          "description": "EXPERIMENTAL - Request input from the user for a tool call.",
+          "properties": {
+            "id": {
+              "$ref": "#/$defs/RequestId"
+            },
+            "method": {
+              "enum": [
+                "item/tool/requestUserInput"
+              ],
+              "title": "Item/tool/requestUserInputRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/$defs/ToolRequestUserInputParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "Item/tool/requestUserInputRequest",
+          "type": "object"
+        },
+        {
+          "description": "Request input for an MCP server elicitation.",
+          "properties": {
+            "id": {
+              "$ref": "#/$defs/RequestId"
+            },
+            "method": {
+              "enum": [
+                "mcpServer/elicitation/request"
+              ],
+              "title": "McpServer/elicitation/requestRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/$defs/McpServerElicitationRequestParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "McpServer/elicitation/requestRequest",
+          "type": "object"
+        },
+        {
+          "description": "Request approval for additional permissions from the user.",
+          "properties": {
+            "id": {
+              "$ref": "#/$defs/RequestId"
+            },
+            "method": {
+              "enum": [
+                "item/permissions/requestApproval"
+              ],
+              "title": "Item/permissions/requestApprovalRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/$defs/PermissionsRequestApprovalParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "Item/permissions/requestApprovalRequest",
+          "type": "object"
+        },
+        {
+          "description": "Execute a dynamic tool call on the client.",
+          "properties": {
+            "id": {
+              "$ref": "#/$defs/RequestId"
+            },
+            "method": {
+              "enum": [
+                "item/tool/call"
+              ],
+              "title": "Item/tool/callRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/$defs/DynamicToolCallParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "Item/tool/callRequest",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "$ref": "#/$defs/RequestId"
+            },
+            "method": {
+              "enum": [
+                "account/chatgptAuthTokens/refresh"
+              ],
+              "title": "Account/chatgptAuthTokens/refreshRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/$defs/ChatgptAuthTokensRefreshParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "Account/chatgptAuthTokens/refreshRequest",
+          "type": "object"
+        },
+        {
+          "description": "Generate a fresh upstream attestation result on demand.",
+          "properties": {
+            "id": {
+              "$ref": "#/$defs/RequestId"
+            },
+            "method": {
+              "enum": [
+                "attestation/generate"
+              ],
+              "title": "Attestation/generateRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/$defs/AttestationGenerateParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "Attestation/generateRequest",
+          "type": "object"
+        },
+        {
+          "description": "DEPRECATED APIs below Request to approve a patch. This request is used for Turns started via the legacy APIs (i.e. SendUserTurn, SendUserMessage).",
+          "properties": {
+            "id": {
+              "$ref": "#/$defs/RequestId"
+            },
+            "method": {
+              "enum": [
+                "applyPatchApproval"
+              ],
+              "title": "ApplyPatchApprovalRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/$defs/ApplyPatchApprovalParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "ApplyPatchApprovalRequest",
+          "type": "object"
+        },
+        {
+          "description": "Request to exec a command. This request is used for Turns started via the legacy APIs (i.e. SendUserTurn, SendUserMessage).",
+          "properties": {
+            "id": {
+              "$ref": "#/$defs/RequestId"
+            },
+            "method": {
+              "enum": [
+                "execCommandApproval"
+              ],
+              "title": "ExecCommandApprovalRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/$defs/ExecCommandApprovalParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "ExecCommandApprovalRequest",
+          "type": "object"
+        }
+      ],
+      "title": "ServerRequest"
+    },
     "ServerRequestResolvedNotification": {
       "additionalProperties": false,
       "properties": {

--- a/appserver/protocol/server_request_approval_params_contract_test.go
+++ b/appserver/protocol/server_request_approval_params_contract_test.go
@@ -153,8 +153,8 @@ func TestServerRequestApprovalParamsRemainStandalone(t *testing.T) {
 			t.Fatalf("dependency-complete %s missing", name)
 		}
 	}
-	if _, ok := defs["ServerRequest"]; ok {
-		t.Fatal("ServerRequest was added before every referenced parameter is source-exact")
+	if _, ok := defs["ServerRequest"]; !ok {
+		t.Fatal("ServerRequest missing after every referenced parameter became source-exact")
 	}
 	for _, binding := range WireTypeBindings() {
 		for _, name := range []string{"CommandExecutionRequestApprovalParams", "FileChangeRequestApprovalParams"} {
@@ -163,8 +163,8 @@ func TestServerRequestApprovalParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(defs); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(defs); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/server_request_contract_test.go
+++ b/appserver/protocol/server_request_contract_test.go
@@ -1,0 +1,146 @@
+package protocol
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestServerRequestSchemaAndBindingAreExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	definition, ok := defs["ServerRequest"].(Schema)
+	if !ok {
+		t.Fatal("$defs missing ServerRequest")
+	}
+	if definition["title"] != "ServerRequest" {
+		t.Fatalf("ServerRequest title = %#v", definition["title"])
+	}
+	if _, present := definition["type"]; present {
+		t.Fatalf("ServerRequest unexpectedly has a top-level type: %#v", definition)
+	}
+	variants, ok := definition["oneOf"].([]any)
+	if !ok || len(variants) != len(serverRequestVariants) {
+		t.Fatalf("ServerRequest variants = %#v", definition["oneOf"])
+	}
+	for index, want := range serverRequestVariants {
+		variant := variants[index].(Schema)
+		if variant["title"] != want.Title {
+			t.Fatalf("variant %d = %#v, want %s/%q", index, variant, want.Title, want.Description)
+		}
+		if want.Description == "" {
+			if _, present := variant["description"]; present {
+				t.Fatalf("variant %s unexpectedly has a description: %#v", want.Method, variant)
+			}
+		} else if variant["description"] != want.Description {
+			t.Fatalf("variant %d description = %#v, want %q", index, variant["description"], want.Description)
+		}
+		if _, closed := variant["additionalProperties"]; closed {
+			t.Fatalf("variant %s unexpectedly closes the serde-open record", want.Method)
+		}
+		assertSchemaRequired(t, variant, "id", "method", "params")
+		properties := variant["properties"].(Schema)
+		if properties["id"].(Schema)["$ref"] != "#/$defs/RequestId" ||
+			properties["method"].(Schema)["title"] != want.Title+"Method" ||
+			properties["method"].(Schema)["enum"].([]any)[0] != want.Method ||
+			properties["params"].(Schema)["$ref"] != "#/$defs/"+want.ParamType {
+			t.Fatalf("variant %s properties = %#v", want.Method, properties)
+		}
+	}
+	for _, binding := range WireTypeBindings() {
+		for _, name := range append(append([]string(nil), binding.Params...), binding.Result...) {
+			if name == "ServerRequest" {
+				t.Fatalf("ServerRequest unexpectedly bound to %s", binding.Method)
+			}
+		}
+	}
+	if got := len(defs); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
+	}
+	typescript, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	for _, want := range []string{
+		`export type ServerRequest = { "method": "item/commandExecution/requestApproval"; "id": RequestId; "params": CommandExecutionRequestApprovalParams; }`,
+		`{ "method": "mcpServer/elicitation/request"; "id": RequestId; "params": McpServerElicitationRequestParams; }`,
+		`{ "method": "execCommandApproval"; "id": RequestId; "params": ExecCommandApprovalParams; };`,
+	} {
+		if !strings.Contains(string(typescript), want) {
+			t.Fatalf("generated TypeScript missing %q", want)
+		}
+	}
+}
+
+func TestServerRequestUsesSourceSerdeSemantics(t *testing.T) {
+	for _, test := range []struct {
+		method string
+		params string
+	}{
+		{"item/commandExecution/requestApproval", `{"threadId":"thread","turnId":"turn","itemId":"item","startedAtMs":1}`},
+		{"item/fileChange/requestApproval", `{"threadId":"thread","turnId":"turn","itemId":"item","startedAtMs":1}`},
+		{"item/tool/requestUserInput", `{"threadId":"thread","turnId":"turn","itemId":"item","questions":[{"id":"question","header":"Header","question":"Question","isOther":false,"isSecret":false,"options":[]}],"isBlocking":true}`},
+		{"mcpServer/elicitation/request", `{"threadId":"thread","serverName":"server","mode":"form","_meta":null,"message":"Choose","requestedSchema":{"type":"object","properties":{}}}`},
+		{"item/permissions/requestApproval", `{"threadId":"thread","turnId":"turn","itemId":"item","startedAtMs":1,"cwd":"/workspace","permissions":{}}`},
+		{"item/tool/call", `{"threadId":"thread","turnId":"turn","callId":"call","tool":"client.search","arguments":null}`},
+		{"account/chatgptAuthTokens/refresh", `{"reason":"unauthorized"}`},
+		{"attestation/generate", `{}`},
+		{"applyPatchApproval", `{"conversationId":"thread","callId":"call","fileChanges":{}}`},
+		{"execCommandApproval", `{"conversationId":"thread","callId":"call","command":[],"cwd":".","parsedCmd":[]}`},
+	} {
+		t.Run(test.method, func(t *testing.T) {
+			input := `{"method":` + quoteServerRequestString(test.method) + `,"id":42,"params":` + test.params + `,"unknown":true}`
+			var request ServerRequest
+			if err := json.Unmarshal([]byte(input), &request); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			if request.Method != test.method || request.ID.Value() == nil || !json.Valid(request.Params) {
+				t.Fatalf("decoded request = %#v", request)
+			}
+			encoded, err := json.Marshal(request)
+			if err != nil {
+				t.Fatalf("Marshal: %v", err)
+			}
+			var canonical map[string]json.RawMessage
+			if err := json.Unmarshal(encoded, &canonical); err != nil {
+				t.Fatalf("decode canonical request: %v", err)
+			}
+			if len(canonical) != 3 || canonical["method"] == nil || canonical["id"] == nil || canonical["params"] == nil {
+				t.Fatalf("canonical request = %s", encoded)
+			}
+		})
+	}
+
+	var request ServerRequest
+	if err := json.Unmarshal([]byte(`{"method":"attestation/generate","id":"request","params":{"unknown":true},"unknown":true}`), &request); err != nil {
+		t.Fatalf("Unmarshal source-open request: %v", err)
+	}
+	encoded, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("Marshal source-open request: %v", err)
+	}
+	if string(encoded) != `{"method":"attestation/generate","id":"request","params":{}}` {
+		t.Fatalf("canonical request = %s", encoded)
+	}
+
+	for _, input := range []string{
+		`{}`,
+		`{"method":"unknown","id":"request","params":{}}`,
+		`{"method":"attestation/generate","id":null,"params":{}}`,
+		`{"method":"attestation/generate","id":"request","params":null}`,
+		`{"method":"attestation/generate","method":"item/tool/call","id":"request","params":{}}`,
+		`{"method":"attestation/generate","id":"request","params":{}} null`,
+	} {
+		if err := json.Unmarshal([]byte(input), &request); err == nil {
+			t.Errorf("Unmarshal(%s) succeeded", input)
+		}
+	}
+	var nilRequest *ServerRequest
+	if err := nilRequest.UnmarshalJSON([]byte(`{}`)); err == nil {
+		t.Fatal("nil ServerRequest receiver succeeded")
+	}
+}
+
+func quoteServerRequestString(value string) string {
+	encoded, _ := json.Marshal(value)
+	return string(encoded)
+}

--- a/appserver/protocol/server_request_types.go
+++ b/appserver/protocol/server_request_types.go
@@ -1,0 +1,159 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// ServerRequest is the exact standalone public server-to-client request union.
+// It deliberately does not replace Gollem's live request envelopes or bindings.
+type ServerRequest struct {
+	Method string          `json:"method"`
+	ID     RequestId       `json:"id"`
+	Params json.RawMessage `json:"params"`
+}
+
+type serverRequestVariant struct {
+	Method      string
+	Title       string
+	Description string
+	ParamType   string
+}
+
+var serverRequestVariants = []serverRequestVariant{
+	{
+		Method: "item/commandExecution/requestApproval", Title: "Item/commandExecution/requestApprovalRequest",
+		Description: "NEW APIs Sent when approval is requested for a specific command execution. This request is used for Turns started via turn/start.",
+		ParamType:   "CommandExecutionRequestApprovalParams",
+	},
+	{
+		Method: "item/fileChange/requestApproval", Title: "Item/fileChange/requestApprovalRequest",
+		Description: "Sent when approval is requested for a specific file change. This request is used for Turns started via turn/start.",
+		ParamType:   "FileChangeRequestApprovalParams",
+	},
+	{
+		Method: "item/tool/requestUserInput", Title: "Item/tool/requestUserInputRequest",
+		Description: "EXPERIMENTAL - Request input from the user for a tool call.",
+		ParamType:   "ToolRequestUserInputParams",
+	},
+	{
+		Method: "mcpServer/elicitation/request", Title: "McpServer/elicitation/requestRequest",
+		Description: "Request input for an MCP server elicitation.",
+		ParamType:   "McpServerElicitationRequestParams",
+	},
+	{
+		Method: "item/permissions/requestApproval", Title: "Item/permissions/requestApprovalRequest",
+		Description: "Request approval for additional permissions from the user.",
+		ParamType:   "PermissionsRequestApprovalParams",
+	},
+	{
+		Method: "item/tool/call", Title: "Item/tool/callRequest",
+		Description: "Execute a dynamic tool call on the client.",
+		ParamType:   "DynamicToolCallParams",
+	},
+	{
+		Method: "account/chatgptAuthTokens/refresh", Title: "Account/chatgptAuthTokens/refreshRequest",
+		ParamType: "ChatgptAuthTokensRefreshParams",
+	},
+	{
+		Method: "attestation/generate", Title: "Attestation/generateRequest",
+		Description: "Generate a fresh upstream attestation result on demand.",
+		ParamType:   "AttestationGenerateParams",
+	},
+	{
+		Method: "applyPatchApproval", Title: "ApplyPatchApprovalRequest",
+		Description: "DEPRECATED APIs below Request to approve a patch. This request is used for Turns started via the legacy APIs (i.e. SendUserTurn, SendUserMessage).",
+		ParamType:   "ApplyPatchApprovalParams",
+	},
+	{
+		Method: "execCommandApproval", Title: "ExecCommandApprovalRequest",
+		Description: "Request to exec a command. This request is used for Turns started via the legacy APIs (i.e. SendUserTurn, SendUserMessage).",
+		ParamType:   "ExecCommandApprovalParams",
+	},
+}
+
+func (r ServerRequest) MarshalJSON() ([]byte, error) {
+	params, err := canonicalServerRequestParams(r.Method, r.Params)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(struct {
+		Method string          `json:"method"`
+		ID     RequestId       `json:"id"`
+		Params json.RawMessage `json:"params"`
+	}{Method: r.Method, ID: r.ID, Params: params})
+}
+
+func (r *ServerRequest) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("decode server request into nil receiver")
+	}
+	const objectName = "server request"
+	payload, err := decodeRustSerdeObject(data, objectName, "method", "id", "params")
+	if err != nil {
+		return err
+	}
+	method, err := decodeRequiredThreadItemValue[string](payload, objectName, "method")
+	if err != nil {
+		return err
+	}
+	id, err := decodeRequiredThreadItemValue[RequestId](payload, objectName, "id")
+	if err != nil {
+		return err
+	}
+	paramsRaw, ok := payload["params"]
+	if !ok || isJSONNull(paramsRaw) {
+		return fmt.Errorf("%s requires params", objectName)
+	}
+	params, err := canonicalServerRequestParams(method, paramsRaw)
+	if err != nil {
+		return err
+	}
+	*r = ServerRequest{Method: method, ID: id, Params: params}
+	return nil
+}
+
+func canonicalServerRequestParams(method string, raw json.RawMessage) (json.RawMessage, error) {
+	switch method {
+	case "item/commandExecution/requestApproval":
+		return decodeServerRequestParams[CommandExecutionRequestApprovalParams](method, raw)
+	case "item/fileChange/requestApproval":
+		return decodeServerRequestParams[FileChangeRequestApprovalParams](method, raw)
+	case "item/tool/requestUserInput":
+		return decodeServerRequestParams[ToolRequestUserInputParams](method, raw)
+	case "mcpServer/elicitation/request":
+		return decodeServerRequestParams[McpServerElicitationRequestParams](method, raw)
+	case "item/permissions/requestApproval":
+		return decodeServerRequestParams[PermissionsRequestApprovalParams](method, raw)
+	case "item/tool/call":
+		return decodeServerRequestParams[DynamicToolCallParams](method, raw)
+	case "account/chatgptAuthTokens/refresh":
+		return decodeServerRequestParams[ChatgptAuthTokensRefreshParams](method, raw)
+	case "attestation/generate":
+		return decodeServerRequestParams[AttestationGenerateParams](method, raw)
+	case "applyPatchApproval":
+		return decodeServerRequestParams[ApplyPatchApprovalParams](method, raw)
+	case "execCommandApproval":
+		return decodeServerRequestParams[ExecCommandApprovalParams](method, raw)
+	default:
+		return nil, fmt.Errorf("unknown server request method %q", method)
+	}
+}
+
+func decodeServerRequestParams[T any](method string, raw json.RawMessage) (json.RawMessage, error) {
+	var params T
+	if err := json.Unmarshal(raw, &params); err != nil {
+		return nil, fmt.Errorf("decode server request params for %s: %w", method, err)
+	}
+	canonical, err := json.Marshal(params)
+	if err != nil {
+		return nil, fmt.Errorf("encode server request params for %s: %w", method, err)
+	}
+	return canonical, nil
+}
+
+var (
+	_ json.Marshaler   = ServerRequest{}
+	_ json.Unmarshaler = (*ServerRequest)(nil)
+)

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/terminal_interaction_notification_contract_test.go
+++ b/appserver/protocol/terminal_interaction_notification_contract_test.go
@@ -72,8 +72,8 @@ func TestTerminalInteractionNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.Surface != SurfaceServerNotification || info.State != MethodBlocked {
 		t.Fatalf("terminal interaction method = %#v, %v; want blocked server notification", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	generated, err := MarshalTypeScript()
 	if err != nil {

--- a/appserver/protocol/thread_approve_guardian_denied_action_contract_test.go
+++ b/appserver/protocol/thread_approve_guardian_denied_action_contract_test.go
@@ -88,8 +88,8 @@ func TestThreadApproveGuardianDeniedActionContractsRemainStandalone(t *testing.T
 	if !ok || info.Surface != SurfaceClientRequest || info.State != MethodDeferredStub {
 		t.Fatalf("guardian denied action method = %#v, %v; want deferred client request", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 }
 

--- a/appserver/protocol/thread_inject_items_contract_test.go
+++ b/appserver/protocol/thread_inject_items_contract_test.go
@@ -96,8 +96,8 @@ func TestThreadInjectItemsContractsFailClosedAndRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 }
 

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 605 {
-		t.Fatalf("definition count = %d, want 605", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 606 {
+		t.Fatalf("definition count = %d, want 606", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -262,8 +262,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_rollback_contract_test.go
+++ b/appserver/protocol/thread_rollback_contract_test.go
@@ -114,8 +114,8 @@ func TestThreadRollbackContractsFailClosedAndRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 }
 

--- a/appserver/protocol/thread_search_result_contract_test.go
+++ b/appserver/protocol/thread_search_result_contract_test.go
@@ -59,8 +59,8 @@ func TestThreadSearchResultFailsClosedAndRemainsStandalone(t *testing.T) {
 			t.Fatalf("ThreadSearchResult unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 }
 

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -252,8 +252,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 	if !foundRuntimeStart {
 		t.Error("thread/start runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -154,8 +154,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 	if !foundRuntimeStart {
 		t.Error("thread/start runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_settings_contract_test.go
+++ b/appserver/protocol/thread_settings_contract_test.go
@@ -162,8 +162,8 @@ func TestThreadSettingsContractsFailClosedAndRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 }
 

--- a/appserver/protocol/thread_shell_command_contract_test.go
+++ b/appserver/protocol/thread_shell_command_contract_test.go
@@ -95,8 +95,8 @@ func TestThreadShellCommandContractsFailClosedAndRemainStandalone(t *testing.T) 
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 }
 

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 605 {
-		t.Fatalf("definition count = %d, want 605", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 606 {
+		t.Fatalf("definition count = %d, want 606", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 605 {
-		t.Fatalf("definition count = %d, want 605", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 606 {
+		t.Fatalf("definition count = %d, want 606", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_environment_contract_test.go
+++ b/appserver/protocol/turn_environment_contract_test.go
@@ -79,8 +79,8 @@ func TestTurnEnvironmentParamsFailsClosedAndRemainsStandalone(t *testing.T) {
 			t.Fatalf("TurnEnvironmentParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 }
 

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -119,8 +119,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 	if !foundRuntimeBinding {
 		t.Error("turn/interrupt runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -241,8 +241,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 	if !foundRuntimeBinding {
 		t.Error("turn/start runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -164,8 +164,8 @@ func TestTurnSteerContractsAreBoundToLiveRuntime(t *testing.T) {
 	if !found {
 		t.Fatal("turn/steer runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -886,6 +886,10 @@ func MarshalTypeScript() ([]byte, error) {
 			definition = Schema{
 				typeScriptRawTypeKeyword: `{ "type": "inputText"; "text": string; } | { "type": "inputImage"; "imageUrl": string; } | { "type": "inputAudio"; "audioUrl": string; }`,
 			}
+		case "ServerRequest":
+			definition = Schema{
+				typeScriptRawTypeKeyword: `{ "method": "item/commandExecution/requestApproval"; "id": RequestId; "params": CommandExecutionRequestApprovalParams; } | { "method": "item/fileChange/requestApproval"; "id": RequestId; "params": FileChangeRequestApprovalParams; } | { "method": "item/tool/requestUserInput"; "id": RequestId; "params": ToolRequestUserInputParams; } | { "method": "mcpServer/elicitation/request"; "id": RequestId; "params": McpServerElicitationRequestParams; } | { "method": "item/permissions/requestApproval"; "id": RequestId; "params": PermissionsRequestApprovalParams; } | { "method": "item/tool/call"; "id": RequestId; "params": DynamicToolCallParams; } | { "method": "account/chatgptAuthTokens/refresh"; "id": RequestId; "params": ChatgptAuthTokensRefreshParams; } | { "method": "attestation/generate"; "id": RequestId; "params": AttestationGenerateParams; } | { "method": "applyPatchApproval"; "id": RequestId; "params": ApplyPatchApprovalParams; } | { "method": "execCommandApproval"; "id": RequestId; "params": ExecCommandApprovalParams; }`,
+			}
 		case "DynamicToolFunctionSpec", "DynamicToolNamespaceSpec":
 			schema, _ := typeScriptSchema(definition)
 			schema["x-gollem-typescript-ignore-additional-properties"] = true

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -3396,6 +3396,8 @@ export type ServerCapabilities = {
   "unavailable": boolean;
 };
 
+export type ServerRequest = { "method": "item/commandExecution/requestApproval"; "id": RequestId; "params": CommandExecutionRequestApprovalParams; } | { "method": "item/fileChange/requestApproval"; "id": RequestId; "params": FileChangeRequestApprovalParams; } | { "method": "item/tool/requestUserInput"; "id": RequestId; "params": ToolRequestUserInputParams; } | { "method": "mcpServer/elicitation/request"; "id": RequestId; "params": McpServerElicitationRequestParams; } | { "method": "item/permissions/requestApproval"; "id": RequestId; "params": PermissionsRequestApprovalParams; } | { "method": "item/tool/call"; "id": RequestId; "params": DynamicToolCallParams; } | { "method": "account/chatgptAuthTokens/refresh"; "id": RequestId; "params": ChatgptAuthTokensRefreshParams; } | { "method": "attestation/generate"; "id": RequestId; "params": AttestationGenerateParams; } | { "method": "applyPatchApproval"; "id": RequestId; "params": ApplyPatchApprovalParams; } | { "method": "execCommandApproval"; "id": RequestId; "params": ExecCommandApprovalParams; };
+
 export type ServerRequestResolvedNotification = {
   "requestId": RequestId;
   "threadId": string;

--- a/appserver/protocol/typescript/testdata/server_request_contract.ts
+++ b/appserver/protocol/typescript/testdata/server_request_contract.ts
@@ -1,0 +1,34 @@
+import type {
+  AttestationGenerateParams,
+  DynamicToolCallParams,
+  ServerRequest,
+} from "../gollem_appserver_protocol";
+
+export const dynamicParams = {
+  threadId: "thread",
+  turnId: "turn",
+  callId: "call",
+  namespace: null,
+  tool: "client.search",
+  arguments: null,
+} satisfies DynamicToolCallParams;
+
+export const dynamicRequest = {
+  method: "item/tool/call",
+  id: "request-1",
+  params: dynamicParams,
+} satisfies ServerRequest;
+
+export const attestationRequest = {
+  method: "attestation/generate",
+  id: 42,
+  params: {},
+} satisfies ServerRequest;
+attestationRequest.params satisfies AttestationGenerateParams;
+
+// @ts-expect-error the method determines the required parameter type.
+({ method: "item/tool/call", id: "request-1", params: {} }) satisfies ServerRequest;
+// @ts-expect-error public server requests require an id.
+({ method: "attestation/generate", params: {} }) satisfies ServerRequest;
+// @ts-expect-error source variants are closed to known method names.
+({ method: "unknown", id: "request-1", params: {} }) satisfies ServerRequest;

--- a/appserver/protocol/w3c_trace_context_contract_test.go
+++ b/appserver/protocol/w3c_trace_context_contract_test.go
@@ -55,8 +55,8 @@ func TestW3cTraceContextRemainsStandalone(t *testing.T) {
 			t.Fatalf("W3cTraceContext unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 }
 

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/workspace_messages_contract_test.go
+++ b/appserver/protocol/workspace_messages_contract_test.go
@@ -209,8 +209,8 @@ func TestWorkspaceMessageContractsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/workspaceMessages/read = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 605 {
-		t.Fatalf("definition count = %d, want 605", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
+		t.Fatalf("definition count = %d, want 606", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- add the source-exact standalone `ServerRequest` server-to-client union
- preserve source serde-open input semantics and canonical parameter encoding
- generate source-matching JSON Schema and TypeScript without widening live bindings

## Verification
- `go test ./appserver/protocol -count=1`
- `go test -race ./appserver/protocol ./appserver -run 'TestServerRequest|TestDynamicToolCall|TestInteractionToolCall' -count=1`\n- non-Monty `go test ./...`\n- non-Monty `go vet ./...`\n- `go mod tidy`\n- `go generate ./appserver/protocol`\n- `golangci-lint run`