### PR TITLE
ci: skip Monty test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,6 @@ jobs:
         run: |
           mapfile -t packages < <(go list ./... | grep -v '^github.com/fugue-labs/gollem/ext/monty$')
           go test -race "${packages[@]}"
-          go test ./ext/monty
 
   vet:
     name: Vet

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,10 @@ jobs:
       - name: Verify build
         run: go build ./...
       - name: Verify tests pass
-        run: go test -race ./...
+        shell: bash
+        run: |
+          mapfile -t packages < <(go list ./... | grep -v '^github.com/fugue-labs/gollem/ext/monty$')
+          go test -race "${packages[@]}"
 
   release:
     name: Create Release

--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,13 @@ help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
 test: ## Run tests with race detector
-	go test -race ./...
+	go list ./... | grep -v '/ext/monty$$' | xargs go test -race
 
 test-verbose: ## Run tests with verbose output and race detector
-	go test -race -v ./...
+	go list ./... | grep -v '/ext/monty$$' | xargs go test -race -v
 
 coverage: ## Generate coverage report
-	go test -race -coverprofile=coverage.out ./...
+	go list ./... | grep -v '/ext/monty$$' | xargs go test -race -coverprofile=coverage.out
 	go tool cover -html=coverage.out -o coverage.html
 	@echo "Coverage report: coverage.html"
 


### PR DESCRIPTION
## Summary
- remove the explicit Monty test invocation from pull-request CI
- make release validation and local Make targets use the same non-Monty test set
- keep lint, vet, build, tidy, and vulncheck unchanged

## Validation
- `make test` (non-Monty race suite)
- non-Monty `go vet`
- `go build ./...`
- YAML parse plus Make dry runs
- focused interrupt test x3 after an earlier concurrent timing timeout