### PR TITLE
fix(provider): redact Vertex HTTP error bodies

### DIFF
--- a/modelutil/retry.go
+++ b/modelutil/retry.go
@@ -50,6 +50,7 @@ func isPermanent429(body string) bool {
 		"spending limit",
 		"billing",
 		"quota exceeded",
+		"quota_exhausted",
 		"plan limit",
 		"subscription",
 	} {

--- a/modelutil/retry_test.go
+++ b/modelutil/retry_test.go
@@ -293,6 +293,7 @@ func TestIsPermanent429(t *testing.T) {
 		{`{"error":"reached its monthly spending limit"}`, true},
 		{`{"error":"billing issue"}`, true},
 		{`{"error":"quota exceeded for model"}`, true},
+		{`quota_exhausted`, true},
 		{`{"error":"plan limit reached"}`, true},
 		{`{"error":"subscription expired"}`, true},
 		{``, false},

--- a/provider/internal/vertexerror/http_error.go
+++ b/provider/internal/vertexerror/http_error.go
@@ -1,0 +1,84 @@
+// Package vertexerror provides bounded, secret-safe HTTP error normalization
+// shared by the Google-backed provider adapters.
+package vertexerror
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/fugue-labs/gollem/core"
+)
+
+const maxProviderErrorBodyBytes = 64 << 10
+
+var providerErrorMarkers = []struct {
+	marker string
+	terms  []string
+}{
+	{marker: "quota_exhausted", terms: []string{"quota exceeded", "quota exhausted", "billing", "spending limit", "subscription"}},
+	{marker: "rate_limited", terms: []string{"rate_limit", "rate limit", "resource_exhausted", "resource exhausted", "too many requests"}},
+	{marker: "overloaded", terms: []string{"overloaded", "capacity", "temporarily unavailable"}},
+	{marker: "authentication", terms: []string{"unauthenticated", "unauthorized", "authentication", "permission denied", "permission_denied", "forbidden"}},
+	{marker: "context_length", terms: []string{"context length", "too many tokens", "token limit", "maximum context"}},
+	{marker: "not_found", terms: []string{"not found", "not_found"}},
+	{marker: "invalid_request", terms: []string{"invalid argument", "invalid_argument", "invalid request", "invalid_request", "bad request"}},
+	{marker: "server_error", terms: []string{"internal error", "backend error", "service unavailable"}},
+}
+
+// NewHTTPError returns a bounded, provider-neutral error receipt. Provider
+// response bodies are untrusted because they may echo request data.
+func NewHTTPError(provider string, status int, body io.Reader, retryAfter, model string) *core.ModelHTTPError {
+	classification := readClassification(body)
+	return &core.ModelHTTPError{
+		Message:    fmt.Sprintf("%s API error (HTTP %d; %s)", provider, status, classification),
+		StatusCode: status,
+		Body:       classification,
+		ModelName:  model,
+		RetryAfter: parseRetryAfter(status, retryAfter),
+	}
+}
+
+func readClassification(reader io.Reader) string {
+	if reader == nil {
+		return "response_unreadable"
+	}
+	body, err := io.ReadAll(io.LimitReader(reader, maxProviderErrorBodyBytes+1))
+	if err != nil {
+		return "response_unreadable"
+	}
+	overflow := len(body) > maxProviderErrorBodyBytes
+	if overflow {
+		body = body[:maxProviderErrorBodyBytes]
+	}
+	classification := classify(string(body))
+	if overflow {
+		return classification + ",response_too_large"
+	}
+	return classification
+}
+
+func classify(body string) string {
+	value := strings.ToLower(body)
+	for _, candidate := range providerErrorMarkers {
+		for _, term := range candidate.terms {
+			if strings.Contains(value, term) {
+				return candidate.marker
+			}
+		}
+	}
+	return "provider_error"
+}
+
+func parseRetryAfter(status int, value string) time.Duration {
+	if status != 429 {
+		return 0
+	}
+	seconds, err := strconv.Atoi(strings.TrimSpace(value))
+	if err != nil || seconds <= 0 {
+		return 0
+	}
+	return time.Duration(seconds) * time.Second
+}

--- a/provider/internal/vertexerror/http_error_test.go
+++ b/provider/internal/vertexerror/http_error_test.go
@@ -1,0 +1,40 @@
+package vertexerror
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewHTTPErrorRedactsAndClassifies(t *testing.T) {
+	const secret = "vertex-provider-secret-must-not-leak"
+	err := NewHTTPError("vertexai", http.StatusTooManyRequests, strings.NewReader(`{"error":{"message":"Quota exceeded: `+secret+`"}}`), "45", "gemini-test")
+	if err.Body != "quota_exhausted" || err.RetryAfter != 45*time.Second || err.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("error = %#v", err)
+	}
+	if strings.Contains(err.Error(), secret) || strings.Contains(err.Body, secret) {
+		t.Fatalf("provider body leaked: %#v", err)
+	}
+}
+
+func TestNewHTTPErrorBoundsOversizedBody(t *testing.T) {
+	const secret = "oversized-provider-secret-must-not-leak"
+	body := strings.Repeat("x", maxProviderErrorBodyBytes+1) + secret
+	err := NewHTTPError("vertexai", 500, strings.NewReader(body), "", "gemini-test")
+	if err.Body != "provider_error,response_too_large" {
+		t.Fatalf("classification = %q", err.Body)
+	}
+	if strings.Contains(err.Error(), secret) || strings.Contains(err.Body, secret) {
+		t.Fatalf("oversized provider body leaked: %#v", err)
+	}
+}
+
+func TestNewHTTPErrorPreservesOnlyValidRateLimitRetryAfter(t *testing.T) {
+	if got := NewHTTPError("vertexai", http.StatusTooManyRequests, strings.NewReader("rate limit"), "0", "model").RetryAfter; got != 0 {
+		t.Fatalf("zero Retry-After = %s, want 0", got)
+	}
+	if got := NewHTTPError("vertexai", http.StatusInternalServerError, strings.NewReader("server error"), "60", "model").RetryAfter; got != 0 {
+		t.Fatalf("non-429 Retry-After = %s, want 0", got)
+	}
+}

--- a/provider/vertexai/vertexai.go
+++ b/provider/vertexai/vertexai.go
@@ -8,17 +8,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
-	"strconv"
 	"sync"
-	"time"
 
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 
 	"github.com/fugue-labs/gollem/core"
+	"github.com/fugue-labs/gollem/provider/internal/vertexerror"
 )
 
 // Model constants for Gemini models.
@@ -213,11 +211,11 @@ func (p *Provider) Request(ctx context.Context, messages []core.ModelMessage, se
 	if err != nil {
 		return nil, fmt.Errorf("vertexai: HTTP request failed: %w", err)
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, p.parseHTTPError(resp)
 	}
+	defer resp.Body.Close()
 
 	var apiResp geminiResponse
 	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
@@ -279,25 +277,10 @@ func (p *Provider) applyCacheSettings(req *geminiRequest) {
 	}
 }
 
-// parseHTTPError constructs a ModelHTTPError from a non-200 response,
-// including Retry-After header parsing for rate-limited responses.
+// parseHTTPError constructs a bounded, redacted ModelHTTPError from a non-200 response.
 func (p *Provider) parseHTTPError(resp *http.Response) error {
-	respBody, _ := io.ReadAll(resp.Body)
-	resp.Body.Close()
-	httpErr := &core.ModelHTTPError{
-		Message:    "vertexai API error: " + string(respBody),
-		StatusCode: resp.StatusCode,
-		Body:       string(respBody),
-		ModelName:  p.model,
-	}
-	if resp.StatusCode == http.StatusTooManyRequests {
-		if ra := resp.Header.Get("Retry-After"); ra != "" {
-			if secs, err := strconv.Atoi(ra); err == nil {
-				httpErr.RetryAfter = time.Duration(secs) * time.Second
-			}
-		}
-	}
-	return httpErr
+	defer resp.Body.Close()
+	return vertexerror.NewHTTPError("vertexai", resp.StatusCode, resp.Body, resp.Header.Get("Retry-After"), p.model)
 }
 
 // Verify Provider implements core.Model.

--- a/provider/vertexai/vertexai_test.go
+++ b/provider/vertexai/vertexai_test.go
@@ -1523,10 +1523,11 @@ func TestParseResponseNilFunctionCallArgs(t *testing.T) {
 // --- parseHTTPError with Retry-After header ---
 
 func TestRequestHTTPErrorRetryAfter(t *testing.T) {
+	const secret = "vertexai-error-body-must-not-leak"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Retry-After", "45")
 		w.WriteHeader(http.StatusTooManyRequests)
-		w.Write([]byte(`{"error":{"message":"Quota exceeded"}}`))
+		w.Write([]byte(`{"error":{"message":"Quota exceeded: ` + secret + `"}}`))
 	}))
 	defer server.Close()
 
@@ -1556,6 +1557,12 @@ func TestRequestHTTPErrorRetryAfter(t *testing.T) {
 	}
 	if httpErr.RetryAfter != 45*time.Second {
 		t.Errorf("RetryAfter = %v, want 45s", httpErr.RetryAfter)
+	}
+	if httpErr.Body != "quota_exhausted" {
+		t.Errorf("Body = %q, want quota_exhausted", httpErr.Body)
+	}
+	if strings.Contains(httpErr.Error(), secret) || strings.Contains(httpErr.Body, secret) {
+		t.Fatalf("provider error body leaked: %#v", httpErr)
 	}
 }
 

--- a/provider/vertexai_anthropic/vertexai_anthropic.go
+++ b/provider/vertexai_anthropic/vertexai_anthropic.go
@@ -8,18 +8,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
-	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 
 	"github.com/fugue-labs/gollem/core"
+	"github.com/fugue-labs/gollem/provider/internal/vertexerror"
 )
 
 // Model constants for Claude models via Vertex AI.
@@ -313,11 +311,11 @@ func (p *Provider) Request(ctx context.Context, messages []core.ModelMessage, se
 	if err != nil {
 		return nil, fmt.Errorf("vertexai_anthropic: HTTP request failed: %w", err)
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, p.parseHTTPError(resp)
 	}
+	defer resp.Body.Close()
 
 	var apiResp apiResponse
 	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
@@ -371,25 +369,10 @@ func (p *Provider) setHeaders(ctx context.Context, req *http.Request) error {
 	return nil
 }
 
-// parseHTTPError constructs a ModelHTTPError from a non-200 response,
-// including Retry-After header parsing for rate-limited responses.
+// parseHTTPError constructs a bounded, redacted ModelHTTPError from a non-200 response.
 func (p *Provider) parseHTTPError(resp *http.Response) error {
-	respBody, _ := io.ReadAll(resp.Body)
-	resp.Body.Close()
-	httpErr := &core.ModelHTTPError{
-		Message:    "vertexai_anthropic API error: " + string(respBody),
-		StatusCode: resp.StatusCode,
-		Body:       string(respBody),
-		ModelName:  p.model,
-	}
-	if resp.StatusCode == http.StatusTooManyRequests {
-		if ra := resp.Header.Get("Retry-After"); ra != "" {
-			if secs, err := strconv.Atoi(ra); err == nil {
-				httpErr.RetryAfter = time.Duration(secs) * time.Second
-			}
-		}
-	}
-	return httpErr
+	defer resp.Body.Close()
+	return vertexerror.NewHTTPError("vertexai_anthropic", resp.StatusCode, resp.Body, resp.Header.Get("Retry-After"), p.model)
 }
 
 func envEnabled(name string) bool {

--- a/provider/vertexai_anthropic/vertexai_anthropic_test.go
+++ b/provider/vertexai_anthropic/vertexai_anthropic_test.go
@@ -1967,10 +1967,11 @@ func TestRequestStreamHTTPError(t *testing.T) {
 }
 
 func TestParseHTTPErrorRetryAfter(t *testing.T) {
+	const secret = "vertexai-anthropic-error-body-must-not-leak"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Retry-After", "45")
 		w.WriteHeader(http.StatusTooManyRequests)
-		w.Write([]byte(`{"error":"rate limited"}`))
+		w.Write([]byte(`{"error":"rate limited: ` + secret + `"}`))
 	}))
 	defer server.Close()
 
@@ -1994,6 +1995,12 @@ func TestParseHTTPErrorRetryAfter(t *testing.T) {
 	}
 	if httpErr.RetryAfter != 45*time.Second {
 		t.Errorf("expected RetryAfter 45s, got %v", httpErr.RetryAfter)
+	}
+	if httpErr.Body != "rate_limited" {
+		t.Errorf("Body = %q, want rate_limited", httpErr.Body)
+	}
+	if strings.Contains(httpErr.Error(), secret) || strings.Contains(httpErr.Body, secret) {
+		t.Fatalf("provider error body leaked: %#v", httpErr)
 	}
 }
 


### PR DESCRIPTION
## Summary
- normalize and redact non-success HTTP receipts for the Vertex AI Gemini and Vertex AI Anthropic drivers
- preserve status and valid 429 Retry-After data while classifying bounded error markers
- prevent permanent quota markers from entering retry loops

## Verification
- `go test ./provider/internal/vertexerror ./provider/vertexai ./provider/vertexai_anthropic ./modelutil -count=1`
- `go test -race ./provider/internal/vertexerror ./provider/vertexai ./provider/vertexai_anthropic ./modelutil -count=1`
- `go test ./provider/openai ./provider/anthropic ./provider/vertexai ./provider/vertexai_anthropic ./provider/conformance ./appserver ./modelutil -count=1`
- `go vet ./provider/internal/vertexerror ./provider/vertexai ./provider/vertexai_anthropic ./modelutil ./appserver`
- `go mod tidy`, `go generate ./appserver/protocol`, and `golangci-lint run`
- configured pre-push full non-Monty `go test -race`