### PR TITLE
Add PluginShareSave protocol contract

### DIFF
--- a/appserver/protocol/account_credit_nudge_values_contract_test.go
+++ b/appserver/protocol/account_credit_nudge_values_contract_test.go
@@ -119,8 +119,8 @@ func TestAccountCreditNudgeValuesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/sendAddCreditsNudgeEmail = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/account_envelope_contract_test.go
+++ b/appserver/protocol/account_envelope_contract_test.go
@@ -268,8 +268,8 @@ func TestAccountEnvelopeContractsRemainStandaloneAndDeferred(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred %s", methodName, method, ok, surface)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/account_login_completed_notification_contract_test.go
+++ b/appserver/protocol/account_login_completed_notification_contract_test.go
@@ -88,8 +88,8 @@ func TestAccountLoginCompletedNotificationRemainsStandaloneAndDeferred(t *testin
 	if !found {
 		t.Fatal("account/login/completed method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/account_rate_limits_contract_test.go
+++ b/appserver/protocol/account_rate_limits_contract_test.go
@@ -484,8 +484,8 @@ func TestAccountRateLimitContractsRemainStandaloneAndDeferred(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred %s", methodName, method, ok, surface)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/account_token_usage_contract_test.go
+++ b/appserver/protocol/account_token_usage_contract_test.go
@@ -146,8 +146,8 @@ func TestAccountTokenUsageRecordsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/usage/read = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(defs); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_config_contract_test.go
+++ b/appserver/protocol/app_config_contract_test.go
@@ -109,8 +109,8 @@ func TestAppConfigRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppConfig unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_info_contract_test.go
+++ b/appserver/protocol/app_info_contract_test.go
@@ -131,8 +131,8 @@ func TestAppInfoRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_list_updated_notification_contract_test.go
+++ b/appserver/protocol/app_list_updated_notification_contract_test.go
@@ -105,8 +105,8 @@ func TestAppListUpdatedNotificationRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceServerNotification || method.State != MethodDeferredStub {
 		t.Fatalf("app/list/updated = %#v, %v; want deferred server notification", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_metadata_contract_test.go
+++ b/appserver/protocol/app_metadata_contract_test.go
@@ -107,8 +107,8 @@ func TestAppMetadataRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_metadata_leaf_contract_test.go
+++ b/appserver/protocol/app_metadata_leaf_contract_test.go
@@ -157,8 +157,8 @@ func TestAppMetadataLeavesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_summary_contract_test.go
+++ b/appserver/protocol/app_summary_contract_test.go
@@ -87,8 +87,8 @@ func TestAppSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppSummary unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_template_summary_contract_test.go
+++ b/appserver/protocol/app_template_summary_contract_test.go
@@ -107,8 +107,8 @@ func TestAppTemplateSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppTemplateSummary unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_template_unavailable_reason_contract_test.go
+++ b/appserver/protocol/app_template_unavailable_reason_contract_test.go
@@ -71,8 +71,8 @@ func TestAppTemplateUnavailableReasonRemainsStandalone(t *testing.T) {
 			t.Fatalf("AppTemplateUnavailableReason unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_tool_approval_contract_test.go
+++ b/appserver/protocol/app_tool_approval_contract_test.go
@@ -73,8 +73,8 @@ func TestAppToolApprovalRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppToolApproval unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_tools_config_contract_test.go
+++ b/appserver/protocol/app_tools_config_contract_test.go
@@ -140,8 +140,8 @@ func TestAppToolConfigsRemainStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/apply_patch_approval_params_contract_test.go
+++ b/appserver/protocol/apply_patch_approval_params_contract_test.go
@@ -139,8 +139,8 @@ func TestApplyPatchApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ApplyPatchApprovalParams unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(defs); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(defs); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/apps_config_contract_test.go
+++ b/appserver/protocol/apps_config_contract_test.go
@@ -185,8 +185,8 @@ func TestAppsConfigsRemainStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/apps_discovery_params_contract_test.go
+++ b/appserver/protocol/apps_discovery_params_contract_test.go
@@ -87,8 +87,8 @@ func TestAppsDiscoveryParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 }
 

--- a/appserver/protocol/apps_list_contract_test.go
+++ b/appserver/protocol/apps_list_contract_test.go
@@ -168,8 +168,8 @@ func TestAppsListContractsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/attestation_contract_test.go
+++ b/appserver/protocol/attestation_contract_test.go
@@ -134,8 +134,8 @@ func TestAttestationContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("attestation/generate = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
+++ b/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
@@ -194,8 +194,8 @@ func TestChatgptAuthTokensRefreshRemainsStandaloneAndDeferred(t *testing.T) {
 	if !found {
 		t.Fatal("refresh method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/client_notification_contract_test.go
+++ b/appserver/protocol/client_notification_contract_test.go
@@ -58,8 +58,8 @@ func TestClientNotificationRemainsStandaloneFromInitializedBinding(t *testing.T)
 	if !ok || info.Surface != SurfaceClientNotification || info.State != MethodImplemented {
 		t.Fatalf("initialized method = %#v, %v; want implemented client notification", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 }
 

--- a/appserver/protocol/collaboration_capability_contract_test.go
+++ b/appserver/protocol/collaboration_capability_contract_test.go
@@ -346,8 +346,8 @@ func TestCollaborationCapabilityContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/command_exec_contract_test.go
+++ b/appserver/protocol/command_exec_contract_test.go
@@ -79,8 +79,8 @@ func TestCommandExecContractsFailClosedAndRemainStandalone(t *testing.T) {
 			t.Fatalf("public command-exec contract unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 }
 

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/conversation_text_role_contract_test.go
+++ b/appserver/protocol/conversation_text_role_contract_test.go
@@ -42,7 +42,7 @@ func TestConversationTextRoleContractIsExact(t *testing.T) {
 			t.Fatalf("standalone conversation role unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(definitions); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(definitions); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 }

--- a/appserver/protocol/dynamic_tool_spec_contract_test.go
+++ b/appserver/protocol/dynamic_tool_spec_contract_test.go
@@ -318,8 +318,8 @@ func TestDynamicToolSpecContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/exec_command_approval_params_contract_test.go
+++ b/appserver/protocol/exec_command_approval_params_contract_test.go
@@ -137,8 +137,8 @@ func TestExecCommandApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ExecCommandApprovalParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(defs); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/experimental_feature_contract_test.go
+++ b/appserver/protocol/experimental_feature_contract_test.go
@@ -41,8 +41,8 @@ func TestExperimentalFeatureContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want implemented client request", methodName, method, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d/%d/%d, want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,8 +217,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,8 +203,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -260,8 +260,8 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_import_history_record_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_record_contract_test.go
@@ -122,8 +122,8 @@ func TestExternalAgentConfigImportHistoryRecordRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 }
 

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,8 +244,8 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -162,8 +162,8 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -175,8 +175,8 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/feedback_upload_params_contract_test.go
+++ b/appserver/protocol/feedback_upload_params_contract_test.go
@@ -70,8 +70,8 @@ func TestFeedbackUploadParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 }
 

--- a/appserver/protocol/file_change_contract_test.go
+++ b/appserver/protocol/file_change_contract_test.go
@@ -108,8 +108,8 @@ func TestFileChangeRemainsStandalone(t *testing.T) {
 			t.Fatalf("FileChange unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/file_change_output_delta_notification_contract_test.go
+++ b/appserver/protocol/file_change_output_delta_notification_contract_test.go
@@ -100,8 +100,8 @@ func TestFileChangeOutputDeltaNotificationRemainsDeprecatedAndStandalone(t *test
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("item/fileChange/outputDelta = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -381,8 +381,8 @@ func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/guardian_approval_review_action_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_action_contract_test.go
@@ -226,8 +226,8 @@ func TestGuardianApprovalReviewActionRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReviewAction unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
@@ -164,8 +164,8 @@ func TestGuardianApprovalReviewCompletedNotificationRemainsStandalone(t *testing
 			t.Fatalf("completed notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/guardian_approval_review_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_contract_test.go
@@ -139,8 +139,8 @@ func TestGuardianApprovalReviewRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReview unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
@@ -175,8 +175,8 @@ func TestGuardianApprovalReviewStartedNotificationRemainsStandalone(t *testing.T
 			t.Fatalf("started notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/guardian_enum_foundation_contract_test.go
+++ b/appserver/protocol/guardian_enum_foundation_contract_test.go
@@ -89,8 +89,8 @@ func TestGuardianEnumFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/hook_metadata_list_contract_test.go
+++ b/appserver/protocol/hook_metadata_list_contract_test.go
@@ -352,8 +352,8 @@ func TestHookMetadataListContractsStayStandalone(t *testing.T) {
 			t.Errorf("standalone definition %s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Errorf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Errorf("definition count = %d, want 640", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 {
 		t.Errorf("wire binding count = %d, want 80", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/hook_run_notification_contract_test.go
+++ b/appserver/protocol/hook_run_notification_contract_test.go
@@ -297,8 +297,8 @@ func TestHookRunNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("surface changed: %d methods, %d wire bindings, %d item bindings", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/hook_value_foundation_contract_test.go
+++ b/appserver/protocol/hook_value_foundation_contract_test.go
@@ -167,8 +167,8 @@ func TestHookValueFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 635 {
-		t.Fatalf("definition count = %d, want 635", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 640 {
+		t.Fatalf("definition count = %d, want 640", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/jsonrpc_envelope_contract_test.go
+++ b/appserver/protocol/jsonrpc_envelope_contract_test.go
@@ -87,8 +87,8 @@ func TestJSONRPCEnvelopesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 }
 

--- a/appserver/protocol/jsonrpc_error_contract_test.go
+++ b/appserver/protocol/jsonrpc_error_contract_test.go
@@ -67,8 +67,8 @@ func TestJSONRPCErrorsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 }
 

--- a/appserver/protocol/jsonrpc_message_contract_test.go
+++ b/appserver/protocol/jsonrpc_message_contract_test.go
@@ -74,8 +74,8 @@ func TestJSONRPCMessageRemainsStandalone(t *testing.T) {
 			t.Fatalf("JSONRPCMessage unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 }
 

--- a/appserver/protocol/legacy_approval_response_contract_test.go
+++ b/appserver/protocol/legacy_approval_response_contract_test.go
@@ -98,8 +98,8 @@ func TestLegacyApprovalResponsesRemainStandaloneAndNominal(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/marketplace_add_params_contract_test.go
+++ b/appserver/protocol/marketplace_add_params_contract_test.go
@@ -69,8 +69,8 @@ func TestMarketplaceAddParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 }
 

--- a/appserver/protocol/marketplace_remove_params_contract_test.go
+++ b/appserver/protocol/marketplace_remove_params_contract_test.go
@@ -52,8 +52,8 @@ func TestMarketplaceRemoveParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 }
 

--- a/appserver/protocol/marketplace_upgrade_params_contract_test.go
+++ b/appserver/protocol/marketplace_upgrade_params_contract_test.go
@@ -49,8 +49,8 @@ func TestMarketplaceUpgradeParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 }
 

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_oauth_login_contract_test.go
+++ b/appserver/protocol/mcp_server_oauth_login_contract_test.go
@@ -228,8 +228,8 @@ func TestMcpServerOauthLoginContractsRemainStandaloneAndBlocked(t *testing.T) {
 	if !ok || notification.Surface != SurfaceServerNotification || notification.State != MethodBlocked {
 		t.Fatalf("mcpServer/oauthLogin/completed = %#v, %v; want blocked server notification", notification, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d/%d/%d, want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_status_contract_test.go
+++ b/appserver/protocol/mcp_server_status_contract_test.go
@@ -277,8 +277,8 @@ func TestMcpServerStatusContractsRemainStandalone(t *testing.T) {
 	if !ok || method.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d/%d/%d, want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_approval_context_contract_test.go
+++ b/appserver/protocol/network_approval_context_contract_test.go
@@ -84,8 +84,8 @@ func TestNetworkApprovalContextRemainsStandalone(t *testing.T) {
 			t.Fatalf("NetworkApprovalContext unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/parsed_command_contract_test.go
+++ b/appserver/protocol/parsed_command_contract_test.go
@@ -120,8 +120,8 @@ func TestParsedCommandRemainsStandalone(t *testing.T) {
 			t.Fatalf("ParsedCommand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/permission_profile_list_contract_test.go
+++ b/appserver/protocol/permission_profile_list_contract_test.go
@@ -255,8 +255,8 @@ func TestPermissionProfileListContractsRemainStandalone(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodImplemented {
 		t.Fatalf("permissionProfile/list = %#v, %v; want existing implemented client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d/%d/%d, want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/permissions_request_approval_params_contract_test.go
+++ b/appserver/protocol/permissions_request_approval_params_contract_test.go
@@ -107,8 +107,8 @@ func TestPermissionsRequestApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("PermissionsRequestApprovalParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(defs); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 }
 

--- a/appserver/protocol/plugin_install_params_contract_test.go
+++ b/appserver/protocol/plugin_install_params_contract_test.go
@@ -35,8 +35,8 @@ func TestPluginInstallParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 }
 func TestPluginInstallParamsTypeScriptIsExact(t *testing.T) {

--- a/appserver/protocol/plugin_installed_params_contract_test.go
+++ b/appserver/protocol/plugin_installed_params_contract_test.go
@@ -35,8 +35,8 @@ func TestPluginInstalledParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 }
 func TestPluginInstalledParamsTypeScriptIsExact(t *testing.T) {

--- a/appserver/protocol/plugin_list_params_contract_test.go
+++ b/appserver/protocol/plugin_list_params_contract_test.go
@@ -82,8 +82,8 @@ func TestPluginListParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 }
 

--- a/appserver/protocol/plugin_read_params_contract_test.go
+++ b/appserver/protocol/plugin_read_params_contract_test.go
@@ -39,8 +39,8 @@ func TestPluginReadParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 }
 func TestPluginReadParamsTypeScriptIsExact(t *testing.T) {

--- a/appserver/protocol/plugin_share_checkout_params_contract_test.go
+++ b/appserver/protocol/plugin_share_checkout_params_contract_test.go
@@ -51,8 +51,8 @@ func TestPluginShareCheckoutParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 }
 

--- a/appserver/protocol/plugin_share_delete_params_contract_test.go
+++ b/appserver/protocol/plugin_share_delete_params_contract_test.go
@@ -51,8 +51,8 @@ func TestPluginShareDeleteParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 }
 

--- a/appserver/protocol/plugin_share_list_params_contract_test.go
+++ b/appserver/protocol/plugin_share_list_params_contract_test.go
@@ -40,8 +40,8 @@ func TestPluginShareListParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 }
 

--- a/appserver/protocol/plugin_share_save_contract_test.go
+++ b/appserver/protocol/plugin_share_save_contract_test.go
@@ -1,0 +1,187 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestPluginShareSaveSchemasAreExact(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	for name, want := range map[string]Schema{
+		"PluginShareDiscoverability": pluginShareDiscoverabilitySchema(),
+		"PluginSharePrincipalType":   pluginSharePrincipalTypeSchema(),
+		"PluginShareTargetRole":      pluginShareTargetRoleSchema(),
+		"PluginShareTarget":          pluginShareTargetSchema(),
+		"PluginShareSaveParams":      pluginShareSaveParamsSchema(),
+	} {
+		if got := defs[name]; !reflect.DeepEqual(got, want) {
+			t.Errorf("%s = %#v, want %#v", name, got, want)
+		}
+	}
+}
+
+func TestPluginShareSaveEnumsAreClosed(t *testing.T) {
+	for _, values := range [][]any{
+		{PluginShareDiscoverabilityListed, PluginShareDiscoverabilityUnlisted, PluginShareDiscoverabilityPrivate},
+		{PluginSharePrincipalTypeUser, PluginSharePrincipalTypeGroup, PluginSharePrincipalTypeWorkspace},
+		{PluginShareTargetRoleReader, PluginShareTargetRoleEditor},
+	} {
+		for _, value := range values {
+			encoded, err := json.Marshal(value)
+			if err != nil {
+				t.Fatalf("Marshal(%T): %v", value, err)
+			}
+			switch value.(type) {
+			case PluginShareDiscoverability:
+				var decoded PluginShareDiscoverability
+				if err := json.Unmarshal(encoded, &decoded); err != nil {
+					t.Fatalf("Unmarshal discoverability: %v", err)
+				}
+			case PluginSharePrincipalType:
+				var decoded PluginSharePrincipalType
+				if err := json.Unmarshal(encoded, &decoded); err != nil {
+					t.Fatalf("Unmarshal principal type: %v", err)
+				}
+			case PluginShareTargetRole:
+				var decoded PluginShareTargetRole
+				if err := json.Unmarshal(encoded, &decoded); err != nil {
+					t.Fatalf("Unmarshal target role: %v", err)
+				}
+			}
+		}
+	}
+	for _, input := range []string{`null`, `"listed"`, `"OTHER"`, `1`, `{}`, `[]`, `"LISTED" {}`} {
+		var value PluginShareDiscoverability
+		if err := json.Unmarshal([]byte(input), &value); err == nil {
+			t.Errorf("discoverability Unmarshal(%s) succeeded", input)
+		}
+	}
+	for _, input := range []string{`null`, `"team"`, `"OTHER"`, `1`, `{}`, `[]`, `"user" {}`} {
+		var value PluginSharePrincipalType
+		if err := json.Unmarshal([]byte(input), &value); err == nil {
+			t.Errorf("principal type Unmarshal(%s) succeeded", input)
+		}
+	}
+	for _, input := range []string{`null`, `"owner"`, `"OTHER"`, `1`, `{}`, `[]`, `"reader" {}`} {
+		var value PluginShareTargetRole
+		if err := json.Unmarshal([]byte(input), &value); err == nil {
+			t.Errorf("target role Unmarshal(%s) succeeded", input)
+		}
+	}
+	if _, err := json.Marshal(PluginShareDiscoverability("listed")); err == nil {
+		t.Fatal("invalid discoverability marshaled")
+	}
+	if _, err := json.Marshal(PluginSharePrincipalType("team")); err == nil {
+		t.Fatal("invalid principal type marshaled")
+	}
+	if _, err := json.Marshal(PluginShareTargetRole("owner")); err == nil {
+		t.Fatal("invalid target role marshaled")
+	}
+	var discoverability *PluginShareDiscoverability
+	if err := discoverability.UnmarshalJSON([]byte(`"LISTED"`)); err == nil {
+		t.Fatal("nil discoverability receiver succeeded")
+	}
+	var principalType *PluginSharePrincipalType
+	if err := principalType.UnmarshalJSON([]byte(`"user"`)); err == nil {
+		t.Fatal("nil principal-type receiver succeeded")
+	}
+	var role *PluginShareTargetRole
+	if err := role.UnmarshalJSON([]byte(`"reader"`)); err == nil {
+		t.Fatal("nil target-role receiver succeeded")
+	}
+}
+
+func TestPluginShareTargetPreservesSerdeWireForms(t *testing.T) {
+	for _, tc := range []struct{ input, want string }{
+		{`{"principalType":"user","principalId":" user ","role":"reader","future":true}`, `{"principalType":"user","principalId":" user ","role":"reader"}`},
+		{`{"principalType":"workspace","principalId":"","role":"editor"}`, `{"principalType":"workspace","principalId":"","role":"editor"}`},
+	} {
+		var target PluginShareTarget
+		if err := json.Unmarshal([]byte(tc.input), &target); err != nil {
+			t.Fatalf("Unmarshal(%s): %v", tc.input, err)
+		}
+		encoded, err := json.Marshal(target)
+		if err != nil || string(encoded) != tc.want {
+			t.Fatalf("round trip %s = %s, %v; want %s", tc.input, encoded, err, tc.want)
+		}
+	}
+}
+
+func TestPluginShareSaveParamsPreserveSerdeWireForms(t *testing.T) {
+	for _, tc := range []struct{ input, want string }{
+		{`{"pluginPath":"/plugins/example","future":true}`, `{"pluginPath":"/plugins/example","remotePluginId":null,"discoverability":null,"shareTargets":null}`},
+		{`{"pluginPath":"/plugins/example","remotePluginId":" remote ","discoverability":"PRIVATE","shareTargets":[{"principalType":"group","principalId":" group ","role":"editor"}]}`, `{"pluginPath":"/plugins/example","remotePluginId":" remote ","discoverability":"PRIVATE","shareTargets":[{"principalType":"group","principalId":" group ","role":"editor"}]}`},
+	} {
+		var value PluginShareSaveParams
+		if err := json.Unmarshal([]byte(tc.input), &value); err != nil {
+			t.Fatalf("Unmarshal(%s): %v", tc.input, err)
+		}
+		encoded, err := json.Marshal(value)
+		if err != nil || string(encoded) != tc.want {
+			t.Fatalf("round trip %s = %s, %v; want %s", tc.input, encoded, err, tc.want)
+		}
+	}
+}
+
+func TestPluginShareSaveRejectsMalformedWireForms(t *testing.T) {
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{}`,
+		`{"principalType":null,"principalId":"id","role":"reader"}`,
+		`{"principalType":"user","role":"reader"}`,
+		`{"principalType":"user","principalId":"id","role":"owner"}`,
+		`{"principalType":"user","principalId":"id","role":"reader","role":"editor"}`,
+	} {
+		assertJSONRejects[PluginShareTarget](t, input)
+	}
+	for _, input := range []string{
+		``, `null`, `[]`, `"value"`, `1`, `true`, `{}`,
+		`{"pluginPath":null}`, `{"pluginPath":"relative"}`, `{"remotePluginId":1,"pluginPath":"/plugins/example"}`,
+		`{"discoverability":"listed","pluginPath":"/plugins/example"}`, `{"shareTargets":{},"pluginPath":"/plugins/example"}`,
+		`{"shareTargets":[null],"pluginPath":"/plugins/example"}`, `{"shareTargets":[{"principalType":"user","principalId":"id","role":"owner"}],"pluginPath":"/plugins/example"}`,
+		`{"pluginPath":"/plugins/example","pluginPath":"/plugins/other"}`, `{"pluginPath":"/plugins/example"} {}`,
+	} {
+		assertJSONRejects[PluginShareSaveParams](t, input)
+	}
+}
+
+func TestPluginShareSaveRemainsStandalone(t *testing.T) {
+	var target *PluginShareTarget
+	if err := target.UnmarshalJSON([]byte(`{"principalType":"user","principalId":"id","role":"reader"}`)); err == nil {
+		t.Fatal("nil target receiver succeeded")
+	}
+	var params *PluginShareSaveParams
+	if err := params.UnmarshalJSON([]byte(`{"pluginPath":"/plugins/example"}`)); err == nil {
+		t.Fatal("nil params receiver succeeded")
+	}
+	for _, binding := range WireTypeBindings() {
+		for _, name := range append(append([]string(nil), binding.Params...), binding.Result...) {
+			switch name {
+			case "PluginShareDiscoverability", "PluginSharePrincipalType", "PluginShareTargetRole", "PluginShareTarget", "PluginShareSaveParams":
+				t.Fatalf("%s unexpectedly bound to %s", name, binding.Method)
+			}
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
+	}
+}
+
+func TestPluginShareSaveTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	for _, want := range []string{
+		`export type PluginShareDiscoverability = "LISTED" | "UNLISTED" | "PRIVATE";`,
+		`export type PluginSharePrincipalType = "user" | "group" | "workspace";`,
+		`export type PluginShareTargetRole = "reader" | "editor";`,
+		`export type PluginShareTarget = { principalType: PluginSharePrincipalType, principalId: string, role: PluginShareTargetRole, };`,
+		`export type PluginShareSaveParams = { pluginPath: AbsolutePathBuf, remotePluginId?: string | null, discoverability?: PluginShareDiscoverability | null, shareTargets?: Array<PluginShareTarget> | null, };`,
+	} {
+		if !strings.Contains(string(generated), want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}

--- a/appserver/protocol/plugin_share_save_types.go
+++ b/appserver/protocol/plugin_share_save_types.go
@@ -1,0 +1,239 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// PluginShareDiscoverability is the exact closed visibility choice for a
+// shared plugin.
+type PluginShareDiscoverability string
+
+const (
+	PluginShareDiscoverabilityListed   PluginShareDiscoverability = "LISTED"
+	PluginShareDiscoverabilityUnlisted PluginShareDiscoverability = "UNLISTED"
+	PluginShareDiscoverabilityPrivate  PluginShareDiscoverability = "PRIVATE"
+)
+
+func (d PluginShareDiscoverability) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(d, "plugin-share discoverability", PluginShareDiscoverability.valid)
+}
+
+func (d *PluginShareDiscoverability) UnmarshalJSON(data []byte) error {
+	return unmarshalThreadTurnLeafEnum(data, d, "plugin-share discoverability", PluginShareDiscoverability.valid)
+}
+
+func (d PluginShareDiscoverability) valid() bool {
+	switch d {
+	case PluginShareDiscoverabilityListed, PluginShareDiscoverabilityUnlisted, PluginShareDiscoverabilityPrivate:
+		return true
+	default:
+		return false
+	}
+}
+
+// PluginSharePrincipalType is the exact closed subject type of a share target.
+type PluginSharePrincipalType string
+
+const (
+	PluginSharePrincipalTypeUser      PluginSharePrincipalType = "user"
+	PluginSharePrincipalTypeGroup     PluginSharePrincipalType = "group"
+	PluginSharePrincipalTypeWorkspace PluginSharePrincipalType = "workspace"
+)
+
+func (t PluginSharePrincipalType) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(t, "plugin-share principal type", PluginSharePrincipalType.valid)
+}
+
+func (t *PluginSharePrincipalType) UnmarshalJSON(data []byte) error {
+	return unmarshalThreadTurnLeafEnum(data, t, "plugin-share principal type", PluginSharePrincipalType.valid)
+}
+
+func (t PluginSharePrincipalType) valid() bool {
+	switch t {
+	case PluginSharePrincipalTypeUser, PluginSharePrincipalTypeGroup, PluginSharePrincipalTypeWorkspace:
+		return true
+	default:
+		return false
+	}
+}
+
+// PluginShareTargetRole is the exact closed access level for a share target.
+type PluginShareTargetRole string
+
+const (
+	PluginShareTargetRoleReader PluginShareTargetRole = "reader"
+	PluginShareTargetRoleEditor PluginShareTargetRole = "editor"
+)
+
+func (r PluginShareTargetRole) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(r, "plugin-share target role", PluginShareTargetRole.valid)
+}
+
+func (r *PluginShareTargetRole) UnmarshalJSON(data []byte) error {
+	return unmarshalThreadTurnLeafEnum(data, r, "plugin-share target role", PluginShareTargetRole.valid)
+}
+
+func (r PluginShareTargetRole) valid() bool {
+	return r == PluginShareTargetRoleReader || r == PluginShareTargetRoleEditor
+}
+
+// PluginShareTarget is the exact standalone principal and access-level pair.
+type PluginShareTarget struct {
+	PrincipalType PluginSharePrincipalType `json:"principalType"`
+	PrincipalID   string                   `json:"principalId"`
+	Role          PluginShareTargetRole    `json:"role"`
+}
+
+func (t PluginShareTarget) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		PrincipalType PluginSharePrincipalType `json:"principalType"`
+		PrincipalID   string                   `json:"principalId"`
+		Role          PluginShareTargetRole    `json:"role"`
+	}{PrincipalType: t.PrincipalType, PrincipalID: t.PrincipalID, Role: t.Role})
+}
+
+func (t *PluginShareTarget) UnmarshalJSON(data []byte) error {
+	if t == nil {
+		return errors.New("decode plugin-share target into nil receiver")
+	}
+	const objectName = "plugin-share target"
+	payload, err := decodeRustSerdeObject(data, objectName, "principalType", "principalId", "role")
+	if err != nil {
+		return err
+	}
+	principalType, err := decodeRequiredThreadItemValue[PluginSharePrincipalType](payload, objectName, "principalType")
+	if err != nil {
+		return err
+	}
+	principalID, err := decodeRequiredThreadItemValue[string](payload, objectName, "principalId")
+	if err != nil {
+		return err
+	}
+	role, err := decodeRequiredThreadItemValue[PluginShareTargetRole](payload, objectName, "role")
+	if err != nil {
+		return err
+	}
+	*t = PluginShareTarget{PrincipalType: principalType, PrincipalID: principalID, Role: role}
+	return nil
+}
+
+// PluginShareSaveParams is the exact standalone source contract for
+// plugin/share/save. It intentionally does not publish or mutate plugins.
+type PluginShareSaveParams struct {
+	PluginPath      AbsolutePathBuf             `json:"pluginPath"`
+	RemotePluginID  *string                     `json:"remotePluginId"`
+	Discoverability *PluginShareDiscoverability `json:"discoverability"`
+	ShareTargets    *[]PluginShareTarget        `json:"shareTargets"`
+}
+
+func (p PluginShareSaveParams) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		PluginPath      AbsolutePathBuf             `json:"pluginPath"`
+		RemotePluginID  *string                     `json:"remotePluginId"`
+		Discoverability *PluginShareDiscoverability `json:"discoverability"`
+		ShareTargets    *[]PluginShareTarget        `json:"shareTargets"`
+	}{
+		PluginPath: p.PluginPath, RemotePluginID: p.RemotePluginID,
+		Discoverability: p.Discoverability, ShareTargets: p.ShareTargets,
+	})
+}
+
+func (p *PluginShareSaveParams) UnmarshalJSON(data []byte) error {
+	if p == nil {
+		return errors.New("decode plugin-share save params into nil receiver")
+	}
+	const objectName = "plugin-share save params"
+	payload, err := decodeRustSerdeObject(data, objectName, "pluginPath", "remotePluginId", "discoverability", "shareTargets")
+	if err != nil {
+		return err
+	}
+	pluginPath, err := decodeRequiredThreadItemValue[AbsolutePathBuf](payload, objectName, "pluginPath")
+	if err != nil {
+		return err
+	}
+	remotePluginID, err := decodeOptionalNullableConfigValue[string](payload, objectName, "remotePluginId")
+	if err != nil {
+		return err
+	}
+	discoverability, err := decodeOptionalNullableConfigValue[PluginShareDiscoverability](payload, objectName, "discoverability")
+	if err != nil {
+		return err
+	}
+	shareTargets, err := decodeOptionalPluginShareTargetArray(payload, objectName, "shareTargets")
+	if err != nil {
+		return err
+	}
+	*p = PluginShareSaveParams{
+		PluginPath: pluginPath, RemotePluginID: remotePluginID,
+		Discoverability: discoverability, ShareTargets: shareTargets,
+	}
+	return nil
+}
+
+func decodeOptionalPluginShareTargetArray(payload map[string]json.RawMessage, objectName, fieldName string) (*[]PluginShareTarget, error) {
+	raw, ok := payload[fieldName]
+	if !ok || isJSONNull(raw) {
+		return nil, nil
+	}
+	var entries []json.RawMessage
+	if err := json.Unmarshal(raw, &entries); err != nil {
+		return nil, fmt.Errorf("decode %s %s: %w", objectName, fieldName, err)
+	}
+	values := make([]PluginShareTarget, len(entries))
+	for index, entry := range entries {
+		if isJSONNull(entry) {
+			return nil, fmt.Errorf("decode %s %s[%d]: cannot be null", objectName, fieldName, index)
+		}
+		if err := json.Unmarshal(entry, &values[index]); err != nil {
+			return nil, fmt.Errorf("decode %s %s[%d]: %w", objectName, fieldName, index, err)
+		}
+	}
+	return &values, nil
+}
+
+func pluginShareDiscoverabilitySchema() Schema {
+	return stringEnumSchema("LISTED", "UNLISTED", "PRIVATE")
+}
+
+func pluginSharePrincipalTypeSchema() Schema {
+	return stringEnumSchema("user", "group", "workspace")
+}
+
+func pluginShareTargetRoleSchema() Schema {
+	return stringEnumSchema("reader", "editor")
+}
+
+func pluginShareTargetSchema() Schema {
+	return Schema{"properties": Schema{
+		"principalId":   Schema{"type": "string"},
+		"principalType": Schema{"$ref": "#/$defs/PluginSharePrincipalType"},
+		"role":          Schema{"$ref": "#/$defs/PluginShareTargetRole"},
+	}, "required": []string{"principalId", "principalType", "role"}, "type": "object"}
+}
+
+func pluginShareSaveParamsSchema() Schema {
+	return Schema{"properties": Schema{
+		"discoverability": Schema{"anyOf": []any{Schema{"$ref": "#/$defs/PluginShareDiscoverability"}, Schema{"type": "null"}}},
+		"pluginPath":      Schema{"$ref": "#/$defs/AbsolutePathBuf"},
+		"remotePluginId":  Schema{"type": []any{"string", "null"}},
+		"shareTargets": Schema{
+			"items": Schema{"$ref": "#/$defs/PluginShareTarget"},
+			"type":  []any{"array", "null"},
+		},
+	}, "required": []string{"pluginPath"}, "type": "object"}
+}
+
+var (
+	_ json.Marshaler   = PluginShareDiscoverability("")
+	_ json.Unmarshaler = (*PluginShareDiscoverability)(nil)
+	_ json.Marshaler   = PluginSharePrincipalType("")
+	_ json.Unmarshaler = (*PluginSharePrincipalType)(nil)
+	_ json.Marshaler   = PluginShareTargetRole("")
+	_ json.Unmarshaler = (*PluginShareTargetRole)(nil)
+	_ json.Marshaler   = PluginShareTarget{}
+	_ json.Unmarshaler = (*PluginShareTarget)(nil)
+	_ json.Marshaler   = PluginShareSaveParams{}
+	_ json.Unmarshaler = (*PluginShareSaveParams)(nil)
+)

--- a/appserver/protocol/plugin_skill_read_params_contract_test.go
+++ b/appserver/protocol/plugin_skill_read_params_contract_test.go
@@ -59,8 +59,8 @@ func TestPluginSkillReadParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 }
 

--- a/appserver/protocol/plugin_uninstall_params_contract_test.go
+++ b/appserver/protocol/plugin_uninstall_params_contract_test.go
@@ -51,8 +51,8 @@ func TestPluginUninstallParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 }
 

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/process_contracts_contract_test.go
+++ b/appserver/protocol/process_contracts_contract_test.go
@@ -308,8 +308,8 @@ func TestProcessContractsRemainStandaloneFromLegacyRuntime(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want unchanged implemented notification", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 635 {
-		t.Fatalf("definition count = %d, want 635", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 640 {
+		t.Fatalf("definition count = %d, want 640", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 635 {
-		t.Fatalf("definition count = %d, want 635", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 640 {
+		t.Fatalf("definition count = %d, want 640", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 635 {
-		t.Fatalf("definition count = %d, want 635", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 640 {
+		t.Fatalf("definition count = %d, want 640", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 635 {
-		t.Fatalf("definition count = %d, want 635", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 640 {
+		t.Fatalf("definition count = %d, want 640", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 635 {
-		t.Fatalf("definition count = %d, want 635", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 640 {
+		t.Fatalf("definition count = %d, want 640", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/review_decision_contract_test.go
+++ b/appserver/protocol/review_decision_contract_test.go
@@ -136,8 +136,8 @@ func TestReviewDecisionRemainsStandalone(t *testing.T) {
 			t.Fatalf("ReviewDecision unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(defs); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/review_start_contract_test.go
+++ b/appserver/protocol/review_start_contract_test.go
@@ -215,8 +215,8 @@ func TestReviewStartContractsFailClosedAndRemainStandalone(t *testing.T) {
 	if !ok || request.Surface != SurfaceClientRequest || request.State != MethodBlocked {
 		t.Fatalf("review/start = %#v, %v; want blocked client request", request, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 }
 

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -408,6 +408,11 @@ func wireSchemaDefinitions() Schema {
 		{Name: "PluginShareCheckoutParams", Type: reflect.TypeFor[PluginShareCheckoutParams]()},
 		{Name: "PluginShareDeleteParams", Type: reflect.TypeFor[PluginShareDeleteParams]()},
 		{Name: "PluginShareListParams", Type: reflect.TypeFor[PluginShareListParams]()},
+		{Name: "PluginShareDiscoverability", Type: reflect.TypeFor[PluginShareDiscoverability]()},
+		{Name: "PluginSharePrincipalType", Type: reflect.TypeFor[PluginSharePrincipalType]()},
+		{Name: "PluginShareTargetRole", Type: reflect.TypeFor[PluginShareTargetRole]()},
+		{Name: "PluginShareTarget", Type: reflect.TypeFor[PluginShareTarget]()},
+		{Name: "PluginShareSaveParams", Type: reflect.TypeFor[PluginShareSaveParams]()},
 		{Name: "PluginListMarketplaceKind", Type: reflect.TypeFor[PluginListMarketplaceKind]()},
 		{Name: "PluginListParams", Type: reflect.TypeFor[PluginListParams]()},
 		{Name: "PluginReadParams", Type: reflect.TypeFor[PluginReadParams]()},
@@ -1055,6 +1060,11 @@ func wireSchemaDefinitions() Schema {
 	schemas["PluginShareCheckoutParams"] = pluginShareCheckoutParamSchema()
 	schemas["PluginShareDeleteParams"] = pluginShareDeleteParamSchema()
 	schemas["PluginShareListParams"] = pluginShareListParamSchema()
+	schemas["PluginShareDiscoverability"] = pluginShareDiscoverabilitySchema()
+	schemas["PluginSharePrincipalType"] = pluginSharePrincipalTypeSchema()
+	schemas["PluginShareTargetRole"] = pluginShareTargetRoleSchema()
+	schemas["PluginShareTarget"] = pluginShareTargetSchema()
+	schemas["PluginShareSaveParams"] = pluginShareSaveParamsSchema()
 	schemas["PluginListMarketplaceKind"] = pluginListMarketplaceKindSchema()
 	schemas["PluginListParams"] = pluginListParamSchema()
 	schemas["PluginReadParams"] = pluginReadParamSchema()

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -12336,8 +12336,86 @@
       ],
       "type": "object"
     },
+    "PluginShareDiscoverability": {
+      "enum": [
+        "LISTED",
+        "UNLISTED",
+        "PRIVATE"
+      ],
+      "type": "string"
+    },
     "PluginShareListParams": {
       "type": "object"
+    },
+    "PluginSharePrincipalType": {
+      "enum": [
+        "user",
+        "group",
+        "workspace"
+      ],
+      "type": "string"
+    },
+    "PluginShareSaveParams": {
+      "properties": {
+        "discoverability": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PluginShareDiscoverability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pluginPath": {
+          "$ref": "#/$defs/AbsolutePathBuf"
+        },
+        "remotePluginId": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "shareTargets": {
+          "items": {
+            "$ref": "#/$defs/PluginShareTarget"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "pluginPath"
+      ],
+      "type": "object"
+    },
+    "PluginShareTarget": {
+      "properties": {
+        "principalId": {
+          "type": "string"
+        },
+        "principalType": {
+          "$ref": "#/$defs/PluginSharePrincipalType"
+        },
+        "role": {
+          "$ref": "#/$defs/PluginShareTargetRole"
+        }
+      },
+      "required": [
+        "principalId",
+        "principalType",
+        "role"
+      ],
+      "type": "object"
+    },
+    "PluginShareTargetRole": {
+      "enum": [
+        "reader",
+        "editor"
+      ],
+      "type": "string"
     },
     "PluginSkillReadParams": {
       "properties": {

--- a/appserver/protocol/server_request_approval_params_contract_test.go
+++ b/appserver/protocol/server_request_approval_params_contract_test.go
@@ -163,8 +163,8 @@ func TestServerRequestApprovalParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(defs); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(defs); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/server_request_contract_test.go
+++ b/appserver/protocol/server_request_contract_test.go
@@ -53,8 +53,8 @@ func TestServerRequestSchemaAndBindingAreExact(t *testing.T) {
 			}
 		}
 	}
-	if got := len(defs); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(defs); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	typescript, err := MarshalTypeScript()
 	if err != nil {

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/skills_config_write_params_contract_test.go
+++ b/appserver/protocol/skills_config_write_params_contract_test.go
@@ -64,8 +64,8 @@ func TestSkillsConfigWriteParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 }
 

--- a/appserver/protocol/skills_extra_roots_set_params_contract_test.go
+++ b/appserver/protocol/skills_extra_roots_set_params_contract_test.go
@@ -60,8 +60,8 @@ func TestSkillsExtraRootsSetParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 }
 

--- a/appserver/protocol/skills_list_params_contract_test.go
+++ b/appserver/protocol/skills_list_params_contract_test.go
@@ -46,8 +46,8 @@ func TestSkillsListParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 }
 

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/terminal_interaction_notification_contract_test.go
+++ b/appserver/protocol/terminal_interaction_notification_contract_test.go
@@ -72,8 +72,8 @@ func TestTerminalInteractionNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.Surface != SurfaceServerNotification || info.State != MethodBlocked {
 		t.Fatalf("terminal interaction method = %#v, %v; want blocked server notification", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	generated, err := MarshalTypeScript()
 	if err != nil {

--- a/appserver/protocol/thread_approve_guardian_denied_action_contract_test.go
+++ b/appserver/protocol/thread_approve_guardian_denied_action_contract_test.go
@@ -88,8 +88,8 @@ func TestThreadApproveGuardianDeniedActionContractsRemainStandalone(t *testing.T
 	if !ok || info.Surface != SurfaceClientRequest || info.State != MethodDeferredStub {
 		t.Fatalf("guardian denied action method = %#v, %v; want deferred client request", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 }
 

--- a/appserver/protocol/thread_inject_items_contract_test.go
+++ b/appserver/protocol/thread_inject_items_contract_test.go
@@ -96,8 +96,8 @@ func TestThreadInjectItemsContractsFailClosedAndRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 }
 

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 635 {
-		t.Fatalf("definition count = %d, want 635", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 640 {
+		t.Fatalf("definition count = %d, want 640", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -262,8 +262,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_rollback_contract_test.go
+++ b/appserver/protocol/thread_rollback_contract_test.go
@@ -114,8 +114,8 @@ func TestThreadRollbackContractsFailClosedAndRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 }
 

--- a/appserver/protocol/thread_search_result_contract_test.go
+++ b/appserver/protocol/thread_search_result_contract_test.go
@@ -59,8 +59,8 @@ func TestThreadSearchResultFailsClosedAndRemainsStandalone(t *testing.T) {
 			t.Fatalf("ThreadSearchResult unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 }
 

--- a/appserver/protocol/thread_section_params_contract_test.go
+++ b/appserver/protocol/thread_section_params_contract_test.go
@@ -213,8 +213,8 @@ func TestThreadSectionParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 }
 

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -252,8 +252,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 	if !foundRuntimeStart {
 		t.Error("thread/start runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -154,8 +154,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 	if !foundRuntimeStart {
 		t.Error("thread/start runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_settings_contract_test.go
+++ b/appserver/protocol/thread_settings_contract_test.go
@@ -162,8 +162,8 @@ func TestThreadSettingsContractsFailClosedAndRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 }
 

--- a/appserver/protocol/thread_shell_command_contract_test.go
+++ b/appserver/protocol/thread_shell_command_contract_test.go
@@ -95,8 +95,8 @@ func TestThreadShellCommandContractsFailClosedAndRemainStandalone(t *testing.T) 
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 }
 

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 635 {
-		t.Fatalf("definition count = %d, want 635", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 640 {
+		t.Fatalf("definition count = %d, want 640", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 635 {
-		t.Fatalf("definition count = %d, want 635", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 640 {
+		t.Fatalf("definition count = %d, want 640", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_environment_contract_test.go
+++ b/appserver/protocol/turn_environment_contract_test.go
@@ -79,8 +79,8 @@ func TestTurnEnvironmentParamsFailsClosedAndRemainsStandalone(t *testing.T) {
 			t.Fatalf("TurnEnvironmentParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 }
 

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -119,8 +119,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 	if !foundRuntimeBinding {
 		t.Error("turn/interrupt runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -241,8 +241,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 	if !foundRuntimeBinding {
 		t.Error("turn/start runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -164,8 +164,8 @@ func TestTurnSteerContractsAreBoundToLiveRuntime(t *testing.T) {
 	if !found {
 		t.Fatal("turn/steer runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -912,6 +912,10 @@ providerId: string,
 itemTypeResults: Array<ExternalAgentConfigImportHistoryRecordTypeResultParams>, }`}
 		case "PluginShareCheckoutParams":
 			definition = Schema{typeScriptRawTypeKeyword: `{ remotePluginId: string, }`}
+		case "PluginShareTarget":
+			definition = Schema{typeScriptRawTypeKeyword: `{ principalType: PluginSharePrincipalType, principalId: string, role: PluginShareTargetRole, }`}
+		case "PluginShareSaveParams":
+			definition = Schema{typeScriptRawTypeKeyword: `{ pluginPath: AbsolutePathBuf, remotePluginId?: string | null, discoverability?: PluginShareDiscoverability | null, shareTargets?: Array<PluginShareTarget> | null, }`}
 		case "PluginShareDeleteParams":
 			definition = Schema{typeScriptRawTypeKeyword: `{ remotePluginId: string, }`}
 		case "PluginReadParams":

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -3004,7 +3004,17 @@ export type PluginShareCheckoutParams = { remotePluginId: string, };
 
 export type PluginShareDeleteParams = { remotePluginId: string, };
 
+export type PluginShareDiscoverability = "LISTED" | "UNLISTED" | "PRIVATE";
+
 export type PluginShareListParams = Record<string, never>;
+
+export type PluginSharePrincipalType = "user" | "group" | "workspace";
+
+export type PluginShareSaveParams = { pluginPath: AbsolutePathBuf, remotePluginId?: string | null, discoverability?: PluginShareDiscoverability | null, shareTargets?: Array<PluginShareTarget> | null, };
+
+export type PluginShareTarget = { principalType: PluginSharePrincipalType, principalId: string, role: PluginShareTargetRole, };
+
+export type PluginShareTargetRole = "reader" | "editor";
 
 export type PluginSkillReadParams = { remoteMarketplaceName: string, remotePluginId: string, skillName: string, };
 

--- a/appserver/protocol/w3c_trace_context_contract_test.go
+++ b/appserver/protocol/w3c_trace_context_contract_test.go
@@ -55,8 +55,8 @@ func TestW3cTraceContextRemainsStandalone(t *testing.T) {
 			t.Fatalf("W3cTraceContext unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 }
 

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/windows_sandbox_setup_start_params_contract_test.go
+++ b/appserver/protocol/windows_sandbox_setup_start_params_contract_test.go
@@ -61,8 +61,8 @@ func TestWindowsSandboxSetupStartParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 }
 

--- a/appserver/protocol/workspace_messages_contract_test.go
+++ b/appserver/protocol/workspace_messages_contract_test.go
@@ -209,8 +209,8 @@ func TestWorkspaceMessageContractsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/workspaceMessages/read = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 635 {
-		t.Fatalf("definition count = %d, want 635", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 640 {
+		t.Fatalf("definition count = %d, want 640", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))


### PR DESCRIPTION
Adds exact standalone current-v2 PluginShareSaveParams parity and its shared plugin-share target definitions.\n\n- Covers discoverability, principal type, target role, strict target records, and optional nullable save selectors.\n- Preserves strict closed enums, unknown-field discard, duplicate-known-field rejection, and null-target rejection.\n- Registers exact schema and generated TypeScript without a live plugin/share/save binding.\n- Updates global schema-definition assertions from 635 to 640.\n\nValidated with focused/protocol/race/non-Monty tests, vet, generation, tidy, lint, and the normal pre-push gate.