### PR TITLE
feat(anthropic): add request diagnostics tracing

### DIFF
--- a/provider/anthropic/anthropic.go
+++ b/provider/anthropic/anthropic.go
@@ -145,6 +145,7 @@ type Provider struct {
 	maxTokens          int
 	disablePromptCache bool
 	disableToolSearch  bool
+	requestObserver    RequestObserver
 }
 
 // Option configures the Anthropic provider.
@@ -175,6 +176,16 @@ func WithBaseURL(url string) Option {
 func WithHTTPClient(c *http.Client) Option {
 	return func(p *Provider) {
 		p.httpClient = c
+	}
+}
+
+// WithRequestObserver installs a secret-safe per-request diagnostics callback.
+// It receives timing, bounded request shape, normalized usage, and sanitized
+// error information only; it never receives credentials, request content,
+// endpoints, headers, or raw provider error bodies.
+func WithRequestObserver(observer RequestObserver) Option {
+	return func(p *Provider) {
+		p.requestObserver = observer
 	}
 }
 
@@ -221,6 +232,9 @@ func New(opts ...Option) *Provider {
 	if p.apiKey == "" {
 		p.apiKey = os.Getenv("ANTHROPIC_API_KEY")
 	}
+	if p.requestObserver == nil && isTruthy(os.Getenv("ANTHROPIC_REQUEST_TRACE")) {
+		p.requestObserver = DefaultStderrRequestObserver()
+	}
 	return p
 }
 
@@ -231,54 +245,72 @@ func (p *Provider) ModelName() string {
 
 // Request sends messages to Anthropic and returns a complete response.
 func (p *Provider) Request(ctx context.Context, messages []core.ModelMessage, settings *core.ModelSettings, params *core.ModelRequestParameters) (*core.ModelResponse, error) {
+	ri := newRequestInstrumentation(p.requestObserver, p.model)
+	defer ri.finish()
 	req, err := buildRequest(messages, settings, params, p.model, p.maxTokens, false, !p.disablePromptCache, p.disableToolSearch)
 	if err != nil {
+		ri.recordError(err)
 		return nil, fmt.Errorf("anthropic: failed to build request: %w", err)
 	}
 
 	body, err := json.Marshal(req)
 	if err != nil {
+		ri.recordError(err)
 		return nil, fmt.Errorf("anthropic: failed to marshal request: %w", err)
 	}
+	ri.setRequestShape(len(body), len(req.System)+len(req.Messages))
 
-	resp, err := p.doRequest(ctx, body)
+	resp, err := p.doRequest(ctx, body, ri)
 	if err != nil {
+		ri.recordError(err)
 		return nil, err
 	}
 	defer resp.Body.Close()
 
 	var apiResp apiResponse
 	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
+		ri.recordError(err)
 		return nil, fmt.Errorf("anthropic: failed to decode response: %w", err)
 	}
 
-	return parseResponse(&apiResp, p.model), nil
+	response := parseResponse(&apiResp, p.model)
+	ri.recordUsage(response.Usage)
+	ri.recordTerminal()
+	return response, nil
 }
 
 // RequestStream sends messages and returns a streaming response.
 func (p *Provider) RequestStream(ctx context.Context, messages []core.ModelMessage, settings *core.ModelSettings, params *core.ModelRequestParameters) (core.StreamedResponse, error) {
+	ri := newRequestInstrumentation(p.requestObserver, p.model)
 	req, err := buildRequest(messages, settings, params, p.model, p.maxTokens, true, !p.disablePromptCache, p.disableToolSearch)
 	if err != nil {
+		ri.recordError(err)
+		ri.finish()
 		return nil, fmt.Errorf("anthropic: failed to build request: %w", err)
 	}
 
 	body, err := json.Marshal(req)
 	if err != nil {
+		ri.recordError(err)
+		ri.finish()
 		return nil, fmt.Errorf("anthropic: failed to marshal request: %w", err)
 	}
+	ri.setRequestShape(len(body), len(req.System)+len(req.Messages))
 
-	resp, err := p.doRequest(ctx, body) //nolint:bodyclose // Response body ownership transfers to streamedResponse.
+	resp, err := p.doRequest(ctx, body, ri) //nolint:bodyclose // Response body ownership transfers to streamedResponse.
 	if err != nil {
+		ri.recordError(err)
+		ri.finish()
 		return nil, err
 	}
 
-	return newStreamedResponse(resp.Body, p.model), nil
+	return newStreamedResponse(resp.Body, p.model, ri), nil
 }
 
 // doRequest sends a single HTTP request and returns the response or a typed
 // error. Retry logic is handled at the model level by modelutil.RetryModel,
 // which uses this error's RetryAfter field for backoff.
-func (p *Provider) doRequest(ctx context.Context, body []byte) (*http.Response, error) {
+func (p *Provider) doRequest(ctx context.Context, body []byte, ri *requestInstrumentation) (*http.Response, error) {
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+messagesEndpoint, bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("anthropic: failed to create HTTP request: %w", err)
@@ -289,6 +321,7 @@ func (p *Provider) doRequest(ctx context.Context, body []byte) (*http.Response, 
 	if err != nil {
 		return nil, fmt.Errorf("anthropic: HTTP request failed: %w", err)
 	}
+	ri.recordHeaders(resp.StatusCode)
 
 	if resp.StatusCode == http.StatusOK {
 		return resp, nil
@@ -296,6 +329,7 @@ func (p *Provider) doRequest(ctx context.Context, body []byte) (*http.Response, 
 
 	classification := readProviderErrorClassification(resp.Body)
 	resp.Body.Close()
+	ri.classifyHTTPResponse(resp.StatusCode, classification)
 
 	httpErr := sanitizedProviderHTTPError(resp.StatusCode, classification, p.model)
 

--- a/provider/anthropic/instrumentation.go
+++ b/provider/anthropic/instrumentation.go
@@ -1,0 +1,229 @@
+package anthropic
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/fugue-labs/gollem/core"
+)
+
+// RequestTrace is a secret-safe record for one physical Anthropic HTTP
+// request. It contains timing, request size, normalized usage, and sanitized
+// error markers only; it never contains credentials, request content, headers,
+// endpoint URLs, or raw provider error bodies.
+type RequestTrace struct {
+	Transport     string
+	Model         string
+	StartedAt     time.Time
+	TotalDuration time.Duration
+
+	RequestBytes int
+	InputItems   int
+
+	TimeToHeaders    time.Duration
+	TimeToFirstEvent time.Duration
+	TimeToFirstToken time.Duration
+	TimeToTerminal   time.Duration
+
+	HTTPStatus          int
+	ErrorClassification string
+	RetryAfter          time.Duration
+	ErrorClass          string
+	CacheReadTokens     int
+	CacheWriteTokens    int
+}
+
+// RequestObserver receives one trace per completed, failed, or closed
+// Anthropic provider request. It runs in the request/streaming goroutine and
+// must be safe for concurrent use.
+type RequestObserver func(RequestTrace)
+
+// DefaultStderrRequestObserver returns a compact, secret-safe trace renderer.
+func DefaultStderrRequestObserver() RequestObserver {
+	return func(trace RequestTrace) {
+		fmt.Fprintln(os.Stderr, formatRequestTrace(trace))
+	}
+}
+
+func formatRequestTrace(trace RequestTrace) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "[gollem-anthropic-trace] transport=%s model=%s started=%s total=%s", trace.Transport, trace.Model, trace.StartedAt.Format(time.RFC3339Nano), trace.TotalDuration)
+	if trace.RequestBytes > 0 || trace.InputItems > 0 {
+		fmt.Fprintf(&b, " req_bytes=%d input_items=%d", trace.RequestBytes, trace.InputItems)
+	}
+	if trace.TimeToHeaders > 0 {
+		fmt.Fprintf(&b, " ttfb=%s", trace.TimeToHeaders)
+	}
+	if trace.TimeToFirstEvent > 0 {
+		fmt.Fprintf(&b, " first_event=%s", trace.TimeToFirstEvent)
+	}
+	if trace.TimeToFirstToken > 0 {
+		fmt.Fprintf(&b, " first_token=%s", trace.TimeToFirstToken)
+	}
+	if trace.TimeToTerminal > 0 {
+		fmt.Fprintf(&b, " terminal=%s", trace.TimeToTerminal)
+	}
+	if trace.HTTPStatus != 0 {
+		fmt.Fprintf(&b, " status=%d", trace.HTTPStatus)
+	}
+	if trace.ErrorClassification != "" {
+		fmt.Fprintf(&b, " err=%s", trace.ErrorClassification)
+	}
+	if trace.RetryAfter > 0 {
+		fmt.Fprintf(&b, " retry_after=%s", trace.RetryAfter)
+	}
+	if trace.ErrorClass != "" {
+		fmt.Fprintf(&b, " err_class=%s", trace.ErrorClass)
+	}
+	if trace.CacheReadTokens > 0 || trace.CacheWriteTokens > 0 {
+		fmt.Fprintf(&b, " cache_read=%d cache_write=%d", trace.CacheReadTokens, trace.CacheWriteTokens)
+	}
+	return b.String()
+}
+
+type requestInstrumentation struct {
+	observer RequestObserver
+	trace    RequestTrace
+	started  time.Time
+	finished bool
+
+	headersRecorded    bool
+	firstEventRecorded bool
+	firstTokenRecorded bool
+	terminalRecorded   bool
+}
+
+func newRequestInstrumentation(observer RequestObserver, model string) *requestInstrumentation {
+	if observer == nil {
+		return nil
+	}
+	now := time.Now()
+	return &requestInstrumentation{
+		observer: observer,
+		started:  now,
+		trace:    RequestTrace{Transport: "http", Model: model, StartedAt: now},
+	}
+}
+
+func (ri *requestInstrumentation) setRequestShape(bytes, items int) {
+	if ri == nil {
+		return
+	}
+	ri.trace.RequestBytes = bytes
+	ri.trace.InputItems = items
+}
+
+func (ri *requestInstrumentation) recordHeaders(status int) {
+	if ri == nil || ri.headersRecorded {
+		return
+	}
+	ri.headersRecorded = true
+	ri.trace.HTTPStatus = status
+	ri.trace.TimeToHeaders = instrumentationDurationSince(ri.started)
+}
+
+func (ri *requestInstrumentation) recordFirstEvent() {
+	if ri == nil || ri.firstEventRecorded {
+		return
+	}
+	ri.firstEventRecorded = true
+	ri.trace.TimeToFirstEvent = instrumentationDurationSince(ri.started)
+}
+
+func (ri *requestInstrumentation) recordFirstToken() {
+	if ri == nil || ri.firstTokenRecorded {
+		return
+	}
+	ri.firstTokenRecorded = true
+	ri.trace.TimeToFirstToken = instrumentationDurationSince(ri.started)
+}
+
+func (ri *requestInstrumentation) recordTerminal() {
+	if ri == nil || ri.terminalRecorded {
+		return
+	}
+	ri.terminalRecorded = true
+	ri.trace.TimeToTerminal = instrumentationDurationSince(ri.started)
+}
+
+func (ri *requestInstrumentation) recordTerminalFailure(classification string) {
+	if ri == nil {
+		return
+	}
+	ri.recordTerminal()
+	ri.trace.ErrorClassification = classification
+	ri.trace.ErrorClass = "transport"
+}
+
+func (ri *requestInstrumentation) recordUsage(usage core.Usage) {
+	if ri == nil {
+		return
+	}
+	ri.trace.CacheReadTokens = usage.CacheReadTokens
+	ri.trace.CacheWriteTokens = usage.CacheWriteTokens
+}
+
+func (ri *requestInstrumentation) classifyHTTPResponse(status int, classification string) {
+	if ri == nil {
+		return
+	}
+	ri.trace.HTTPStatus = status
+	ri.trace.ErrorClassification = classification
+}
+
+func (ri *requestInstrumentation) recordError(err error) {
+	if ri == nil || err == nil {
+		return
+	}
+	ri.trace.ErrorClass = anthropicTraceErrorClass(err)
+	var httpErr *core.ModelHTTPError
+	if errors.As(err, &httpErr) {
+		if ri.trace.HTTPStatus == 0 {
+			ri.trace.HTTPStatus = httpErr.StatusCode
+		}
+		if httpErr.Body != "" {
+			ri.trace.ErrorClassification = httpErr.Body
+		}
+		ri.trace.RetryAfter = httpErr.RetryAfter
+	}
+}
+
+func (ri *requestInstrumentation) finish() {
+	if ri == nil || ri.finished {
+		return
+	}
+	ri.finished = true
+	ri.trace.TotalDuration = instrumentationDurationSince(ri.started)
+	ri.observer(ri.trace)
+}
+
+func instrumentationDurationSince(start time.Time) time.Duration {
+	if elapsed := time.Since(start); elapsed > 0 {
+		return elapsed
+	}
+	return time.Nanosecond
+}
+
+func anthropicTraceErrorClass(err error) string {
+	var httpErr *core.ModelHTTPError
+	if errors.As(err, &httpErr) {
+		return "http"
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return "context"
+	}
+	return "transport"
+}
+
+func isTruthy(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}

--- a/provider/anthropic/instrumentation_test.go
+++ b/provider/anthropic/instrumentation_test.go
@@ -1,0 +1,168 @@
+package anthropic
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/fugue-labs/gollem/core"
+)
+
+func captureRequestObserver() (RequestObserver, func() (RequestTrace, bool)) {
+	var (
+		mu    sync.Mutex
+		trace RequestTrace
+		got   bool
+	)
+	return func(value RequestTrace) {
+			mu.Lock()
+			defer mu.Unlock()
+			trace = value
+			got = true
+		}, func() (RequestTrace, bool) {
+			mu.Lock()
+			defer mu.Unlock()
+			return trace, got
+		}
+}
+
+func TestRequestObserverCapturesStreamingCacheUsage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, `event: message_start
+data: {"type":"message_start","message":{"usage":{"input_tokens":10,"cache_creation_input_tokens":20,"cache_read_input_tokens":30}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"trace"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}
+
+event: message_stop
+data: {"type":"message_stop"}
+
+`)
+	}))
+	defer server.Close()
+
+	observer, snapshot := captureRequestObserver()
+	provider := New(WithAPIKey("secret-must-not-leak"), WithBaseURL(server.URL), WithRequestObserver(observer))
+	stream, err := provider.RequestStream(context.Background(), []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "private prompt"}}},
+	}, nil, &core.ModelRequestParameters{AllowTextOutput: true})
+	if err != nil {
+		t.Fatalf("RequestStream: %v", err)
+	}
+	defer stream.Close()
+	for {
+		_, err := stream.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("stream: %v", err)
+		}
+	}
+
+	trace, ok := snapshot()
+	if !ok {
+		t.Fatal("request observer did not fire")
+	}
+	if trace.Transport != "http" || trace.Model != ClaudeSonnet46 || trace.HTTPStatus != http.StatusOK {
+		t.Fatalf("trace identity = %#v", trace)
+	}
+	if trace.TotalDuration <= 0 || trace.RequestBytes == 0 || trace.InputItems != 1 {
+		t.Fatalf("trace request shape = %#v", trace)
+	}
+	if trace.TimeToHeaders <= 0 || trace.TimeToFirstEvent <= 0 || trace.TimeToFirstToken <= 0 || trace.TimeToTerminal <= 0 {
+		t.Fatalf("trace phases = %#v", trace)
+	}
+	if trace.CacheReadTokens != 30 || trace.CacheWriteTokens != 20 {
+		t.Fatalf("trace cache usage = %#v", trace)
+	}
+	rendered := formatRequestTrace(trace)
+	if strings.Contains(rendered, "secret-must-not-leak") || strings.Contains(rendered, "private prompt") || strings.Contains(rendered, server.URL) {
+		t.Fatalf("trace renderer leaked sensitive request data: %q", rendered)
+	}
+}
+
+func TestRequestObserverRedactsHTTPErrorAndRetryAfter(t *testing.T) {
+	const secret = "anthropic-provider-body-must-not-leak"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "7")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = io.WriteString(w, `{"error":{"type":"rate_limit_error","message":"`+secret+`"}}`)
+	}))
+	defer server.Close()
+
+	observer, snapshot := captureRequestObserver()
+	provider := New(WithAPIKey("secret-must-not-leak"), WithBaseURL(server.URL), WithRequestObserver(observer))
+	if _, err := provider.Request(context.Background(), nil, nil, &core.ModelRequestParameters{}); err == nil {
+		t.Fatal("Request unexpectedly succeeded")
+	}
+	trace, ok := snapshot()
+	if !ok {
+		t.Fatal("request observer did not fire")
+	}
+	if trace.HTTPStatus != http.StatusTooManyRequests || trace.ErrorClassification != "rate_limited" || trace.ErrorClass != "http" || trace.RetryAfter != 7*time.Second {
+		t.Fatalf("HTTP error trace = %#v", trace)
+	}
+	rendered := formatRequestTrace(trace)
+	if strings.Contains(rendered, secret) || strings.Contains(rendered, "secret-must-not-leak") || strings.Contains(rendered, server.URL) {
+		t.Fatalf("trace renderer leaked sensitive error data: %q", rendered)
+	}
+}
+
+func TestRequestObserverClassifiesCancellation(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		close(started)
+		<-release
+	}))
+	defer server.Close()
+
+	observer, snapshot := captureRequestObserver()
+	provider := New(WithAPIKey("test-key"), WithBaseURL(server.URL), WithRequestObserver(observer))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	result := make(chan error, 1)
+	go func() {
+		_, err := provider.Request(ctx, nil, nil, &core.ModelRequestParameters{})
+		result <- err
+	}()
+	select {
+	case <-started:
+		cancel()
+	case <-time.After(time.Second):
+		t.Fatal("request did not start")
+	}
+	if err := <-result; err == nil {
+		close(release)
+		t.Fatal("Request unexpectedly succeeded")
+	}
+	close(release)
+	trace, ok := snapshot()
+	if !ok || trace.ErrorClass != "context" || trace.HTTPStatus != 0 {
+		t.Fatalf("cancellation trace = %#v, observer=%t", trace, ok)
+	}
+}
+
+func TestRequestTraceEnvironmentEnablesDefaultObserver(t *testing.T) {
+	t.Setenv("ANTHROPIC_REQUEST_TRACE", "true")
+	provider := New(WithAPIKey("test-key"))
+	if provider.requestObserver == nil {
+		t.Fatal("ANTHROPIC_REQUEST_TRACE did not enable the default observer")
+	}
+}

--- a/provider/anthropic/stream.go
+++ b/provider/anthropic/stream.go
@@ -15,22 +15,23 @@ import (
 
 // streamedResponse implements core.StreamedResponse for Anthropic SSE streams.
 type streamedResponse struct {
-	reader     *bufio.Reader
-	body       io.ReadCloser
-	model      string
-	usage      core.Usage
-	parts      []core.ModelResponsePart
-	stopReason core.FinishReason
-	done       bool
-	streamErr  error // non-nil if server sent an error event mid-stream
+	reader          *bufio.Reader
+	body            io.ReadCloser
+	model           string
+	usage           core.Usage
+	parts           []core.ModelResponsePart
+	stopReason      core.FinishReason
+	done            bool
+	streamErr       error // non-nil if server sent an error event mid-stream
+	instrumentation *requestInstrumentation
 
 	// State for tracking current blocks being built.
 	currentParts map[int]core.ModelResponsePart
 	argsBuffers  map[int]*strings.Builder // accumulate tool call JSON across deltas
 }
 
-func newStreamedResponse(body io.ReadCloser, model string) *streamedResponse {
-	return &streamedResponse{
+func newStreamedResponse(body io.ReadCloser, model string, instrumentation ...*requestInstrumentation) *streamedResponse {
+	stream := &streamedResponse{
 		reader:       bufio.NewReader(body),
 		body:         body,
 		model:        model,
@@ -38,6 +39,10 @@ func newStreamedResponse(body io.ReadCloser, model string) *streamedResponse {
 		argsBuffers:  make(map[int]*strings.Builder),
 		stopReason:   core.FinishReasonStop,
 	}
+	if len(instrumentation) > 0 {
+		stream.instrumentation = instrumentation[0]
+	}
+	return stream
 }
 
 // sseEvent represents a parsed Server-Sent Event.
@@ -65,6 +70,7 @@ func (s *streamedResponse) Next() (core.ModelResponseStreamEvent, error) {
 			s.failStream(normalizeStreamReadError(err))
 			return nil, s.streamErr
 		}
+		s.instrumentation.recordFirstEvent()
 
 		gollemEvent, ok := s.processSSEEvent(event)
 		if ok {
@@ -204,6 +210,7 @@ func (s *streamedResponse) processSSEEvent(event *sseEvent) (core.ModelResponseS
 
 		switch delta.Delta.Type {
 		case "text_delta":
+			s.instrumentation.recordFirstToken()
 			// Update current text part.
 			if tp, ok := s.currentParts[delta.Index].(core.TextPart); ok {
 				tp.Content += delta.Delta.Text
@@ -215,6 +222,7 @@ func (s *streamedResponse) processSSEEvent(event *sseEvent) (core.ModelResponseS
 			}, true
 
 		case "input_json_delta":
+			s.instrumentation.recordFirstToken()
 			if buf, ok := s.argsBuffers[delta.Index]; ok {
 				buf.WriteString(delta.Delta.PartialJSON)
 			}
@@ -224,6 +232,7 @@ func (s *streamedResponse) processSSEEvent(event *sseEvent) (core.ModelResponseS
 			}, true
 
 		case "thinking_delta":
+			s.instrumentation.recordFirstToken()
 			if tp, ok := s.currentParts[delta.Index].(core.ThinkingPart); ok {
 				tp.Content += delta.Delta.Thinking
 				s.currentParts[delta.Index] = tp
@@ -290,12 +299,18 @@ func (s *streamedResponse) processSSEEvent(event *sseEvent) (core.ModelResponseS
 	case "message_stop":
 		s.done = true
 		s.finalizeAll()
+		s.instrumentation.recordUsage(s.usage)
+		s.instrumentation.recordTerminal()
+		s.instrumentation.finish()
 		return nil, false
 
 	case "error":
 		s.done = true
 		s.finalizeAll()
-		s.streamErr = errors.New("anthropic stream error (" + classifyProviderErrorBody(event.Data) + ")")
+		classification := classifyProviderErrorBody(event.Data)
+		s.streamErr = errors.New("anthropic stream error (" + classification + ")")
+		s.instrumentation.recordTerminalFailure(classification)
+		s.instrumentation.finish()
 		return nil, false
 
 	default:
@@ -312,6 +327,8 @@ func (s *streamedResponse) failStream(err error) {
 	s.done = true
 	s.finalizeAll()
 	s.streamErr = err
+	s.instrumentation.recordError(err)
+	s.instrumentation.finish()
 }
 
 func (s *streamedResponse) finalizeAll() {
@@ -355,6 +372,7 @@ func (s *streamedResponse) Usage() core.Usage {
 
 // Close releases resources.
 func (s *streamedResponse) Close() error {
+	s.instrumentation.finish()
 	return s.body.Close()
 }
 


### PR DESCRIPTION
## Summary
- add opt-in secret-safe HTTP request tracing for the native Anthropic provider
- record request shape, timing phases, normalized cache usage, and sanitized HTTP/cancellation outcomes
- preserve raw-content, endpoint, header, credential, and raw error-body boundaries
- enable the default stderr observer only with `ANTHROPIC_REQUEST_TRACE=1`

## Verification
- `go test ./provider/anthropic ./provider/conformance ./appserver -count=1`
- selected race coverage for Anthropic, conformance, and app-server
- full non-Monty test/vet/race gates, `go mod tidy`, `go generate ./appserver/protocol`, and `golangci-lint run`

All provider evidence uses deterministic loopback fixtures; credentialed native-provider acceptance was not run.