### PR TITLE
fix(mcp): complete tool input schemas missing the root type:object

### DIFF
--- a/ext/mcp/server.go
+++ b/ext/mcp/server.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -336,6 +337,7 @@ func (s *Server) cacheableLocked() CacheableResult {
 func (s *Server) AddTool(tool Tool, handler ServerToolHandler) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	tool.InputSchema = completeToolInputSchema(tool.InputSchema)
 	for i := range s.tools {
 		if s.tools[i].definition.Name == tool.Name {
 			s.tools[i] = serverTool{definition: tool, handler: handler}
@@ -344,6 +346,131 @@ func (s *Server) AddTool(tool Tool, handler ServerToolHandler) {
 	}
 	s.tools = append(s.tools, serverTool{definition: tool, handler: handler})
 }
+
+// completeToolInputSchema fills in a missing root `type: "object"` on a tool's
+// raw JSON Schema. MCP requires the tool input schema to be an object schema,
+// and strict clients (e.g. the TypeScript SDK's ListToolsResultSchema) reject
+// a schema whose root omits `type`. Servers that register tools with bare
+// `{"properties":…}` schemas (sleepy.run) were rejected by such clients over
+// the stateless protocol; completing the schema at registration preserves
+// every existing key while satisfying them.
+//
+// Policy:
+//   - an empty or whitespace-only input, or the literal JSON null, becomes
+//     {"type":"object"} (a tool with no declared input takes no arguments),
+//     matching the client-side decodeToolSchema default for both shapes;
+//   - a root that already declares "type", that is not a JSON object (array,
+//     string, number, boolean), or that is malformed, is left as-is;
+//   - a bare {} (the common no-argument tool shape) completes like an empty
+//     schema;
+//   - a root whose keys are not ALL object-applicable or annotation keywords
+//     is left as-is: injecting "object" into a schema also governed by value
+//     keywords (enum, const, minimum, pattern, items, if/then/else, …) or
+//     combinators ($ref, oneOf, anyOf, allOf, not) could change its meaning
+//     or make it unsatisfiable, and such a root is already non-conformant as
+//     an MCP tool input schema, so the server author must fix it explicitly.
+//
+// Completion therefore applies only to schemas that are already purely
+// object-shaped: a JSON object root without "type" whose every key is an
+// object-applicable keyword or an annotation. Those roots describe object
+// arguments today; adding the root type changes nothing for object
+// instances — the only instances an MCP tool call carries.
+func completeToolInputSchema(raw json.RawMessage) json.RawMessage {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return json.RawMessage(`{"type":"object"}`)
+	}
+	var root map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &root); err != nil || root == nil {
+		if root == nil && bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+			return json.RawMessage(`{"type":"object"}`)
+		}
+		return raw // not an object schema; leave untouched
+	}
+	if _, ok := root["type"]; ok {
+		return raw
+	}
+	if !objectOnly(root) {
+		return raw
+	}
+	out := make(map[string]json.RawMessage, len(root)+1)
+	out["type"] = json.RawMessage(`"object"`)
+	for k, v := range root {
+		out[k] = v
+	}
+	// json.Marshal cannot fail here: every value was produced by a successful
+	// Unmarshal of the input, so each RawMessage is valid JSON by construction.
+	data, _ := json.Marshal(out)
+	return data
+}
+
+// objectApplicableKeywords lists the JSON Schema keywords that constrain only
+// object instances. Completing the root type of a schema made solely from
+// these (plus annotations) cannot change its meaning for objects.
+var objectApplicableKeywords = []string{
+	"additionalProperties",
+	"dependencies",
+	"dependentRequired",
+	"dependentSchemas",
+	"maxProperties",
+	"minProperties",
+	"patternProperties",
+	"properties",
+	"propertyNames",
+	"required",
+	"unevaluatedProperties",
+}
+
+// annotationKeywords are informational and place no instance constraints.
+var annotationKeywords = []string{
+	"$comment",
+	"$defs",
+	"$id",
+	"$schema",
+	"default",
+	"definitions",
+	"deprecated",
+	"description",
+	"examples",
+	"readOnly",
+	"title",
+	"writeOnly",
+}
+
+// objectOnly reports whether every root key is an object-applicable keyword
+// or an annotation, with an empty root counting as object-shaped. A bare {}
+// is the common no-argument tool shape and completes like an empty schema;
+// a schema made only of annotations but with no object keyword says nothing
+// specific about shape, so it passes through untouched.
+func objectOnly(root map[string]json.RawMessage) bool {
+	if len(root) == 0 {
+		return true
+	}
+	allowed := make(map[string]bool, len(objectApplicableKeywords)+len(annotationKeywords))
+	for _, key := range objectApplicableKeywords {
+		allowed[key] = true
+	}
+	for _, key := range annotationKeywords {
+		allowed[key] = true
+	}
+	hasObject := false
+	for key := range root {
+		if !allowed[key] {
+			return false
+		}
+		if _, ok := allowedObjectKeyword[key]; ok {
+			hasObject = true
+		}
+	}
+	return hasObject
+}
+
+var allowedObjectKeyword = func() map[string]bool {
+	m := make(map[string]bool, len(objectApplicableKeywords))
+	for _, key := range objectApplicableKeywords {
+		m[key] = true
+	}
+	return m
+}()
 
 // SetResources configures server resources and the optional read handler.
 func (s *Server) SetResources(resources []Resource, templates []ResourceTemplate, reader ResourceReadHandler) {

--- a/ext/mcp/server_http_test.go
+++ b/ext/mcp/server_http_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -354,4 +355,45 @@ func doHTTP(t *testing.T, req *http.Request) *jsonRPCResponse {
 		t.Fatalf("failed to decode response: %v", err)
 	}
 	return &out
+}
+
+func TestHTTPServerTransportToolSchemaRootTypeCompletion(t *testing.T) {
+	server := NewServer(WithServerInfo(ServerInfo{Name: "schema-test", Version: "1.0.0"}))
+	server.AddTool(Tool{
+		Name:        "sloppy",
+		Description: "schema whose root omits type",
+		InputSchema: json.RawMessage(`{"properties":{"run_id":{"type":"string"}},"required":["run_id"]}`),
+	}, func(_ context.Context, _ *RequestContext, _ map[string]any) (*ToolResult, error) {
+		return textToolResult("ok"), nil
+	})
+	transport := NewHTTPServerTransport(server)
+	httpServer := httptest.NewServer(transport)
+	defer httpServer.Close()
+
+	listResp := postJSON(t, httpServer.URL, jsonRPCMessage{
+		JSONRPC: "2.0",
+		ID:      rawJSONID(1),
+		Method:  "tools/list",
+		Params:  mustRawJSON(statelessParams(nil)),
+	})
+	if listResp.Error != nil {
+		t.Fatalf("tools/list error: %+v", listResp.Error)
+	}
+	var list struct {
+		Tools []struct {
+			InputSchema map[string]json.RawMessage `json:"inputSchema"`
+		} `json:"tools"`
+	}
+	if err := json.Unmarshal(listResp.Result, &list); err != nil {
+		t.Fatalf("failed to parse tools/list result: %v", err)
+	}
+	if len(list.Tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(list.Tools))
+	}
+	if got := string(list.Tools[0].InputSchema["type"]); got != `"object"` {
+		t.Fatalf(`expected root schema type "object", got %s`, got)
+	}
+	if got := string(list.Tools[0].InputSchema["properties"]); !strings.Contains(got, "run_id") {
+		t.Fatalf("expected original properties preserved, got %s", got)
+	}
 }

--- a/ext/mcp/server_schema_test.go
+++ b/ext/mcp/server_schema_test.go
@@ -1,0 +1,64 @@
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestCompleteToolInputSchema(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty becomes bare object schema", "", `{"type":"object"}`},
+		{"whitespace becomes bare object schema", " \n\t ", `{"type":"object"}`},
+		{"already typed passes through", `{"type":"object","properties":{"a":{"type":"string"}}}`, `{"type":"object","properties":{"a":{"type":"string"}}}`},
+		{"bare properties gains object type", `{"properties":{"run_id":{"type":"string"}},"required":["run_id"]}`, `{"properties":{"run_id":{"type":"string"}},"required":["run_id"],"type":"object"}`},
+		{"malformed passes through", `{`, `{`},
+		{"array root passes through", `[1,2]`, `[1,2]`},
+		{"string root passes through", `"hi"`, `"hi"`},
+		{"null root completes", `null`, `{"type":"object"}`},
+		{"whitespace padded null completes", ` null 
+`, `{"type":"object"}`},
+		{"boolean root passes through", `true`, `true`},
+		{"ref root passes through", `{"$ref":"#/definitions/x"}`, `{"$ref":"#/definitions/x"}`},
+		{"oneOf root passes through", `{"oneOf":[{"type":"string"},{"type":"number"}]}`, `{"oneOf":[{"type":"string"},{"type":"number"}]}`},
+		{"anyOf root passes through", `{"anyOf":[{"type":"string"}]}`, `{"anyOf":[{"type":"string"}]}`},
+		{"allOf root passes through", `{"allOf":[{"type":"object"}]}`, `{"allOf":[{"type":"object"}]}`},
+		{"not root passes through", `{"not":{"type":"null"}}`, `{"not":{"type":"null"}}`},
+		{"enum root passes through", `{"enum":[1,2]}`, `{"enum":[1,2]}`},
+		{"const root passes through", `{"const":5}`, `{"const":5}`},
+		{"minimum root passes through", `{"minimum":0}`, `{"minimum":0}`},
+		{"items root passes through", `{"items":{"type":"string"}}`, `{"items":{"type":"string"}}`},
+		{"if root passes through", `{"if":{"const":5},"then":false}`, `{"if":{"const":5},"then":false}`},
+		{"empty object completes", `{}`, `{"type":"object"}`},
+		{"number root passes through", `42`, `42`},
+		{"false schema passes through", `false`, `false`},
+		{"properties only completes", `{"properties":{}}`, `{"properties":{},"type":"object"}`},
+		{"required only completes", `{"required":["a"]}`, `{"required":["a"],"type":"object"}`},
+		{"additionalProperties only completes", `{"additionalProperties":true}`, `{"additionalProperties":true,"type":"object"}`},
+		{"patternProperties only completes", `{"patternProperties":{"^x":{}}}`, `{"patternProperties":{"^x":{}},"type":"object"}`},
+		{"minProperties only completes", `{"minProperties":1}`, `{"minProperties":1,"type":"object"}`},
+		{"draft7 dependencies completes", `{"dependencies":{"a":["b"]}}`, `{"dependencies":{"a":["b"]},"type":"object"}`},
+		{"annotations with object keyword complete", `{"title":"t","properties":{}}`, `{"properties":{},"title":"t","type":"object"}`},
+		{"mixed object and value keyword passes through", `{"properties":{},"minimum":0}`, `{"properties":{},"minimum":0}`},
+		{"mixed object and combinator passes through", `{"required":["a"],"oneOf":[{"type":"string"}]}`, `{"required":["a"],"oneOf":[{"type":"string"}]}`},
+		{"annotations alone pass through", `{"title":"t"}`, `{"title":"t"}`},
+		{"array form type passes through", `{"type":["object","null"]}`, `{"type":["object","null"]}`},
+		{"dependentRequired only completes", `{"dependentRequired":{"a":["b"]}}`, `{"dependentRequired":{"a":["b"]},"type":"object"}`},
+		{"dependentSchemas only completes", `{"dependentSchemas":{"a":{"type":"string"}}}`, `{"dependentSchemas":{"a":{"type":"string"}},"type":"object"}`},
+		{"maxProperties only completes", `{"maxProperties":2}`, `{"maxProperties":2,"type":"object"}`},
+		{"propertyNames only completes", `{"propertyNames":{"minLength":1}}`, `{"propertyNames":{"minLength":1},"type":"object"}`},
+		{"unevaluatedProperties only completes", `{"unevaluatedProperties":false}`, `{"type":"object","unevaluatedProperties":false}`},
+		{"schema and defs with object keyword complete", `{"$schema":"x","$defs":{},"properties":{}}`, `{"$defs":{},"$schema":"x","properties":{},"type":"object"}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := string(completeToolInputSchema(json.RawMessage(tc.in)))
+			if got != tc.want {
+				t.Errorf("completeToolInputSchema(%q) = %s, want %s", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
MCP requires the tool input schema to be an object schema; strict clients (the TypeScript SDK's ListToolsResultSchema) reject a schema whose root omits `type`. sleepy.run's registered tools shipped bare `{"properties":…}` schemas, which the stateless 2026-07-28 protocol exposed to such clients. `AddTool` now completes the schema at registration, preserving every existing key.\n\nBase: 325101d3 (the sleepy containment pin) so the contained-tree import stays minimal.