### PR TITLE
feat(protocol): add realtime notification contracts

### DIFF
--- a/appserver/protocol/account_credit_nudge_values_contract_test.go
+++ b/appserver/protocol/account_credit_nudge_values_contract_test.go
@@ -119,8 +119,8 @@ func TestAccountCreditNudgeValuesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/sendAddCreditsNudgeEmail = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/account_envelope_contract_test.go
+++ b/appserver/protocol/account_envelope_contract_test.go
@@ -305,8 +305,8 @@ func TestAccountEnvelopeContractsRemainStandaloneAndDeferred(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred %s", methodName, method, ok, surface)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/account_login_completed_notification_contract_test.go
+++ b/appserver/protocol/account_login_completed_notification_contract_test.go
@@ -88,8 +88,8 @@ func TestAccountLoginCompletedNotificationRemainsStandaloneAndDeferred(t *testin
 	if !found {
 		t.Fatal("account/login/completed method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/account_rate_limits_contract_test.go
+++ b/appserver/protocol/account_rate_limits_contract_test.go
@@ -484,8 +484,8 @@ func TestAccountRateLimitContractsRemainStandaloneAndDeferred(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred %s", methodName, method, ok, surface)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/account_token_usage_contract_test.go
+++ b/appserver/protocol/account_token_usage_contract_test.go
@@ -146,8 +146,8 @@ func TestAccountTokenUsageRecordsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/usage/read = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -148,8 +148,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly exports additionalContext", paramsName)
 		}
 	}
-	if got := len(defs); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(defs); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -54,8 +54,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AmazonBedrockCredentialSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_config_contract_test.go
+++ b/appserver/protocol/app_config_contract_test.go
@@ -109,8 +109,8 @@ func TestAppConfigRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppConfig unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_info_contract_test.go
+++ b/appserver/protocol/app_info_contract_test.go
@@ -131,8 +131,8 @@ func TestAppInfoRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_list_updated_notification_contract_test.go
+++ b/appserver/protocol/app_list_updated_notification_contract_test.go
@@ -105,8 +105,8 @@ func TestAppListUpdatedNotificationRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceServerNotification || method.State != MethodDeferredStub {
 		t.Fatalf("app/list/updated = %#v, %v; want deferred server notification", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_metadata_contract_test.go
+++ b/appserver/protocol/app_metadata_contract_test.go
@@ -107,8 +107,8 @@ func TestAppMetadataRemainsStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_metadata_leaf_contract_test.go
+++ b/appserver/protocol/app_metadata_leaf_contract_test.go
@@ -157,8 +157,8 @@ func TestAppMetadataLeavesRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_summary_contract_test.go
+++ b/appserver/protocol/app_summary_contract_test.go
@@ -87,8 +87,8 @@ func TestAppSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppSummary unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_template_summary_contract_test.go
+++ b/appserver/protocol/app_template_summary_contract_test.go
@@ -107,8 +107,8 @@ func TestAppTemplateSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppTemplateSummary unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_template_unavailable_reason_contract_test.go
+++ b/appserver/protocol/app_template_unavailable_reason_contract_test.go
@@ -71,8 +71,8 @@ func TestAppTemplateUnavailableReasonRemainsStandalone(t *testing.T) {
 			t.Fatalf("AppTemplateUnavailableReason unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_tool_approval_contract_test.go
+++ b/appserver/protocol/app_tool_approval_contract_test.go
@@ -73,8 +73,8 @@ func TestAppToolApprovalRemainsStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("AppToolApproval unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/app_tools_config_contract_test.go
+++ b/appserver/protocol/app_tools_config_contract_test.go
@@ -140,8 +140,8 @@ func TestAppToolConfigsRemainStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/apply_patch_approval_params_contract_test.go
+++ b/appserver/protocol/apply_patch_approval_params_contract_test.go
@@ -139,8 +139,8 @@ func TestApplyPatchApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ApplyPatchApprovalParams unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(defs); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(defs); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/apps_config_contract_test.go
+++ b/appserver/protocol/apps_config_contract_test.go
@@ -185,8 +185,8 @@ func TestAppsConfigsRemainStandaloneAndUnbound(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/apps_discovery_params_contract_test.go
+++ b/appserver/protocol/apps_discovery_params_contract_test.go
@@ -87,8 +87,8 @@ func TestAppsDiscoveryParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 }
 

--- a/appserver/protocol/apps_list_contract_test.go
+++ b/appserver/protocol/apps_list_contract_test.go
@@ -168,8 +168,8 @@ func TestAppsListContractsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("app/list = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/attestation_contract_test.go
+++ b/appserver/protocol/attestation_contract_test.go
@@ -134,8 +134,8 @@ func TestAttestationContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("attestation/generate = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -74,8 +74,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 			t.Fatalf("AuthMode unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -52,8 +52,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("AutoReviewDecisionSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -148,8 +148,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
+++ b/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
@@ -194,8 +194,8 @@ func TestChatgptAuthTokensRefreshRemainsStandaloneAndDeferred(t *testing.T) {
 	if !found {
 		t.Fatal("refresh method inventory entry missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/client_notification_contract_test.go
+++ b/appserver/protocol/client_notification_contract_test.go
@@ -58,8 +58,8 @@ func TestClientNotificationRemainsStandaloneFromInitializedBinding(t *testing.T)
 	if !ok || info.Surface != SurfaceClientNotification || info.State != MethodImplemented {
 		t.Fatalf("initialized method = %#v, %v; want implemented client notification", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 }
 

--- a/appserver/protocol/collaboration_capability_contract_test.go
+++ b/appserver/protocol/collaboration_capability_contract_test.go
@@ -346,8 +346,8 @@ func TestCollaborationCapabilityContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/command_exec_contract_test.go
+++ b/appserver/protocol/command_exec_contract_test.go
@@ -79,8 +79,8 @@ func TestCommandExecContractsFailClosedAndRemainStandalone(t *testing.T) {
 			t.Fatalf("public command-exec contract unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 }
 

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -217,8 +217,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -146,8 +146,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigLayerSource unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -321,8 +321,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -67,8 +67,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -200,8 +200,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("ConfigReadResponse unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -228,8 +228,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("configWarning = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -332,8 +332,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/conversation_text_role_contract_test.go
+++ b/appserver/protocol/conversation_text_role_contract_test.go
@@ -42,7 +42,7 @@ func TestConversationTextRoleContractIsExact(t *testing.T) {
 			t.Fatalf("standalone conversation role unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(definitions); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(definitions); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 }

--- a/appserver/protocol/dynamic_tool_spec_contract_test.go
+++ b/appserver/protocol/dynamic_tool_spec_contract_test.go
@@ -318,8 +318,8 @@ func TestDynamicToolSpecContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/exec_command_approval_params_contract_test.go
+++ b/appserver/protocol/exec_command_approval_params_contract_test.go
@@ -137,8 +137,8 @@ func TestExecCommandApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ExecCommandApprovalParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(defs); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/experimental_feature_contract_test.go
+++ b/appserver/protocol/experimental_feature_contract_test.go
@@ -41,8 +41,8 @@ func TestExperimentalFeatureContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want implemented client request", methodName, method, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d/%d/%d, want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -217,8 +217,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/detect = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -203,8 +203,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("externalAgentConfig/import = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -260,8 +260,8 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_import_history_record_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_record_contract_test.go
@@ -122,8 +122,8 @@ func TestExternalAgentConfigImportHistoryRecordRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 }
 

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -244,8 +244,8 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -162,8 +162,8 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -175,8 +175,8 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -186,8 +186,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -84,8 +84,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/feedback_upload_params_contract_test.go
+++ b/appserver/protocol/feedback_upload_params_contract_test.go
@@ -70,8 +70,8 @@ func TestFeedbackUploadParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 }
 

--- a/appserver/protocol/file_change_contract_test.go
+++ b/appserver/protocol/file_change_contract_test.go
@@ -108,8 +108,8 @@ func TestFileChangeRemainsStandalone(t *testing.T) {
 			t.Fatalf("FileChange unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/file_change_output_delta_notification_contract_test.go
+++ b/appserver/protocol/file_change_output_delta_notification_contract_test.go
@@ -100,8 +100,8 @@ func TestFileChangeOutputDeltaNotificationRemainsDeprecatedAndStandalone(t *test
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("item/fileChange/outputDelta = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -381,8 +381,8 @@ func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/guardian_approval_review_action_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_action_contract_test.go
@@ -226,8 +226,8 @@ func TestGuardianApprovalReviewActionRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReviewAction unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
@@ -164,8 +164,8 @@ func TestGuardianApprovalReviewCompletedNotificationRemainsStandalone(t *testing
 			t.Fatalf("completed notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/guardian_approval_review_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_contract_test.go
@@ -139,8 +139,8 @@ func TestGuardianApprovalReviewRemainsStandalone(t *testing.T) {
 			t.Fatalf("GuardianApprovalReview unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
@@ -175,8 +175,8 @@ func TestGuardianApprovalReviewStartedNotificationRemainsStandalone(t *testing.T
 			t.Fatalf("started notification unexpectedly bound to item %s", binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/guardian_enum_foundation_contract_test.go
+++ b/appserver/protocol/guardian_enum_foundation_contract_test.go
@@ -89,8 +89,8 @@ func TestGuardianEnumFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/hook_metadata_list_contract_test.go
+++ b/appserver/protocol/hook_metadata_list_contract_test.go
@@ -352,8 +352,8 @@ func TestHookMetadataListContractsStayStandalone(t *testing.T) {
 			t.Errorf("standalone definition %s unexpectedly bound to item %s", binding.Type, binding.Kind)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Errorf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Errorf("definition count = %d, want 661", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 {
 		t.Errorf("wire binding count = %d, want 80", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/hook_run_notification_contract_test.go
+++ b/appserver/protocol/hook_run_notification_contract_test.go
@@ -297,8 +297,8 @@ func TestHookRunNotificationsRemainStandalone(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("surface changed: %d methods, %d wire bindings, %d item bindings", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/hook_value_foundation_contract_test.go
+++ b/appserver/protocol/hook_value_foundation_contract_test.go
@@ -167,8 +167,8 @@ func TestHookValueFoundationRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -223,8 +223,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want %s", method, info, ok, want)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -159,8 +159,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(want) != 0 {
 		t.Fatalf("missing lifecycle bindings: %v", want)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 651 {
-		t.Fatalf("definition count = %d, want 651", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 661 {
+		t.Fatalf("definition count = %d, want 661", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/jsonrpc_envelope_contract_test.go
+++ b/appserver/protocol/jsonrpc_envelope_contract_test.go
@@ -87,8 +87,8 @@ func TestJSONRPCEnvelopesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 }
 

--- a/appserver/protocol/jsonrpc_error_contract_test.go
+++ b/appserver/protocol/jsonrpc_error_contract_test.go
@@ -67,8 +67,8 @@ func TestJSONRPCErrorsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 }
 

--- a/appserver/protocol/jsonrpc_message_contract_test.go
+++ b/appserver/protocol/jsonrpc_message_contract_test.go
@@ -74,8 +74,8 @@ func TestJSONRPCMessageRemainsStandalone(t *testing.T) {
 			t.Fatalf("JSONRPCMessage unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 }
 

--- a/appserver/protocol/legacy_approval_response_contract_test.go
+++ b/appserver/protocol/legacy_approval_response_contract_test.go
@@ -98,8 +98,8 @@ func TestLegacyApprovalResponsesRemainStandaloneAndNominal(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -127,8 +127,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("ListMcpServerStatusParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -276,8 +276,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -57,8 +57,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 			t.Fatalf("LoginAppBrand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -70,8 +70,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodDeferredStub {
 		t.Fatalf("account/logout = %#v, %v; want deferred stub", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -227,8 +227,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/marketplace_add_params_contract_test.go
+++ b/appserver/protocol/marketplace_add_params_contract_test.go
@@ -69,8 +69,8 @@ func TestMarketplaceAddParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 }
 

--- a/appserver/protocol/marketplace_remove_params_contract_test.go
+++ b/appserver/protocol/marketplace_remove_params_contract_test.go
@@ -52,8 +52,8 @@ func TestMarketplaceRemoveParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 }
 

--- a/appserver/protocol/marketplace_upgrade_params_contract_test.go
+++ b/appserver/protocol/marketplace_upgrade_params_contract_test.go
@@ -49,8 +49,8 @@ func TestMarketplaceUpgradeParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 }
 

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -74,8 +74,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpAuthStatus unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -114,8 +114,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpResourceReadParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -130,8 +130,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -148,8 +148,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_oauth_login_contract_test.go
+++ b/appserver/protocol/mcp_server_oauth_login_contract_test.go
@@ -228,8 +228,8 @@ func TestMcpServerOauthLoginContractsRemainStandaloneAndBlocked(t *testing.T) {
 	if !ok || notification.Surface != SurfaceServerNotification || notification.State != MethodBlocked {
 		t.Fatalf("mcpServer/oauthLogin/completed = %#v, %v; want blocked server notification", notification, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d/%d/%d, want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -70,8 +70,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("config/mcpServer/reload = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -116,8 +116,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_status_contract_test.go
+++ b/appserver/protocol/mcp_server_status_contract_test.go
@@ -277,8 +277,8 @@ func TestMcpServerStatusContractsRemainStandalone(t *testing.T) {
 	if !ok || method.State != MethodImplemented {
 		t.Fatalf("mcpServerStatus/list = %#v, %v; want implemented", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d/%d/%d, want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -69,8 +69,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerStatusDetail unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -125,8 +125,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("mcpServer/startupStatus/updated = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallParams unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -134,8 +134,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 			t.Fatalf("McpServerToolCallResponse unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -168,8 +168,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -184,8 +184,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -235,8 +235,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 			t.Fatalf("Model unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -201,8 +201,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 			t.Fatalf("model-list type unexpectedly bound: %#v", binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -140,8 +140,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("modelProvider/capabilities/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -159,8 +159,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("configRequirements/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -248,8 +248,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/network_approval_context_contract_test.go
+++ b/appserver/protocol/network_approval_context_contract_test.go
@@ -84,8 +84,8 @@ func TestNetworkApprovalContextRemainsStandalone(t *testing.T) {
 			t.Fatalf("NetworkApprovalContext unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -163,8 +163,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if _, ok := configProperties["network"]; ok {
 		t.Fatal("standalone NetworkRequirements widened ConfigRequirements")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/operational_notification_leaves_contract_test.go
+++ b/appserver/protocol/operational_notification_leaves_contract_test.go
@@ -199,8 +199,8 @@ func TestOperationalNotificationLeavesFailClosedAndRemainStandalone(t *testing.T
 			t.Errorf("%s = %#v; want no experimental method registration", methodName, method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/parsed_command_contract_test.go
+++ b/appserver/protocol/parsed_command_contract_test.go
@@ -120,8 +120,8 @@ func TestParsedCommandRemainsStandalone(t *testing.T) {
 			t.Fatalf("ParsedCommand unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/permission_profile_list_contract_test.go
+++ b/appserver/protocol/permission_profile_list_contract_test.go
@@ -255,8 +255,8 @@ func TestPermissionProfileListContractsRemainStandalone(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodImplemented {
 		t.Fatalf("permissionProfile/list = %#v, %v; want existing implemented client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d/%d/%d, want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/permissions_request_approval_params_contract_test.go
+++ b/appserver/protocol/permissions_request_approval_params_contract_test.go
@@ -107,8 +107,8 @@ func TestPermissionsRequestApprovalParamsRemainsStandalone(t *testing.T) {
 			t.Fatalf("PermissionsRequestApprovalParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(defs); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 }
 

--- a/appserver/protocol/plugin_install_params_contract_test.go
+++ b/appserver/protocol/plugin_install_params_contract_test.go
@@ -35,8 +35,8 @@ func TestPluginInstallParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 }
 func TestPluginInstallParamsTypeScriptIsExact(t *testing.T) {

--- a/appserver/protocol/plugin_installed_params_contract_test.go
+++ b/appserver/protocol/plugin_installed_params_contract_test.go
@@ -35,8 +35,8 @@ func TestPluginInstalledParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 }
 func TestPluginInstalledParamsTypeScriptIsExact(t *testing.T) {

--- a/appserver/protocol/plugin_list_params_contract_test.go
+++ b/appserver/protocol/plugin_list_params_contract_test.go
@@ -82,8 +82,8 @@ func TestPluginListParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 }
 

--- a/appserver/protocol/plugin_read_params_contract_test.go
+++ b/appserver/protocol/plugin_read_params_contract_test.go
@@ -39,8 +39,8 @@ func TestPluginReadParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 }
 func TestPluginReadParamsTypeScriptIsExact(t *testing.T) {

--- a/appserver/protocol/plugin_share_checkout_params_contract_test.go
+++ b/appserver/protocol/plugin_share_checkout_params_contract_test.go
@@ -51,8 +51,8 @@ func TestPluginShareCheckoutParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 }
 

--- a/appserver/protocol/plugin_share_delete_params_contract_test.go
+++ b/appserver/protocol/plugin_share_delete_params_contract_test.go
@@ -51,8 +51,8 @@ func TestPluginShareDeleteParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 }
 

--- a/appserver/protocol/plugin_share_list_params_contract_test.go
+++ b/appserver/protocol/plugin_share_list_params_contract_test.go
@@ -40,8 +40,8 @@ func TestPluginShareListParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 }
 

--- a/appserver/protocol/plugin_share_save_contract_test.go
+++ b/appserver/protocol/plugin_share_save_contract_test.go
@@ -163,8 +163,8 @@ func TestPluginShareSaveRemainsStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 }
 

--- a/appserver/protocol/plugin_share_update_targets_contract_test.go
+++ b/appserver/protocol/plugin_share_update_targets_contract_test.go
@@ -96,8 +96,8 @@ func TestPluginShareUpdateTargetsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 }
 

--- a/appserver/protocol/plugin_skill_read_params_contract_test.go
+++ b/appserver/protocol/plugin_skill_read_params_contract_test.go
@@ -59,8 +59,8 @@ func TestPluginSkillReadParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 }
 

--- a/appserver/protocol/plugin_uninstall_params_contract_test.go
+++ b/appserver/protocol/plugin_uninstall_params_contract_test.go
@@ -51,8 +51,8 @@ func TestPluginUninstallParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 }
 

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -127,8 +127,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/process_contracts_contract_test.go
+++ b/appserver/protocol/process_contracts_contract_test.go
@@ -308,8 +308,8 @@ func TestProcessContractsRemainStandaloneFromLegacyRuntime(t *testing.T) {
 			t.Fatalf("%s = %#v, %v; want unchanged implemented notification", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -258,8 +258,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 			t.Fatalf("Config unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 651 {
-		t.Fatalf("definition count = %d, want 651", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 661 {
+		t.Fatalf("definition count = %d, want 661", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -204,8 +204,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Thread:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 651 {
-		t.Fatalf("definition count = %d, want 651", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 661 {
+		t.Fatalf("definition count = %d, want 661", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -197,8 +197,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 			}
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 651 {
-		t.Fatalf("definition count = %d, want 651", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 661 {
+		t.Fatalf("definition count = %d, want 661", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(bindings) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(bindings), len(ItemPayloadBindings()))

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -146,8 +146,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if !strings.Contains(string(generated), want) {
 		t.Fatalf("generated TypeScript missing exact Turn:\n%s", generated)
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 651 {
-		t.Fatalf("definition count = %d, want 651", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 661 {
+		t.Fatalf("definition count = %d, want 661", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -94,8 +94,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 			t.Fatalf("raw response notification unexpectedly bound: %#v", binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 651 {
-		t.Fatalf("definition count = %d, want 651", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 661 {
+		t.Fatalf("definition count = %d, want 661", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/realtime_notification_contract_test.go
+++ b/appserver/protocol/realtime_notification_contract_test.go
@@ -1,0 +1,264 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestRealtimeNotificationSchemasAreExact(t *testing.T) {
+	object := func(description, title string, properties Schema, required ...string) Schema {
+		return Schema{
+			"$schema":     "http://json-schema.org/draft-07/schema#",
+			"description": description,
+			"properties":  properties,
+			"required":    required,
+			"title":       title,
+			"type":        "object",
+		}
+	}
+	want := map[string]Schema{
+		"RealtimeConversationVersion": stringEnumSchema("v1", "v2", "v3"),
+		"ThreadRealtimeAudioChunk": {
+			"description": "EXPERIMENTAL - thread realtime audio chunk.",
+			"properties": Schema{
+				"data":              Schema{"type": "string"},
+				"itemId":            Schema{"type": []any{"string", "null"}},
+				"numChannels":       Schema{"format": "uint16", "minimum": float64(0), "type": "integer"},
+				"sampleRate":        Schema{"format": "uint32", "minimum": float64(0), "type": "integer"},
+				"samplesPerChannel": Schema{"format": "uint32", "minimum": float64(0), "type": []any{"integer", "null"}},
+			},
+			"required": []string{"data", "numChannels", "sampleRate"},
+			"type":     "object",
+		},
+		"ThreadRealtimeClosedNotification": object(
+			"EXPERIMENTAL - emitted when thread realtime transport closes.",
+			"ThreadRealtimeClosedNotification",
+			Schema{"reason": Schema{"type": []any{"string", "null"}}, "threadId": Schema{"type": "string"}},
+			"threadId",
+		),
+		"ThreadRealtimeErrorNotification": object(
+			"EXPERIMENTAL - emitted when thread realtime encounters an error.",
+			"ThreadRealtimeErrorNotification",
+			Schema{"message": Schema{"type": "string"}, "threadId": Schema{"type": "string"}},
+			"message", "threadId",
+		),
+		"ThreadRealtimeItemAddedNotification": object(
+			"EXPERIMENTAL - raw non-audio thread realtime item emitted by the backend.",
+			"ThreadRealtimeItemAddedNotification",
+			Schema{"item": true, "threadId": Schema{"type": "string"}},
+			"item", "threadId",
+		),
+		"ThreadRealtimeOutputAudioDeltaNotification": object(
+			"EXPERIMENTAL - streamed output audio emitted by thread realtime.",
+			"ThreadRealtimeOutputAudioDeltaNotification",
+			Schema{"audio": Schema{"$ref": "#/$defs/ThreadRealtimeAudioChunk"}, "threadId": Schema{"type": "string"}},
+			"audio", "threadId",
+		),
+		"ThreadRealtimeSdpNotification": object(
+			"EXPERIMENTAL - emitted with the remote SDP for a WebRTC realtime session.",
+			"ThreadRealtimeSdpNotification",
+			Schema{"sdp": Schema{"type": "string"}, "threadId": Schema{"type": "string"}},
+			"sdp", "threadId",
+		),
+		"ThreadRealtimeStartedNotification": object(
+			"EXPERIMENTAL - emitted when thread realtime startup is accepted.",
+			"ThreadRealtimeStartedNotification",
+			Schema{
+				"realtimeSessionId": Schema{"type": []any{"string", "null"}},
+				"threadId":          Schema{"type": "string"},
+				"version":           Schema{"$ref": "#/$defs/RealtimeConversationVersion"},
+			},
+			"threadId", "version",
+		),
+		"ThreadRealtimeTranscriptDeltaNotification": object(
+			"EXPERIMENTAL - flat transcript delta emitted whenever realtime transcript text changes.",
+			"ThreadRealtimeTranscriptDeltaNotification",
+			Schema{
+				"delta":    Schema{"description": "Live transcript delta from the realtime event.", "type": "string"},
+				"role":     Schema{"type": "string"},
+				"threadId": Schema{"type": "string"},
+			},
+			"delta", "role", "threadId",
+		),
+		"ThreadRealtimeTranscriptDoneNotification": object(
+			"EXPERIMENTAL - final transcript text emitted when realtime completes a transcript part.",
+			"ThreadRealtimeTranscriptDoneNotification",
+			Schema{
+				"role":     Schema{"type": "string"},
+				"text":     Schema{"description": "Final complete text for the transcript part.", "type": "string"},
+				"threadId": Schema{"type": "string"},
+			},
+			"role", "text", "threadId",
+		),
+	}
+	definitions := JSONSchema()["$defs"].(Schema)
+	for name, expected := range want {
+		if got := definitions[name]; !reflect.DeepEqual(got, expected) {
+			t.Errorf("%s = %#v, want %#v", name, got, expected)
+		}
+	}
+}
+
+func TestRealtimeNotificationsPreserveSerdeWireForms(t *testing.T) {
+	fixtures := []struct {
+		name  string
+		input string
+		want  string
+		value func() any
+	}{
+		{"audio absent options", `{"future":1,"data":"AA==","sampleRate":4294967295,"numChannels":65535}`, `{"data":"AA==","sampleRate":4294967295,"numChannels":65535,"samplesPerChannel":null,"itemId":null}`, func() any { return new(ThreadRealtimeAudioChunk) }},
+		{"audio options", `{"data":"","sampleRate":0,"numChannels":0,"samplesPerChannel":0,"itemId":"item"}`, `{"data":"","sampleRate":0,"numChannels":0,"samplesPerChannel":0,"itemId":"item"}`, func() any { return new(ThreadRealtimeAudioChunk) }},
+		{"started absent session", `{"future":1,"threadId":"thread","version":"v2"}`, `{"threadId":"thread","realtimeSessionId":null,"version":"v2"}`, func() any { return new(ThreadRealtimeStartedNotification) }},
+		{"started session", `{"threadId":"thread","realtimeSessionId":"session","version":"v3"}`, `{"threadId":"thread","realtimeSessionId":"session","version":"v3"}`, func() any { return new(ThreadRealtimeStartedNotification) }},
+		{"item null", `{"future":1,"threadId":"thread","item":null}`, `{"threadId":"thread","item":null}`, func() any { return new(ThreadRealtimeItemAddedNotification) }},
+		{"transcript delta", `{"future":1,"threadId":"thread","role":"assistant","delta":"delta"}`, `{"threadId":"thread","role":"assistant","delta":"delta"}`, func() any { return new(ThreadRealtimeTranscriptDeltaNotification) }},
+		{"transcript done", `{"future":1,"threadId":"thread","role":"user","text":"text"}`, `{"threadId":"thread","role":"user","text":"text"}`, func() any { return new(ThreadRealtimeTranscriptDoneNotification) }},
+		{"output audio", `{"future":1,"threadId":"thread","audio":{"data":"AA==","sampleRate":16000,"numChannels":1}}`, `{"threadId":"thread","audio":{"data":"AA==","sampleRate":16000,"numChannels":1,"samplesPerChannel":null,"itemId":null}}`, func() any { return new(ThreadRealtimeOutputAudioDeltaNotification) }},
+		{"sdp", `{"future":1,"threadId":"thread","sdp":"v=0"}`, `{"threadId":"thread","sdp":"v=0"}`, func() any { return new(ThreadRealtimeSdpNotification) }},
+		{"error", `{"future":1,"threadId":"thread","message":"message"}`, `{"threadId":"thread","message":"message"}`, func() any { return new(ThreadRealtimeErrorNotification) }},
+		{"closed absent reason", `{"future":1,"threadId":"thread"}`, `{"threadId":"thread","reason":null}`, func() any { return new(ThreadRealtimeClosedNotification) }},
+		{"closed reason", `{"threadId":"thread","reason":"closed"}`, `{"threadId":"thread","reason":"closed"}`, func() any { return new(ThreadRealtimeClosedNotification) }},
+	}
+	for _, fixture := range fixtures {
+		t.Run(fixture.name, func(t *testing.T) {
+			value := fixture.value()
+			if err := json.Unmarshal([]byte(fixture.input), value); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			encoded, err := json.Marshal(value)
+			if err != nil || string(encoded) != fixture.want {
+				t.Fatalf("round trip = %s, %v; want %s", encoded, err, fixture.want)
+			}
+		})
+	}
+
+	for _, value := range []RealtimeConversationVersion{
+		RealtimeConversationVersionV1, RealtimeConversationVersionV2, RealtimeConversationVersionV3,
+	} {
+		encoded, err := json.Marshal(value)
+		if err != nil || string(encoded) != `"`+string(value)+`"` {
+			t.Errorf("version %q = %s, %v", value, encoded, err)
+		}
+	}
+}
+
+func TestRealtimeNotificationsRejectMalformedWireForms(t *testing.T) {
+	assertRealtimeNotificationRejects[RealtimeConversationVersion](t, ``, `null`, `[]`, `{}`, `"future"`, `"v1" {}`)
+	assertRealtimeNotificationRejects[ThreadRealtimeAudioChunk](t,
+		``, `null`, `[]`, `{}`, `{"sampleRate":1,"numChannels":1}`, `{"data":"data","sampleRate":null,"numChannels":1}`,
+		`{"data":"data","sampleRate":4294967296,"numChannels":1}`, `{"data":"data","sampleRate":1,"numChannels":65536}`,
+		`{"data":"data","sampleRate":1,"numChannels":1,"samplesPerChannel":-1}`, `{"data":"data","sampleRate":1,"numChannels":1,"itemId":false}`,
+		`{"data":"one","data":"two","sampleRate":1,"numChannels":1}`, `{} {}`)
+	assertRealtimeNotificationRejects[ThreadRealtimeStartedNotification](t,
+		``, `null`, `[]`, `{}`, `{"threadId":"thread"}`, `{"threadId":null,"version":"v1"}`,
+		`{"threadId":"thread","version":"future"}`, `{"threadId":"thread","realtimeSessionId":false,"version":"v1"}`,
+		`{"threadId":"one","threadId":"two","version":"v1"}`, `{} {}`)
+	assertRealtimeNotificationRejects[ThreadRealtimeItemAddedNotification](t,
+		``, `null`, `[]`, `{}`, `{"threadId":"thread"}`, `{"threadId":null,"item":null}`,
+		`{"threadId":"one","threadId":"two","item":null}`, `{} {}`)
+	assertRealtimeNotificationRejects[ThreadRealtimeTranscriptDeltaNotification](t,
+		``, `null`, `[]`, `{}`, `{"threadId":"thread","role":"assistant"}`, `{"threadId":"thread","role":null,"delta":"delta"}`,
+		`{"threadId":"thread","role":"assistant","delta":false}`, `{"threadId":"one","threadId":"two","role":"assistant","delta":"delta"}`, `{} {}`)
+	assertRealtimeNotificationRejects[ThreadRealtimeTranscriptDoneNotification](t,
+		``, `null`, `[]`, `{}`, `{"threadId":"thread","role":"assistant"}`, `{"threadId":"thread","role":null,"text":"text"}`,
+		`{"threadId":"thread","role":"assistant","text":false}`, `{"threadId":"one","threadId":"two","role":"assistant","text":"text"}`, `{} {}`)
+	assertRealtimeNotificationRejects[ThreadRealtimeOutputAudioDeltaNotification](t,
+		``, `null`, `[]`, `{}`, `{"threadId":"thread"}`, `{"threadId":"thread","audio":null}`,
+		`{"threadId":"thread","audio":{"data":"data","sampleRate":1}}`, `{"threadId":"one","threadId":"two","audio":{"data":"data","sampleRate":1,"numChannels":1}}`, `{} {}`)
+	assertRealtimeNotificationRejects[ThreadRealtimeSdpNotification](t,
+		``, `null`, `[]`, `{}`, `{"threadId":"thread"}`, `{"threadId":null,"sdp":"v=0"}`,
+		`{"threadId":"thread","sdp":false}`, `{"threadId":"one","threadId":"two","sdp":"v=0"}`, `{} {}`)
+	assertRealtimeNotificationRejects[ThreadRealtimeErrorNotification](t,
+		``, `null`, `[]`, `{}`, `{"threadId":"thread"}`, `{"threadId":null,"message":"message"}`,
+		`{"threadId":"thread","message":false}`, `{"threadId":"one","threadId":"two","message":"message"}`, `{} {}`)
+	assertRealtimeNotificationRejects[ThreadRealtimeClosedNotification](t,
+		``, `null`, `[]`, `{}`, `{"reason":"closed"}`, `{"threadId":null}`,
+		`{"threadId":"thread","reason":false}`, `{"threadId":"one","threadId":"two"}`, `{} {}`)
+}
+
+func TestRealtimeNotificationsFailClosedAndRemainStandalone(t *testing.T) {
+	checks := map[string]func() error{
+		"version": func() error { var value *RealtimeConversationVersion; return value.UnmarshalJSON([]byte(`"v1"`)) },
+		"audio":   func() error { var value *ThreadRealtimeAudioChunk; return value.UnmarshalJSON([]byte(`{}`)) },
+		"started": func() error { var value *ThreadRealtimeStartedNotification; return value.UnmarshalJSON([]byte(`{}`)) },
+		"item":    func() error { var value *ThreadRealtimeItemAddedNotification; return value.UnmarshalJSON([]byte(`{}`)) },
+		"delta": func() error {
+			var value *ThreadRealtimeTranscriptDeltaNotification
+			return value.UnmarshalJSON([]byte(`{}`))
+		},
+		"done": func() error {
+			var value *ThreadRealtimeTranscriptDoneNotification
+			return value.UnmarshalJSON([]byte(`{}`))
+		},
+		"audio delta": func() error {
+			var value *ThreadRealtimeOutputAudioDeltaNotification
+			return value.UnmarshalJSON([]byte(`{}`))
+		},
+		"sdp":    func() error { var value *ThreadRealtimeSdpNotification; return value.UnmarshalJSON([]byte(`{}`)) },
+		"error":  func() error { var value *ThreadRealtimeErrorNotification; return value.UnmarshalJSON([]byte(`{}`)) },
+		"closed": func() error { var value *ThreadRealtimeClosedNotification; return value.UnmarshalJSON([]byte(`{}`)) },
+	}
+	for name, check := range checks {
+		if err := check(); err == nil {
+			t.Errorf("nil %s receiver succeeded", name)
+		}
+	}
+
+	names := []string{
+		"RealtimeConversationVersion", "ThreadRealtimeAudioChunk", "ThreadRealtimeClosedNotification", "ThreadRealtimeErrorNotification",
+		"ThreadRealtimeItemAddedNotification", "ThreadRealtimeOutputAudioDeltaNotification", "ThreadRealtimeSdpNotification",
+		"ThreadRealtimeStartedNotification", "ThreadRealtimeTranscriptDeltaNotification", "ThreadRealtimeTranscriptDoneNotification",
+	}
+	for _, binding := range WireTypeBindings() {
+		for _, name := range names {
+			if slices.Contains(binding.Params, name) || slices.Contains(binding.Result, name) {
+				t.Fatalf("%s unexpectedly bound to %s", name, binding.Method)
+			}
+		}
+	}
+	for _, binding := range ItemPayloadBindings() {
+		if slices.Contains(names, binding.Type) {
+			t.Fatalf("%s unexpectedly bound to item %s", binding.Type, binding.Kind)
+		}
+	}
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
+	}
+	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
+	}
+}
+
+func TestRealtimeNotificationsTypeScriptIsExact(t *testing.T) {
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	source := string(generated)
+	for _, want := range []string{
+		`export type RealtimeConversationVersion = "v1" | "v2" | "v3";`,
+		"export type ThreadRealtimeAudioChunk = {\n  \"data\": string;\n  \"itemId\": string | null;\n  \"numChannels\": number;\n  \"sampleRate\": number;\n  \"samplesPerChannel\": number | null;\n};",
+		"export type ThreadRealtimeClosedNotification = {\n  \"reason\": string | null;\n  \"threadId\": string;\n};",
+		"export type ThreadRealtimeErrorNotification = {\n  \"message\": string;\n  \"threadId\": string;\n};",
+		"export type ThreadRealtimeItemAddedNotification = {\n  \"item\": JsonValue;\n  \"threadId\": string;\n};",
+		"export type ThreadRealtimeOutputAudioDeltaNotification = {\n  \"audio\": ThreadRealtimeAudioChunk;\n  \"threadId\": string;\n};",
+		"export type ThreadRealtimeSdpNotification = {\n  \"sdp\": string;\n  \"threadId\": string;\n};",
+		"export type ThreadRealtimeStartedNotification = {\n  \"realtimeSessionId\": string | null;\n  \"threadId\": string;\n  \"version\": RealtimeConversationVersion;\n};",
+		"export type ThreadRealtimeTranscriptDeltaNotification = {\n  \"delta\": string;\n  \"role\": string;\n  \"threadId\": string;\n};",
+		"export type ThreadRealtimeTranscriptDoneNotification = {\n  \"role\": string;\n  \"text\": string;\n  \"threadId\": string;\n};",
+	} {
+		if !strings.Contains(source, want) {
+			t.Errorf("generated TypeScript missing %q", want)
+		}
+	}
+}
+
+func assertRealtimeNotificationRejects[T any](t *testing.T, inputs ...string) {
+	t.Helper()
+	for _, input := range inputs {
+		assertJSONRejects[T](t, input)
+	}
+}

--- a/appserver/protocol/realtime_notification_types.go
+++ b/appserver/protocol/realtime_notification_types.go
@@ -1,0 +1,420 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// RealtimeConversationVersion is the exact closed realtime protocol version.
+type RealtimeConversationVersion string
+
+const (
+	RealtimeConversationVersionV1 RealtimeConversationVersion = "v1"
+	RealtimeConversationVersionV2 RealtimeConversationVersion = "v2"
+	RealtimeConversationVersionV3 RealtimeConversationVersion = "v3"
+)
+
+func (v RealtimeConversationVersion) MarshalJSON() ([]byte, error) {
+	return marshalThreadTurnLeafEnum(v, "realtime conversation version", RealtimeConversationVersion.valid)
+}
+
+func (v *RealtimeConversationVersion) UnmarshalJSON(data []byte) error {
+	return unmarshalThreadTurnLeafEnum(data, v, "realtime conversation version", RealtimeConversationVersion.valid)
+}
+
+func (v RealtimeConversationVersion) valid() bool {
+	return v == RealtimeConversationVersionV1 || v == RealtimeConversationVersionV2 || v == RealtimeConversationVersionV3
+}
+
+// ThreadRealtimeAudioChunk is an experimental realtime audio payload.
+type ThreadRealtimeAudioChunk struct {
+	Data              string  `json:"data"`
+	SampleRate        uint32  `json:"sampleRate"`
+	NumChannels       uint16  `json:"numChannels"`
+	SamplesPerChannel *uint32 `json:"samplesPerChannel,omitempty"`
+	ItemID            *string `json:"itemId,omitempty"`
+}
+
+func (c ThreadRealtimeAudioChunk) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Data              string  `json:"data"`
+		SampleRate        uint32  `json:"sampleRate"`
+		NumChannels       uint16  `json:"numChannels"`
+		SamplesPerChannel *uint32 `json:"samplesPerChannel"`
+		ItemID            *string `json:"itemId"`
+	}{
+		Data: c.Data, SampleRate: c.SampleRate, NumChannels: c.NumChannels,
+		SamplesPerChannel: c.SamplesPerChannel, ItemID: c.ItemID,
+	})
+}
+
+func (c *ThreadRealtimeAudioChunk) UnmarshalJSON(data []byte) error {
+	if c == nil {
+		return errors.New("decode thread realtime audio chunk into nil receiver")
+	}
+	const objectName = "thread realtime audio chunk"
+	payload, err := decodeRustSerdeObject(data, objectName, "data", "sampleRate", "numChannels", "samplesPerChannel", "itemId")
+	if err != nil {
+		return err
+	}
+	value, err := decodeRequiredThreadItemValue[string](payload, objectName, "data")
+	if err != nil {
+		return err
+	}
+	sampleRate, err := decodeRequiredThreadItemValue[uint32](payload, objectName, "sampleRate")
+	if err != nil {
+		return err
+	}
+	numChannels, err := decodeRequiredThreadItemValue[uint16](payload, objectName, "numChannels")
+	if err != nil {
+		return err
+	}
+	samplesPerChannel, err := decodeOptionalNullableConfigValue[uint32](payload, objectName, "samplesPerChannel")
+	if err != nil {
+		return err
+	}
+	itemID, err := decodeOptionalNullableConfigValue[string](payload, objectName, "itemId")
+	if err != nil {
+		return err
+	}
+	*c = ThreadRealtimeAudioChunk{
+		Data: value, SampleRate: sampleRate, NumChannels: numChannels,
+		SamplesPerChannel: samplesPerChannel, ItemID: itemID,
+	}
+	return nil
+}
+
+// ThreadRealtimeStartedNotification reports accepted realtime startup.
+type ThreadRealtimeStartedNotification struct {
+	ThreadID          string                      `json:"threadId"`
+	RealtimeSessionID *string                     `json:"realtimeSessionId,omitempty"`
+	Version           RealtimeConversationVersion `json:"version"`
+}
+
+func (n ThreadRealtimeStartedNotification) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		ThreadID          string                      `json:"threadId"`
+		RealtimeSessionID *string                     `json:"realtimeSessionId"`
+		Version           RealtimeConversationVersion `json:"version"`
+	}{ThreadID: n.ThreadID, RealtimeSessionID: n.RealtimeSessionID, Version: n.Version})
+}
+
+func (n *ThreadRealtimeStartedNotification) UnmarshalJSON(data []byte) error {
+	if n == nil {
+		return errors.New("decode thread realtime started notification into nil receiver")
+	}
+	const objectName = "thread realtime started notification"
+	payload, err := decodeRustSerdeObject(data, objectName, "threadId", "realtimeSessionId", "version")
+	if err != nil {
+		return err
+	}
+	threadID, err := decodeRequiredThreadItemValue[string](payload, objectName, "threadId")
+	if err != nil {
+		return err
+	}
+	realtimeSessionID, err := decodeOptionalNullableConfigValue[string](payload, objectName, "realtimeSessionId")
+	if err != nil {
+		return err
+	}
+	version, err := decodeRequiredThreadItemValue[RealtimeConversationVersion](payload, objectName, "version")
+	if err != nil {
+		return err
+	}
+	*n = ThreadRealtimeStartedNotification{ThreadID: threadID, RealtimeSessionID: realtimeSessionID, Version: version}
+	return nil
+}
+
+// ThreadRealtimeItemAddedNotification reports one raw realtime item.
+type ThreadRealtimeItemAddedNotification struct {
+	ThreadID string    `json:"threadId"`
+	Item     JsonValue `json:"item"`
+}
+
+func (n *ThreadRealtimeItemAddedNotification) UnmarshalJSON(data []byte) error {
+	if n == nil {
+		return errors.New("decode thread realtime item-added notification into nil receiver")
+	}
+	const objectName = "thread realtime item-added notification"
+	payload, err := decodeRustSerdeObject(data, objectName, "threadId", "item")
+	if err != nil {
+		return err
+	}
+	threadID, err := decodeRequiredThreadItemValue[string](payload, objectName, "threadId")
+	if err != nil {
+		return err
+	}
+	item, err := decodeRequiredThreadItemJSONValue(payload, objectName, "item")
+	if err != nil {
+		return err
+	}
+	*n = ThreadRealtimeItemAddedNotification{ThreadID: threadID, Item: item}
+	return nil
+}
+
+// ThreadRealtimeTranscriptDeltaNotification reports a live transcript delta.
+type ThreadRealtimeTranscriptDeltaNotification struct {
+	ThreadID string `json:"threadId"`
+	Role     string `json:"role"`
+	Delta    string `json:"delta"`
+}
+
+func (n *ThreadRealtimeTranscriptDeltaNotification) UnmarshalJSON(data []byte) error {
+	if n == nil {
+		return errors.New("decode thread realtime transcript-delta notification into nil receiver")
+	}
+	const objectName = "thread realtime transcript-delta notification"
+	payload, err := decodeRustSerdeObject(data, objectName, "threadId", "role", "delta")
+	if err != nil {
+		return err
+	}
+	threadID, err := decodeRequiredThreadItemValue[string](payload, objectName, "threadId")
+	if err != nil {
+		return err
+	}
+	role, err := decodeRequiredThreadItemValue[string](payload, objectName, "role")
+	if err != nil {
+		return err
+	}
+	delta, err := decodeRequiredThreadItemValue[string](payload, objectName, "delta")
+	if err != nil {
+		return err
+	}
+	*n = ThreadRealtimeTranscriptDeltaNotification{ThreadID: threadID, Role: role, Delta: delta}
+	return nil
+}
+
+// ThreadRealtimeTranscriptDoneNotification reports final transcript text.
+type ThreadRealtimeTranscriptDoneNotification struct {
+	ThreadID string `json:"threadId"`
+	Role     string `json:"role"`
+	Text     string `json:"text"`
+}
+
+func (n *ThreadRealtimeTranscriptDoneNotification) UnmarshalJSON(data []byte) error {
+	if n == nil {
+		return errors.New("decode thread realtime transcript-done notification into nil receiver")
+	}
+	const objectName = "thread realtime transcript-done notification"
+	payload, err := decodeRustSerdeObject(data, objectName, "threadId", "role", "text")
+	if err != nil {
+		return err
+	}
+	threadID, err := decodeRequiredThreadItemValue[string](payload, objectName, "threadId")
+	if err != nil {
+		return err
+	}
+	role, err := decodeRequiredThreadItemValue[string](payload, objectName, "role")
+	if err != nil {
+		return err
+	}
+	text, err := decodeRequiredThreadItemValue[string](payload, objectName, "text")
+	if err != nil {
+		return err
+	}
+	*n = ThreadRealtimeTranscriptDoneNotification{ThreadID: threadID, Role: role, Text: text}
+	return nil
+}
+
+// ThreadRealtimeOutputAudioDeltaNotification reports streamed output audio.
+type ThreadRealtimeOutputAudioDeltaNotification struct {
+	ThreadID string                   `json:"threadId"`
+	Audio    ThreadRealtimeAudioChunk `json:"audio"`
+}
+
+func (n *ThreadRealtimeOutputAudioDeltaNotification) UnmarshalJSON(data []byte) error {
+	if n == nil {
+		return errors.New("decode thread realtime output-audio notification into nil receiver")
+	}
+	const objectName = "thread realtime output-audio notification"
+	payload, err := decodeRustSerdeObject(data, objectName, "threadId", "audio")
+	if err != nil {
+		return err
+	}
+	threadID, err := decodeRequiredThreadItemValue[string](payload, objectName, "threadId")
+	if err != nil {
+		return err
+	}
+	audio, err := decodeRequiredThreadItemValue[ThreadRealtimeAudioChunk](payload, objectName, "audio")
+	if err != nil {
+		return err
+	}
+	*n = ThreadRealtimeOutputAudioDeltaNotification{ThreadID: threadID, Audio: audio}
+	return nil
+}
+
+// ThreadRealtimeSdpNotification reports remote WebRTC SDP.
+type ThreadRealtimeSdpNotification struct {
+	ThreadID string `json:"threadId"`
+	SDP      string `json:"sdp"`
+}
+
+func (n *ThreadRealtimeSdpNotification) UnmarshalJSON(data []byte) error {
+	if n == nil {
+		return errors.New("decode thread realtime SDP notification into nil receiver")
+	}
+	const objectName = "thread realtime SDP notification"
+	payload, err := decodeRustSerdeObject(data, objectName, "threadId", "sdp")
+	if err != nil {
+		return err
+	}
+	threadID, err := decodeRequiredThreadItemValue[string](payload, objectName, "threadId")
+	if err != nil {
+		return err
+	}
+	sdp, err := decodeRequiredThreadItemValue[string](payload, objectName, "sdp")
+	if err != nil {
+		return err
+	}
+	*n = ThreadRealtimeSdpNotification{ThreadID: threadID, SDP: sdp}
+	return nil
+}
+
+// ThreadRealtimeErrorNotification reports one realtime error.
+type ThreadRealtimeErrorNotification struct {
+	ThreadID string `json:"threadId"`
+	Message  string `json:"message"`
+}
+
+func (n *ThreadRealtimeErrorNotification) UnmarshalJSON(data []byte) error {
+	if n == nil {
+		return errors.New("decode thread realtime error notification into nil receiver")
+	}
+	const objectName = "thread realtime error notification"
+	payload, err := decodeRustSerdeObject(data, objectName, "threadId", "message")
+	if err != nil {
+		return err
+	}
+	threadID, err := decodeRequiredThreadItemValue[string](payload, objectName, "threadId")
+	if err != nil {
+		return err
+	}
+	message, err := decodeRequiredThreadItemValue[string](payload, objectName, "message")
+	if err != nil {
+		return err
+	}
+	*n = ThreadRealtimeErrorNotification{ThreadID: threadID, Message: message}
+	return nil
+}
+
+// ThreadRealtimeClosedNotification reports realtime transport closure.
+type ThreadRealtimeClosedNotification struct {
+	ThreadID string  `json:"threadId"`
+	Reason   *string `json:"reason,omitempty"`
+}
+
+func (n ThreadRealtimeClosedNotification) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		ThreadID string  `json:"threadId"`
+		Reason   *string `json:"reason"`
+	}{ThreadID: n.ThreadID, Reason: n.Reason})
+}
+
+func (n *ThreadRealtimeClosedNotification) UnmarshalJSON(data []byte) error {
+	if n == nil {
+		return errors.New("decode thread realtime closed notification into nil receiver")
+	}
+	const objectName = "thread realtime closed notification"
+	payload, err := decodeRustSerdeObject(data, objectName, "threadId", "reason")
+	if err != nil {
+		return err
+	}
+	threadID, err := decodeRequiredThreadItemValue[string](payload, objectName, "threadId")
+	if err != nil {
+		return err
+	}
+	reason, err := decodeOptionalNullableConfigValue[string](payload, objectName, "reason")
+	if err != nil {
+		return err
+	}
+	*n = ThreadRealtimeClosedNotification{ThreadID: threadID, Reason: reason}
+	return nil
+}
+
+func realtimeNotificationSchemas() map[string]Schema {
+	return map[string]Schema{
+		"RealtimeConversationVersion": stringEnumSchema("v1", "v2", "v3"),
+		"ThreadRealtimeAudioChunk": {
+			"description": "EXPERIMENTAL - thread realtime audio chunk.",
+			"properties": Schema{
+				"data":              Schema{"type": "string"},
+				"itemId":            Schema{"type": []any{"string", "null"}},
+				"numChannels":       Schema{"format": "uint16", "minimum": float64(0), "type": "integer"},
+				"sampleRate":        Schema{"format": "uint32", "minimum": float64(0), "type": "integer"},
+				"samplesPerChannel": Schema{"format": "uint32", "minimum": float64(0), "type": []any{"integer", "null"}},
+			},
+			"required": []string{"data", "numChannels", "sampleRate"},
+			"type":     "object",
+		},
+		"ThreadRealtimeClosedNotification": realtimeNotificationSchema(
+			"EXPERIMENTAL - emitted when thread realtime transport closes.",
+			"ThreadRealtimeClosedNotification",
+			Schema{"reason": Schema{"type": []any{"string", "null"}}, "threadId": Schema{"type": "string"}},
+			"threadId",
+		),
+		"ThreadRealtimeErrorNotification": realtimeNotificationSchema(
+			"EXPERIMENTAL - emitted when thread realtime encounters an error.",
+			"ThreadRealtimeErrorNotification",
+			Schema{"message": Schema{"type": "string"}, "threadId": Schema{"type": "string"}},
+			"message", "threadId",
+		),
+		"ThreadRealtimeItemAddedNotification": realtimeNotificationSchema(
+			"EXPERIMENTAL - raw non-audio thread realtime item emitted by the backend.",
+			"ThreadRealtimeItemAddedNotification",
+			Schema{"item": true, "threadId": Schema{"type": "string"}},
+			"item", "threadId",
+		),
+		"ThreadRealtimeOutputAudioDeltaNotification": realtimeNotificationSchema(
+			"EXPERIMENTAL - streamed output audio emitted by thread realtime.",
+			"ThreadRealtimeOutputAudioDeltaNotification",
+			Schema{"audio": Schema{"$ref": "#/$defs/ThreadRealtimeAudioChunk"}, "threadId": Schema{"type": "string"}},
+			"audio", "threadId",
+		),
+		"ThreadRealtimeSdpNotification": realtimeNotificationSchema(
+			"EXPERIMENTAL - emitted with the remote SDP for a WebRTC realtime session.",
+			"ThreadRealtimeSdpNotification",
+			Schema{"sdp": Schema{"type": "string"}, "threadId": Schema{"type": "string"}},
+			"sdp", "threadId",
+		),
+		"ThreadRealtimeStartedNotification": realtimeNotificationSchema(
+			"EXPERIMENTAL - emitted when thread realtime startup is accepted.",
+			"ThreadRealtimeStartedNotification",
+			Schema{
+				"realtimeSessionId": Schema{"type": []any{"string", "null"}},
+				"threadId":          Schema{"type": "string"},
+				"version":           Schema{"$ref": "#/$defs/RealtimeConversationVersion"},
+			},
+			"threadId", "version",
+		),
+		"ThreadRealtimeTranscriptDeltaNotification": realtimeNotificationSchema(
+			"EXPERIMENTAL - flat transcript delta emitted whenever realtime transcript text changes.",
+			"ThreadRealtimeTranscriptDeltaNotification",
+			Schema{
+				"delta":    Schema{"description": "Live transcript delta from the realtime event.", "type": "string"},
+				"role":     Schema{"type": "string"},
+				"threadId": Schema{"type": "string"},
+			},
+			"delta", "role", "threadId",
+		),
+		"ThreadRealtimeTranscriptDoneNotification": realtimeNotificationSchema(
+			"EXPERIMENTAL - final transcript text emitted when realtime completes a transcript part.",
+			"ThreadRealtimeTranscriptDoneNotification",
+			Schema{
+				"role":     Schema{"type": "string"},
+				"text":     Schema{"description": "Final complete text for the transcript part.", "type": "string"},
+				"threadId": Schema{"type": "string"},
+			},
+			"role", "text", "threadId",
+		),
+	}
+}
+
+func realtimeNotificationSchema(description, title string, properties Schema, required ...string) Schema {
+	return Schema{
+		"$schema":     "http://json-schema.org/draft-07/schema#",
+		"description": description,
+		"properties":  properties,
+		"required":    required,
+		"title":       title,
+		"type":        "object",
+	}
+}

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -159,8 +159,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if !ok || info.State != MethodImplemented {
 		t.Fatalf("mcpServer/resource/read = %#v, %v; want implemented", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/review_decision_contract_test.go
+++ b/appserver/protocol/review_decision_contract_test.go
@@ -136,8 +136,8 @@ func TestReviewDecisionRemainsStandalone(t *testing.T) {
 			t.Fatalf("ReviewDecision unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(defs); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(defs); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/review_start_contract_test.go
+++ b/appserver/protocol/review_start_contract_test.go
@@ -215,8 +215,8 @@ func TestReviewStartContractsFailClosedAndRemainStandalone(t *testing.T) {
 	if !ok || request.Surface != SurfaceClientRequest || request.State != MethodBlocked {
 		t.Fatalf("review/start = %#v, %v; want blocked client request", request, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 }
 

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -714,6 +714,16 @@ func wireSchemaDefinitions() Schema {
 		{Name: "ThreadRevertedNotification", Type: reflect.TypeFor[ThreadRevertedNotification]()},
 		{Name: "WindowsSandboxSetupCompletedNotification", Type: reflect.TypeFor[WindowsSandboxSetupCompletedNotification]()},
 		{Name: "WindowsWorldWritableWarningNotification", Type: reflect.TypeFor[WindowsWorldWritableWarningNotification]()},
+		{Name: "RealtimeConversationVersion", Type: reflect.TypeFor[RealtimeConversationVersion]()},
+		{Name: "ThreadRealtimeAudioChunk", Type: reflect.TypeFor[ThreadRealtimeAudioChunk]()},
+		{Name: "ThreadRealtimeClosedNotification", Type: reflect.TypeFor[ThreadRealtimeClosedNotification]()},
+		{Name: "ThreadRealtimeErrorNotification", Type: reflect.TypeFor[ThreadRealtimeErrorNotification]()},
+		{Name: "ThreadRealtimeItemAddedNotification", Type: reflect.TypeFor[ThreadRealtimeItemAddedNotification]()},
+		{Name: "ThreadRealtimeOutputAudioDeltaNotification", Type: reflect.TypeFor[ThreadRealtimeOutputAudioDeltaNotification]()},
+		{Name: "ThreadRealtimeSdpNotification", Type: reflect.TypeFor[ThreadRealtimeSdpNotification]()},
+		{Name: "ThreadRealtimeStartedNotification", Type: reflect.TypeFor[ThreadRealtimeStartedNotification]()},
+		{Name: "ThreadRealtimeTranscriptDeltaNotification", Type: reflect.TypeFor[ThreadRealtimeTranscriptDeltaNotification]()},
+		{Name: "ThreadRealtimeTranscriptDoneNotification", Type: reflect.TypeFor[ThreadRealtimeTranscriptDoneNotification]()},
 		// Register exact public names after their aliases so nested schemas refer
 		// to the public names. JSON and TypeScript output remain key-sorted.
 		{Name: "ContextCompactedNotification", Type: reflect.TypeFor[ContextCompactedNotification]()},
@@ -1368,6 +1378,9 @@ func wireSchemaDefinitions() Schema {
 		schemas[name] = schema
 	}
 	for name, schema := range operationalNotificationLeafSchemas() {
+		schemas[name] = schema
+	}
+	for name, schema := range realtimeNotificationSchemas() {
 		schemas[name] = schema
 	}
 	for name, schema := range workspaceMessageSchemas() {

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -13130,6 +13130,14 @@
       ],
       "type": "object"
     },
+    "RealtimeConversationVersion": {
+      "enum": [
+        "v1",
+        "v2",
+        "v3"
+      ],
+      "type": "string"
+    },
     "ReasoningEffort": {
       "minLength": 1,
       "type": "string"
@@ -18218,6 +18226,204 @@
       "required": [
         "thread"
       ],
+      "type": "object"
+    },
+    "ThreadRealtimeAudioChunk": {
+      "description": "EXPERIMENTAL - thread realtime audio chunk.",
+      "properties": {
+        "data": {
+          "type": "string"
+        },
+        "itemId": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "numChannels": {
+          "format": "uint16",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "sampleRate": {
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "samplesPerChannel": {
+          "format": "uint32",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "data",
+        "numChannels",
+        "sampleRate"
+      ],
+      "type": "object"
+    },
+    "ThreadRealtimeClosedNotification": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "description": "EXPERIMENTAL - emitted when thread realtime transport closes.",
+      "properties": {
+        "reason": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "threadId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "threadId"
+      ],
+      "title": "ThreadRealtimeClosedNotification",
+      "type": "object"
+    },
+    "ThreadRealtimeErrorNotification": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "description": "EXPERIMENTAL - emitted when thread realtime encounters an error.",
+      "properties": {
+        "message": {
+          "type": "string"
+        },
+        "threadId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "message",
+        "threadId"
+      ],
+      "title": "ThreadRealtimeErrorNotification",
+      "type": "object"
+    },
+    "ThreadRealtimeItemAddedNotification": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "description": "EXPERIMENTAL - raw non-audio thread realtime item emitted by the backend.",
+      "properties": {
+        "item": true,
+        "threadId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "item",
+        "threadId"
+      ],
+      "title": "ThreadRealtimeItemAddedNotification",
+      "type": "object"
+    },
+    "ThreadRealtimeOutputAudioDeltaNotification": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "description": "EXPERIMENTAL - streamed output audio emitted by thread realtime.",
+      "properties": {
+        "audio": {
+          "$ref": "#/$defs/ThreadRealtimeAudioChunk"
+        },
+        "threadId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "audio",
+        "threadId"
+      ],
+      "title": "ThreadRealtimeOutputAudioDeltaNotification",
+      "type": "object"
+    },
+    "ThreadRealtimeSdpNotification": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "description": "EXPERIMENTAL - emitted with the remote SDP for a WebRTC realtime session.",
+      "properties": {
+        "sdp": {
+          "type": "string"
+        },
+        "threadId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "sdp",
+        "threadId"
+      ],
+      "title": "ThreadRealtimeSdpNotification",
+      "type": "object"
+    },
+    "ThreadRealtimeStartedNotification": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "description": "EXPERIMENTAL - emitted when thread realtime startup is accepted.",
+      "properties": {
+        "realtimeSessionId": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "threadId": {
+          "type": "string"
+        },
+        "version": {
+          "$ref": "#/$defs/RealtimeConversationVersion"
+        }
+      },
+      "required": [
+        "threadId",
+        "version"
+      ],
+      "title": "ThreadRealtimeStartedNotification",
+      "type": "object"
+    },
+    "ThreadRealtimeTranscriptDeltaNotification": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "description": "EXPERIMENTAL - flat transcript delta emitted whenever realtime transcript text changes.",
+      "properties": {
+        "delta": {
+          "description": "Live transcript delta from the realtime event.",
+          "type": "string"
+        },
+        "role": {
+          "type": "string"
+        },
+        "threadId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "delta",
+        "role",
+        "threadId"
+      ],
+      "title": "ThreadRealtimeTranscriptDeltaNotification",
+      "type": "object"
+    },
+    "ThreadRealtimeTranscriptDoneNotification": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "description": "EXPERIMENTAL - final transcript text emitted when realtime completes a transcript part.",
+      "properties": {
+        "role": {
+          "type": "string"
+        },
+        "text": {
+          "description": "Final complete text for the transcript part.",
+          "type": "string"
+        },
+        "threadId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "role",
+        "text",
+        "threadId"
+      ],
+      "title": "ThreadRealtimeTranscriptDoneNotification",
       "type": "object"
     },
     "ThreadRecord": {

--- a/appserver/protocol/server_request_approval_params_contract_test.go
+++ b/appserver/protocol/server_request_approval_params_contract_test.go
@@ -163,8 +163,8 @@ func TestServerRequestApprovalParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(defs); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(defs); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/server_request_contract_test.go
+++ b/appserver/protocol/server_request_contract_test.go
@@ -53,8 +53,8 @@ func TestServerRequestSchemaAndBindingAreExact(t *testing.T) {
 			}
 		}
 	}
-	if got := len(defs); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(defs); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	typescript, err := MarshalTypeScript()
 	if err != nil {

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -128,8 +128,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/skills_config_write_params_contract_test.go
+++ b/appserver/protocol/skills_config_write_params_contract_test.go
@@ -64,8 +64,8 @@ func TestSkillsConfigWriteParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 }
 

--- a/appserver/protocol/skills_extra_roots_set_params_contract_test.go
+++ b/appserver/protocol/skills_extra_roots_set_params_contract_test.go
@@ -60,8 +60,8 @@ func TestSkillsExtraRootsSetParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 }
 

--- a/appserver/protocol/skills_list_params_contract_test.go
+++ b/appserver/protocol/skills_list_params_contract_test.go
@@ -46,8 +46,8 @@ func TestSkillsListParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 }
 

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -102,8 +102,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want deferred stub", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(Methods()); got != 226 {
 		t.Fatalf("methods = %d, want 226", got)

--- a/appserver/protocol/terminal_interaction_notification_contract_test.go
+++ b/appserver/protocol/terminal_interaction_notification_contract_test.go
@@ -72,8 +72,8 @@ func TestTerminalInteractionNotificationRemainsStandalone(t *testing.T) {
 	if !ok || info.Surface != SurfaceServerNotification || info.State != MethodBlocked {
 		t.Fatalf("terminal interaction method = %#v, %v; want blocked server notification", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	generated, err := MarshalTypeScript()
 	if err != nil {

--- a/appserver/protocol/thread_approve_guardian_denied_action_contract_test.go
+++ b/appserver/protocol/thread_approve_guardian_denied_action_contract_test.go
@@ -88,8 +88,8 @@ func TestThreadApproveGuardianDeniedActionContractsRemainStandalone(t *testing.T
 	if !ok || info.Surface != SurfaceClientRequest || info.State != MethodDeferredStub {
 		t.Fatalf("guardian denied action method = %#v, %v; want deferred client request", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 }
 

--- a/appserver/protocol/thread_inject_items_contract_test.go
+++ b/appserver/protocol/thread_inject_items_contract_test.go
@@ -96,8 +96,8 @@ func TestThreadInjectItemsContractsFailClosedAndRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 }
 

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -387,8 +387,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 			t.Errorf("generated TypeScript missing %q", want)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 651 {
-		t.Fatalf("definition count = %d, want 651", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 661 {
+		t.Fatalf("definition count = %d, want 661", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -94,8 +94,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -262,8 +262,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -194,8 +194,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if _, ok := resume["properties"].(Schema)["initialTurnsPage"]; ok {
 		t.Fatal("ThreadResumeParams unexpectedly gained initialTurnsPage")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_rollback_contract_test.go
+++ b/appserver/protocol/thread_rollback_contract_test.go
@@ -114,8 +114,8 @@ func TestThreadRollbackContractsFailClosedAndRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 }
 

--- a/appserver/protocol/thread_search_result_contract_test.go
+++ b/appserver/protocol/thread_search_result_contract_test.go
@@ -59,8 +59,8 @@ func TestThreadSearchResultFailsClosedAndRemainsStandalone(t *testing.T) {
 			t.Fatalf("ThreadSearchResult unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 }
 

--- a/appserver/protocol/thread_section_params_contract_test.go
+++ b/appserver/protocol/thread_section_params_contract_test.go
@@ -213,8 +213,8 @@ func TestThreadSectionParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 }
 

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -252,8 +252,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 	if !foundRuntimeStart {
 		t.Error("thread/start runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -154,8 +154,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 	if !foundRuntimeStart {
 		t.Error("thread/start runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_settings_contract_test.go
+++ b/appserver/protocol/thread_settings_contract_test.go
@@ -162,8 +162,8 @@ func TestThreadSettingsContractsFailClosedAndRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 }
 

--- a/appserver/protocol/thread_shell_command_contract_test.go
+++ b/appserver/protocol/thread_shell_command_contract_test.go
@@ -95,8 +95,8 @@ func TestThreadShellCommandContractsFailClosedAndRemainStandalone(t *testing.T) 
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 }
 

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -311,8 +311,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 651 {
-		t.Fatalf("definition count = %d, want 651", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 661 {
+		t.Fatalf("definition count = %d, want 661", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -220,8 +220,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 			t.Fatalf("%s unexpectedly bound by %#v", binding.Type, binding)
 		}
 	}
-	if len(JSONSchema()["$defs"].(Schema)) != 651 {
-		t.Fatalf("definition count = %d, want 651", len(JSONSchema()["$defs"].(Schema)))
+	if len(JSONSchema()["$defs"].(Schema)) != 661 {
+		t.Fatalf("definition count = %d, want 661", len(JSONSchema()["$defs"].(Schema)))
 	}
 	if len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", len(WireTypeBindings()), len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_environment_contract_test.go
+++ b/appserver/protocol/turn_environment_contract_test.go
@@ -79,8 +79,8 @@ func TestTurnEnvironmentParamsFailsClosedAndRemainsStandalone(t *testing.T) {
 			t.Fatalf("TurnEnvironmentParams unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 }
 

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -119,8 +119,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 	if !foundRuntimeBinding {
 		t.Error("turn/interrupt runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -209,8 +209,8 @@ func TestTurnPlanContractsRemainStandalone(t *testing.T) {
 	if !ok || info.State != MethodBlocked {
 		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -241,8 +241,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 	if !foundRuntimeBinding {
 		t.Error("turn/start runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -164,8 +164,8 @@ func TestTurnSteerContractsAreBoundToLiveRuntime(t *testing.T) {
 	if !found {
 		t.Fatal("turn/steer runtime binding missing")
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/typescript.go
+++ b/appserver/protocol/typescript.go
@@ -58,6 +58,11 @@ func MarshalTypeScript() ([]byte, error) {
 			name == "ThreadQueueChangedNotification" || name == "ThreadRevertedNotification" ||
 			name == "RemoteControlStatusChangedNotification" ||
 			name == "WindowsSandboxSetupCompletedNotification" || name == "WindowsWorldWritableWarningNotification" ||
+			name == "ThreadRealtimeAudioChunk" || name == "ThreadRealtimeClosedNotification" ||
+			name == "ThreadRealtimeErrorNotification" || name == "ThreadRealtimeItemAddedNotification" ||
+			name == "ThreadRealtimeOutputAudioDeltaNotification" || name == "ThreadRealtimeSdpNotification" ||
+			name == "ThreadRealtimeStartedNotification" || name == "ThreadRealtimeTranscriptDeltaNotification" ||
+			name == "ThreadRealtimeTranscriptDoneNotification" ||
 			name == "MigrationDetails" ||
 			name == "ExternalAgentConfigMigrationItem" ||
 			name == "ExternalAgentConfigImportItemTypeFailure" ||
@@ -226,6 +231,25 @@ func MarshalTypeScript() ([]byte, error) {
 				schema["required"] = []string{"error", "mode", "success"}
 				schema["x-gollem-typescript-ignore-additional-properties"] = true
 				schema["properties"].(Schema)["error"] = nullableStringSchema()
+			case "ThreadRealtimeAudioChunk":
+				schema["required"] = []string{"data", "itemId", "numChannels", "sampleRate", "samplesPerChannel"}
+				schema["x-gollem-typescript-ignore-additional-properties"] = true
+				properties := schema["properties"].(Schema)
+				properties["itemId"] = nullableStringSchema()
+				properties["samplesPerChannel"] = nullableIntegerSchema()
+			case "ThreadRealtimeClosedNotification":
+				schema["required"] = []string{"reason", "threadId"}
+				schema["x-gollem-typescript-ignore-additional-properties"] = true
+				schema["properties"].(Schema)["reason"] = nullableStringSchema()
+			case "ThreadRealtimeErrorNotification", "ThreadRealtimeOutputAudioDeltaNotification", "ThreadRealtimeSdpNotification", "ThreadRealtimeTranscriptDeltaNotification", "ThreadRealtimeTranscriptDoneNotification":
+				schema["x-gollem-typescript-ignore-additional-properties"] = true
+			case "ThreadRealtimeItemAddedNotification":
+				schema["x-gollem-typescript-ignore-additional-properties"] = true
+				schema["properties"].(Schema)["item"] = Schema{"$ref": "#/$defs/JsonValue"}
+			case "ThreadRealtimeStartedNotification":
+				schema["required"] = []string{"realtimeSessionId", "threadId", "version"}
+				schema["x-gollem-typescript-ignore-additional-properties"] = true
+				schema["properties"].(Schema)["realtimeSessionId"] = nullableStringSchema()
 			case "GetWorkspaceMessagesResponse":
 				schema["x-gollem-typescript-ignore-additional-properties"] = true
 			case "ExecCommandApprovalParams":

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -3161,6 +3161,8 @@ export type RawResponseItemCompletedNotification = {
   "turnId": string;
 };
 
+export type RealtimeConversationVersion = "v1" | "v2" | "v3";
+
 export type ReasoningEffort = string;
 
 export type ReasoningEffortOption = {
@@ -4099,6 +4101,57 @@ export type ThreadReadResult = {
   "items"?: Array<TimelineItem>;
   "thread": ThreadRecord;
   "turns"?: Array<TurnRecord>;
+};
+
+export type ThreadRealtimeAudioChunk = {
+  "data": string;
+  "itemId": string | null;
+  "numChannels": number;
+  "sampleRate": number;
+  "samplesPerChannel": number | null;
+};
+
+export type ThreadRealtimeClosedNotification = {
+  "reason": string | null;
+  "threadId": string;
+};
+
+export type ThreadRealtimeErrorNotification = {
+  "message": string;
+  "threadId": string;
+};
+
+export type ThreadRealtimeItemAddedNotification = {
+  "item": JsonValue;
+  "threadId": string;
+};
+
+export type ThreadRealtimeOutputAudioDeltaNotification = {
+  "audio": ThreadRealtimeAudioChunk;
+  "threadId": string;
+};
+
+export type ThreadRealtimeSdpNotification = {
+  "sdp": string;
+  "threadId": string;
+};
+
+export type ThreadRealtimeStartedNotification = {
+  "realtimeSessionId": string | null;
+  "threadId": string;
+  "version": RealtimeConversationVersion;
+};
+
+export type ThreadRealtimeTranscriptDeltaNotification = {
+  "delta": string;
+  "role": string;
+  "threadId": string;
+};
+
+export type ThreadRealtimeTranscriptDoneNotification = {
+  "role": string;
+  "text": string;
+  "threadId": string;
 };
 
 export type ThreadRecord = {

--- a/appserver/protocol/w3c_trace_context_contract_test.go
+++ b/appserver/protocol/w3c_trace_context_contract_test.go
@@ -55,8 +55,8 @@ func TestW3cTraceContextRemainsStandalone(t *testing.T) {
 			t.Fatalf("W3cTraceContext unexpectedly bound to %s", binding.Method)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 }
 

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -163,8 +163,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if got := len(WireTypeBindings()); got != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("bindings = %d methods/%d items, want 80/5", got, len(ItemPayloadBindings()))

--- a/appserver/protocol/windows_sandbox_setup_start_params_contract_test.go
+++ b/appserver/protocol/windows_sandbox_setup_start_params_contract_test.go
@@ -61,8 +61,8 @@ func TestWindowsSandboxSetupStartParamsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 }
 

--- a/appserver/protocol/workspace_messages_contract_test.go
+++ b/appserver/protocol/workspace_messages_contract_test.go
@@ -209,8 +209,8 @@ func TestWorkspaceMessageContractsRemainStandaloneAndDeferred(t *testing.T) {
 	if !ok || method.Surface != SurfaceClientRequest || method.State != MethodDeferredStub {
 		t.Fatalf("account/workspaceMessages/read = %#v, %v; want deferred client request", method, ok)
 	}
-	if got := len(JSONSchema()["$defs"].(Schema)); got != 651 {
-		t.Fatalf("definition count = %d, want 651", got)
+	if got := len(JSONSchema()["$defs"].(Schema)); got != 661 {
+		t.Fatalf("definition count = %d, want 661", got)
 	}
 	if len(Methods()) != 226 || len(WireTypeBindings()) != 80 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 226/80/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))


### PR DESCRIPTION
## Summary
- add exact standalone contracts for the remaining realtime server-notification payload closure
- preserve Rust serde wire behavior, source JSON Schema, and source TypeScript projections
- leave experimental realtime producer and method bindings unchanged

## Validation
- `go test ./appserver/protocol -run 'TestRealtimeNotifications|TestRealtimeNotificationSchemas' -count=1`\n- `go test ./appserver/protocol -count=1`\n- `go test -race ./appserver/protocol ./appserver -run 'TestRealtimeNotifications|TestRealtimeNotificationSchemas|TestWireTypeBindings' -count=1`\n- `go list ./... | rg -v '^github\\.com/fugue-labs/gollem/ext/monty(/|$)' | xargs go test -count=1`\n- `go list ./... | rg -v '^github\\.com/fugue-labs/gollem/ext/monty(/|$)' | xargs go vet`\n- `go mod tidy`\n- `go generate ./appserver/protocol`\n- `golangci-lint run`\n- pre-push non-Monty race suite