### PR TITLE
feat(protocol): add operational notification contracts

### DIFF
--- a/appserver/protocol/account_credit_nudge_values_contract_test.go
+++ b/appserver/protocol/account_credit_nudge_values_contract_test.go
@@ -119,8 +119,8 @@ func TestAccountCreditNudgeValuesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/sendAddCreditsNudgeEmail = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/account_envelope_contract_test.go
+++ b/appserver/protocol/account_envelope_contract_test.go
@@ -305,8 +305,8 @@ func TestAccountEnvelopeContractsRemainStandaloneAndDeferred(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred %s", methodName, method, ok, surface)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/account_login_completed_notification_contract_test.go
+++ b/appserver/protocol/account_login_completed_notification_contract_test.go
@@ -88,8 +88,8 @@ func TestAccountLoginCompletedNotificationRemainsStandaloneAndDeferred(t *testin
 	if !found {
 		t.Fatal("account/login/completed method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/account_rate_limits_contract_test.go
+++ b/appserver/protocol/account_rate_limits_contract_test.go
@@ -484,8 +484,8 @@ func TestAccountRateLimitContractsRemainStandaloneAndDeferred(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred %s", methodName, method, ok, surface)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/account_token_usage_contract_test.go
+++ b/appserver/protocol/account_token_usage_contract_test.go
@@ -146,8 +146,8 @@ func TestAccountTokenUsageRecordsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/usage/read = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(defs); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_config_contract_test.go
+++ b/appserver/protocol/app_config_contract_test.go
@@ -109,8 +109,8 @@ func TestAppConfigRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppConfig unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_info_contract_test.go
+++ b/appserver/protocol/app_info_contract_test.go
@@ -131,8 +131,8 @@ func TestAppInfoRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_list_updated_notification_contract_test.go
+++ b/appserver/protocol/app_list_updated_notification_contract_test.go
@@ -105,8 +105,8 @@ func TestAppListUpdatedNotificationRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceServerNotification || method.State != MethodDeferredStub {
 		t.Fatalf("app/list/updated = %#v, %v; want deferred server notification", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_metadata_contract_test.go
+++ b/appserver/protocol/app_metadata_contract_test.go
@@ -107,8 +107,8 @@ func TestAppMetadataRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_metadata_leaf_contract_test.go
+++ b/appserver/protocol/app_metadata_leaf_contract_test.go
@@ -157,8 +157,8 @@ func TestAppMetadataLeavesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_summary_contract_test.go
+++ b/appserver/protocol/app_summary_contract_test.go
@@ -87,8 +87,8 @@ func TestAppSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppSummary unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_template_summary_contract_test.go
+++ b/appserver/protocol/app_template_summary_contract_test.go
@@ -107,8 +107,8 @@ func TestAppTemplateSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppTemplateSummary unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_template_unavailable_reason_contract_test.go
+++ b/appserver/protocol/app_template_unavailable_reason_contract_test.go
@@ -71,8 +71,8 @@ func TestAppTemplateUnavailableReasonRemainsStandalone(t *testing.T) {
 			t.Fatalf("AppTemplateUnavailableReason unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_tool_approval_contract_test.go
+++ b/appserver/protocol/app_tool_approval_contract_test.go
@@ -73,8 +73,8 @@ func TestAppToolApprovalRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppToolApproval unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_tools_config_contract_test.go
+++ b/appserver/protocol/app_tools_config_contract_test.go
@@ -140,8 +140,8 @@ func TestAppToolConfigsRemainStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/apply_patch_approval_params_contract_test.go
+++ b/appserver/protocol/apply_patch_approval_params_contract_test.go
@@ -139,8 +139,8 @@ func TestApplyPatchApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ApplyPatchApprovalParams unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(defs); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(defs); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/apps_config_contract_test.go
+++ b/appserver/protocol/apps_config_contract_test.go
@@ -185,8 +185,8 @@ func TestAppsConfigsRemainStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/apps_discovery_params_contract_test.go
+++ b/appserver/protocol/apps_discovery_params_contract_test.go
@@ -87,8 +87,8 @@ func TestAppsDiscoveryParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 }
 

--- a/appserver/protocol/apps_list_contract_test.go
+++ b/appserver/protocol/apps_list_contract_test.go
@@ -168,8 +168,8 @@ func TestAppsListContractsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/attestation_contract_test.go
+++ b/appserver/protocol/attestation_contract_test.go
@@ -134,8 +134,8 @@ func TestAttestationContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("attestation/generate = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
+++ b/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
@@ -194,8 +194,8 @@ func TestChatgptAuthTokensRefreshRemainsStandaloneAndDeferred(t *testing.T) {
 	if !found {
 		t.Fatal("refresh method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/client_notification_contract_test.go
+++ b/appserver/protocol/client_notification_contract_test.go
@@ -58,8 +58,8 @@ func TestClientNotificationRemainsStandaloneFromInitializedBinding(t *testing.T)
 	if !ok || info.Surface != SurfaceClientNotification || info.State != MethodImplemented {
 		t.Fatalf("initialized method = %#v, %v; want implemented client notification", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 }
 

--- a/appserver/protocol/collaboration_capability_contract_test.go
+++ b/appserver/protocol/collaboration_capability_contract_test.go
@@ -346,8 +346,8 @@ func TestCollaborationCapabilityContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/command_exec_contract_test.go
+++ b/appserver/protocol/command_exec_contract_test.go
@@ -79,8 +79,8 @@ func TestCommandExecContractsFailClosedAndRemainStandalone(t *testing.T) {
 			t.Fatalf("public command-exec contract unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 }
 

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/conversation_text_role_contract_test.go
+++ b/appserver/protocol/conversation_text_role_contract_test.go
@@ -42,7 +42,7 @@ func TestConversationTextRoleContractIsExact(t *testing.T) {
 			t.Fatalf("standalone conversation role unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(definitions); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(definitions); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 }

--- a/appserver/protocol/dynamic_tool_spec_contract_test.go
+++ b/appserver/protocol/dynamic_tool_spec_contract_test.go
@@ -318,8 +318,8 @@ func TestDynamicToolSpecContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/exec_command_approval_params_contract_test.go
+++ b/appserver/protocol/exec_command_approval_params_contract_test.go
@@ -137,8 +137,8 @@ func TestExecCommandApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ExecCommandApprovalParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(defs); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/experimental_feature_contract_test.go
+++ b/appserver/protocol/experimental_feature_contract_test.go
@@ -41,8 +41,8 @@ func TestExperimentalFeatureContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want implemented client request", methodName, method, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d/%d/%d, want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,8 +217,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,8 +203,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -260,8 +260,8 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_import_history_record_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_record_contract_test.go
@@ -122,8 +122,8 @@ func TestExternalAgentConfigImportHistoryRecordRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 }
 

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,8 +244,8 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -162,8 +162,8 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -175,8 +175,8 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/feedback_upload_params_contract_test.go
+++ b/appserver/protocol/feedback_upload_params_contract_test.go
@@ -70,8 +70,8 @@ func TestFeedbackUploadParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 }
 

--- a/appserver/protocol/file_change_contract_test.go
+++ b/appserver/protocol/file_change_contract_test.go
@@ -108,8 +108,8 @@ func TestFileChangeRemainsStandalone(t *testing.T) {
 			t.Fatalf("FileChange unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/file_change_output_delta_notification_contract_test.go
+++ b/appserver/protocol/file_change_output_delta_notification_contract_test.go
@@ -100,8 +100,8 @@ func TestFileChangeOutputDeltaNotificationRemainsDeprecatedAndStandalone(t *test
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("item/fileChange/outputDelta = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -381,8 +381,8 @@ func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/guardian_approval_review_action_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_action_contract_test.go
@@ -226,8 +226,8 @@ func TestGuardianApprovalReviewActionRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReviewAction unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
@@ -164,8 +164,8 @@ func TestGuardianApprovalReviewCompletedNotificationRemainsStandalone(t *testing
 			t.Fatalf("completed notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/guardian_approval_review_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_contract_test.go
@@ -139,8 +139,8 @@ func TestGuardianApprovalReviewRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReview unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
@@ -175,8 +175,8 @@ func TestGuardianApprovalReviewStartedNotificationRemainsStandalone(t *testing.T
 			t.Fatalf("started notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/guardian_enum_foundation_contract_test.go
+++ b/appserver/protocol/guardian_enum_foundation_contract_test.go
@@ -89,8 +89,8 @@ func TestGuardianEnumFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/hook_metadata_list_contract_test.go
+++ b/appserver/protocol/hook_metadata_list_contract_test.go
@@ -352,8 +352,8 @@ func TestHookMetadataListContractsStayStandalone(t *testing.T) {
 			t.Errorf("standalone definition %s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Errorf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Errorf("definition count = %d, want 651", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 {
 		t.Errorf("wire binding count = %d, want 80", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/hook_run_notification_contract_test.go
+++ b/appserver/protocol/hook_run_notification_contract_test.go
@@ -297,8 +297,8 @@ func TestHookRunNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("surface changed: %d methods, %d wire bindings, %d item bindings", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/hook_value_foundation_contract_test.go
+++ b/appserver/protocol/hook_value_foundation_contract_test.go
@@ -167,8 +167,8 @@ func TestHookValueFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 643 {
-		t.Fatalf("definition count = %d, want 643", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 651 {
+		t.Fatalf("definition count = %d, want 651", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/jsonrpc_envelope_contract_test.go
+++ b/appserver/protocol/jsonrpc_envelope_contract_test.go
@@ -87,8 +87,8 @@ func TestJSONRPCEnvelopesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 }
 

--- a/appserver/protocol/jsonrpc_error_contract_test.go
+++ b/appserver/protocol/jsonrpc_error_contract_test.go
@@ -67,8 +67,8 @@ func TestJSONRPCErrorsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 }
 

--- a/appserver/protocol/jsonrpc_message_contract_test.go
+++ b/appserver/protocol/jsonrpc_message_contract_test.go
@@ -74,8 +74,8 @@ func TestJSONRPCMessageRemainsStandalone(t *testing.T) {
 			t.Fatalf("JSONRPCMessage unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 }
 

--- a/appserver/protocol/legacy_approval_response_contract_test.go
+++ b/appserver/protocol/legacy_approval_response_contract_test.go
@@ -98,8 +98,8 @@ func TestLegacyApprovalResponsesRemainStandaloneAndNominal(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/marketplace_add_params_contract_test.go
+++ b/appserver/protocol/marketplace_add_params_contract_test.go
@@ -69,8 +69,8 @@ func TestMarketplaceAddParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 }
 

--- a/appserver/protocol/marketplace_remove_params_contract_test.go
+++ b/appserver/protocol/marketplace_remove_params_contract_test.go
@@ -52,8 +52,8 @@ func TestMarketplaceRemoveParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 }
 

--- a/appserver/protocol/marketplace_upgrade_params_contract_test.go
+++ b/appserver/protocol/marketplace_upgrade_params_contract_test.go
@@ -49,8 +49,8 @@ func TestMarketplaceUpgradeParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 }
 

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_oauth_login_contract_test.go
+++ b/appserver/protocol/mcp_server_oauth_login_contract_test.go
@@ -228,8 +228,8 @@ func TestMcpServerOauthLoginContractsRemainStandaloneAndBlocked(t *testing.T) {
 	if !ok || notification.Surface != SurfaceServerNotification || notification.State != MethodBlocked {
 		t.Fatalf("mcpServer/oauthLogin/completed = %#v, %v; want blocked server notification", notification, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d/%d/%d, want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_status_contract_test.go
+++ b/appserver/protocol/mcp_server_status_contract_test.go
@@ -277,8 +277,8 @@ func TestMcpServerStatusContractsRemainStandalone(t *testing.T) {
 	if !ok || method.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d/%d/%d, want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_approval_context_contract_test.go
+++ b/appserver/protocol/network_approval_context_contract_test.go
@@ -84,8 +84,8 @@ func TestNetworkApprovalContextRemainsStandalone(t *testing.T) {
 			t.Fatalf("NetworkApprovalContext unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/operational_notification_leaves_contract_test.go
+++ b/appserver/protocol/operational_notification_leaves_contract_test.go
@@ -1,0 +1,237 @@
+package protocol
+
+import (
+	"encoding/json"
+	"math"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestOperationalNotificationLeafSchemasAreExact(t *testing.T) {
+	object := func(title string, properties Schema, required ...string) Schema {
+		out := Schema{"$schema": "http://json-schema.org/draft-07/schema#", "properties": properties, "title": title, "type": "object"}
+		if len(required) != 0 {
+			out["required"] = required
+		}
+		return out
+	}
+	want := map[string]Schema{
+		"EnvironmentConnectionNotification": object("EnvironmentConnectionNotification", Schema{
+			"environmentId": Schema{"type": "string"}, "threadId": Schema{"type": "string"},
+		}, "environmentId", "threadId"),
+		"RemoteControlConnectionStatus": stringEnumSchema("disabled", "connecting", "connected", "errored"),
+		"RemoteControlStatusChangedNotification": {
+			"$schema":     "http://json-schema.org/draft-07/schema#",
+			"description": "Current remote-control connection status and remote identity exposed to clients.",
+			"properties": Schema{
+				"environmentId":  Schema{"type": []any{"string", "null"}},
+				"installationId": Schema{"type": "string"},
+				"serverName":     Schema{"type": "string"},
+				"status":         Schema{"$ref": "#/$defs/RemoteControlConnectionStatus"},
+			},
+			"required": []string{"installationId", "serverName", "status"},
+			"title":    "RemoteControlStatusChangedNotification",
+			"type":     "object",
+		},
+		"SkillsChangedNotification": {
+			"$schema": "http://json-schema.org/draft-07/schema#",
+			"description": "Notification emitted when watched local skill files change.\n\n" +
+				"Treat this as an invalidation signal and re-run `skills/list` with the client's current parameters when refreshed skill metadata is needed.",
+			"title": "SkillsChangedNotification",
+			"type":  "object",
+		},
+		"ThreadQueueChangedNotification": object("ThreadQueueChangedNotification", Schema{"threadId": Schema{"type": "string"}}, "threadId"),
+		"ThreadRevertedNotification":     object("ThreadRevertedNotification", Schema{"threadId": Schema{"type": "string"}}, "threadId"),
+		"WindowsSandboxSetupCompletedNotification": object("WindowsSandboxSetupCompletedNotification", Schema{
+			"error": Schema{"type": []any{"string", "null"}}, "mode": Schema{"$ref": "#/$defs/WindowsSandboxSetupMode"}, "success": Schema{"type": "boolean"},
+		}, "mode", "success"),
+		"WindowsWorldWritableWarningNotification": object("WindowsWorldWritableWarningNotification", Schema{
+			"extraCount":  Schema{"format": "uint", "minimum": 0, "type": "integer"},
+			"failedScan":  Schema{"type": "boolean"},
+			"samplePaths": Schema{"items": Schema{"type": "string"}, "type": "array"},
+		}, "extraCount", "failedScan", "samplePaths"),
+	}
+	definitions := JSONSchema()["$defs"].(Schema)
+	for name, expected := range want {
+		if got := definitions[name]; !reflect.DeepEqual(got, expected) {
+			t.Errorf("%s = %#v, want %#v", name, got, expected)
+		}
+	}
+}
+
+func TestOperationalNotificationLeavesPreserveSerdeWireForms(t *testing.T) {
+	fixtures := []struct {
+		name  string
+		input string
+		want  string
+		value func() any
+	}{
+		{"environment", `{"future":1,"threadId":"thread","environmentId":"environment"}`, `{"threadId":"thread","environmentId":"environment"}`, func() any { return new(EnvironmentConnectionNotification) }},
+		{"skills empty", `{"future":1,"future":2}`, `{}`, func() any { return new(SkillsChangedNotification) }},
+		{"queue", `{"future":1,"threadId":"thread"}`, `{"threadId":"thread"}`, func() any { return new(ThreadQueueChangedNotification) }},
+		{"reverted", `{"future":1,"threadId":"thread"}`, `{"threadId":"thread"}`, func() any { return new(ThreadRevertedNotification) }},
+		{"remote absent environment", `{"future":1,"status":"connected","serverName":"server","installationId":"install"}`, `{"status":"connected","serverName":"server","installationId":"install","environmentId":null}`, func() any { return new(RemoteControlStatusChangedNotification) }},
+		{"remote environment", `{"status":"errored","serverName":"","installationId":"","environmentId":"environment"}`, `{"status":"errored","serverName":"","installationId":"","environmentId":"environment"}`, func() any { return new(RemoteControlStatusChangedNotification) }},
+		{"windows setup absent error", `{"future":1,"mode":"elevated","success":false}`, `{"mode":"elevated","success":false,"error":null}`, func() any { return new(WindowsSandboxSetupCompletedNotification) }},
+		{"windows setup error", `{"mode":"unelevated","success":true,"error":"message"}`, `{"mode":"unelevated","success":true,"error":"message"}`, func() any { return new(WindowsSandboxSetupCompletedNotification) }},
+		{"world writable", `{"future":1,"samplePaths":["","path"],"extraCount":18446744073709551615,"failedScan":true}`, `{"samplePaths":["","path"],"extraCount":18446744073709551615,"failedScan":true}`, func() any { return new(WindowsWorldWritableWarningNotification) }},
+	}
+	for _, fixture := range fixtures {
+		t.Run(fixture.name, func(t *testing.T) {
+			value := fixture.value()
+			if err := json.Unmarshal([]byte(fixture.input), value); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			encoded, err := json.Marshal(value)
+			if err != nil || string(encoded) != fixture.want {
+				t.Fatalf("round trip = %s, %v; want %s", encoded, err, fixture.want)
+			}
+		})
+	}
+
+	for _, value := range []RemoteControlConnectionStatus{
+		RemoteControlConnectionStatusDisabled,
+		RemoteControlConnectionStatusConnecting,
+		RemoteControlConnectionStatusConnected,
+		RemoteControlConnectionStatusErrored,
+	} {
+		encoded, err := json.Marshal(value)
+		if err != nil || string(encoded) != `"`+string(value)+`"` {
+			t.Errorf("remote status %q = %s, %v", value, encoded, err)
+		}
+	}
+	var warning WindowsWorldWritableWarningNotification
+	if encoded, err := json.Marshal(warning); err != nil || string(encoded) != `{"samplePaths":[],"extraCount":0,"failedScan":false}` {
+		t.Fatalf("zero world writable warning = %s, %v", encoded, err)
+	}
+	if uint64(math.MaxUint64) != ^uint64(0) {
+		t.Fatal("unexpected uint64 maximum")
+	}
+}
+
+func TestOperationalNotificationLeavesRejectMalformedWireForms(t *testing.T) {
+	assertOperationalLeafRejects[EnvironmentConnectionNotification](t,
+		``, `null`, `[]`, `{}`, `{"threadId":null,"environmentId":"environment"}`,
+		`{"threadId":"thread","environmentId":1}`, `{"threadId":"one","threadId":"two","environmentId":"environment"}`, `{} {}`)
+	assertOperationalLeafRejects[SkillsChangedNotification](t, ``, `null`, `[]`, `"value"`, `{`, `{} {}`, `{} x`)
+	assertOperationalLeafRejects[ThreadQueueChangedNotification](t,
+		``, `null`, `[]`, `{}`, `{"threadId":null}`, `{"threadId":1}`, `{"threadId":"one","threadId":"two"}`, `{} {}`)
+	assertOperationalLeafRejects[ThreadRevertedNotification](t,
+		``, `null`, `[]`, `{}`, `{"threadId":null}`, `{"threadId":1}`, `{"threadId":"one","threadId":"two"}`, `{} {}`)
+	assertOperationalLeafRejects[RemoteControlStatusChangedNotification](t,
+		``, `null`, `[]`, `{}`, `{"status":"connected","serverName":"server"}`,
+		`{"status":"future","serverName":"server","installationId":"install"}`,
+		`{"status":null,"serverName":"server","installationId":"install"}`,
+		`{"status":"connected","serverName":"server","installationId":"install","environmentId":1}`,
+		`{"status":"connected","status":"errored","serverName":"server","installationId":"install"}`, `{} {}`)
+	assertOperationalLeafRejects[WindowsSandboxSetupCompletedNotification](t,
+		``, `null`, `[]`, `{}`, `{"success":true}`, `{"mode":"elevated"}`,
+		`{"mode":"future","success":true}`, `{"mode":"elevated","success":null}`,
+		`{"mode":"elevated","success":true,"error":false}`,
+		`{"mode":"elevated","mode":"unelevated","success":true}`, `{} {}`)
+	assertOperationalLeafRejects[WindowsWorldWritableWarningNotification](t,
+		``, `null`, `[]`, `{}`, `{"samplePaths":[],"extraCount":0}`,
+		`{"samplePaths":null,"extraCount":0,"failedScan":false}`,
+		`{"samplePaths":[null],"extraCount":0,"failedScan":false}`,
+		`{"samplePaths":[],"extraCount":-1,"failedScan":false}`,
+		`{"samplePaths":[],"extraCount":18446744073709551616,"failedScan":false}`,
+		`{"samplePaths":[],"extraCount":0,"failedScan":0}`,
+		`{"samplePaths":[],"extraCount":0,"extraCount":1,"failedScan":false}`, `{} {}`)
+	assertOperationalLeafRejects[RemoteControlConnectionStatus](t,
+		``, `null`, `[]`, `{}`, `"future"`, `"connected" {}`)
+}
+
+func TestOperationalNotificationLeavesFailClosedAndRemainStandalone(t *testing.T) {
+	checks := map[string]func() error{
+		"environment": func() error { var value *EnvironmentConnectionNotification; return value.UnmarshalJSON([]byte(`{}`)) },
+		"skills":      func() error { var value *SkillsChangedNotification; return value.UnmarshalJSON([]byte(`{}`)) },
+		"queue":       func() error { var value *ThreadQueueChangedNotification; return value.UnmarshalJSON([]byte(`{}`)) },
+		"reverted":    func() error { var value *ThreadRevertedNotification; return value.UnmarshalJSON([]byte(`{}`)) },
+		"remote": func() error {
+			var value *RemoteControlStatusChangedNotification
+			return value.UnmarshalJSON([]byte(`{}`))
+		},
+		"windows setup": func() error {
+			var value *WindowsSandboxSetupCompletedNotification
+			return value.UnmarshalJSON([]byte(`{}`))
+		},
+		"world writable": func() error {
+			var value *WindowsWorldWritableWarningNotification
+			return value.UnmarshalJSON([]byte(`{}`))
+		},
+		"remote status": func() error {
+			var value *RemoteControlConnectionStatus
+			return value.UnmarshalJSON([]byte(`"connected"`))
+		},
+	}
+	for name, check := range checks {
+		if err := check(); err == nil {
+			t.Errorf("nil %s receiver succeeded", name)
+		}
+	}
+
+	names := []string{
+		"EnvironmentConnectionNotification", "SkillsChangedNotification", "ThreadQueueChangedNotification", "ThreadRevertedNotification",
+		"RemoteControlConnectionStatus", "RemoteControlStatusChangedNotification", "WindowsSandboxSetupCompletedNotification", "WindowsWorldWritableWarningNotification",
+	}
+	for _, binding := range WireTypeBindings() {
+		for _, name := range names {
+			if slices.Contains(binding.Params, name) || slices.Contains(binding.Result, name) {
+				t.Fatalf("%s unexpectedly bound to %s", name, binding.Method)
+			}
+		}
+	}
+	for _, binding := range ItemPayloadBindings() {
+		if slices.Contains(names, binding.Type) {
+			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
+		}
+	}
+	for _, methodName := range []string{"skills/changed", "remoteControl/status/changed", "windows/worldWritableWarning", "windowsSandbox/setupCompleted"} {
+		method, ok := LookupMethod(methodName)
+		if !ok || method.Surface != SurfaceServerNotification || method.State != MethodDeferredStub {
+			t.Errorf("%s = %#v, %v; want deferred notification", methodName, method, ok)
+		}
+	}
+	for _, methodName := range []string{"thread/environment/connected", "thread/environment/disconnected", "thread/queue/changed", "thread/reverted"} {
+		if method, ok := LookupMethod(methodName); ok {
+			t.Errorf("%s = %#v; want no experimental method registration", methodName, method)
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
+	}
+	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
+	}
+}
+
+func TestOperationalNotificationLeavesTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	source := string(generated)
+	for _, want := range []string{
+		"export type EnvironmentConnectionNotification = {\n  \"environmentId\": string;\n  \"threadId\": string;\n};",
+		`export type RemoteControlConnectionStatus = "disabled" | "connecting" | "connected" | "errored";`,
+		"export type RemoteControlStatusChangedNotification = {\n  \"environmentId\": string | null;\n  \"installationId\": string;\n  \"serverName\": string;\n  \"status\": RemoteControlConnectionStatus;\n};",
+		`export type SkillsChangedNotification = Record<string, never>;`,
+		"export type ThreadQueueChangedNotification = {\n  \"threadId\": string;\n};",
+		"export type ThreadRevertedNotification = {\n  \"threadId\": string;\n};",
+		"export type WindowsSandboxSetupCompletedNotification = {\n  \"error\": string | null;\n  \"mode\": WindowsSandboxSetupMode;\n  \"success\": boolean;\n};",
+		"export type WindowsWorldWritableWarningNotification = {\n  \"extraCount\": number;\n  \"failedScan\": boolean;\n  \"samplePaths\": Array<string>;\n};",
+	} {
+		if !strings.Contains(source, want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}
+
+func assertOperationalLeafRejects[T any](t *testing.T, inputs ...string) {
+	t.Helper()
+	for _, input := range inputs {
+		assertJSONRejects[T](t, input)
+	}
+}

--- a/appserver/protocol/operational_notification_leaves_types.go
+++ b/appserver/protocol/operational_notification_leaves_types.go
@@ -1,0 +1,337 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// EnvironmentConnectionNotification identifies a thread environment transition.
+type EnvironmentConnectionNotification struct {
+	ThreadID      string `json:"threadId"`
+	EnvironmentID string `json:"environmentId"`
+}
+
+func (n *EnvironmentConnectionNotification) UnmarshalJSON(data []byte) error {
+	if n == nil {
+		return errors.New("decode environment connection notification into nil receiver")
+	}
+	const objectName = "environment connection notification"
+	payload, err := decodeRustSerdeObject(data, objectName, "threadId", "environmentId")
+	if err != nil {
+		return err
+	}
+	threadID, err := decodeRequiredThreadItemValue[string](payload, objectName, "threadId")
+	if err != nil {
+		return err
+	}
+	environmentID, err := decodeRequiredThreadItemValue[string](payload, objectName, "environmentId")
+	if err != nil {
+		return err
+	}
+	*n = EnvironmentConnectionNotification{ThreadID: threadID, EnvironmentID: environmentID}
+	return nil
+}
+
+// SkillsChangedNotification invalidates watched local skill metadata.
+type SkillsChangedNotification struct{}
+
+func (n *SkillsChangedNotification) UnmarshalJSON(data []byte) error {
+	if n == nil {
+		return errors.New("decode skills changed notification into nil receiver")
+	}
+	if _, err := decodeRustSerdeObject(data, "skills changed notification"); err != nil {
+		return err
+	}
+	*n = SkillsChangedNotification{}
+	return nil
+}
+
+// ThreadQueueChangedNotification identifies a thread whose queue changed.
+type ThreadQueueChangedNotification struct {
+	ThreadID string `json:"threadId"`
+}
+
+func (n *ThreadQueueChangedNotification) UnmarshalJSON(data []byte) error {
+	if n == nil {
+		return errors.New("decode thread queue changed notification into nil receiver")
+	}
+	const objectName = "thread queue changed notification"
+	payload, err := decodeRustSerdeObject(data, objectName, "threadId")
+	if err != nil {
+		return err
+	}
+	threadID, err := decodeRequiredThreadItemValue[string](payload, objectName, "threadId")
+	if err != nil {
+		return err
+	}
+	*n = ThreadQueueChangedNotification{ThreadID: threadID}
+	return nil
+}
+
+// ThreadRevertedNotification identifies a thread with reverted history.
+type ThreadRevertedNotification struct {
+	ThreadID string `json:"threadId"`
+}
+
+func (n *ThreadRevertedNotification) UnmarshalJSON(data []byte) error {
+	if n == nil {
+		return errors.New("decode thread reverted notification into nil receiver")
+	}
+	const objectName = "thread reverted notification"
+	payload, err := decodeRustSerdeObject(data, objectName, "threadId")
+	if err != nil {
+		return err
+	}
+	threadID, err := decodeRequiredThreadItemValue[string](payload, objectName, "threadId")
+	if err != nil {
+		return err
+	}
+	*n = ThreadRevertedNotification{ThreadID: threadID}
+	return nil
+}
+
+// RemoteControlConnectionStatus is the exact closed remote-control state.
+type RemoteControlConnectionStatus string
+
+const (
+	RemoteControlConnectionStatusDisabled   RemoteControlConnectionStatus = "disabled"
+	RemoteControlConnectionStatusConnecting RemoteControlConnectionStatus = "connecting"
+	RemoteControlConnectionStatusConnected  RemoteControlConnectionStatus = "connected"
+	RemoteControlConnectionStatusErrored    RemoteControlConnectionStatus = "errored"
+)
+
+func (s RemoteControlConnectionStatus) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(s, "remote control connection status", RemoteControlConnectionStatus.valid)
+}
+
+func (s *RemoteControlConnectionStatus) UnmarshalJSON(data []byte) error {
+	return unmarshalThreadTurnLeafEnum(data, s, "remote control connection status", RemoteControlConnectionStatus.valid)
+}
+
+func (s RemoteControlConnectionStatus) valid() bool {
+	return s == RemoteControlConnectionStatusDisabled ||
+		s == RemoteControlConnectionStatusConnecting ||
+		s == RemoteControlConnectionStatusConnected ||
+		s == RemoteControlConnectionStatusErrored
+}
+
+// RemoteControlStatusChangedNotification reports bounded remote-control state.
+type RemoteControlStatusChangedNotification struct {
+	Status         RemoteControlConnectionStatus `json:"status"`
+	ServerName     string                        `json:"serverName"`
+	InstallationID string                        `json:"installationId"`
+	EnvironmentID  *string                       `json:"environmentId,omitempty"`
+}
+
+func (n RemoteControlStatusChangedNotification) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Status         RemoteControlConnectionStatus `json:"status"`
+		ServerName     string                        `json:"serverName"`
+		InstallationID string                        `json:"installationId"`
+		EnvironmentID  *string                       `json:"environmentId"`
+	}{
+		Status: n.Status, ServerName: n.ServerName, InstallationID: n.InstallationID, EnvironmentID: n.EnvironmentID,
+	})
+}
+
+func (n *RemoteControlStatusChangedNotification) UnmarshalJSON(data []byte) error {
+	if n == nil {
+		return errors.New("decode remote control status changed notification into nil receiver")
+	}
+	const objectName = "remote control status changed notification"
+	payload, err := decodeRustSerdeObject(data, objectName, "status", "serverName", "installationId", "environmentId")
+	if err != nil {
+		return err
+	}
+	status, err := decodeRequiredThreadItemValue[RemoteControlConnectionStatus](payload, objectName, "status")
+	if err != nil {
+		return err
+	}
+	serverName, err := decodeRequiredThreadItemValue[string](payload, objectName, "serverName")
+	if err != nil {
+		return err
+	}
+	installationID, err := decodeRequiredThreadItemValue[string](payload, objectName, "installationId")
+	if err != nil {
+		return err
+	}
+	environmentID, err := decodeOptionalNullableConfigValue[string](payload, objectName, "environmentId")
+	if err != nil {
+		return err
+	}
+	*n = RemoteControlStatusChangedNotification{
+		Status: status, ServerName: serverName, InstallationID: installationID, EnvironmentID: environmentID,
+	}
+	return nil
+}
+
+// WindowsSandboxSetupCompletedNotification reports a Windows sandbox setup result.
+type WindowsSandboxSetupCompletedNotification struct {
+	Mode    WindowsSandboxSetupMode `json:"mode"`
+	Success bool                    `json:"success"`
+	Error   *string                 `json:"error,omitempty"`
+}
+
+func (n WindowsSandboxSetupCompletedNotification) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Mode    WindowsSandboxSetupMode `json:"mode"`
+		Success bool                    `json:"success"`
+		Error   *string                 `json:"error"`
+	}{Mode: n.Mode, Success: n.Success, Error: n.Error})
+}
+
+func (n *WindowsSandboxSetupCompletedNotification) UnmarshalJSON(data []byte) error {
+	if n == nil {
+		return errors.New("decode Windows sandbox setup completed notification into nil receiver")
+	}
+	const objectName = "Windows sandbox setup completed notification"
+	payload, err := decodeRustSerdeObject(data, objectName, "mode", "success", "error")
+	if err != nil {
+		return err
+	}
+	mode, err := decodeRequiredThreadItemValue[WindowsSandboxSetupMode](payload, objectName, "mode")
+	if err != nil {
+		return err
+	}
+	success, err := decodeRequiredThreadItemValue[bool](payload, objectName, "success")
+	if err != nil {
+		return err
+	}
+	message, err := decodeOptionalNullableConfigValue[string](payload, objectName, "error")
+	if err != nil {
+		return err
+	}
+	*n = WindowsSandboxSetupCompletedNotification{Mode: mode, Success: success, Error: message}
+	return nil
+}
+
+// WindowsWorldWritableWarningNotification reports unprotected Windows paths.
+type WindowsWorldWritableWarningNotification struct {
+	SamplePaths []string `json:"samplePaths"`
+	ExtraCount  uint64   `json:"extraCount"`
+	FailedScan  bool     `json:"failedScan"`
+}
+
+func (n WindowsWorldWritableWarningNotification) MarshalJSON() ([]byte, error) {
+	samplePaths := n.SamplePaths
+	if samplePaths == nil {
+		samplePaths = []string{}
+	}
+	return json.Marshal(struct {
+		SamplePaths []string `json:"samplePaths"`
+		ExtraCount  uint64   `json:"extraCount"`
+		FailedScan  bool     `json:"failedScan"`
+	}{SamplePaths: samplePaths, ExtraCount: n.ExtraCount, FailedScan: n.FailedScan})
+}
+
+func (n *WindowsWorldWritableWarningNotification) UnmarshalJSON(data []byte) error {
+	if n == nil {
+		return errors.New("decode Windows world writable warning notification into nil receiver")
+	}
+	const objectName = "Windows world writable warning notification"
+	payload, err := decodeRustSerdeObject(data, objectName, "samplePaths", "extraCount", "failedScan")
+	if err != nil {
+		return err
+	}
+	samplePaths, err := decodeRequiredThreadItemArray[string](payload, objectName, "samplePaths")
+	if err != nil {
+		return err
+	}
+	extraCount, err := decodeRequiredThreadItemValue[uint64](payload, objectName, "extraCount")
+	if err != nil {
+		return err
+	}
+	failedScan, err := decodeRequiredThreadItemValue[bool](payload, objectName, "failedScan")
+	if err != nil {
+		return err
+	}
+	*n = WindowsWorldWritableWarningNotification{
+		SamplePaths: samplePaths, ExtraCount: extraCount, FailedScan: failedScan,
+	}
+	return nil
+}
+
+func operationalNotificationLeafSchemas() map[string]Schema {
+	object := func(title string, properties Schema, required ...string) Schema {
+		out := Schema{"$schema": "http://json-schema.org/draft-07/schema#", "properties": properties, "title": title, "type": "object"}
+		if len(required) != 0 {
+			out["required"] = required
+		}
+		return out
+	}
+	return map[string]Schema{
+		"EnvironmentConnectionNotification": {
+			"$schema": "http://json-schema.org/draft-07/schema#",
+			"properties": Schema{
+				"environmentId": Schema{"type": "string"},
+				"threadId":      Schema{"type": "string"},
+			},
+			"required": []string{"environmentId", "threadId"},
+			"title":    "EnvironmentConnectionNotification",
+			"type":     "object",
+		},
+		"RemoteControlConnectionStatus": stringEnumSchema(
+			string(RemoteControlConnectionStatusDisabled), string(RemoteControlConnectionStatusConnecting),
+			string(RemoteControlConnectionStatusConnected), string(RemoteControlConnectionStatusErrored),
+		),
+		"RemoteControlStatusChangedNotification": {
+			"$schema":     "http://json-schema.org/draft-07/schema#",
+			"description": "Current remote-control connection status and remote identity exposed to clients.",
+			"properties": Schema{
+				"environmentId":  Schema{"type": []any{"string", "null"}},
+				"installationId": Schema{"type": "string"},
+				"serverName":     Schema{"type": "string"},
+				"status":         Schema{"$ref": "#/$defs/RemoteControlConnectionStatus"},
+			},
+			"required": []string{"installationId", "serverName", "status"},
+			"title":    "RemoteControlStatusChangedNotification",
+			"type":     "object",
+		},
+		"SkillsChangedNotification": {
+			"$schema": "http://json-schema.org/draft-07/schema#",
+			"description": "Notification emitted when watched local skill files change.\n\n" +
+				"Treat this as an invalidation signal and re-run `skills/list` with the client's current parameters when refreshed skill metadata is needed.",
+			"title": "SkillsChangedNotification",
+			"type":  "object",
+		},
+		"ThreadQueueChangedNotification": object("ThreadQueueChangedNotification", Schema{"threadId": Schema{"type": "string"}}, "threadId"),
+		"ThreadRevertedNotification":     object("ThreadRevertedNotification", Schema{"threadId": Schema{"type": "string"}}, "threadId"),
+		"WindowsSandboxSetupCompletedNotification": {
+			"$schema": "http://json-schema.org/draft-07/schema#",
+			"properties": Schema{
+				"error":   Schema{"type": []any{"string", "null"}},
+				"mode":    Schema{"$ref": "#/$defs/WindowsSandboxSetupMode"},
+				"success": Schema{"type": "boolean"},
+			},
+			"required": []string{"mode", "success"},
+			"title":    "WindowsSandboxSetupCompletedNotification",
+			"type":     "object",
+		},
+		"WindowsWorldWritableWarningNotification": {
+			"$schema": "http://json-schema.org/draft-07/schema#",
+			"properties": Schema{
+				"extraCount":  Schema{"format": "uint", "minimum": 0, "type": "integer"},
+				"failedScan":  Schema{"type": "boolean"},
+				"samplePaths": Schema{"items": Schema{"type": "string"}, "type": "array"},
+			},
+			"required": []string{"extraCount", "failedScan", "samplePaths"},
+			"title":    "WindowsWorldWritableWarningNotification",
+			"type":     "object",
+		},
+	}
+}
+
+var (
+	_ json.Unmarshaler = (*EnvironmentConnectionNotification)(nil)
+	_ json.Unmarshaler = (*SkillsChangedNotification)(nil)
+	_ json.Unmarshaler = (*ThreadQueueChangedNotification)(nil)
+	_ json.Unmarshaler = (*ThreadRevertedNotification)(nil)
+	_ json.Marshaler   = RemoteControlConnectionStatus("")
+	_ json.Unmarshaler = (*RemoteControlConnectionStatus)(nil)
+	_ json.Marshaler   = RemoteControlStatusChangedNotification{}
+	_ json.Unmarshaler = (*RemoteControlStatusChangedNotification)(nil)
+	_ json.Marshaler   = WindowsSandboxSetupCompletedNotification{}
+	_ json.Unmarshaler = (*WindowsSandboxSetupCompletedNotification)(nil)
+	_ json.Marshaler   = WindowsWorldWritableWarningNotification{}
+	_ json.Unmarshaler = (*WindowsWorldWritableWarningNotification)(nil)
+)

--- a/appserver/protocol/parsed_command_contract_test.go
+++ b/appserver/protocol/parsed_command_contract_test.go
@@ -120,8 +120,8 @@ func TestParsedCommandRemainsStandalone(t *testing.T) {
 			t.Fatalf("ParsedCommand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/permission_profile_list_contract_test.go
+++ b/appserver/protocol/permission_profile_list_contract_test.go
@@ -255,8 +255,8 @@ func TestPermissionProfileListContractsRemainStandalone(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodImplemented {
 		t.Fatalf("permissionProfile/list = %#v, %v; want existing implemented client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d/%d/%d, want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/permissions_request_approval_params_contract_test.go
+++ b/appserver/protocol/permissions_request_approval_params_contract_test.go
@@ -107,8 +107,8 @@ func TestPermissionsRequestApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("PermissionsRequestApprovalParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(defs); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 }
 

--- a/appserver/protocol/plugin_install_params_contract_test.go
+++ b/appserver/protocol/plugin_install_params_contract_test.go
@@ -35,8 +35,8 @@ func TestPluginInstallParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 }
 func TestPluginInstallParamsTypeScriptIsExact(t *testing.T) {

--- a/appserver/protocol/plugin_installed_params_contract_test.go
+++ b/appserver/protocol/plugin_installed_params_contract_test.go
@@ -35,8 +35,8 @@ func TestPluginInstalledParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 }
 func TestPluginInstalledParamsTypeScriptIsExact(t *testing.T) {

--- a/appserver/protocol/plugin_list_params_contract_test.go
+++ b/appserver/protocol/plugin_list_params_contract_test.go
@@ -82,8 +82,8 @@ func TestPluginListParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 }
 

--- a/appserver/protocol/plugin_read_params_contract_test.go
+++ b/appserver/protocol/plugin_read_params_contract_test.go
@@ -39,8 +39,8 @@ func TestPluginReadParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 }
 func TestPluginReadParamsTypeScriptIsExact(t *testing.T) {

--- a/appserver/protocol/plugin_share_checkout_params_contract_test.go
+++ b/appserver/protocol/plugin_share_checkout_params_contract_test.go
@@ -51,8 +51,8 @@ func TestPluginShareCheckoutParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 }
 

--- a/appserver/protocol/plugin_share_delete_params_contract_test.go
+++ b/appserver/protocol/plugin_share_delete_params_contract_test.go
@@ -51,8 +51,8 @@ func TestPluginShareDeleteParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 }
 

--- a/appserver/protocol/plugin_share_list_params_contract_test.go
+++ b/appserver/protocol/plugin_share_list_params_contract_test.go
@@ -40,8 +40,8 @@ func TestPluginShareListParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 }
 

--- a/appserver/protocol/plugin_share_save_contract_test.go
+++ b/appserver/protocol/plugin_share_save_contract_test.go
@@ -163,8 +163,8 @@ func TestPluginShareSaveRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 }
 

--- a/appserver/protocol/plugin_share_update_targets_contract_test.go
+++ b/appserver/protocol/plugin_share_update_targets_contract_test.go
@@ -96,8 +96,8 @@ func TestPluginShareUpdateTargetsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 }
 

--- a/appserver/protocol/plugin_skill_read_params_contract_test.go
+++ b/appserver/protocol/plugin_skill_read_params_contract_test.go
@@ -59,8 +59,8 @@ func TestPluginSkillReadParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 }
 

--- a/appserver/protocol/plugin_uninstall_params_contract_test.go
+++ b/appserver/protocol/plugin_uninstall_params_contract_test.go
@@ -51,8 +51,8 @@ func TestPluginUninstallParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 }
 

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/process_contracts_contract_test.go
+++ b/appserver/protocol/process_contracts_contract_test.go
@@ -308,8 +308,8 @@ func TestProcessContractsRemainStandaloneFromLegacyRuntime(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want unchanged implemented notification", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 643 {
-		t.Fatalf("definition count = %d, want 643", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 651 {
+		t.Fatalf("definition count = %d, want 651", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 643 {
-		t.Fatalf("definition count = %d, want 643", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 651 {
+		t.Fatalf("definition count = %d, want 651", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 643 {
-		t.Fatalf("definition count = %d, want 643", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 651 {
+		t.Fatalf("definition count = %d, want 651", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 643 {
-		t.Fatalf("definition count = %d, want 643", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 651 {
+		t.Fatalf("definition count = %d, want 651", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 643 {
-		t.Fatalf("definition count = %d, want 643", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 651 {
+		t.Fatalf("definition count = %d, want 651", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/review_decision_contract_test.go
+++ b/appserver/protocol/review_decision_contract_test.go
@@ -136,8 +136,8 @@ func TestReviewDecisionRemainsStandalone(t *testing.T) {
 			t.Fatalf("ReviewDecision unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(defs); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/review_start_contract_test.go
+++ b/appserver/protocol/review_start_contract_test.go
@@ -215,8 +215,8 @@ func TestReviewStartContractsFailClosedAndRemainStandalone(t *testing.T) {
 	if !ok || request.Surface != SurfaceClientRequest || request.State != MethodBlocked {
 		t.Fatalf("review/start = %#v, %v; want blocked client request", request, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 }
 

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -706,6 +706,14 @@ func wireSchemaDefinitions() Schema {
 		{Name: "WorkspaceMessage", Type: reflect.TypeFor[WorkspaceMessage]()},
 		{Name: "WorkspaceMessageType", Type: reflect.TypeFor[WorkspaceMessageType]()},
 		{Name: "WriteStatus", Type: reflect.TypeFor[WriteStatus]()},
+		{Name: "EnvironmentConnectionNotification", Type: reflect.TypeFor[EnvironmentConnectionNotification]()},
+		{Name: "RemoteControlConnectionStatus", Type: reflect.TypeFor[RemoteControlConnectionStatus]()},
+		{Name: "RemoteControlStatusChangedNotification", Type: reflect.TypeFor[RemoteControlStatusChangedNotification]()},
+		{Name: "SkillsChangedNotification", Type: reflect.TypeFor[SkillsChangedNotification]()},
+		{Name: "ThreadQueueChangedNotification", Type: reflect.TypeFor[ThreadQueueChangedNotification]()},
+		{Name: "ThreadRevertedNotification", Type: reflect.TypeFor[ThreadRevertedNotification]()},
+		{Name: "WindowsSandboxSetupCompletedNotification", Type: reflect.TypeFor[WindowsSandboxSetupCompletedNotification]()},
+		{Name: "WindowsWorldWritableWarningNotification", Type: reflect.TypeFor[WindowsWorldWritableWarningNotification]()},
 		// Register exact public names after their aliases so nested schemas refer
 		// to the public names. JSON and TypeScript output remain key-sorted.
 		{Name: "ContextCompactedNotification", Type: reflect.TypeFor[ContextCompactedNotification]()},
@@ -1357,6 +1365,9 @@ func wireSchemaDefinitions() Schema {
 		schemas[name] = schema
 	}
 	for name, schema := range accountEnvelopeSchemas() {
+		schemas[name] = schema
+	}
+	for name, schema := range operationalNotificationLeafSchemas() {
 		schemas[name] = schema
 	}
 	for name, schema := range workspaceMessageSchemas() {

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -5003,6 +5003,23 @@
         }
       ]
     },
+    "EnvironmentConnectionNotification": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "environmentId": {
+          "type": "string"
+        },
+        "threadId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "environmentId",
+        "threadId"
+      ],
+      "title": "EnvironmentConnectionNotification",
+      "type": "object"
+    },
     "Error": {
       "properties": {
         "code": {
@@ -13287,6 +13304,43 @@
       ],
       "type": "object"
     },
+    "RemoteControlConnectionStatus": {
+      "enum": [
+        "disabled",
+        "connecting",
+        "connected",
+        "errored"
+      ],
+      "type": "string"
+    },
+    "RemoteControlStatusChangedNotification": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "description": "Current remote-control connection status and remote identity exposed to clients.",
+      "properties": {
+        "environmentId": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "installationId": {
+          "type": "string"
+        },
+        "serverName": {
+          "type": "string"
+        },
+        "status": {
+          "$ref": "#/$defs/RemoteControlConnectionStatus"
+        }
+      },
+      "required": [
+        "installationId",
+        "serverName",
+        "status"
+      ],
+      "title": "RemoteControlStatusChangedNotification",
+      "type": "object"
+    },
     "Request": {
       "additionalProperties": false,
       "properties": {
@@ -15265,6 +15319,12 @@
       "required": [
         "name"
       ],
+      "type": "object"
+    },
+    "SkillsChangedNotification": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "description": "Notification emitted when watched local skill files change.\n\nTreat this as an invalidation signal and re-run `skills/list` with the client's current parameters when refreshed skill metadata is needed.",
+      "title": "SkillsChangedNotification",
       "type": "object"
     },
     "SkillsConfigWriteParams": {
@@ -18077,6 +18137,19 @@
       ],
       "type": "object"
     },
+    "ThreadQueueChangedNotification": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "threadId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "threadId"
+      ],
+      "title": "ThreadQueueChangedNotification",
+      "type": "object"
+    },
     "ThreadReadParams": {
       "additionalProperties": false,
       "properties": {
@@ -18444,6 +18517,19 @@
         "sandbox",
         "reasoningEffort"
       ],
+      "type": "object"
+    },
+    "ThreadRevertedNotification": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "threadId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "threadId"
+      ],
+      "title": "ThreadRevertedNotification",
       "type": "object"
     },
     "ThreadRollbackParams": {
@@ -21123,6 +21209,29 @@
       ],
       "type": "object"
     },
+    "WindowsSandboxSetupCompletedNotification": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "error": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "mode": {
+          "$ref": "#/$defs/WindowsSandboxSetupMode"
+        },
+        "success": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "mode",
+        "success"
+      ],
+      "title": "WindowsSandboxSetupCompletedNotification",
+      "type": "object"
+    },
     "WindowsSandboxSetupMode": {
       "enum": [
         "elevated",
@@ -21149,6 +21258,32 @@
       "required": [
         "mode"
       ],
+      "type": "object"
+    },
+    "WindowsWorldWritableWarningNotification": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "extraCount": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "failedScan": {
+          "type": "boolean"
+        },
+        "samplePaths": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "extraCount",
+        "failedScan",
+        "samplePaths"
+      ],
+      "title": "WindowsWorldWritableWarningNotification",
       "type": "object"
     },
     "WorkspaceMessage": {

--- a/appserver/protocol/server_request_approval_params_contract_test.go
+++ b/appserver/protocol/server_request_approval_params_contract_test.go
@@ -163,8 +163,8 @@ func TestServerRequestApprovalParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(defs); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(defs); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/server_request_contract_test.go
+++ b/appserver/protocol/server_request_contract_test.go
@@ -53,8 +53,8 @@ func TestServerRequestSchemaAndBindingAreExact(t *testing.T) {
 			}
 		}
 	}
-	if got := len(defs); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(defs); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	typescript, err := MarshalTypeScript()
 	if err != nil {

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/skills_config_write_params_contract_test.go
+++ b/appserver/protocol/skills_config_write_params_contract_test.go
@@ -64,8 +64,8 @@ func TestSkillsConfigWriteParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 }
 

--- a/appserver/protocol/skills_extra_roots_set_params_contract_test.go
+++ b/appserver/protocol/skills_extra_roots_set_params_contract_test.go
@@ -60,8 +60,8 @@ func TestSkillsExtraRootsSetParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 }
 

--- a/appserver/protocol/skills_list_params_contract_test.go
+++ b/appserver/protocol/skills_list_params_contract_test.go
@@ -46,8 +46,8 @@ func TestSkillsListParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 }
 

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/terminal_interaction_notification_contract_test.go
+++ b/appserver/protocol/terminal_interaction_notification_contract_test.go
@@ -72,8 +72,8 @@ func TestTerminalInteractionNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.Surface != SurfaceServerNotification || info.State != MethodBlocked {
 		t.Fatalf("terminal interaction method = %#v, %v; want blocked server notification", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	generated, err := MarshalTypeScript()
 	if err != nil {

--- a/appserver/protocol/thread_approve_guardian_denied_action_contract_test.go
+++ b/appserver/protocol/thread_approve_guardian_denied_action_contract_test.go
@@ -88,8 +88,8 @@ func TestThreadApproveGuardianDeniedActionContractsRemainStandalone(t *testing.T
 	if !ok || info.Surface != SurfaceClientRequest || info.State != MethodDeferredStub {
 		t.Fatalf("guardian denied action method = %#v, %v; want deferred client request", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 }
 

--- a/appserver/protocol/thread_inject_items_contract_test.go
+++ b/appserver/protocol/thread_inject_items_contract_test.go
@@ -96,8 +96,8 @@ func TestThreadInjectItemsContractsFailClosedAndRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 }
 

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 643 {
-		t.Fatalf("definition count = %d, want 643", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 651 {
+		t.Fatalf("definition count = %d, want 651", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -262,8 +262,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_rollback_contract_test.go
+++ b/appserver/protocol/thread_rollback_contract_test.go
@@ -114,8 +114,8 @@ func TestThreadRollbackContractsFailClosedAndRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 }
 

--- a/appserver/protocol/thread_search_result_contract_test.go
+++ b/appserver/protocol/thread_search_result_contract_test.go
@@ -59,8 +59,8 @@ func TestThreadSearchResultFailsClosedAndRemainsStandalone(t *testing.T) {
 			t.Fatalf("ThreadSearchResult unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 }
 

--- a/appserver/protocol/thread_section_params_contract_test.go
+++ b/appserver/protocol/thread_section_params_contract_test.go
@@ -213,8 +213,8 @@ func TestThreadSectionParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 }
 

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -252,8 +252,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 	if !foundRuntimeStart {
 		t.Error("thread/start runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -154,8 +154,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 	if !foundRuntimeStart {
 		t.Error("thread/start runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_settings_contract_test.go
+++ b/appserver/protocol/thread_settings_contract_test.go
@@ -162,8 +162,8 @@ func TestThreadSettingsContractsFailClosedAndRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 }
 

--- a/appserver/protocol/thread_shell_command_contract_test.go
+++ b/appserver/protocol/thread_shell_command_contract_test.go
@@ -95,8 +95,8 @@ func TestThreadShellCommandContractsFailClosedAndRemainStandalone(t *testing.T) 
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 }
 

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 643 {
-		t.Fatalf("definition count = %d, want 643", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 651 {
+		t.Fatalf("definition count = %d, want 651", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 643 {
-		t.Fatalf("definition count = %d, want 643", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 651 {
+		t.Fatalf("definition count = %d, want 651", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_environment_contract_test.go
+++ b/appserver/protocol/turn_environment_contract_test.go
@@ -79,8 +79,8 @@ func TestTurnEnvironmentParamsFailsClosedAndRemainsStandalone(t *testing.T) {
 			t.Fatalf("TurnEnvironmentParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 }
 

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -119,8 +119,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 	if !foundRuntimeBinding {
 		t.Error("turn/interrupt runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -241,8 +241,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 	if !foundRuntimeBinding {
 		t.Error("turn/start runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -164,8 +164,8 @@ func TestTurnSteerContractsAreBoundToLiveRuntime(t *testing.T) {
 	if !found {
 		t.Fatal("turn/steer runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -54,6 +54,10 @@ func MarshalTypeScript() ([]byte, error) {
 			name == "ConsumeAccountRateLimitResetCreditResponse" || name == "CreditsSnapshot" ||
 			name == "GetAccountParams" || name == "GetAccountRateLimitsResponse" || name == "GetAccountResponse" ||
 			name == "GetAccountTokenUsageParams" || name == "GetAccountTokenUsageResponse" || name == "GetWorkspaceMessagesResponse" ||
+			name == "EnvironmentConnectionNotification" || name == "SkillsChangedNotification" ||
+			name == "ThreadQueueChangedNotification" || name == "ThreadRevertedNotification" ||
+			name == "RemoteControlStatusChangedNotification" ||
+			name == "WindowsSandboxSetupCompletedNotification" || name == "WindowsWorldWritableWarningNotification" ||
 			name == "MigrationDetails" ||
 			name == "ExternalAgentConfigMigrationItem" ||
 			name == "ExternalAgentConfigImportItemTypeFailure" ||
@@ -203,6 +207,14 @@ func MarshalTypeScript() ([]byte, error) {
 			case "GetAccountTokenUsageParams":
 				schema["x-gollem-typescript-ignore-additional-properties"] = true
 				schema["properties"].(Schema)["threadId"] = nullableStringSchema()
+			case "EnvironmentConnectionNotification", "ThreadQueueChangedNotification", "ThreadRevertedNotification", "WindowsWorldWritableWarningNotification":
+				schema["x-gollem-typescript-ignore-additional-properties"] = true
+			case "SkillsChangedNotification":
+				schema["additionalProperties"] = false
+			case "RemoteControlStatusChangedNotification":
+				schema["required"] = []string{"environmentId", "installationId", "serverName", "status"}
+				schema["x-gollem-typescript-ignore-additional-properties"] = true
+				schema["properties"].(Schema)["environmentId"] = nullableStringSchema()
 			case "GetAccountTokenUsageResponse":
 				schema["required"] = []string{"dailyUsageBuckets", "summary"}
 				schema["x-gollem-typescript-ignore-additional-properties"] = true
@@ -210,6 +222,10 @@ func MarshalTypeScript() ([]byte, error) {
 					Schema{"type": "array", "items": Schema{"$ref": "#/$defs/AccountTokenUsageDailyBucket"}},
 					Schema{"type": "null"},
 				}}
+			case "WindowsSandboxSetupCompletedNotification":
+				schema["required"] = []string{"error", "mode", "success"}
+				schema["x-gollem-typescript-ignore-additional-properties"] = true
+				schema["properties"].(Schema)["error"] = nullableStringSchema()
 			case "GetWorkspaceMessagesResponse":
 				schema["x-gollem-typescript-ignore-additional-properties"] = true
 			case "ExecCommandApprovalParams":

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -1425,6 +1425,11 @@ export type DynamicToolNamespaceTool = { "type": "function" } & DynamicToolFunct
 
 export type DynamicToolSpec = { "type": "function" } & DynamicToolFunctionSpec | { "type": "namespace" } & DynamicToolNamespaceSpec;
 
+export type EnvironmentConnectionNotification = {
+  "environmentId": string;
+  "threadId": string;
+};
+
 export type Error = ({
   "code": number;
   "data"?: unknown;
@@ -3201,6 +3206,15 @@ export type ReasoningTextDeltaNotification = {
   "turnId": string;
 };
 
+export type RemoteControlConnectionStatus = "disabled" | "connecting" | "connected" | "errored";
+
+export type RemoteControlStatusChangedNotification = {
+  "environmentId": string | null;
+  "installationId": string;
+  "serverName": string;
+  "status": RemoteControlConnectionStatus;
+};
+
 export type Request = {
   "id": RequestID;
   "method": "account/login/cancel" | "account/login/start" | "account/logout" | "account/rateLimitResetCredit/consume" | "account/rateLimits/read" | "account/read" | "account/sendAddCreditsNudgeEmail" | "account/usage/read" | "account/workspaceMessages/read" | "app/list" | "collaborationMode/list" | "command/exec" | "command/exec/resize" | "command/exec/terminate" | "command/exec/write" | "config/batchWrite" | "config/mcpServer/reload" | "config/read" | "config/value/write" | "configRequirements/read" | "environment/add" | "environment/info" | "experimentalFeature/enablement/set" | "experimentalFeature/list" | "externalAgentConfig/detect" | "externalAgentConfig/import" | "externalAgentConfig/import/readHistories" | "feedback/upload" | "fs/copy" | "fs/createDirectory" | "fs/getMetadata" | "fs/readDirectory" | "fs/readFile" | "fs/remove" | "fs/unwatch" | "fs/watch" | "fs/writeFile" | "fuzzyFileSearch" | "fuzzyFileSearch/sessionStart" | "fuzzyFileSearch/sessionStop" | "fuzzyFileSearch/sessionUpdate" | "getAuthStatus" | "getConversationSummary" | "gitDiffToRemote" | "hooks/list" | "initialize" | "marketplace/add" | "marketplace/remove" | "marketplace/upgrade" | "mcpServer/oauth/login" | "mcpServer/resource/read" | "mcpServer/tool/call" | "mcpServerStatus/list" | "memory/reset" | "mock/experimentalMethod" | "model/list" | "modelProvider/capabilities/read" | "permissionProfile/list" | "plugin/install" | "plugin/installed" | "plugin/list" | "plugin/read" | "plugin/share/checkout" | "plugin/share/delete" | "plugin/share/list" | "plugin/share/save" | "plugin/share/updateTargets" | "plugin/skill/read" | "plugin/uninstall" | "process/kill" | "process/resizePty" | "process/spawn" | "process/writeStdin" | "remoteControl/client/list" | "remoteControl/client/revoke" | "remoteControl/disable" | "remoteControl/enable" | "remoteControl/pairing/start" | "remoteControl/pairing/status" | "remoteControl/status/read" | "review/start" | "skills/config/write" | "skills/extraRoots/set" | "skills/list" | "thread/approveGuardianDeniedAction" | "thread/archive" | "thread/backgroundTerminals/clean" | "thread/backgroundTerminals/list" | "thread/backgroundTerminals/terminate" | "thread/compact/start" | "thread/decrement_elicitation" | "thread/delete" | "thread/fork" | "thread/goal/clear" | "thread/goal/get" | "thread/goal/set" | "thread/increment_elicitation" | "thread/inject_items" | "thread/items/list" | "thread/list" | "thread/loaded/list" | "thread/memoryMode/set" | "thread/metadata/update" | "thread/name/set" | "thread/read" | "thread/realtime/appendAudio" | "thread/realtime/appendSpeech" | "thread/realtime/appendText" | "thread/realtime/listVoices" | "thread/realtime/start" | "thread/realtime/stop" | "thread/resume" | "thread/rollback" | "thread/search" | "thread/settings/update" | "thread/shellCommand" | "thread/start" | "thread/turns/list" | "thread/unarchive" | "thread/unsubscribe" | "turn/interrupt" | "turn/start" | "turn/steer" | "windowsSandbox/readiness" | "windowsSandbox/setupStart" | "approval/respond" | "cache/benchmark" | "cache/stats" | "daemon/restart" | "daemon/start" | "daemon/status" | "daemon/stop" | "daemon/version" | "git/commit" | "git/diff" | "git/status" | "git/worktree/create" | "git/worktree/list" | "item/fileChange/revert" | "provider/capabilities/read" | "provider/health/probe" | "provider/list" | "tool/list" | "turn/retry";
@@ -3517,6 +3531,8 @@ export type Settings = { "model": string; "reasoning_effort": ReasoningEffort | 
 export type SkillMigration = {
   "name": string;
 };
+
+export type SkillsChangedNotification = Record<string, never>;
 
 export type SkillsConfigWriteParams = {
 /**
@@ -4062,6 +4078,10 @@ export type ThreadNameUpdatedNotification = {
   "threadName"?: string;
 };
 
+export type ThreadQueueChangedNotification = {
+  "threadId": string;
+};
+
 export type ThreadReadParams = {
   "afterSeq"?: number;
   "id"?: string;
@@ -4128,6 +4148,10 @@ export type ThreadResumeResponse = {
   "sandbox": SandboxPolicy;
   "serviceTier": string | null;
   "thread": Thread;
+};
+
+export type ThreadRevertedNotification = {
+  "threadId": string;
 };
 
 export type ThreadRollbackParams = {
@@ -4667,9 +4691,21 @@ export type WebSearchToolConfig = {
   "location": WebSearchLocation | null;
 };
 
+export type WindowsSandboxSetupCompletedNotification = {
+  "error": string | null;
+  "mode": WindowsSandboxSetupMode;
+  "success": boolean;
+};
+
 export type WindowsSandboxSetupMode = "elevated" | "unelevated";
 
 export type WindowsSandboxSetupStartParams = { mode: WindowsSandboxSetupMode, cwd?: AbsolutePathBuf | null, };
+
+export type WindowsWorldWritableWarningNotification = {
+  "extraCount": number;
+  "failedScan": boolean;
+  "samplePaths": Array<string>;
+};
 
 export type WorkspaceMessage = {
   "archivedAt": number | null;

--- a/appserver/protocol/w3c_trace_context_contract_test.go
+++ b/appserver/protocol/w3c_trace_context_contract_test.go
@@ -55,8 +55,8 @@ func TestW3cTraceContextRemainsStandalone(t *testing.T) {
 			t.Fatalf("W3cTraceContext unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 }
 

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/windows_sandbox_setup_start_params_contract_test.go
+++ b/appserver/protocol/windows_sandbox_setup_start_params_contract_test.go
@@ -61,8 +61,8 @@ func TestWindowsSandboxSetupStartParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 }
 

--- a/appserver/protocol/workspace_messages_contract_test.go
+++ b/appserver/protocol/workspace_messages_contract_test.go
@@ -209,8 +209,8 @@ func TestWorkspaceMessageContractsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/workspaceMessages/read = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 643 {
-		t.Fatalf("definition count = %d, want 643", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
+		t.Fatalf("definition count = %d, want 651", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- add exact standalone contracts for eight non-realtime operational server-notification payloads
- preserve Rust serde wire behavior, source JSON Schema, and source TypeScript projections
- regenerate protocol artifacts and update global definition-count coverage from 643 to 651

## Validation
- `go test ./appserver/protocol -run 'TestOperationalNotificationLeaves|TestOperationalNotificationLeafSchemas' -count=1`\n- `go test ./appserver/protocol -count=1`\n- `go test -race ./appserver/protocol ./appserver -run 'TestOperationalNotificationLeaves|TestOperationalNotificationLeafSchemas|TestWireTypeBindings' -count=1`\n- `go list ./... | rg -v '^github\\.com/fugue-labs/gollem/ext/monty(/|$)' | xargs go test -count=1`\n- `go list ./... | rg -v '^github\\.com/fugue-labs/gollem/ext/monty(/|$)' | xargs go vet`\n- `go mod tidy`\n- `go generate ./appserver/protocol`\n- `golangci-lint run`\n- pre-push non-Monty race suite