### PR TITLE
feat(protocol): add standalone app discovery params

### DIFF
--- a/appserver/protocol/account_credit_nudge_values_contract_test.go
+++ b/appserver/protocol/account_credit_nudge_values_contract_test.go
@@ -119,8 +119,8 @@ func TestAccountCreditNudgeValuesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/sendAddCreditsNudgeEmail = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/account_envelope_contract_test.go
+++ b/appserver/protocol/account_envelope_contract_test.go
@@ -268,8 +268,8 @@ func TestAccountEnvelopeContractsRemainStandaloneAndDeferred(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred %s", methodName, method, ok, surface)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/account_login_completed_notification_contract_test.go
+++ b/appserver/protocol/account_login_completed_notification_contract_test.go
@@ -88,8 +88,8 @@ func TestAccountLoginCompletedNotificationRemainsStandaloneAndDeferred(t *testin
 	if !found {
 		t.Fatal("account/login/completed method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/account_rate_limits_contract_test.go
+++ b/appserver/protocol/account_rate_limits_contract_test.go
@@ -484,8 +484,8 @@ func TestAccountRateLimitContractsRemainStandaloneAndDeferred(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred %s", methodName, method, ok, surface)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/account_token_usage_contract_test.go
+++ b/appserver/protocol/account_token_usage_contract_test.go
@@ -146,8 +146,8 @@ func TestAccountTokenUsageRecordsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/usage/read = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(defs); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_config_contract_test.go
+++ b/appserver/protocol/app_config_contract_test.go
@@ -109,8 +109,8 @@ func TestAppConfigRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppConfig unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_info_contract_test.go
+++ b/appserver/protocol/app_info_contract_test.go
@@ -131,8 +131,8 @@ func TestAppInfoRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_list_updated_notification_contract_test.go
+++ b/appserver/protocol/app_list_updated_notification_contract_test.go
@@ -105,8 +105,8 @@ func TestAppListUpdatedNotificationRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceServerNotification || method.State != MethodDeferredStub {
 		t.Fatalf("app/list/updated = %#v, %v; want deferred server notification", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_metadata_contract_test.go
+++ b/appserver/protocol/app_metadata_contract_test.go
@@ -107,8 +107,8 @@ func TestAppMetadataRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_metadata_leaf_contract_test.go
+++ b/appserver/protocol/app_metadata_leaf_contract_test.go
@@ -157,8 +157,8 @@ func TestAppMetadataLeavesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_summary_contract_test.go
+++ b/appserver/protocol/app_summary_contract_test.go
@@ -87,8 +87,8 @@ func TestAppSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppSummary unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_template_summary_contract_test.go
+++ b/appserver/protocol/app_template_summary_contract_test.go
@@ -107,8 +107,8 @@ func TestAppTemplateSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppTemplateSummary unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_template_unavailable_reason_contract_test.go
+++ b/appserver/protocol/app_template_unavailable_reason_contract_test.go
@@ -71,8 +71,8 @@ func TestAppTemplateUnavailableReasonRemainsStandalone(t *testing.T) {
 			t.Fatalf("AppTemplateUnavailableReason unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_tool_approval_contract_test.go
+++ b/appserver/protocol/app_tool_approval_contract_test.go
@@ -73,8 +73,8 @@ func TestAppToolApprovalRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppToolApproval unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_tools_config_contract_test.go
+++ b/appserver/protocol/app_tools_config_contract_test.go
@@ -140,8 +140,8 @@ func TestAppToolConfigsRemainStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/apply_patch_approval_params_contract_test.go
+++ b/appserver/protocol/apply_patch_approval_params_contract_test.go
@@ -139,8 +139,8 @@ func TestApplyPatchApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ApplyPatchApprovalParams unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(defs); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(defs); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/apps_config_contract_test.go
+++ b/appserver/protocol/apps_config_contract_test.go
@@ -185,8 +185,8 @@ func TestAppsConfigsRemainStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/apps_discovery_params_contract_test.go
+++ b/appserver/protocol/apps_discovery_params_contract_test.go
@@ -1,0 +1,120 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestAppsDiscoveryParamSchemasAreExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	threadID := Schema{
+		"description": "Optional loaded thread id used to evaluate effective app configuration.",
+		"type":        []any{"string", "null"},
+	}
+	want := map[string]Schema{
+		"AppsInstalledParams": {
+			"description": "Read the committed installed connector runtime snapshot.",
+			"properties": Schema{
+				"forceRefresh": Schema{
+					"description": "When true and Apps are permitted, refresh and publish the hosted connector runtime tool snapshot first.",
+					"type":        "boolean",
+				},
+				"threadId": threadID,
+			},
+			"type": "object",
+		},
+		"AppsReadParams": {
+			"description": "EXPERIMENTAL - read metadata for specific apps/connectors.",
+			"properties": Schema{
+				"appIds": Schema{
+					"description": "App ids to read. The server accepts at most 100 ids and deduplicates repeated ids while preserving their first-request order.",
+					"items":       Schema{"type": "string"},
+					"type":        "array",
+				},
+				"includeTools": Schema{
+					"description": "When true, include display-only public tool summaries in the returned metadata.",
+					"type":        "boolean",
+				},
+				"threadId": threadID,
+			},
+			"required": []string{"appIds"},
+			"type":     "object",
+		},
+	}
+	for name, expected := range want {
+		if got := defs[name]; !reflect.DeepEqual(got, expected) {
+			t.Errorf("%s = %#v, want %#v", name, got, expected)
+		}
+	}
+}
+
+func TestAppsDiscoveryParamsPreserveSerdeWireForms(t *testing.T) {
+	assertAppsDiscoveryRoundTrip[AppsInstalledParams](t, `{"future":true}`, `{"threadId":null}`)
+	assertAppsDiscoveryRoundTrip[AppsInstalledParams](t, `{"threadId":"thread","forceRefresh":true,"future":true}`, `{"threadId":"thread","forceRefresh":true}`)
+	assertAppsDiscoveryRoundTrip[AppsReadParams](t, `{"appIds":[],"future":true}`, `{"appIds":[],"threadId":null}`)
+	assertAppsDiscoveryRoundTrip[AppsReadParams](t, `{"appIds":["one","one","two"],"threadId":null,"includeTools":true,"future":true}`, `{"appIds":["one","one","two"],"threadId":null,"includeTools":true}`)
+}
+
+func TestAppsDiscoveryParamsRejectMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{`,
+		`{"threadId":1}`, `{"forceRefresh":null}`, `{"forceRefresh":"true"}`,
+		`{"threadId":"thread","threadId":"duplicate"}`, `{} {}`,
+	} {
+		assertJSONRejects[AppsInstalledParams](t, input)
+	}
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{}`, `{"appIds":null}`, `{"appIds":"one"}`,
+		`{"appIds":[1]}`, `{"appIds":[],"threadId":1}`, `{"appIds":[],"includeTools":null}`,
+		`{"appIds":[],"includeTools":1}`, `{"appIds":[],"appIds":[]}`, `{"appIds":[]} {}`,
+	} {
+		assertJSONRejects[AppsReadParams](t, input)
+	}
+}
+
+func TestAppsDiscoveryParamsRemainStandalone(t *testing.T) {
+	for _, value := range []json.Unmarshaler{(*AppsInstalledParams)(nil), (*AppsReadParams)(nil)} {
+		if err := value.UnmarshalJSON([]byte(`{}`)); err == nil {
+			t.Errorf("nil %T receiver succeeded", value)
+		}
+	}
+	for _, binding := range WireTypeBindings() {
+		for _, name := range append(append([]string(nil), binding.Params...), binding.Result...) {
+			if name == "AppsInstalledParams" || name == "AppsReadParams" {
+				t.Fatalf("%s unexpectedly bound to %s", name, binding.Method)
+			}
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
+	}
+}
+
+func TestAppsDiscoveryParamsTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	for _, want := range []string{
+		`export type AppsInstalledParams = { threadId?: string | null, forceRefresh?: boolean, };`,
+		`export type AppsReadParams = { appIds: Array<string>, threadId?: string | null, includeTools?: boolean, };`,
+	} {
+		if !strings.Contains(string(generated), want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}
+
+func assertAppsDiscoveryRoundTrip[T any](t *testing.T, input, want string) {
+	t.Helper()
+	var value T
+	if err := json.Unmarshal([]byte(input), &value); err != nil {
+		t.Fatalf("Unmarshal(%s): %v", input, err)
+	}
+	encoded, err := json.Marshal(value)
+	if err != nil || string(encoded) != want {
+		t.Fatalf("round trip %s = %s, %v; want %s", input, encoded, err, want)
+	}
+}

--- a/appserver/protocol/apps_discovery_params_types.go
+++ b/appserver/protocol/apps_discovery_params_types.go
@@ -1,0 +1,143 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// AppsInstalledParams is the exact standalone source contract for
+// app/installed. It intentionally does not bind Gollem's runtime discovery.
+type AppsInstalledParams struct {
+	ThreadID     *string `json:"threadId"`
+	ForceRefresh bool    `json:"forceRefresh,omitempty"`
+}
+
+func (p *AppsInstalledParams) UnmarshalJSON(data []byte) error {
+	if p == nil {
+		return errors.New("decode apps installed params into nil receiver")
+	}
+	payload, err := decodeRustSerdeObject(data, "apps installed params", "threadId", "forceRefresh")
+	if err != nil {
+		return err
+	}
+	threadID, err := decodeOptionalAppsDiscoveryValue[string](payload, "apps installed params", "threadId")
+	if err != nil {
+		return err
+	}
+	forceRefresh, err := decodeOptionalAppsDiscoveryBool(payload, "apps installed params", "forceRefresh")
+	if err != nil {
+		return err
+	}
+	*p = AppsInstalledParams{ThreadID: threadID, ForceRefresh: forceRefresh}
+	return nil
+}
+
+// AppsReadParams is the exact standalone source contract for app/read. It
+// intentionally does not bind Gollem's runtime discovery.
+type AppsReadParams struct {
+	AppIDs       []string `json:"appIds"`
+	ThreadID     *string  `json:"threadId"`
+	IncludeTools bool     `json:"includeTools,omitempty"`
+}
+
+func (p *AppsReadParams) UnmarshalJSON(data []byte) error {
+	if p == nil {
+		return errors.New("decode apps read params into nil receiver")
+	}
+	payload, err := decodeRustSerdeObject(data, "apps read params", "appIds", "threadId", "includeTools")
+	if err != nil {
+		return err
+	}
+	appIDs, err := decodeRequiredThreadItemValue[[]string](payload, "apps read params", "appIds")
+	if err != nil {
+		return err
+	}
+	threadID, err := decodeOptionalAppsDiscoveryValue[string](payload, "apps read params", "threadId")
+	if err != nil {
+		return err
+	}
+	includeTools, err := decodeOptionalAppsDiscoveryBool(payload, "apps read params", "includeTools")
+	if err != nil {
+		return err
+	}
+	*p = AppsReadParams{AppIDs: appIDs, ThreadID: threadID, IncludeTools: includeTools}
+	return nil
+}
+
+func decodeOptionalAppsDiscoveryValue[T any](
+	payload map[string]json.RawMessage,
+	objectName string,
+	fieldName string,
+) (*T, error) {
+	raw, ok := payload[fieldName]
+	if !ok || isJSONNull(raw) {
+		return nil, nil
+	}
+	var value T
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return nil, fmt.Errorf("decode %s %s: %w", objectName, fieldName, err)
+	}
+	return &value, nil
+}
+
+func decodeOptionalAppsDiscoveryBool(
+	payload map[string]json.RawMessage,
+	objectName string,
+	fieldName string,
+) (bool, error) {
+	raw, ok := payload[fieldName]
+	if !ok {
+		return false, nil
+	}
+	if isJSONNull(raw) {
+		return false, fmt.Errorf("decode %s %s: value cannot be null", objectName, fieldName)
+	}
+	var value bool
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return false, fmt.Errorf("decode %s %s: %w", objectName, fieldName, err)
+	}
+	return value, nil
+}
+
+func appsDiscoveryParamSchemas() map[string]Schema {
+	threadID := Schema{
+		"description": "Optional loaded thread id used to evaluate effective app configuration.",
+		"type":        []any{"string", "null"},
+	}
+	return map[string]Schema{
+		"AppsInstalledParams": {
+			"description": "Read the committed installed connector runtime snapshot.",
+			"properties": Schema{
+				"forceRefresh": Schema{
+					"description": "When true and Apps are permitted, refresh and publish the hosted connector runtime tool snapshot first.",
+					"type":        "boolean",
+				},
+				"threadId": threadID,
+			},
+			"type": "object",
+		},
+		"AppsReadParams": {
+			"description": "EXPERIMENTAL - read metadata for specific apps/connectors.",
+			"properties": Schema{
+				"appIds": Schema{
+					"description": "App ids to read. The server accepts at most 100 ids and deduplicates repeated ids while preserving their first-request order.",
+					"items":       Schema{"type": "string"},
+					"type":        "array",
+				},
+				"includeTools": Schema{
+					"description": "When true, include display-only public tool summaries in the returned metadata.",
+					"type":        "boolean",
+				},
+				"threadId": threadID,
+			},
+			"required": []string{"appIds"},
+			"type":     "object",
+		},
+	}
+}
+
+var (
+	_ json.Unmarshaler = (*AppsInstalledParams)(nil)
+	_ json.Unmarshaler = (*AppsReadParams)(nil)
+)

--- a/appserver/protocol/apps_list_contract_test.go
+++ b/appserver/protocol/apps_list_contract_test.go
@@ -168,8 +168,8 @@ func TestAppsListContractsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/attestation_contract_test.go
+++ b/appserver/protocol/attestation_contract_test.go
@@ -134,8 +134,8 @@ func TestAttestationContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("attestation/generate = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
+++ b/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
@@ -194,8 +194,8 @@ func TestChatgptAuthTokensRefreshRemainsStandaloneAndDeferred(t *testing.T) {
 	if !found {
 		t.Fatal("refresh method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/client_notification_contract_test.go
+++ b/appserver/protocol/client_notification_contract_test.go
@@ -58,8 +58,8 @@ func TestClientNotificationRemainsStandaloneFromInitializedBinding(t *testing.T)
 	if !ok || info.Surface != SurfaceClientNotification || info.State != MethodImplemented {
 		t.Fatalf("initialized method = %#v, %v; want implemented client notification", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 }
 

--- a/appserver/protocol/collaboration_capability_contract_test.go
+++ b/appserver/protocol/collaboration_capability_contract_test.go
@@ -346,8 +346,8 @@ func TestCollaborationCapabilityContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/command_exec_contract_test.go
+++ b/appserver/protocol/command_exec_contract_test.go
@@ -79,8 +79,8 @@ func TestCommandExecContractsFailClosedAndRemainStandalone(t *testing.T) {
 			t.Fatalf("public command-exec contract unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 }
 

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/conversation_text_role_contract_test.go
+++ b/appserver/protocol/conversation_text_role_contract_test.go
@@ -42,7 +42,7 @@ func TestConversationTextRoleContractIsExact(t *testing.T) {
 			t.Fatalf("standalone conversation role unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(definitions); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(definitions); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 }

--- a/appserver/protocol/dynamic_tool_spec_contract_test.go
+++ b/appserver/protocol/dynamic_tool_spec_contract_test.go
@@ -318,8 +318,8 @@ func TestDynamicToolSpecContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/exec_command_approval_params_contract_test.go
+++ b/appserver/protocol/exec_command_approval_params_contract_test.go
@@ -137,8 +137,8 @@ func TestExecCommandApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ExecCommandApprovalParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(defs); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/experimental_feature_contract_test.go
+++ b/appserver/protocol/experimental_feature_contract_test.go
@@ -41,8 +41,8 @@ func TestExperimentalFeatureContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want implemented client request", methodName, method, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d/%d/%d, want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,8 +217,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,8 +203,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -260,8 +260,8 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,8 +244,8 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -162,8 +162,8 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -175,8 +175,8 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/file_change_contract_test.go
+++ b/appserver/protocol/file_change_contract_test.go
@@ -108,8 +108,8 @@ func TestFileChangeRemainsStandalone(t *testing.T) {
 			t.Fatalf("FileChange unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/file_change_output_delta_notification_contract_test.go
+++ b/appserver/protocol/file_change_output_delta_notification_contract_test.go
@@ -100,8 +100,8 @@ func TestFileChangeOutputDeltaNotificationRemainsDeprecatedAndStandalone(t *test
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("item/fileChange/outputDelta = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -381,8 +381,8 @@ func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/guardian_approval_review_action_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_action_contract_test.go
@@ -226,8 +226,8 @@ func TestGuardianApprovalReviewActionRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReviewAction unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
@@ -164,8 +164,8 @@ func TestGuardianApprovalReviewCompletedNotificationRemainsStandalone(t *testing
 			t.Fatalf("completed notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/guardian_approval_review_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_contract_test.go
@@ -139,8 +139,8 @@ func TestGuardianApprovalReviewRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReview unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
@@ -175,8 +175,8 @@ func TestGuardianApprovalReviewStartedNotificationRemainsStandalone(t *testing.T
 			t.Fatalf("started notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/guardian_enum_foundation_contract_test.go
+++ b/appserver/protocol/guardian_enum_foundation_contract_test.go
@@ -89,8 +89,8 @@ func TestGuardianEnumFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/hook_metadata_list_contract_test.go
+++ b/appserver/protocol/hook_metadata_list_contract_test.go
@@ -352,8 +352,8 @@ func TestHookMetadataListContractsStayStandalone(t *testing.T) {
 			t.Errorf("standalone definition %s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Errorf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Errorf("definition count = %d, want 614", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 {
 		t.Errorf("wire binding count = %d, want 80", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/hook_run_notification_contract_test.go
+++ b/appserver/protocol/hook_run_notification_contract_test.go
@@ -297,8 +297,8 @@ func TestHookRunNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("surface changed: %d methods, %d wire bindings, %d item bindings", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/hook_value_foundation_contract_test.go
+++ b/appserver/protocol/hook_value_foundation_contract_test.go
@@ -167,8 +167,8 @@ func TestHookValueFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 612 {
-		t.Fatalf("definition count = %d, want 612", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 614 {
+		t.Fatalf("definition count = %d, want 614", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/jsonrpc_envelope_contract_test.go
+++ b/appserver/protocol/jsonrpc_envelope_contract_test.go
@@ -87,8 +87,8 @@ func TestJSONRPCEnvelopesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 }
 

--- a/appserver/protocol/jsonrpc_error_contract_test.go
+++ b/appserver/protocol/jsonrpc_error_contract_test.go
@@ -67,8 +67,8 @@ func TestJSONRPCErrorsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 }
 

--- a/appserver/protocol/jsonrpc_message_contract_test.go
+++ b/appserver/protocol/jsonrpc_message_contract_test.go
@@ -74,8 +74,8 @@ func TestJSONRPCMessageRemainsStandalone(t *testing.T) {
 			t.Fatalf("JSONRPCMessage unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 }
 

--- a/appserver/protocol/legacy_approval_response_contract_test.go
+++ b/appserver/protocol/legacy_approval_response_contract_test.go
@@ -98,8 +98,8 @@ func TestLegacyApprovalResponsesRemainStandaloneAndNominal(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_oauth_login_contract_test.go
+++ b/appserver/protocol/mcp_server_oauth_login_contract_test.go
@@ -228,8 +228,8 @@ func TestMcpServerOauthLoginContractsRemainStandaloneAndBlocked(t *testing.T) {
 	if !ok || notification.Surface != SurfaceServerNotification || notification.State != MethodBlocked {
 		t.Fatalf("mcpServer/oauthLogin/completed = %#v, %v; want blocked server notification", notification, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d/%d/%d, want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_status_contract_test.go
+++ b/appserver/protocol/mcp_server_status_contract_test.go
@@ -277,8 +277,8 @@ func TestMcpServerStatusContractsRemainStandalone(t *testing.T) {
 	if !ok || method.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d/%d/%d, want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_approval_context_contract_test.go
+++ b/appserver/protocol/network_approval_context_contract_test.go
@@ -84,8 +84,8 @@ func TestNetworkApprovalContextRemainsStandalone(t *testing.T) {
 			t.Fatalf("NetworkApprovalContext unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/parsed_command_contract_test.go
+++ b/appserver/protocol/parsed_command_contract_test.go
@@ -120,8 +120,8 @@ func TestParsedCommandRemainsStandalone(t *testing.T) {
 			t.Fatalf("ParsedCommand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/permission_profile_list_contract_test.go
+++ b/appserver/protocol/permission_profile_list_contract_test.go
@@ -255,8 +255,8 @@ func TestPermissionProfileListContractsRemainStandalone(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodImplemented {
 		t.Fatalf("permissionProfile/list = %#v, %v; want existing implemented client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d/%d/%d, want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/permissions_request_approval_params_contract_test.go
+++ b/appserver/protocol/permissions_request_approval_params_contract_test.go
@@ -107,8 +107,8 @@ func TestPermissionsRequestApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("PermissionsRequestApprovalParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(defs); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 }
 

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/process_contracts_contract_test.go
+++ b/appserver/protocol/process_contracts_contract_test.go
@@ -308,8 +308,8 @@ func TestProcessContractsRemainStandaloneFromLegacyRuntime(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want unchanged implemented notification", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 612 {
-		t.Fatalf("definition count = %d, want 612", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 614 {
+		t.Fatalf("definition count = %d, want 614", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 612 {
-		t.Fatalf("definition count = %d, want 612", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 614 {
+		t.Fatalf("definition count = %d, want 614", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 612 {
-		t.Fatalf("definition count = %d, want 612", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 614 {
+		t.Fatalf("definition count = %d, want 614", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 612 {
-		t.Fatalf("definition count = %d, want 612", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 614 {
+		t.Fatalf("definition count = %d, want 614", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 612 {
-		t.Fatalf("definition count = %d, want 612", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 614 {
+		t.Fatalf("definition count = %d, want 614", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/review_decision_contract_test.go
+++ b/appserver/protocol/review_decision_contract_test.go
@@ -136,8 +136,8 @@ func TestReviewDecisionRemainsStandalone(t *testing.T) {
 			t.Fatalf("ReviewDecision unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(defs); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/review_start_contract_test.go
+++ b/appserver/protocol/review_start_contract_test.go
@@ -215,8 +215,8 @@ func TestReviewStartContractsFailClosedAndRemainStandalone(t *testing.T) {
 	if !ok || request.Surface != SurfaceClientRequest || request.State != MethodBlocked {
 		t.Fatalf("review/start = %#v, %v; want blocked client request", request, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 }
 

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -127,6 +127,8 @@ func wireSchemaDefinitions() Schema {
 		{Name: "AppToolApproval", Type: reflect.TypeFor[AppToolApproval]()},
 		{Name: "AppToolConfig", Type: reflect.TypeFor[AppToolConfig]()},
 		{Name: "AppToolsConfig", Type: reflect.TypeFor[AppToolsConfig]()},
+		{Name: "AppsInstalledParams", Type: reflect.TypeFor[AppsInstalledParams]()},
+		{Name: "AppsReadParams", Type: reflect.TypeFor[AppsReadParams]()},
 		{Name: "AppsConfig", Type: reflect.TypeFor[AppsConfig]()},
 		{Name: "AppsDefaultConfig", Type: reflect.TypeFor[AppsDefaultConfig]()},
 		{Name: "AppsListParams", Type: reflect.TypeFor[AppsListParams]()},
@@ -861,6 +863,9 @@ func wireSchemaDefinitions() Schema {
 		},
 	}
 	schemas["AppToolsConfig"] = Schema{"type": "object"}
+	for name, schema := range appsDiscoveryParamSchemas() {
+		schemas[name] = schema
+	}
 	schemas["AppConfig"] = Schema{
 		"type": "object",
 		"properties": Schema{

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -1265,6 +1265,23 @@
       },
       "type": "object"
     },
+    "AppsInstalledParams": {
+      "description": "Read the committed installed connector runtime snapshot.",
+      "properties": {
+        "forceRefresh": {
+          "description": "When true and Apps are permitted, refresh and publish the hosted connector runtime tool snapshot first.",
+          "type": "boolean"
+        },
+        "threadId": {
+          "description": "Optional loaded thread id used to evaluate effective app configuration.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
     "AppsListParams": {
       "description": "EXPERIMENTAL - list available apps/connectors.",
       "properties": {
@@ -1317,6 +1334,33 @@
       },
       "required": [
         "data"
+      ],
+      "type": "object"
+    },
+    "AppsReadParams": {
+      "description": "EXPERIMENTAL - read metadata for specific apps/connectors.",
+      "properties": {
+        "appIds": {
+          "description": "App ids to read. The server accepts at most 100 ids and deduplicates repeated ids while preserving their first-request order.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "includeTools": {
+          "description": "When true, include display-only public tool summaries in the returned metadata.",
+          "type": "boolean"
+        },
+        "threadId": {
+          "description": "Optional loaded thread id used to evaluate effective app configuration.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "appIds"
       ],
       "type": "object"
     },

--- a/appserver/protocol/server_request_approval_params_contract_test.go
+++ b/appserver/protocol/server_request_approval_params_contract_test.go
@@ -163,8 +163,8 @@ func TestServerRequestApprovalParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(defs); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(defs); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/server_request_contract_test.go
+++ b/appserver/protocol/server_request_contract_test.go
@@ -53,8 +53,8 @@ func TestServerRequestSchemaAndBindingAreExact(t *testing.T) {
 			}
 		}
 	}
-	if got := len(defs); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(defs); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	typescript, err := MarshalTypeScript()
 	if err != nil {

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/terminal_interaction_notification_contract_test.go
+++ b/appserver/protocol/terminal_interaction_notification_contract_test.go
@@ -72,8 +72,8 @@ func TestTerminalInteractionNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.Surface != SurfaceServerNotification || info.State != MethodBlocked {
 		t.Fatalf("terminal interaction method = %#v, %v; want blocked server notification", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	generated, err := MarshalTypeScript()
 	if err != nil {

--- a/appserver/protocol/thread_approve_guardian_denied_action_contract_test.go
+++ b/appserver/protocol/thread_approve_guardian_denied_action_contract_test.go
@@ -88,8 +88,8 @@ func TestThreadApproveGuardianDeniedActionContractsRemainStandalone(t *testing.T
 	if !ok || info.Surface != SurfaceClientRequest || info.State != MethodDeferredStub {
 		t.Fatalf("guardian denied action method = %#v, %v; want deferred client request", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 }
 

--- a/appserver/protocol/thread_inject_items_contract_test.go
+++ b/appserver/protocol/thread_inject_items_contract_test.go
@@ -96,8 +96,8 @@ func TestThreadInjectItemsContractsFailClosedAndRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 }
 

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 612 {
-		t.Fatalf("definition count = %d, want 612", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 614 {
+		t.Fatalf("definition count = %d, want 614", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -262,8 +262,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_rollback_contract_test.go
+++ b/appserver/protocol/thread_rollback_contract_test.go
@@ -114,8 +114,8 @@ func TestThreadRollbackContractsFailClosedAndRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 }
 

--- a/appserver/protocol/thread_search_result_contract_test.go
+++ b/appserver/protocol/thread_search_result_contract_test.go
@@ -59,8 +59,8 @@ func TestThreadSearchResultFailsClosedAndRemainsStandalone(t *testing.T) {
 			t.Fatalf("ThreadSearchResult unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 }
 

--- a/appserver/protocol/thread_section_params_contract_test.go
+++ b/appserver/protocol/thread_section_params_contract_test.go
@@ -213,8 +213,8 @@ func TestThreadSectionParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 }
 

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -252,8 +252,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 	if !foundRuntimeStart {
 		t.Error("thread/start runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -154,8 +154,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 	if !foundRuntimeStart {
 		t.Error("thread/start runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_settings_contract_test.go
+++ b/appserver/protocol/thread_settings_contract_test.go
@@ -162,8 +162,8 @@ func TestThreadSettingsContractsFailClosedAndRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 }
 

--- a/appserver/protocol/thread_shell_command_contract_test.go
+++ b/appserver/protocol/thread_shell_command_contract_test.go
@@ -95,8 +95,8 @@ func TestThreadShellCommandContractsFailClosedAndRemainStandalone(t *testing.T) 
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 }
 

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 612 {
-		t.Fatalf("definition count = %d, want 612", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 614 {
+		t.Fatalf("definition count = %d, want 614", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 612 {
-		t.Fatalf("definition count = %d, want 612", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 614 {
+		t.Fatalf("definition count = %d, want 614", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_environment_contract_test.go
+++ b/appserver/protocol/turn_environment_contract_test.go
@@ -79,8 +79,8 @@ func TestTurnEnvironmentParamsFailsClosedAndRemainsStandalone(t *testing.T) {
 			t.Fatalf("TurnEnvironmentParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 }
 

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -119,8 +119,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 	if !foundRuntimeBinding {
 		t.Error("turn/interrupt runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -241,8 +241,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 	if !foundRuntimeBinding {
 		t.Error("turn/start runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -164,8 +164,8 @@ func TestTurnSteerContractsAreBoundToLiveRuntime(t *testing.T) {
 	if !found {
 		t.Fatal("turn/steer runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -862,6 +862,10 @@ func MarshalTypeScript() ([]byte, error) {
 			definition = schema
 		}
 		switch name {
+		case "AppsInstalledParams":
+			definition = Schema{typeScriptRawTypeKeyword: `{ threadId?: string | null, forceRefresh?: boolean, }`}
+		case "AppsReadParams":
+			definition = Schema{typeScriptRawTypeKeyword: `{ appIds: Array<string>, threadId?: string | null, includeTools?: boolean, }`}
 		case "McpServerElicitationRequestParams":
 			// The raw schema mirrors serde's open, flattened record. ts-rs instead
 			// emits the exact closed intersection and makes Option fields nullable.

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -739,6 +739,8 @@ export type AppsDefaultConfig = {
   "open_world_enabled": boolean;
 };
 
+export type AppsInstalledParams = { threadId?: string | null, forceRefresh?: boolean, };
+
 export type AppsListParams = {
   "cursor"?: string | null;
   "forceRefetch"?: boolean;
@@ -750,6 +752,8 @@ export type AppsListResponse = {
   "data": Array<AppInfo>;
   "nextCursor": string | null;
 };
+
+export type AppsReadParams = { appIds: Array<string>, threadId?: string | null, includeTools?: boolean, };
 
 export type AskForApproval = "untrusted" | "on-request" | {
   "granular": {

--- a/appserver/protocol/typescript/testdata/apps_discovery_params_contract.ts
+++ b/appserver/protocol/typescript/testdata/apps_discovery_params_contract.ts
@@ -1,0 +1,22 @@
+import type {
+  AppsInstalledParams,
+  AppsReadParams,
+} from "../gollem_appserver_protocol";
+
+export const installed = {
+  threadId: null,
+  forceRefresh: true,
+} satisfies AppsInstalledParams;
+
+export const read = {
+  appIds: ["app-a", "app-b"],
+  threadId: "thread",
+  includeTools: true,
+} satisfies AppsReadParams;
+
+// @ts-expect-error app/read requires its app ids.
+({}) satisfies AppsReadParams;
+// @ts-expect-error app ids are text values.
+({ appIds: [1] }) satisfies AppsReadParams;
+// @ts-expect-error source flags are booleans.
+({ forceRefresh: "true" }) satisfies AppsInstalledParams;

--- a/appserver/protocol/w3c_trace_context_contract_test.go
+++ b/appserver/protocol/w3c_trace_context_contract_test.go
@@ -55,8 +55,8 @@ func TestW3cTraceContextRemainsStandalone(t *testing.T) {
 			t.Fatalf("W3cTraceContext unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 }
 

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/workspace_messages_contract_test.go
+++ b/appserver/protocol/workspace_messages_contract_test.go
@@ -209,8 +209,8 @@ func TestWorkspaceMessageContractsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/workspaceMessages/read = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 612 {
-		t.Fatalf("definition count = %d, want 612", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 614 {
+		t.Fatalf("definition count = %d, want 614", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- add source-exact standalone `AppsInstalledParams` and `AppsReadParams` contracts
- preserve source-open serde behavior, nullable `threadId`, and false-flag omission
- generate matching JSON Schema and TypeScript artifacts without binding discovery or connector runtime behavior

## Verification
- `go test ./appserver/protocol -count=1`
- `go test -race ./appserver/protocol ./appserver -run 'TestAppsDiscovery|TestThreadSection|TestServerRequest' -count=1`\n- `go list ./... | rg -v '^github\\.com/fugue-labs/gollem/ext/monty(/|$)' | xargs go test -count=1`\n- `go list ./... | rg -v '^github\\.com/fugue-labs/gollem/ext/monty(/|$)' | xargs go vet`\n- `go mod tidy`\n- `go generate ./appserver/protocol`\n- `golangci-lint run`\n- normal pre-push race suite with `hooks.skipMontyRace=true`