### PR TITLE
feat(appserver): add PTY process support

### DIFF
--- a/appserver/server.go
+++ b/appserver/server.go
@@ -2072,6 +2072,11 @@ func (s *Server) handleProcessStart(ctx context.Context, method string, raw json
 		Env:            params.Env,
 		Timeout:        time.Duration(params.TimeoutMillis) * time.Millisecond,
 		MaxOutputBytes: params.MaxOutputBytes,
+		PTY:            params.PTY,
+		PTYSize: toolprocess.TerminalSize{
+			Rows: params.EffectivePTYRows(),
+			Cols: params.EffectivePTYCols(),
+		},
 	})
 	if err != nil {
 		if registeredCommandExec {
@@ -2487,6 +2492,9 @@ func mapError(method string, err error) *protocol.Error {
 		errors.Is(err, toolprocess.ErrProcessNotFound),
 		errors.Is(err, toolprocess.ErrProcessNotRunning),
 		errors.Is(err, toolprocess.ErrProcessAlreadyExists),
+		errors.Is(err, toolprocess.ErrInvalidPTYSize),
+		errors.Is(err, toolprocess.ErrPTYUnsupported),
+		errors.Is(err, toolprocess.ErrPTYCloseStdin),
 		errors.Is(err, store.ErrThreadNotFound),
 		errors.Is(err, store.ErrTurnNotFound),
 		errors.Is(err, store.ErrItemNotFound),
@@ -2547,12 +2555,19 @@ func processSnapshotResultFrom(snapshot *toolprocess.Snapshot) processSnapshotRe
 	}
 	stdout, stdoutEncoding := encodeContent(snapshot.Stdout)
 	stderr, stderrEncoding := encodeContent(snapshot.Stderr)
+	var ptySize *toolprocess.TerminalSize
+	if snapshot.PTY {
+		size := snapshot.PTYSize
+		ptySize = &size
+	}
 	return processSnapshotResult{
 		ID:             snapshot.ID,
 		PID:            snapshot.PID,
 		Command:        snapshot.Command,
 		Args:           snapshot.Args,
 		Shell:          snapshot.Shell,
+		PTY:            snapshot.PTY,
+		PTYSize:        ptySize,
 		WorkDir:        snapshot.WorkDir,
 		Status:         snapshot.Status,
 		ExitCode:       snapshot.ExitCode,
@@ -2712,15 +2727,31 @@ type fileContentResult struct {
 }
 
 type processStartParams struct {
-	ID             string            `json:"id,omitempty"`
-	ProcessID      string            `json:"processId,omitempty"`
-	Command        string            `json:"command"`
-	Args           []string          `json:"args,omitempty"`
-	Shell          *bool             `json:"shell,omitempty"`
-	WorkDir        string            `json:"workDir,omitempty"`
-	Env            map[string]string `json:"env,omitempty"`
-	TimeoutMillis  int64             `json:"timeoutMillis,omitempty"`
-	MaxOutputBytes int               `json:"maxOutputBytes,omitempty"`
+	ID             string                        `json:"id,omitempty"`
+	ProcessID      string                        `json:"processId,omitempty"`
+	Command        string                        `json:"command"`
+	Args           []string                      `json:"args,omitempty"`
+	Shell          *bool                         `json:"shell,omitempty"`
+	WorkDir        string                        `json:"workDir,omitempty"`
+	Env            map[string]string             `json:"env,omitempty"`
+	TimeoutMillis  int64                         `json:"timeoutMillis,omitempty"`
+	MaxOutputBytes int                           `json:"maxOutputBytes,omitempty"`
+	PTY            bool                          `json:"pty,omitempty"`
+	PTYSize        *protocol.ProcessTerminalSize `json:"ptySize,omitempty"`
+}
+
+func (p processStartParams) EffectivePTYRows() int {
+	if p.PTYSize == nil {
+		return 0
+	}
+	return int(p.PTYSize.Rows)
+}
+
+func (p processStartParams) EffectivePTYCols() int {
+	if p.PTYSize == nil {
+		return 0
+	}
+	return int(p.PTYSize.Cols)
 }
 
 type processIDParams struct {
@@ -2744,21 +2775,23 @@ type processResizeParams struct {
 }
 
 type processSnapshotResult struct {
-	ID             string             `json:"id"`
-	PID            int                `json:"pid"`
-	Command        string             `json:"command"`
-	Args           []string           `json:"args,omitempty"`
-	Shell          bool               `json:"shell"`
-	WorkDir        string             `json:"workDir"`
-	Status         toolprocess.Status `json:"status"`
-	ExitCode       int                `json:"exitCode"`
-	StartedAt      time.Time          `json:"startedAt"`
-	EndedAt        time.Time          `json:"endedAt,omitempty"`
-	Error          string             `json:"error,omitempty"`
-	Stdout         string             `json:"stdout,omitempty"`
-	StdoutEncoding string             `json:"stdoutEncoding,omitempty"`
-	Stderr         string             `json:"stderr,omitempty"`
-	StderrEncoding string             `json:"stderrEncoding,omitempty"`
+	ID             string                    `json:"id"`
+	PID            int                       `json:"pid"`
+	Command        string                    `json:"command"`
+	Args           []string                  `json:"args,omitempty"`
+	Shell          bool                      `json:"shell"`
+	PTY            bool                      `json:"pty"`
+	PTYSize        *toolprocess.TerminalSize `json:"ptySize,omitempty"`
+	WorkDir        string                    `json:"workDir"`
+	Status         toolprocess.Status        `json:"status"`
+	ExitCode       int                       `json:"exitCode"`
+	StartedAt      time.Time                 `json:"startedAt"`
+	EndedAt        time.Time                 `json:"endedAt,omitempty"`
+	Error          string                    `json:"error,omitempty"`
+	Stdout         string                    `json:"stdout,omitempty"`
+	StdoutEncoding string                    `json:"stdoutEncoding,omitempty"`
+	Stderr         string                    `json:"stderr,omitempty"`
+	StderrEncoding string                    `json:"stderrEncoding,omitempty"`
 }
 
 type gitDiffParams struct {

--- a/appserver/server_test.go
+++ b/appserver/server_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -2170,6 +2171,104 @@ func TestServerProcessHandlers(t *testing.T) {
 	}))
 	if resizeResp.Error == nil || resizeResp.Error.Code != protocol.CodeMethodUnavailable {
 		t.Fatalf("resize error = %#v, want unavailable", resizeResp.Error)
+	}
+}
+
+func TestServerProcessPTYHandlers(t *testing.T) {
+	ctx := context.Background()
+	processSvc, err := toolprocess.NewService(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	server := readyServer(WithProcess(processSvc))
+	probe, err := processSvc.Start(ctx, toolprocess.StartRequest{Command: "true", Shell: true, PTY: true})
+	if errors.Is(err, syscall.EPERM) || errors.Is(err, syscall.ENOTTY) || errors.Is(err, syscall.ENOSYS) {
+		t.Skipf("PTY allocation is unavailable in this environment: %v", err)
+	}
+	if err != nil {
+		t.Fatalf("start PTY probe: %v", err)
+	}
+	if _, err := waitProcessSnapshot(t, processSvc, probe.ID); err != nil {
+		t.Fatalf("wait PTY probe: %v", err)
+	}
+
+	startResp := server.HandleRequest(ctx, request("process/spawn", map[string]any{
+		"command": "cat",
+		"pty":     true,
+		"ptySize": map[string]any{"rows": 24, "cols": 80},
+	}))
+	if startResp.Error != nil {
+		t.Fatalf("process/spawn PTY error: %v", startResp.Error)
+	}
+	var started struct {
+		Process processSnapshotResult `json:"process"`
+	}
+	decodeResult(t, startResp, &started)
+	if !started.Process.PTY || started.Process.PTYSize == nil ||
+		*started.Process.PTYSize != (toolprocess.TerminalSize{Rows: 24, Cols: 80}) {
+		t.Fatalf("process/spawn PTY result = %#v", started.Process)
+	}
+
+	resizeResp := server.HandleRequest(ctx, request("process/resizePty", map[string]any{
+		"id": started.Process.ID, "cols": 120, "rows": 40,
+	}))
+	if resizeResp.Error != nil {
+		t.Fatalf("process/resizePty error: %v", resizeResp.Error)
+	}
+	writeResp := server.HandleRequest(ctx, request("process/writeStdin", map[string]any{
+		"id": started.Process.ID, "data": "hello\n",
+	}))
+	if writeResp.Error != nil {
+		t.Fatalf("process/writeStdin PTY error: %v", writeResp.Error)
+	}
+	if err := processSvc.Kill(ctx, started.Process.ID); err != nil {
+		t.Fatalf("Kill PTY process: %v", err)
+	}
+	completed, err := waitProcessSnapshot(t, processSvc, started.Process.ID)
+	if err != nil {
+		t.Fatalf("wait PTY process: %v", err)
+	}
+	if !completed.PTY || completed.PTYSize != (toolprocess.TerminalSize{Rows: 40, Cols: 120}) ||
+		!strings.Contains(string(completed.Stdout), "hello") || len(completed.Stderr) != 0 {
+		t.Fatalf("completed PTY process = %#v", completed)
+	}
+
+	nonPTYResizeResp := server.HandleRequest(ctx, request("process/resizePty", map[string]any{
+		"id": "missing", "cols": 0, "rows": 24,
+	}))
+	if nonPTYResizeResp.Error == nil || nonPTYResizeResp.Error.Code != protocol.CodeInvalidParams {
+		t.Fatalf("invalid PTY resize response = %#v", nonPTYResizeResp)
+	}
+}
+
+func TestProcessSnapshotResultPTYWireShape(t *testing.T) {
+	nonPTY, err := json.Marshal(processSnapshotResultFrom(&toolprocess.Snapshot{ID: "pipe"}))
+	if err != nil {
+		t.Fatalf("marshal non-PTY snapshot: %v", err)
+	}
+	var nonPTYFields map[string]json.RawMessage
+	if err := json.Unmarshal(nonPTY, &nonPTYFields); err != nil {
+		t.Fatalf("unmarshal non-PTY snapshot: %v", err)
+	}
+	if _, ok := nonPTYFields["ptySize"]; ok {
+		t.Fatalf("non-PTY snapshot leaked ptySize: %s", nonPTY)
+	}
+
+	ptySnapshot, err := json.Marshal(processSnapshotResultFrom(&toolprocess.Snapshot{
+		ID: "terminal", PTY: true, PTYSize: toolprocess.TerminalSize{Rows: 24, Cols: 80},
+	}))
+	if err != nil {
+		t.Fatalf("marshal PTY snapshot: %v", err)
+	}
+	var ptyFields struct {
+		PTY     bool                     `json:"pty"`
+		PTYSize toolprocess.TerminalSize `json:"ptySize"`
+	}
+	if err := json.Unmarshal(ptySnapshot, &ptyFields); err != nil {
+		t.Fatalf("unmarshal PTY snapshot: %v", err)
+	}
+	if !ptyFields.PTY || ptyFields.PTYSize != (toolprocess.TerminalSize{Rows: 24, Cols: 80}) {
+		t.Fatalf("PTY snapshot wire result = %s", ptySnapshot)
 	}
 }
 

--- a/appserver/tools/process/service.go
+++ b/appserver/tools/process/service.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -14,6 +15,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/creack/pty"
 	workspacefs "github.com/fugue-labs/gollem/appserver/tools/fs"
 )
 
@@ -21,6 +23,8 @@ const (
 	defaultMaxProcesses = 32
 	defaultOutputBytes  = 1 << 20
 	defaultCancelWait   = 5 * time.Second
+	defaultPTYRows      = 24
+	defaultPTYCols      = 80
 )
 
 var (
@@ -32,6 +36,8 @@ var (
 	ErrProcessAlreadyExists = errors.New("appserver/process: process already exists")
 	ErrTooManyProcesses     = errors.New("appserver/process: too many running processes")
 	ErrPTYUnsupported       = errors.New("appserver/process: pty resize is not supported")
+	ErrInvalidPTYSize       = errors.New("appserver/process: pty size must be positive and fit uint16")
+	ErrPTYCloseStdin        = errors.New("appserver/process: cannot close stdin for an active pty")
 	ErrInvalidOutputBufSize = errors.New("appserver/process: output buffer size must be positive")
 )
 
@@ -165,9 +171,18 @@ type StartRequest struct {
 	Env                 map[string]string
 	Timeout             time.Duration
 	MaxOutputBytes      int
+	PTY                 bool
+	PTYSize             TerminalSize
 	OutputSink          OutputSink
 	ExitSink            ExitSink
 	SuppressGlobalSinks bool
+}
+
+// TerminalSize is the current size of an allocated pseudo-terminal in cells.
+// Rows and Cols use zero only before a process has allocated a PTY.
+type TerminalSize struct {
+	Rows int `json:"rows"`
+	Cols int `json:"cols"`
 }
 
 type Snapshot struct {
@@ -176,6 +191,8 @@ type Snapshot struct {
 	Command         string
 	Args            []string
 	Shell           bool
+	PTY             bool
+	PTYSize         TerminalSize
 	WorkDir         string
 	Status          Status
 	ExitCode        int
@@ -206,6 +223,9 @@ type managedProcess struct {
 	stdout              *outputBuffer
 	stderr              *outputBuffer
 	stdin               io.WriteCloser
+	pty                 *os.File
+	ptySize             TerminalSize
+	ptyReadDone         chan struct{}
 	cmd                 *exec.Cmd
 	done                chan struct{}
 	output              OutputSink
@@ -279,13 +299,10 @@ func (s *Service) Start(ctx context.Context, req StartRequest) (*Snapshot, error
 	cmd := exec.CommandContext(context.Background(), spec.name, spec.args...)
 	cmd.Dir = workDir
 	cmd.Env = buildEnv(req.Env)
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-
-	stdin, err := cmd.StdinPipe()
-	if err != nil {
-		s.emit(op, "", 0, false, err)
-		return nil, fmt.Errorf("stdin pipe: %w", err)
+	if !req.PTY {
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	}
+
 	bufSize := req.MaxOutputBytes
 	if bufSize == 0 {
 		bufSize = s.defaultOutputBytes
@@ -302,15 +319,12 @@ func (s *Service) Start(ctx context.Context, req StartRequest) (*Snapshot, error
 		status:              StatusRunning,
 		stdout:              newOutputBuffer(bufSize),
 		stderr:              newOutputBuffer(bufSize),
-		stdin:               stdin,
 		cmd:                 cmd,
 		done:                make(chan struct{}),
 		output:              req.OutputSink,
 		exit:                req.ExitSink,
 		suppressGlobalSinks: req.SuppressGlobalSinks,
 	}
-	cmd.Stdout = processWriter{svc: s, proc: proc, stream: StreamStdout}
-	cmd.Stderr = processWriter{svc: s, proc: proc, stream: StreamStderr}
 	cmd.WaitDelay = 5 * time.Second
 
 	s.mu.Lock()
@@ -328,17 +342,64 @@ func (s *Service) Start(ctx context.Context, req StartRequest) (*Snapshot, error
 		s.emit(op, proc.id, 0, false, ErrProcessAlreadyExists)
 		return nil, ErrProcessAlreadyExists
 	}
-	if err := cmd.Start(); err != nil {
+	if req.PTY {
+		size, sizeErr := normalizedPTYSize(req.PTYSize)
+		if sizeErr != nil {
+			s.mu.Unlock()
+			s.emit(op, proc.id, 0, false, sizeErr)
+			return nil, sizeErr
+		}
+		ptyFile, startErr := pty.StartWithSize(cmd, &pty.Winsize{
+			Rows: uint16(size.Rows), // #nosec G115 -- normalizedPTYSize bounds dimensions to uint16.
+			Cols: uint16(size.Cols), // #nosec G115 -- normalizedPTYSize bounds dimensions to uint16.
+		})
+		if startErr != nil {
+			s.mu.Unlock()
+			s.emit(op, proc.id, 0, false, startErr)
+			return nil, fmt.Errorf("start pty process: %w", startErr)
+		}
+		proc.stdin = ptyFile
+		proc.pty = ptyFile
+		proc.ptySize = size
+		proc.ptyReadDone = make(chan struct{})
+	} else {
+		stdin, startErr := cmd.StdinPipe()
+		if startErr != nil {
+			s.mu.Unlock()
+			s.emit(op, proc.id, 0, false, startErr)
+			return nil, fmt.Errorf("stdin pipe: %w", startErr)
+		}
+		proc.stdin = stdin
+		cmd.Stdout = processWriter{svc: s, proc: proc, stream: StreamStdout}
+		cmd.Stderr = processWriter{svc: s, proc: proc, stream: StreamStderr}
+		if startErr := cmd.Start(); startErr != nil {
+			s.mu.Unlock()
+			s.emit(op, proc.id, 0, false, startErr)
+			return nil, fmt.Errorf("start process: %w", startErr)
+		}
+	}
+	if cmd.Process == nil {
 		s.mu.Unlock()
-		s.emit(op, proc.id, 0, false, err)
-		return nil, fmt.Errorf("start process: %w", err)
+		s.emit(op, proc.id, 0, false, errors.New("process started without a pid"))
+		return nil, errors.New("appserver/process: process started without a pid")
 	}
 	proc.setPID(cmd.Process.Pid)
 	s.processes[proc.id] = proc
 	s.mu.Unlock()
 
+	if proc.pty != nil {
+		go func(terminal *os.File, writer io.Writer, done chan struct{}) {
+			_, _ = io.Copy(writer, terminal)
+			close(done)
+		}(proc.pty, processWriter{svc: s, proc: proc, stream: StreamStdout}, proc.ptyReadDone)
+	}
+
 	go func() {
 		waitErr := cmd.Wait()
+		if proc.pty != nil {
+			_ = proc.pty.Close()
+			<-proc.ptyReadDone
+		}
 		proc.finish(waitErr)
 		s.emitExit(proc)
 		close(proc.done)
@@ -522,13 +583,26 @@ func (s *Service) ResizePTY(ctx context.Context, id string, cols, rows int) erro
 		s.emit(op, id, 0, false, err)
 		return err
 	}
-	if cols <= 0 || rows <= 0 {
-		err := errors.New("appserver/process: pty size must be positive")
+	if cols <= 0 || rows <= 0 || cols > math.MaxUint16 || rows > math.MaxUint16 {
+		err := ErrInvalidPTYSize
 		s.emit(op, id, proc.pid, false, err)
 		return err
 	}
-	s.emit(op, id, proc.pid, false, ErrPTYUnsupported)
-	return ErrPTYUnsupported
+	proc.mu.Lock()
+	terminal := proc.pty
+	proc.mu.Unlock()
+	if terminal == nil {
+		s.emit(op, id, proc.pid, false, ErrPTYUnsupported)
+		return ErrPTYUnsupported
+	}
+	if err := pty.Setsize(terminal, &pty.Winsize{Rows: uint16(rows), Cols: uint16(cols)}); err != nil {
+		err = fmt.Errorf("resize pty: %w", err)
+		s.emit(op, id, proc.pid, false, err)
+		return err
+	}
+	proc.setPTYSize(TerminalSize{Rows: rows, Cols: cols})
+	s.emit(op, id, proc.pid, true, nil)
+	return nil
 }
 
 func (s *Service) signal(ctx context.Context, id string, kind OperationKind, signalName string, sig syscall.Signal) error {
@@ -674,6 +748,8 @@ func (p *managedProcess) snapshot() Snapshot {
 		Command:         p.command,
 		Args:            cloneStrings(p.args),
 		Shell:           p.shell,
+		PTY:             p.pty != nil,
+		PTYSize:         p.ptySize,
 		WorkDir:         p.workDir,
 		Status:          p.status,
 		ExitCode:        p.exitCode,
@@ -730,7 +806,11 @@ func (p *managedProcess) closeStdin() error {
 		return ErrProcessNotRunning
 	}
 	stdin := p.stdin
+	isPTY := p.pty != nil
 	p.mu.Unlock()
+	if isPTY {
+		return ErrPTYCloseStdin
+	}
 
 	p.stdinMu.Lock()
 	defer p.stdinMu.Unlock()
@@ -738,6 +818,12 @@ func (p *managedProcess) closeStdin() error {
 		return fmt.Errorf("close stdin: %w", err)
 	}
 	return nil
+}
+
+func (p *managedProcess) setPTYSize(size TerminalSize) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.ptySize = size
 }
 
 func (p *managedProcess) requestKill(status Status) error {
@@ -831,6 +917,16 @@ func normalizeStart(req StartRequest) (commandSpec, error) {
 		return commandSpec{name: "bash", args: []string{"-c", req.Command}}, nil
 	}
 	return commandSpec{name: req.Command, args: cloneStrings(req.Args)}, nil
+}
+
+func normalizedPTYSize(size TerminalSize) (TerminalSize, error) {
+	if size.Rows == 0 && size.Cols == 0 {
+		return TerminalSize{Rows: defaultPTYRows, Cols: defaultPTYCols}, nil
+	}
+	if size.Rows <= 0 || size.Cols <= 0 || size.Rows > math.MaxUint16 || size.Cols > math.MaxUint16 {
+		return TerminalSize{}, ErrInvalidPTYSize
+	}
+	return size, nil
 }
 
 func buildEnv(extra map[string]string) []string {

--- a/appserver/tools/process/service_test.go
+++ b/appserver/tools/process/service_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -346,6 +347,75 @@ func TestServiceApprovalAuditAndResize(t *testing.T) {
 	}
 }
 
+func TestServicePTYAcceptsInputAndResize(t *testing.T) {
+	ctx := context.Background()
+	svc := newTestService(t)
+	started, err := svc.Start(ctx, StartRequest{
+		Command: "read -r line; printf 'got:%s\\n' \"$line\"",
+		Shell:   true,
+		PTY:     true,
+		PTYSize: TerminalSize{Rows: 24, Cols: 80},
+	})
+	if ptyUnavailable(err) {
+		t.Skipf("PTY allocation is unavailable in this environment: %v", err)
+	}
+	if err != nil {
+		t.Fatalf("Start PTY: %v", err)
+	}
+	if !started.PTY || started.PTYSize != (TerminalSize{Rows: 24, Cols: 80}) {
+		t.Fatalf("started PTY snapshot = %+v", started)
+	}
+	if err := svc.ResizePTY(ctx, started.ID, 120, 40); err != nil {
+		t.Fatalf("ResizePTY: %v", err)
+	}
+	if err := svc.WriteStdin(ctx, started.ID, []byte("hello\n")); err != nil {
+		t.Fatalf("WriteStdin: %v", err)
+	}
+	done, err := waitWithTimeout(t, svc, started.ID)
+	if err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if !done.PTY || done.PTYSize != (TerminalSize{Rows: 40, Cols: 120}) {
+		t.Fatalf("completed PTY snapshot = %+v", done)
+	}
+	if !strings.Contains(string(done.Stdout), "got:hello") {
+		t.Fatalf("PTY stdout = %q", done.Stdout)
+	}
+	if len(done.Stderr) != 0 {
+		t.Fatalf("PTY stderr = %q, want empty because PTY output is multiplexed", done.Stderr)
+	}
+	if err := svc.CloseStdin(ctx, started.ID); !errors.Is(err, ErrProcessNotRunning) {
+		t.Fatalf("CloseStdin after completion = %v, want ErrProcessNotRunning", err)
+	}
+}
+
+func TestServicePTYRejectsCloseStdinAndInvalidSize(t *testing.T) {
+	ctx := context.Background()
+	svc := newTestService(t)
+	started, err := svc.Start(ctx, StartRequest{Command: "sleep 30", Shell: true, PTY: true})
+	if ptyUnavailable(err) {
+		t.Skipf("PTY allocation is unavailable in this environment: %v", err)
+	}
+	if err != nil {
+		t.Fatalf("Start PTY: %v", err)
+	}
+	defer func() {
+		_ = svc.Kill(context.Background(), started.ID)
+		_, _ = waitWithTimeout(t, svc, started.ID)
+	}()
+	if err := svc.CloseStdin(ctx, started.ID); !errors.Is(err, ErrPTYCloseStdin) {
+		t.Fatalf("CloseStdin PTY error = %v, want ErrPTYCloseStdin", err)
+	}
+	if err := svc.ResizePTY(ctx, started.ID, 0, 24); !errors.Is(err, ErrInvalidPTYSize) {
+		t.Fatalf("ResizePTY zero size error = %v, want ErrInvalidPTYSize", err)
+	}
+	if _, err := svc.Start(ctx, StartRequest{
+		Command: "printf ignored", Shell: true, PTY: true, PTYSize: TerminalSize{Rows: 0, Cols: 80},
+	}); !errors.Is(err, ErrInvalidPTYSize) {
+		t.Fatalf("Start partial PTY size error = %v, want ErrInvalidPTYSize", err)
+	}
+}
+
 func TestServiceListAndOutputLimit(t *testing.T) {
 	ctx := context.Background()
 	svc := newTestService(t)
@@ -423,4 +493,8 @@ func waitWithTimeout(t *testing.T, svc *Service, id string) (*Snapshot, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	return svc.Wait(ctx, id)
+}
+
+func ptyUnavailable(err error) bool {
+	return errors.Is(err, syscall.EPERM) || errors.Is(err, syscall.ENOTTY) || errors.Is(err, syscall.ENOSYS)
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/term v0.2.1
+	github.com/creack/pty v1.1.24
 	github.com/fugue-labs/gollem-langsmith v0.0.2
 	github.com/fugue-labs/langfuse-go v0.0.0-20260221064316-0b4a57eccdb7
 	github.com/fugue-labs/monty-go v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/charmbracelet/x/term v0.2.1 h1:AQeHeLZ1OqSXhrAWpYUtZyX1T3zVxfpZuEQMIQ
 github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNEEkHUMCmsxdUg=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
+github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
+github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
## Summary
- add opt-in pseudo-terminal allocation to the workspace-scoped process service
- make `process/resizePty` functional only for allocated PTYs and expose truthful PTY status/size on process spawn results
- retain pipe behavior by default; PTY output is bounded and multiplexed onto stdout

## Validation
- `golangci-lint run ./appserver/... ./cmd/...`
- focused appserver/process tests and race tests
- full non-Monty test and vet suites
- pre-push full non-Monty race suite (hook skipped only `ext/monty`)

The current sandbox forbids a child controlling terminal, so live PTY execution tests skip only for that explicit environment capability; they remain live tests elsewhere.