### PR TITLE
feat(protocol): add standalone thread section params

### DIFF
--- a/appserver/protocol/account_credit_nudge_values_contract_test.go
+++ b/appserver/protocol/account_credit_nudge_values_contract_test.go
@@ -119,8 +119,8 @@ func TestAccountCreditNudgeValuesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/sendAddCreditsNudgeEmail = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/account_envelope_contract_test.go
+++ b/appserver/protocol/account_envelope_contract_test.go
@@ -268,8 +268,8 @@ func TestAccountEnvelopeContractsRemainStandaloneAndDeferred(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred %s", methodName, method, ok, surface)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/account_login_completed_notification_contract_test.go
+++ b/appserver/protocol/account_login_completed_notification_contract_test.go
@@ -88,8 +88,8 @@ func TestAccountLoginCompletedNotificationRemainsStandaloneAndDeferred(t *testin
 	if !found {
 		t.Fatal("account/login/completed method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/account_rate_limits_contract_test.go
+++ b/appserver/protocol/account_rate_limits_contract_test.go
@@ -484,8 +484,8 @@ func TestAccountRateLimitContractsRemainStandaloneAndDeferred(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred %s", methodName, method, ok, surface)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/account_token_usage_contract_test.go
+++ b/appserver/protocol/account_token_usage_contract_test.go
@@ -146,8 +146,8 @@ func TestAccountTokenUsageRecordsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/usage/read = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(defs); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_config_contract_test.go
+++ b/appserver/protocol/app_config_contract_test.go
@@ -109,8 +109,8 @@ func TestAppConfigRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppConfig unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_info_contract_test.go
+++ b/appserver/protocol/app_info_contract_test.go
@@ -131,8 +131,8 @@ func TestAppInfoRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_list_updated_notification_contract_test.go
+++ b/appserver/protocol/app_list_updated_notification_contract_test.go
@@ -105,8 +105,8 @@ func TestAppListUpdatedNotificationRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceServerNotification || method.State != MethodDeferredStub {
 		t.Fatalf("app/list/updated = %#v, %v; want deferred server notification", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_metadata_contract_test.go
+++ b/appserver/protocol/app_metadata_contract_test.go
@@ -107,8 +107,8 @@ func TestAppMetadataRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_metadata_leaf_contract_test.go
+++ b/appserver/protocol/app_metadata_leaf_contract_test.go
@@ -157,8 +157,8 @@ func TestAppMetadataLeavesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_summary_contract_test.go
+++ b/appserver/protocol/app_summary_contract_test.go
@@ -87,8 +87,8 @@ func TestAppSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppSummary unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_template_summary_contract_test.go
+++ b/appserver/protocol/app_template_summary_contract_test.go
@@ -107,8 +107,8 @@ func TestAppTemplateSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppTemplateSummary unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_template_unavailable_reason_contract_test.go
+++ b/appserver/protocol/app_template_unavailable_reason_contract_test.go
@@ -71,8 +71,8 @@ func TestAppTemplateUnavailableReasonRemainsStandalone(t *testing.T) {
 			t.Fatalf("AppTemplateUnavailableReason unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_tool_approval_contract_test.go
+++ b/appserver/protocol/app_tool_approval_contract_test.go
@@ -73,8 +73,8 @@ func TestAppToolApprovalRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppToolApproval unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_tools_config_contract_test.go
+++ b/appserver/protocol/app_tools_config_contract_test.go
@@ -140,8 +140,8 @@ func TestAppToolConfigsRemainStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/apply_patch_approval_params_contract_test.go
+++ b/appserver/protocol/apply_patch_approval_params_contract_test.go
@@ -139,8 +139,8 @@ func TestApplyPatchApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ApplyPatchApprovalParams unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(defs); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(defs); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/apps_config_contract_test.go
+++ b/appserver/protocol/apps_config_contract_test.go
@@ -185,8 +185,8 @@ func TestAppsConfigsRemainStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/apps_list_contract_test.go
+++ b/appserver/protocol/apps_list_contract_test.go
@@ -168,8 +168,8 @@ func TestAppsListContractsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/attestation_contract_test.go
+++ b/appserver/protocol/attestation_contract_test.go
@@ -134,8 +134,8 @@ func TestAttestationContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("attestation/generate = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
+++ b/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
@@ -194,8 +194,8 @@ func TestChatgptAuthTokensRefreshRemainsStandaloneAndDeferred(t *testing.T) {
 	if !found {
 		t.Fatal("refresh method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/client_notification_contract_test.go
+++ b/appserver/protocol/client_notification_contract_test.go
@@ -58,8 +58,8 @@ func TestClientNotificationRemainsStandaloneFromInitializedBinding(t *testing.T)
 	if !ok || info.Surface != SurfaceClientNotification || info.State != MethodImplemented {
 		t.Fatalf("initialized method = %#v, %v; want implemented client notification", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 }
 

--- a/appserver/protocol/collaboration_capability_contract_test.go
+++ b/appserver/protocol/collaboration_capability_contract_test.go
@@ -346,8 +346,8 @@ func TestCollaborationCapabilityContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/command_exec_contract_test.go
+++ b/appserver/protocol/command_exec_contract_test.go
@@ -79,8 +79,8 @@ func TestCommandExecContractsFailClosedAndRemainStandalone(t *testing.T) {
 			t.Fatalf("public command-exec contract unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 }
 

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/conversation_text_role_contract_test.go
+++ b/appserver/protocol/conversation_text_role_contract_test.go
@@ -42,7 +42,7 @@ func TestConversationTextRoleContractIsExact(t *testing.T) {
 			t.Fatalf("standalone conversation role unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(definitions); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(definitions); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 }

--- a/appserver/protocol/dynamic_tool_spec_contract_test.go
+++ b/appserver/protocol/dynamic_tool_spec_contract_test.go
@@ -318,8 +318,8 @@ func TestDynamicToolSpecContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/exec_command_approval_params_contract_test.go
+++ b/appserver/protocol/exec_command_approval_params_contract_test.go
@@ -137,8 +137,8 @@ func TestExecCommandApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ExecCommandApprovalParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(defs); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/experimental_feature_contract_test.go
+++ b/appserver/protocol/experimental_feature_contract_test.go
@@ -41,8 +41,8 @@ func TestExperimentalFeatureContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want implemented client request", methodName, method, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d/%d/%d, want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,8 +217,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,8 +203,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -260,8 +260,8 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,8 +244,8 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -162,8 +162,8 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -175,8 +175,8 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/file_change_contract_test.go
+++ b/appserver/protocol/file_change_contract_test.go
@@ -108,8 +108,8 @@ func TestFileChangeRemainsStandalone(t *testing.T) {
 			t.Fatalf("FileChange unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/file_change_output_delta_notification_contract_test.go
+++ b/appserver/protocol/file_change_output_delta_notification_contract_test.go
@@ -100,8 +100,8 @@ func TestFileChangeOutputDeltaNotificationRemainsDeprecatedAndStandalone(t *test
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("item/fileChange/outputDelta = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -381,8 +381,8 @@ func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/guardian_approval_review_action_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_action_contract_test.go
@@ -226,8 +226,8 @@ func TestGuardianApprovalReviewActionRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReviewAction unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
@@ -164,8 +164,8 @@ func TestGuardianApprovalReviewCompletedNotificationRemainsStandalone(t *testing
 			t.Fatalf("completed notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/guardian_approval_review_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_contract_test.go
@@ -139,8 +139,8 @@ func TestGuardianApprovalReviewRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReview unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
@@ -175,8 +175,8 @@ func TestGuardianApprovalReviewStartedNotificationRemainsStandalone(t *testing.T
 			t.Fatalf("started notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/guardian_enum_foundation_contract_test.go
+++ b/appserver/protocol/guardian_enum_foundation_contract_test.go
@@ -89,8 +89,8 @@ func TestGuardianEnumFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/hook_metadata_list_contract_test.go
+++ b/appserver/protocol/hook_metadata_list_contract_test.go
@@ -352,8 +352,8 @@ func TestHookMetadataListContractsStayStandalone(t *testing.T) {
 			t.Errorf("standalone definition %s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Errorf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Errorf("definition count = %d, want 612", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 {
 		t.Errorf("wire binding count = %d, want 80", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/hook_run_notification_contract_test.go
+++ b/appserver/protocol/hook_run_notification_contract_test.go
@@ -297,8 +297,8 @@ func TestHookRunNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("surface changed: %d methods, %d wire bindings, %d item bindings", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/hook_value_foundation_contract_test.go
+++ b/appserver/protocol/hook_value_foundation_contract_test.go
@@ -167,8 +167,8 @@ func TestHookValueFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 606 {
-		t.Fatalf("definition count = %d, want 606", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 612 {
+		t.Fatalf("definition count = %d, want 612", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/jsonrpc_envelope_contract_test.go
+++ b/appserver/protocol/jsonrpc_envelope_contract_test.go
@@ -87,8 +87,8 @@ func TestJSONRPCEnvelopesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 }
 

--- a/appserver/protocol/jsonrpc_error_contract_test.go
+++ b/appserver/protocol/jsonrpc_error_contract_test.go
@@ -67,8 +67,8 @@ func TestJSONRPCErrorsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 }
 

--- a/appserver/protocol/jsonrpc_message_contract_test.go
+++ b/appserver/protocol/jsonrpc_message_contract_test.go
@@ -74,8 +74,8 @@ func TestJSONRPCMessageRemainsStandalone(t *testing.T) {
 			t.Fatalf("JSONRPCMessage unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 }
 

--- a/appserver/protocol/legacy_approval_response_contract_test.go
+++ b/appserver/protocol/legacy_approval_response_contract_test.go
@@ -98,8 +98,8 @@ func TestLegacyApprovalResponsesRemainStandaloneAndNominal(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_oauth_login_contract_test.go
+++ b/appserver/protocol/mcp_server_oauth_login_contract_test.go
@@ -228,8 +228,8 @@ func TestMcpServerOauthLoginContractsRemainStandaloneAndBlocked(t *testing.T) {
 	if !ok || notification.Surface != SurfaceServerNotification || notification.State != MethodBlocked {
 		t.Fatalf("mcpServer/oauthLogin/completed = %#v, %v; want blocked server notification", notification, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d/%d/%d, want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_status_contract_test.go
+++ b/appserver/protocol/mcp_server_status_contract_test.go
@@ -277,8 +277,8 @@ func TestMcpServerStatusContractsRemainStandalone(t *testing.T) {
 	if !ok || method.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d/%d/%d, want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_approval_context_contract_test.go
+++ b/appserver/protocol/network_approval_context_contract_test.go
@@ -84,8 +84,8 @@ func TestNetworkApprovalContextRemainsStandalone(t *testing.T) {
 			t.Fatalf("NetworkApprovalContext unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/parsed_command_contract_test.go
+++ b/appserver/protocol/parsed_command_contract_test.go
@@ -120,8 +120,8 @@ func TestParsedCommandRemainsStandalone(t *testing.T) {
 			t.Fatalf("ParsedCommand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/permission_profile_list_contract_test.go
+++ b/appserver/protocol/permission_profile_list_contract_test.go
@@ -255,8 +255,8 @@ func TestPermissionProfileListContractsRemainStandalone(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodImplemented {
 		t.Fatalf("permissionProfile/list = %#v, %v; want existing implemented client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d/%d/%d, want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/permissions_request_approval_params_contract_test.go
+++ b/appserver/protocol/permissions_request_approval_params_contract_test.go
@@ -107,8 +107,8 @@ func TestPermissionsRequestApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("PermissionsRequestApprovalParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(defs); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 }
 

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/process_contracts_contract_test.go
+++ b/appserver/protocol/process_contracts_contract_test.go
@@ -308,8 +308,8 @@ func TestProcessContractsRemainStandaloneFromLegacyRuntime(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want unchanged implemented notification", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 606 {
-		t.Fatalf("definition count = %d, want 606", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 612 {
+		t.Fatalf("definition count = %d, want 612", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 606 {
-		t.Fatalf("definition count = %d, want 606", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 612 {
+		t.Fatalf("definition count = %d, want 612", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 606 {
-		t.Fatalf("definition count = %d, want 606", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 612 {
+		t.Fatalf("definition count = %d, want 612", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 606 {
-		t.Fatalf("definition count = %d, want 606", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 612 {
+		t.Fatalf("definition count = %d, want 612", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 606 {
-		t.Fatalf("definition count = %d, want 606", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 612 {
+		t.Fatalf("definition count = %d, want 612", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/review_decision_contract_test.go
+++ b/appserver/protocol/review_decision_contract_test.go
@@ -136,8 +136,8 @@ func TestReviewDecisionRemainsStandalone(t *testing.T) {
 			t.Fatalf("ReviewDecision unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(defs); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/review_start_contract_test.go
+++ b/appserver/protocol/review_start_contract_test.go
@@ -215,8 +215,8 @@ func TestReviewStartContractsFailClosedAndRemainStandalone(t *testing.T) {
 	if !ok || request.Surface != SurfaceClientRequest || request.State != MethodBlocked {
 		t.Fatalf("review/start = %#v, %v; want blocked client request", request, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 }
 

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -565,6 +565,12 @@ func wireSchemaDefinitions() Schema {
 		{Name: "ThreadRollbackParams", Type: reflect.TypeFor[ThreadRollbackParams]()},
 		{Name: "ThreadRollbackResponse", Type: reflect.TypeFor[ThreadRollbackResponse]()},
 		{Name: "ThreadSearchResult", Type: reflect.TypeFor[ThreadSearchResult]()},
+		{Name: "ThreadSectionAppearance", Type: reflect.TypeFor[ThreadSectionAppearance]()},
+		{Name: "ThreadSectionCreateParams", Type: reflect.TypeFor[ThreadSectionCreateParams]()},
+		{Name: "ThreadSectionDeleteParams", Type: reflect.TypeFor[ThreadSectionDeleteParams]()},
+		{Name: "ThreadSectionListParams", Type: reflect.TypeFor[ThreadSectionListParams]()},
+		{Name: "ThreadSectionMoveParams", Type: reflect.TypeFor[ThreadSectionMoveParams]()},
+		{Name: "ThreadSectionUpdateParams", Type: reflect.TypeFor[ThreadSectionUpdateParams]()},
 		{Name: "ThreadShellCommandParams", Type: reflect.TypeFor[ThreadShellCommandParams]()},
 		{Name: "ThreadShellCommandResponse", Type: reflect.TypeFor[ThreadShellCommandResponse]()},
 		{Name: "ThreadId", Type: reflect.TypeFor[ThreadId]()},
@@ -1404,6 +1410,9 @@ func wireSchemaDefinitions() Schema {
 		schemas[name] = schema
 	}
 	schemas["ThreadSearchResult"] = threadSearchResultSchema()
+	for name, schema := range threadSectionParamSchemas() {
+		schemas[name] = schema
+	}
 	for name, schema := range threadShellCommandSchemas() {
 		schemas[name] = schema
 	}

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -18065,6 +18065,140 @@
       ],
       "type": "object"
     },
+    "ThreadSectionAppearance": {
+      "description": "Extensible visual presentation for a custom thread section.",
+      "properties": {
+        "color": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "icon": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "ThreadSectionCreateParams": {
+      "description": "Parameters for creating an independently persisted thread section.",
+      "properties": {
+        "appearance": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ThreadSectionAppearance"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "name": {
+          "description": "The user-visible name of the section.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "ThreadSectionDeleteParams": {
+      "description": "Parameters for deleting an independently persisted thread section.",
+      "properties": {
+        "sectionId": {
+          "description": "The stable, server-generated identity of the section to delete.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "sectionId"
+      ],
+      "type": "object"
+    },
+    "ThreadSectionListParams": {
+      "description": "Parameters for listing independently persisted thread sections.",
+      "properties": {
+        "cursor": {
+          "description": "Opaque pagination cursor returned by a previous call.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "limit": {
+          "description": "Maximum number of sections to return.",
+          "format": "uint32",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "ThreadSectionMoveParams": {
+      "description": "Parameters for moving a thread within a server-owned section ordering.",
+      "properties": {
+        "beforeThreadId": {
+          "description": "Existing thread to insert before; omission or null appends to the section.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "sectionId": {
+          "description": "Destination section, or `null` to remove the thread from its section.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "threadId": {
+          "description": "Thread to move into, within, or out of a section.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "sectionId",
+        "threadId"
+      ],
+      "type": "object"
+    },
+    "ThreadSectionUpdateParams": {
+      "description": "Parameters for updating an independently persisted thread section.",
+      "properties": {
+        "appearance": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ThreadSectionAppearance"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Omit to preserve appearance, use `null` to clear it, or provide a replacement."
+        },
+        "name": {
+          "description": "The updated user-visible name of the section.",
+          "type": "string"
+        },
+        "sectionId": {
+          "description": "The stable, server-generated identity of the section to update.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "sectionId"
+      ],
+      "type": "object"
+    },
     "ThreadSetNameParams": {
       "additionalProperties": false,
       "properties": {

--- a/appserver/protocol/server_request_approval_params_contract_test.go
+++ b/appserver/protocol/server_request_approval_params_contract_test.go
@@ -163,8 +163,8 @@ func TestServerRequestApprovalParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(defs); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(defs); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/server_request_contract_test.go
+++ b/appserver/protocol/server_request_contract_test.go
@@ -53,8 +53,8 @@ func TestServerRequestSchemaAndBindingAreExact(t *testing.T) {
 			}
 		}
 	}
-	if got := len(defs); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(defs); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	typescript, err := MarshalTypeScript()
 	if err != nil {

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/terminal_interaction_notification_contract_test.go
+++ b/appserver/protocol/terminal_interaction_notification_contract_test.go
@@ -72,8 +72,8 @@ func TestTerminalInteractionNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.Surface != SurfaceServerNotification || info.State != MethodBlocked {
 		t.Fatalf("terminal interaction method = %#v, %v; want blocked server notification", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	generated, err := MarshalTypeScript()
 	if err != nil {

--- a/appserver/protocol/thread_approve_guardian_denied_action_contract_test.go
+++ b/appserver/protocol/thread_approve_guardian_denied_action_contract_test.go
@@ -88,8 +88,8 @@ func TestThreadApproveGuardianDeniedActionContractsRemainStandalone(t *testing.T
 	if !ok || info.Surface != SurfaceClientRequest || info.State != MethodDeferredStub {
 		t.Fatalf("guardian denied action method = %#v, %v; want deferred client request", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 }
 

--- a/appserver/protocol/thread_inject_items_contract_test.go
+++ b/appserver/protocol/thread_inject_items_contract_test.go
@@ -96,8 +96,8 @@ func TestThreadInjectItemsContractsFailClosedAndRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 }
 

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 606 {
-		t.Fatalf("definition count = %d, want 606", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 612 {
+		t.Fatalf("definition count = %d, want 612", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -262,8 +262,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_rollback_contract_test.go
+++ b/appserver/protocol/thread_rollback_contract_test.go
@@ -114,8 +114,8 @@ func TestThreadRollbackContractsFailClosedAndRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 }
 

--- a/appserver/protocol/thread_search_result_contract_test.go
+++ b/appserver/protocol/thread_search_result_contract_test.go
@@ -59,8 +59,8 @@ func TestThreadSearchResultFailsClosedAndRemainsStandalone(t *testing.T) {
 			t.Fatalf("ThreadSearchResult unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 }
 

--- a/appserver/protocol/thread_section_params_contract_test.go
+++ b/appserver/protocol/thread_section_params_contract_test.go
@@ -1,0 +1,250 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestThreadSectionParamSchemasAreExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	appearanceOrNull := []any{
+		Schema{"$ref": "#/$defs/ThreadSectionAppearance"},
+		Schema{"type": "null"},
+	}
+	want := map[string]Schema{
+		"ThreadSectionAppearance": {
+			"description": "Extensible visual presentation for a custom thread section.",
+			"properties": Schema{
+				"color": Schema{"type": []any{"string", "null"}},
+				"icon":  Schema{"type": []any{"string", "null"}},
+			},
+			"type": "object",
+		},
+		"ThreadSectionCreateParams": {
+			"description": "Parameters for creating an independently persisted thread section.",
+			"properties": Schema{
+				"appearance": Schema{"anyOf": appearanceOrNull, "default": nil},
+				"name": Schema{
+					"description": "The user-visible name of the section.",
+					"type":        "string",
+				},
+			},
+			"required": []string{"name"},
+			"type":     "object",
+		},
+		"ThreadSectionDeleteParams": {
+			"description": "Parameters for deleting an independently persisted thread section.",
+			"properties": Schema{
+				"sectionId": Schema{
+					"description": "The stable, server-generated identity of the section to delete.",
+					"type":        "string",
+				},
+			},
+			"required": []string{"sectionId"},
+			"type":     "object",
+		},
+		"ThreadSectionListParams": {
+			"description": "Parameters for listing independently persisted thread sections.",
+			"properties": Schema{
+				"cursor": Schema{
+					"description": "Opaque pagination cursor returned by a previous call.",
+					"type":        []any{"string", "null"},
+				},
+				"limit": Schema{
+					"description": "Maximum number of sections to return.",
+					"format":      "uint32",
+					"minimum":     json.Number("0.0"),
+					"type":        []any{"integer", "null"},
+				},
+			},
+			"type": "object",
+		},
+		"ThreadSectionMoveParams": {
+			"description": "Parameters for moving a thread within a server-owned section ordering.",
+			"properties": Schema{
+				"beforeThreadId": Schema{
+					"description": "Existing thread to insert before; omission or null appends to the section.",
+					"type":        []any{"string", "null"},
+				},
+				"sectionId": Schema{
+					"description": "Destination section, or `null` to remove the thread from its section.",
+					"type":        []any{"string", "null"},
+				},
+				"threadId": Schema{
+					"description": "Thread to move into, within, or out of a section.",
+					"type":        "string",
+				},
+			},
+			"required": []string{"sectionId", "threadId"},
+			"type":     "object",
+		},
+		"ThreadSectionUpdateParams": {
+			"description": "Parameters for updating an independently persisted thread section.",
+			"properties": Schema{
+				"appearance": Schema{
+					"anyOf":       appearanceOrNull,
+					"description": "Omit to preserve appearance, use `null` to clear it, or provide a replacement.",
+				},
+				"name": Schema{
+					"description": "The updated user-visible name of the section.",
+					"type":        "string",
+				},
+				"sectionId": Schema{
+					"description": "The stable, server-generated identity of the section to update.",
+					"type":        "string",
+				},
+			},
+			"required": []string{"name", "sectionId"},
+			"type":     "object",
+		},
+	}
+	for name, expected := range want {
+		if got := defs[name]; !reflect.DeepEqual(got, expected) {
+			t.Errorf("%s = %#v, want %#v", name, got, expected)
+		}
+	}
+}
+
+func TestThreadSectionParamsPreserveSerdeWireForms(t *testing.T) {
+	assertThreadSectionRoundTrip[ThreadSectionAppearance](t,
+		`{"future":true}`, `{"icon":null,"color":null}`)
+	assertThreadSectionRoundTrip[ThreadSectionAppearance](t,
+		`{"icon":"bookmark","color":null,"future":true}`, `{"icon":"bookmark","color":null}`)
+	assertThreadSectionRoundTrip[ThreadSectionCreateParams](t,
+		`{"name":"Pinned","future":true}`, `{"name":"Pinned","appearance":null}`)
+	assertThreadSectionRoundTrip[ThreadSectionCreateParams](t,
+		`{"name":"Pinned","appearance":{"color":"blue","future":true}}`, `{"name":"Pinned","appearance":{"icon":null,"color":"blue"}}`)
+	assertThreadSectionRoundTrip[ThreadSectionDeleteParams](t,
+		`{"sectionId":"section","future":true}`, `{"sectionId":"section"}`)
+	assertThreadSectionRoundTrip[ThreadSectionListParams](t,
+		`{"future":true}`, `{"cursor":null,"limit":null}`)
+	assertThreadSectionRoundTrip[ThreadSectionListParams](t,
+		`{"cursor":"next","limit":4294967295,"future":true}`, `{"cursor":"next","limit":4294967295}`)
+	assertThreadSectionRoundTrip[ThreadSectionMoveParams](t,
+		`{"threadId":"thread","sectionId":null,"future":true}`, `{"threadId":"thread","sectionId":null,"beforeThreadId":null}`)
+	assertThreadSectionRoundTrip[ThreadSectionMoveParams](t,
+		`{"threadId":"thread","sectionId":"section","beforeThreadId":"before","future":true}`, `{"threadId":"thread","sectionId":"section","beforeThreadId":"before"}`)
+	assertThreadSectionRoundTrip[ThreadSectionUpdateParams](t,
+		`{"sectionId":"section","name":"Pinned","future":true}`, `{"sectionId":"section","name":"Pinned"}`)
+	assertThreadSectionRoundTrip[ThreadSectionUpdateParams](t,
+		`{"sectionId":"section","name":"Pinned","appearance":null,"future":true}`, `{"sectionId":"section","name":"Pinned","appearance":null}`)
+	assertThreadSectionRoundTrip[ThreadSectionUpdateParams](t,
+		`{"sectionId":"section","name":"Pinned","appearance":{"icon":"bookmark","color":"blue","future":true}}`, `{"sectionId":"section","name":"Pinned","appearance":{"icon":"bookmark","color":"blue"}}`)
+
+	update := ThreadSectionUpdateParams{SectionID: "section", Name: "Pinned"}
+	update.SetAppearance(nil)
+	encoded, err := json.Marshal(update)
+	if err != nil || string(encoded) != `{"sectionId":"section","name":"Pinned","appearance":null}` {
+		t.Fatalf("explicit-null update = %s, %v", encoded, err)
+	}
+	appearance := &ThreadSectionAppearance{}
+	update = ThreadSectionUpdateParams{SectionID: "section", Name: "Pinned", Appearance: appearance}
+	encoded, err = json.Marshal(update)
+	if err != nil || string(encoded) != `{"sectionId":"section","name":"Pinned","appearance":{"icon":null,"color":null}}` {
+		t.Fatalf("replacement update = %s, %v", encoded, err)
+	}
+}
+
+func TestThreadSectionParamsRejectMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`,
+		`{"icon":1}`, `{"icon":"one","icon":"two"}`, `{"icon":"one"} {}`,
+	} {
+		assertJSONRejects[ThreadSectionAppearance](t, input)
+	}
+	for _, input := range []string{
+		``, `null`, `[]`, `{}`, `{"name":null}`, `{"name":1}`,
+		`{"name":"Pinned","appearance":1}`, `{"name":"Pinned","appearance":{"icon":"one","icon":"two"}}`,
+		`{"name":"Pinned","name":"duplicate"}`, `{"name":"Pinned"} {}`,
+	} {
+		assertJSONRejects[ThreadSectionCreateParams](t, input)
+	}
+	for _, input := range []string{
+		``, `null`, `[]`, `{}`, `{"sectionId":null}`, `{"sectionId":1}`,
+		`{"sectionId":"section","sectionId":"duplicate"}`, `{"sectionId":"section"} {}`,
+	} {
+		assertJSONRejects[ThreadSectionDeleteParams](t, input)
+	}
+	for _, input := range []string{
+		``, `null`, `[]`, `{"cursor":1}`, `{"limit":-1}`, `{"limit":4294967296}`,
+		`{"limit":1.5}`, `{"cursor":"next","cursor":"duplicate"}`, `{} {}`,
+	} {
+		assertJSONRejects[ThreadSectionListParams](t, input)
+	}
+	for _, input := range []string{
+		``, `null`, `[]`, `{}`, `{"threadId":"thread"}`, `{"sectionId":null}`,
+		`{"threadId":null,"sectionId":null}`, `{"threadId":"thread","sectionId":1}`,
+		`{"threadId":"thread","sectionId":null,"beforeThreadId":1}`,
+		`{"threadId":"thread","sectionId":null,"sectionId":"duplicate"}`, `{"threadId":"thread","sectionId":null} {}`,
+	} {
+		assertJSONRejects[ThreadSectionMoveParams](t, input)
+	}
+	for _, input := range []string{
+		``, `null`, `[]`, `{}`, `{"sectionId":"section"}`, `{"name":"Pinned"}`,
+		`{"sectionId":null,"name":"Pinned"}`, `{"sectionId":"section","name":null}`,
+		`{"sectionId":"section","name":"Pinned","appearance":1}`,
+		`{"sectionId":"section","name":"Pinned","appearance":{"color":"one","color":"two"}}`,
+		`{"sectionId":"section","name":"Pinned","appearance":null,"appearance":{}}`,
+		`{"sectionId":"section","name":"Pinned"} {}`,
+	} {
+		assertJSONRejects[ThreadSectionUpdateParams](t, input)
+	}
+}
+
+func TestThreadSectionParamsRemainStandalone(t *testing.T) {
+	for _, value := range []json.Unmarshaler{
+		(*ThreadSectionAppearance)(nil),
+		(*ThreadSectionCreateParams)(nil),
+		(*ThreadSectionDeleteParams)(nil),
+		(*ThreadSectionListParams)(nil),
+		(*ThreadSectionMoveParams)(nil),
+		(*ThreadSectionUpdateParams)(nil),
+	} {
+		if err := value.UnmarshalJSON([]byte(`{}`)); err == nil {
+			t.Errorf("nil %T receiver succeeded", value)
+		}
+	}
+	for _, binding := range WireTypeBindings() {
+		for _, name := range append(append([]string(nil), binding.Params...), binding.Result...) {
+			if strings.HasPrefix(name, "ThreadSection") {
+				t.Fatalf("%s unexpectedly bound to %s", name, binding.Method)
+			}
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
+	}
+}
+
+func TestThreadSectionParamsTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	for _, want := range []string{
+		`export type ThreadSectionAppearance = { icon: string | null, color: string | null, };`,
+		`export type ThreadSectionCreateParams = { name: string, appearance?: ThreadSectionAppearance | null, };`,
+		`export type ThreadSectionDeleteParams = { sectionId: string, };`,
+		`export type ThreadSectionListParams = { cursor?: string | null, limit?: number | null, };`,
+		`export type ThreadSectionMoveParams = { threadId: string, sectionId: string | null, beforeThreadId?: string | null, };`,
+		`export type ThreadSectionUpdateParams = { sectionId: string, name: string, appearance?: ThreadSectionAppearance | null, };`,
+	} {
+		if !strings.Contains(string(generated), want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}
+
+func assertThreadSectionRoundTrip[T any](t *testing.T, input, want string) {
+	t.Helper()
+	var value T
+	if err := json.Unmarshal([]byte(input), &value); err != nil {
+		t.Fatalf("Unmarshal(%s): %v", input, err)
+	}
+	encoded, err := json.Marshal(value)
+	if err != nil || string(encoded) != want {
+		t.Fatalf("round trip %s = %s, %v; want %s", input, encoded, err, want)
+	}
+}

--- a/appserver/protocol/thread_section_params_types.go
+++ b/appserver/protocol/thread_section_params_types.go
@@ -1,0 +1,348 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// ThreadSectionAppearance is the source-defined extensible presentation for a
+// server-owned thread section. It remains standalone with the section request
+// contracts until the thread-section runtime has an exact compatibility path.
+type ThreadSectionAppearance struct {
+	Icon  *string `json:"icon"`
+	Color *string `json:"color"`
+}
+
+func (a *ThreadSectionAppearance) UnmarshalJSON(data []byte) error {
+	if a == nil {
+		return errors.New("decode thread section appearance into nil receiver")
+	}
+	payload, err := decodeRustSerdeObject(data, "thread section appearance", "icon", "color")
+	if err != nil {
+		return err
+	}
+	icon, err := decodeOptionalThreadSectionValue[string](payload, "thread section appearance", "icon")
+	if err != nil {
+		return err
+	}
+	color, err := decodeOptionalThreadSectionValue[string](payload, "thread section appearance", "color")
+	if err != nil {
+		return err
+	}
+	*a = ThreadSectionAppearance{Icon: icon, Color: color}
+	return nil
+}
+
+// ThreadSectionCreateParams is the exact standalone source contract for
+// threadSection/create. It is intentionally not bound to the live runtime.
+type ThreadSectionCreateParams struct {
+	Name       string                   `json:"name"`
+	Appearance *ThreadSectionAppearance `json:"appearance"`
+}
+
+func (p *ThreadSectionCreateParams) UnmarshalJSON(data []byte) error {
+	if p == nil {
+		return errors.New("decode thread section create params into nil receiver")
+	}
+	payload, err := decodeRustSerdeObject(data, "thread section create params", "name", "appearance")
+	if err != nil {
+		return err
+	}
+	name, err := decodeRequiredThreadItemValue[string](payload, "thread section create params", "name")
+	if err != nil {
+		return err
+	}
+	appearance, err := decodeOptionalThreadSectionValue[ThreadSectionAppearance](payload, "thread section create params", "appearance")
+	if err != nil {
+		return err
+	}
+	*p = ThreadSectionCreateParams{Name: name, Appearance: appearance}
+	return nil
+}
+
+// ThreadSectionDeleteParams is the exact standalone source contract for
+// threadSection/delete. It is intentionally not bound to the live runtime.
+type ThreadSectionDeleteParams struct {
+	SectionID string `json:"sectionId"`
+}
+
+func (p *ThreadSectionDeleteParams) UnmarshalJSON(data []byte) error {
+	if p == nil {
+		return errors.New("decode thread section delete params into nil receiver")
+	}
+	payload, err := decodeRustSerdeObject(data, "thread section delete params", "sectionId")
+	if err != nil {
+		return err
+	}
+	sectionID, err := decodeRequiredThreadItemValue[string](payload, "thread section delete params", "sectionId")
+	if err != nil {
+		return err
+	}
+	*p = ThreadSectionDeleteParams{SectionID: sectionID}
+	return nil
+}
+
+// ThreadSectionListParams is the exact standalone source contract for
+// threadSection/list. It is intentionally not bound to the live runtime.
+type ThreadSectionListParams struct {
+	Cursor *string `json:"cursor"`
+	Limit  *uint32 `json:"limit"`
+}
+
+func (p *ThreadSectionListParams) UnmarshalJSON(data []byte) error {
+	if p == nil {
+		return errors.New("decode thread section list params into nil receiver")
+	}
+	payload, err := decodeRustSerdeObject(data, "thread section list params", "cursor", "limit")
+	if err != nil {
+		return err
+	}
+	cursor, err := decodeOptionalThreadSectionValue[string](payload, "thread section list params", "cursor")
+	if err != nil {
+		return err
+	}
+	limit, err := decodeOptionalThreadSectionValue[uint32](payload, "thread section list params", "limit")
+	if err != nil {
+		return err
+	}
+	*p = ThreadSectionListParams{Cursor: cursor, Limit: limit}
+	return nil
+}
+
+// ThreadSectionMoveParams is the exact standalone source contract for
+// thread/section/move. It is intentionally not bound to the live runtime.
+type ThreadSectionMoveParams struct {
+	ThreadID       string  `json:"threadId"`
+	SectionID      *string `json:"sectionId"`
+	BeforeThreadID *string `json:"beforeThreadId"`
+}
+
+func (p *ThreadSectionMoveParams) UnmarshalJSON(data []byte) error {
+	if p == nil {
+		return errors.New("decode thread section move params into nil receiver")
+	}
+	payload, err := decodeRustSerdeObject(data, "thread section move params", "threadId", "sectionId", "beforeThreadId")
+	if err != nil {
+		return err
+	}
+	threadID, err := decodeRequiredThreadItemValue[string](payload, "thread section move params", "threadId")
+	if err != nil {
+		return err
+	}
+	sectionID, err := decodeRequiredNullableThreadSectionValue[string](payload, "thread section move params", "sectionId")
+	if err != nil {
+		return err
+	}
+	beforeThreadID, err := decodeOptionalThreadSectionValue[string](payload, "thread section move params", "beforeThreadId")
+	if err != nil {
+		return err
+	}
+	*p = ThreadSectionMoveParams{ThreadID: threadID, SectionID: sectionID, BeforeThreadID: beforeThreadID}
+	return nil
+}
+
+// ThreadSectionUpdateParams is the exact standalone source contract for
+// threadSection/update. Appearance preserves the source's omission versus
+// explicit-null distinction.
+type ThreadSectionUpdateParams struct {
+	SectionID  string                   `json:"sectionId"`
+	Name       string                   `json:"name"`
+	Appearance *ThreadSectionAppearance `json:"appearance,omitempty"`
+
+	appearancePresent bool
+}
+
+func (p *ThreadSectionUpdateParams) UnmarshalJSON(data []byte) error {
+	if p == nil {
+		return errors.New("decode thread section update params into nil receiver")
+	}
+	payload, err := decodeRustSerdeObject(data, "thread section update params", "sectionId", "name", "appearance")
+	if err != nil {
+		return err
+	}
+	sectionID, err := decodeRequiredThreadItemValue[string](payload, "thread section update params", "sectionId")
+	if err != nil {
+		return err
+	}
+	name, err := decodeRequiredThreadItemValue[string](payload, "thread section update params", "name")
+	if err != nil {
+		return err
+	}
+	appearance, err := decodeOptionalThreadSectionValue[ThreadSectionAppearance](payload, "thread section update params", "appearance")
+	if err != nil {
+		return err
+	}
+	_, appearancePresent := payload["appearance"]
+	*p = ThreadSectionUpdateParams{
+		SectionID: sectionID, Name: name, Appearance: appearance, appearancePresent: appearancePresent,
+	}
+	return nil
+}
+
+func (p ThreadSectionUpdateParams) MarshalJSON() ([]byte, error) {
+	if !p.HasAppearance() {
+		return json.Marshal(struct {
+			SectionID string `json:"sectionId"`
+			Name      string `json:"name"`
+		}{SectionID: p.SectionID, Name: p.Name})
+	}
+	return json.Marshal(struct {
+		SectionID  string                   `json:"sectionId"`
+		Name       string                   `json:"name"`
+		Appearance *ThreadSectionAppearance `json:"appearance"`
+	}{SectionID: p.SectionID, Name: p.Name, Appearance: p.Appearance})
+}
+
+// HasAppearance reports whether an update carries either a replacement or an
+// explicit null that clears the source appearance.
+func (p ThreadSectionUpdateParams) HasAppearance() bool {
+	return p.appearancePresent || p.Appearance != nil
+}
+
+// SetAppearance makes an update carry value. A nil value is the source's
+// explicit-null clear operation; leaving it unset preserves the appearance.
+func (p *ThreadSectionUpdateParams) SetAppearance(value *ThreadSectionAppearance) {
+	p.Appearance = value
+	p.appearancePresent = true
+}
+
+func decodeOptionalThreadSectionValue[T any](
+	payload map[string]json.RawMessage,
+	objectName string,
+	fieldName string,
+) (*T, error) {
+	raw, ok := payload[fieldName]
+	if !ok || isJSONNull(raw) {
+		return nil, nil
+	}
+	var value T
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return nil, fmt.Errorf("decode %s %s: %w", objectName, fieldName, err)
+	}
+	return &value, nil
+}
+
+func decodeRequiredNullableThreadSectionValue[T any](
+	payload map[string]json.RawMessage,
+	objectName string,
+	fieldName string,
+) (*T, error) {
+	raw, ok := payload[fieldName]
+	if !ok {
+		return nil, fmt.Errorf("%s requires %s", objectName, fieldName)
+	}
+	if isJSONNull(raw) {
+		return nil, nil
+	}
+	var value T
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return nil, fmt.Errorf("decode %s %s: %w", objectName, fieldName, err)
+	}
+	return &value, nil
+}
+
+func threadSectionParamSchemas() map[string]Schema {
+	appearance := Schema{
+		"description": "Extensible visual presentation for a custom thread section.",
+		"properties": Schema{
+			"color": Schema{"type": []any{"string", "null"}},
+			"icon":  Schema{"type": []any{"string", "null"}},
+		},
+		"type": "object",
+	}
+	appearanceOrNull := Schema{"anyOf": []any{
+		Schema{"$ref": "#/$defs/ThreadSectionAppearance"},
+		Schema{"type": "null"},
+	}}
+	return map[string]Schema{
+		"ThreadSectionAppearance": appearance,
+		"ThreadSectionCreateParams": {
+			"description": "Parameters for creating an independently persisted thread section.",
+			"properties": Schema{
+				"appearance": Schema{"anyOf": appearanceOrNull["anyOf"], "default": nil},
+				"name": Schema{
+					"description": "The user-visible name of the section.",
+					"type":        "string",
+				},
+			},
+			"required": []string{"name"},
+			"type":     "object",
+		},
+		"ThreadSectionDeleteParams": {
+			"description": "Parameters for deleting an independently persisted thread section.",
+			"properties": Schema{
+				"sectionId": Schema{
+					"description": "The stable, server-generated identity of the section to delete.",
+					"type":        "string",
+				},
+			},
+			"required": []string{"sectionId"},
+			"type":     "object",
+		},
+		"ThreadSectionListParams": {
+			"description": "Parameters for listing independently persisted thread sections.",
+			"properties": Schema{
+				"cursor": Schema{
+					"description": "Opaque pagination cursor returned by a previous call.",
+					"type":        []any{"string", "null"},
+				},
+				"limit": Schema{
+					"description": "Maximum number of sections to return.",
+					"format":      "uint32",
+					"minimum":     json.Number("0.0"),
+					"type":        []any{"integer", "null"},
+				},
+			},
+			"type": "object",
+		},
+		"ThreadSectionMoveParams": {
+			"description": "Parameters for moving a thread within a server-owned section ordering.",
+			"properties": Schema{
+				"beforeThreadId": Schema{
+					"description": "Existing thread to insert before; omission or null appends to the section.",
+					"type":        []any{"string", "null"},
+				},
+				"sectionId": Schema{
+					"description": "Destination section, or `null` to remove the thread from its section.",
+					"type":        []any{"string", "null"},
+				},
+				"threadId": Schema{
+					"description": "Thread to move into, within, or out of a section.",
+					"type":        "string",
+				},
+			},
+			"required": []string{"sectionId", "threadId"},
+			"type":     "object",
+		},
+		"ThreadSectionUpdateParams": {
+			"description": "Parameters for updating an independently persisted thread section.",
+			"properties": Schema{
+				"appearance": Schema{
+					"anyOf":       appearanceOrNull["anyOf"],
+					"description": "Omit to preserve appearance, use `null` to clear it, or provide a replacement.",
+				},
+				"name": Schema{
+					"description": "The updated user-visible name of the section.",
+					"type":        "string",
+				},
+				"sectionId": Schema{
+					"description": "The stable, server-generated identity of the section to update.",
+					"type":        "string",
+				},
+			},
+			"required": []string{"name", "sectionId"},
+			"type":     "object",
+		},
+	}
+}
+
+var (
+	_ json.Unmarshaler = (*ThreadSectionAppearance)(nil)
+	_ json.Unmarshaler = (*ThreadSectionCreateParams)(nil)
+	_ json.Unmarshaler = (*ThreadSectionDeleteParams)(nil)
+	_ json.Unmarshaler = (*ThreadSectionListParams)(nil)
+	_ json.Unmarshaler = (*ThreadSectionMoveParams)(nil)
+	_ json.Marshaler   = ThreadSectionUpdateParams{}
+	_ json.Unmarshaler = (*ThreadSectionUpdateParams)(nil)
+)

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -252,8 +252,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 	if !foundRuntimeStart {
 		t.Error("thread/start runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -154,8 +154,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 	if !foundRuntimeStart {
 		t.Error("thread/start runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_settings_contract_test.go
+++ b/appserver/protocol/thread_settings_contract_test.go
@@ -162,8 +162,8 @@ func TestThreadSettingsContractsFailClosedAndRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 }
 

--- a/appserver/protocol/thread_shell_command_contract_test.go
+++ b/appserver/protocol/thread_shell_command_contract_test.go
@@ -95,8 +95,8 @@ func TestThreadShellCommandContractsFailClosedAndRemainStandalone(t *testing.T) 
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 }
 

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 606 {
-		t.Fatalf("definition count = %d, want 606", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 612 {
+		t.Fatalf("definition count = %d, want 612", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 606 {
-		t.Fatalf("definition count = %d, want 606", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 612 {
+		t.Fatalf("definition count = %d, want 612", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_environment_contract_test.go
+++ b/appserver/protocol/turn_environment_contract_test.go
@@ -79,8 +79,8 @@ func TestTurnEnvironmentParamsFailsClosedAndRemainsStandalone(t *testing.T) {
 			t.Fatalf("TurnEnvironmentParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 }
 

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -119,8 +119,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 	if !foundRuntimeBinding {
 		t.Error("turn/interrupt runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -241,8 +241,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 	if !foundRuntimeBinding {
 		t.Error("turn/start runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -164,8 +164,8 @@ func TestTurnSteerContractsAreBoundToLiveRuntime(t *testing.T) {
 	if !found {
 		t.Fatal("turn/steer runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -890,6 +890,18 @@ func MarshalTypeScript() ([]byte, error) {
 			definition = Schema{
 				typeScriptRawTypeKeyword: `{ "method": "item/commandExecution/requestApproval"; "id": RequestId; "params": CommandExecutionRequestApprovalParams; } | { "method": "item/fileChange/requestApproval"; "id": RequestId; "params": FileChangeRequestApprovalParams; } | { "method": "item/tool/requestUserInput"; "id": RequestId; "params": ToolRequestUserInputParams; } | { "method": "mcpServer/elicitation/request"; "id": RequestId; "params": McpServerElicitationRequestParams; } | { "method": "item/permissions/requestApproval"; "id": RequestId; "params": PermissionsRequestApprovalParams; } | { "method": "item/tool/call"; "id": RequestId; "params": DynamicToolCallParams; } | { "method": "account/chatgptAuthTokens/refresh"; "id": RequestId; "params": ChatgptAuthTokensRefreshParams; } | { "method": "attestation/generate"; "id": RequestId; "params": AttestationGenerateParams; } | { "method": "applyPatchApproval"; "id": RequestId; "params": ApplyPatchApprovalParams; } | { "method": "execCommandApproval"; "id": RequestId; "params": ExecCommandApprovalParams; }`,
 			}
+		case "ThreadSectionAppearance":
+			definition = Schema{typeScriptRawTypeKeyword: `{ icon: string | null, color: string | null, }`}
+		case "ThreadSectionCreateParams":
+			definition = Schema{typeScriptRawTypeKeyword: `{ name: string, appearance?: ThreadSectionAppearance | null, }`}
+		case "ThreadSectionDeleteParams":
+			definition = Schema{typeScriptRawTypeKeyword: `{ sectionId: string, }`}
+		case "ThreadSectionListParams":
+			definition = Schema{typeScriptRawTypeKeyword: `{ cursor?: string | null, limit?: number | null, }`}
+		case "ThreadSectionMoveParams":
+			definition = Schema{typeScriptRawTypeKeyword: `{ threadId: string, sectionId: string | null, beforeThreadId?: string | null, }`}
+		case "ThreadSectionUpdateParams":
+			definition = Schema{typeScriptRawTypeKeyword: `{ sectionId: string, name: string, appearance?: ThreadSectionAppearance | null, }`}
 		case "DynamicToolFunctionSpec", "DynamicToolNamespaceSpec":
 			schema, _ := typeScriptSchema(definition)
 			schema["x-gollem-typescript-ignore-additional-properties"] = true

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -4053,6 +4053,18 @@ export type ThreadSearchResult = {
   "thread": Thread;
 };
 
+export type ThreadSectionAppearance = { icon: string | null, color: string | null, };
+
+export type ThreadSectionCreateParams = { name: string, appearance?: ThreadSectionAppearance | null, };
+
+export type ThreadSectionDeleteParams = { sectionId: string, };
+
+export type ThreadSectionListParams = { cursor?: string | null, limit?: number | null, };
+
+export type ThreadSectionMoveParams = { threadId: string, sectionId: string | null, beforeThreadId?: string | null, };
+
+export type ThreadSectionUpdateParams = { sectionId: string, name: string, appearance?: ThreadSectionAppearance | null, };
+
 export type ThreadSetNameParams = {
   "id"?: string;
   "name": string;

--- a/appserver/protocol/typescript/testdata/thread_section_params_contract.ts
+++ b/appserver/protocol/typescript/testdata/thread_section_params_contract.ts
@@ -1,0 +1,48 @@
+import type {
+  ThreadSectionAppearance,
+  ThreadSectionCreateParams,
+  ThreadSectionDeleteParams,
+  ThreadSectionListParams,
+  ThreadSectionMoveParams,
+  ThreadSectionUpdateParams,
+} from "../gollem_appserver_protocol";
+
+export const appearance = {
+  icon: "bookmark",
+  color: null,
+} satisfies ThreadSectionAppearance;
+
+export const create = {
+  name: "Pinned",
+  appearance,
+} satisfies ThreadSectionCreateParams;
+
+export const remove = {
+  sectionId: "section",
+} satisfies ThreadSectionDeleteParams;
+
+export const list = {} satisfies ThreadSectionListParams;
+
+export const move = {
+  threadId: "thread",
+  sectionId: null,
+} satisfies ThreadSectionMoveParams;
+
+export const update = {
+  sectionId: "section",
+  name: "Pinned",
+  appearance: null,
+} satisfies ThreadSectionUpdateParams;
+
+// @ts-expect-error the visual record carries both nullable source properties.
+({ icon: "bookmark" }) satisfies ThreadSectionAppearance;
+// @ts-expect-error creation requires a source name.
+({}) satisfies ThreadSectionCreateParams;
+// @ts-expect-error deletion requires a section identity.
+({}) satisfies ThreadSectionDeleteParams;
+// @ts-expect-error the list limit is an unsigned number, not text.
+({ limit: "one" }) satisfies ThreadSectionListParams;
+// @ts-expect-error move requires the nullable destination property.
+({ threadId: "thread" }) satisfies ThreadSectionMoveParams;
+// @ts-expect-error update requires the section identity and name.
+({ sectionId: "section" }) satisfies ThreadSectionUpdateParams;

--- a/appserver/protocol/w3c_trace_context_contract_test.go
+++ b/appserver/protocol/w3c_trace_context_contract_test.go
@@ -55,8 +55,8 @@ func TestW3cTraceContextRemainsStandalone(t *testing.T) {
 			t.Fatalf("W3cTraceContext unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 }
 

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/workspace_messages_contract_test.go
+++ b/appserver/protocol/workspace_messages_contract_test.go
@@ -209,8 +209,8 @@ func TestWorkspaceMessageContractsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/workspaceMessages/read = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 606 {
-		t.Fatalf("definition count = %d, want 606", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
+		t.Fatalf("definition count = %d, want 612", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- add source-exact standalone thread-section appearance and parameter contracts
- preserve omitted versus explicit-null update semantics and source-open serde decoding
- generate matching JSON Schema and TypeScript without binding `threadSection/*` runtime methods

## Verification
- `go test ./appserver/protocol -count=1`
- `go test -race ./appserver/protocol ./appserver -run 'TestThreadSection|TestServerRequest|TestThread' -count=1`\n- non-Monty `go test ./...`\n- non-Monty `go vet ./...`\n- `go mod tidy`\n- `go generate ./appserver/protocol`\n- `golangci-lint run`