### PR TITLE
test: prove native provider vision conformance

### DIFF
--- a/docs/PROVIDER_DRIVER_CONFORMANCE.md
+++ b/docs/PROVIDER_DRIVER_CONFORMANCE.md
@@ -15,7 +15,7 @@ of behavior and must not enable a control solely on provider identity.
 | Streaming text and terminal usage | Proven | Proven | Proven | `provider/conformance` |
 | In-flight request cancellation | Proven | Proven | Proven | `provider/conformance` |
 | Structured output | Proven native JSON-schema output | Unsupported | Proven schema-backed `final_result` tool output | `provider/conformance` runs native output mode through a typed agent and verifies the normalized result; fixtures assert OpenAI `response_format` and Anthropic's generated output tool schema |
-| Vision | Catalog-supported | Unsupported | Catalog-supported | Provider-specific tests; no common conformance claim yet |
+| Vision image input | Proven | Unsupported | Proven | `provider/conformance` sends a deterministic PNG data URI through `core.ImagePart`, asserts each provider's native image wire format, and verifies the normalized response |
 | Reasoning visibility | Proven where catalog-supported | Unsupported | Proven where catalog-supported | `provider/conformance` verifies native `ThinkingPart` start/delta events and final retention; local Chat Completions remains unsupported |
 | Prompt cache / Responses API | Catalog-supported where applicable | Unsupported | Catalog-supported where applicable | Provider-specific tests; no common conformance claim yet |
 | Malformed JSON stream event normalization | Proven | Proven | Proven | `provider/conformance` plus provider parser tests; returns `StreamProtocolError` without raw event data |

--- a/provider/conformance/conformance.go
+++ b/provider/conformance/conformance.go
@@ -23,6 +23,7 @@ import (
 type Claims struct {
 	ToolCalls           bool
 	StructuredOutput    bool
+	Vision              bool
 	Streaming           bool
 	Usage               bool
 	Cancellation        bool
@@ -38,7 +39,8 @@ type Claims struct {
 // Expectations declares the normalized outputs a deterministic fixture
 // produces. ToolName, ToolCallID, and ToolArgumentsJSON are required when
 // Claims.ToolCalls is true. StructuredOutputValue is required when
-// Claims.StructuredOutput is true. StreamText is required when
+// Claims.StructuredOutput is true. VisionText is required when Claims.Vision
+// is true. StreamText is required when
 // Claims.Streaming is true.
 type Expectations struct {
 	ResponseText          string
@@ -46,6 +48,7 @@ type Expectations struct {
 	ToolCallID            string
 	ToolArgumentsJSON     string
 	StructuredOutputValue string
+	VisionText            string
 	StreamText            string
 	PartialText           string
 	DisconnectText        string
@@ -86,6 +89,9 @@ func Verify(ctx context.Context, driver Driver) error {
 	}
 	if driver.Claims.StructuredOutput && strings.TrimSpace(driver.Expectations.StructuredOutputValue) == "" {
 		return fmt.Errorf("provider conformance: %s structured-output fixture must expect a typed value", driver.Name)
+	}
+	if driver.Claims.Vision && strings.TrimSpace(driver.Expectations.VisionText) == "" {
+		return fmt.Errorf("provider conformance: %s vision fixture must expect a response", driver.Name)
 	}
 	if driver.Claims.Streaming && strings.TrimSpace(driver.Expectations.StreamText) == "" {
 		return fmt.Errorf("provider conformance: %s streaming fixture must expect stream text", driver.Name)
@@ -141,6 +147,11 @@ func Verify(ctx context.Context, driver Driver) error {
 	}
 	if driver.Claims.StructuredOutput {
 		if err := verifyStructuredOutput(ctx, driver); err != nil {
+			return err
+		}
+	}
+	if driver.Claims.Vision {
+		if err := verifyVision(ctx, driver); err != nil {
 			return err
 		}
 	}
@@ -235,6 +246,22 @@ func verifyStructuredOutput(ctx context.Context, driver Driver) error {
 			got,
 			driver.Expectations.StructuredOutputValue,
 		)
+	}
+	return nil
+}
+
+// verifyVision sends a small deterministic PNG data URI through the public
+// core.Model request path. Provider fixtures assert their native wire shape.
+func verifyVision(ctx context.Context, driver Driver) error {
+	response, err := driver.Model.Request(ctx, visionMessages(), nil, &core.ModelRequestParameters{AllowTextOutput: true})
+	if err != nil {
+		return fmt.Errorf("provider conformance: %s vision request: %w", driver.Name, err)
+	}
+	if response == nil {
+		return fmt.Errorf("provider conformance: %s vision request returned a nil response", driver.Name)
+	}
+	if got := response.TextContent(); got != driver.Expectations.VisionText {
+		return fmt.Errorf("provider conformance: %s vision text = %q, want %q", driver.Name, got, driver.Expectations.VisionText)
 	}
 	return nil
 }
@@ -518,6 +545,15 @@ func verifyToolCall(driver Driver, parts []core.ModelResponsePart) error {
 func conformanceMessages() []core.ModelMessage {
 	return []core.ModelMessage{
 		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "run conformance"}}},
+	}
+}
+
+func visionMessages() []core.ModelMessage {
+	return []core.ModelMessage{
+		core.ModelRequest{Parts: []core.ModelRequestPart{
+			core.UserPromptPart{Content: "vision conformance"},
+			core.ImagePart{URL: core.BinaryContent([]byte{1, 2, 3}, "image/png"), MIMEType: "image/png", Detail: "low"},
+		}},
 	}
 }
 

--- a/provider/conformance/conformance_test.go
+++ b/provider/conformance/conformance_test.go
@@ -40,7 +40,7 @@ func TestDeterministicProviderDriverConformance(t *testing.T) {
 					Name:                "native OpenAI",
 					Model:               openai.New(openai.WithAPIKey("test-openai-key"), openai.WithBaseURL(openAIServer.URL), openai.WithModel("gpt-4o")),
 					ReasoningModel:      openai.New(openai.WithAPIKey("test-openai-key"), openai.WithBaseURL(openAIServer.URL), openai.WithModel("gpt-5")),
-					Claims:              conformance.Claims{ToolCalls: true, StructuredOutput: true, Streaming: true, Usage: true, Cancellation: true, PartialStream: true, MalformedStream: true, DisconnectStream: true, Retryability: true, RequestTimeout: true, StreamTimeout: true, ReasoningVisibility: true},
+					Claims:              conformance.Claims{ToolCalls: true, StructuredOutput: true, Vision: true, Streaming: true, Usage: true, Cancellation: true, PartialStream: true, MalformedStream: true, DisconnectStream: true, Retryability: true, RequestTimeout: true, StreamTimeout: true, ReasoningVisibility: true},
 					CancellationReady:   openAICancellationReady,
 					RequestTimeoutReady: openAITimeout.readyFor("gpt-4o"),
 					Expectations: conformance.Expectations{
@@ -49,6 +49,7 @@ func TestDeterministicProviderDriverConformance(t *testing.T) {
 						ToolCallID:            "call_openai",
 						ToolArgumentsJSON:     `{"value":"ok"}`,
 						StructuredOutputValue: "openai structured",
+						VisionText:            "openai vision",
 						StreamText:            "openai stream",
 						PartialText:           "openai partial",
 						DisconnectText:        "openai disconnect",
@@ -98,7 +99,7 @@ func TestDeterministicProviderDriverConformance(t *testing.T) {
 					Name:                "native Anthropic",
 					Model:               model,
 					ReasoningModel:      model,
-					Claims:              conformance.Claims{ToolCalls: true, StructuredOutput: true, Streaming: true, Usage: true, Cancellation: true, PartialStream: true, MalformedStream: true, DisconnectStream: true, Retryability: true, RequestTimeout: true, StreamTimeout: true, ReasoningVisibility: true},
+					Claims:              conformance.Claims{ToolCalls: true, StructuredOutput: true, Vision: true, Streaming: true, Usage: true, Cancellation: true, PartialStream: true, MalformedStream: true, DisconnectStream: true, Retryability: true, RequestTimeout: true, StreamTimeout: true, ReasoningVisibility: true},
 					CancellationReady:   anthropicCancellationReady,
 					RequestTimeoutReady: anthropicTimeout.readyFor(anthropic.ClaudeSonnet46),
 					Expectations: conformance.Expectations{
@@ -107,6 +108,7 @@ func TestDeterministicProviderDriverConformance(t *testing.T) {
 						ToolCallID:            "call_anthropic",
 						ToolArgumentsJSON:     `{"value":"ok"}`,
 						StructuredOutputValue: "anthropic structured",
+						VisionText:            "anthropic vision",
 						StreamText:            "anthropic stream",
 						PartialText:           "anthropic partial",
 						DisconnectText:        "anthropic disconnect",
@@ -140,6 +142,14 @@ func TestVerifyRejectsUnprovenClaims(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("Verify accepted a structured-output claim without a typed expectation")
+	}
+	err = conformance.Verify(context.Background(), conformance.Driver{
+		Name:   "missing vision fixture",
+		Model:  openai.New(openai.WithAPIKey("test-key")),
+		Claims: conformance.Claims{Vision: true},
+	})
+	if err == nil {
+		t.Fatal("Verify accepted a vision claim without an expected response")
 	}
 	err = conformance.Verify(context.Background(), conformance.Driver{
 		Name:   "missing tool fixture",
@@ -401,6 +411,12 @@ func openAIConformanceFixture(t *testing.T, cancellationReady chan<- struct{}, r
 			_, _ = fmt.Fprint(w, `{"id":"chatcmpl-structured","object":"chat.completion","model":"gpt-4o","choices":[{"message":{"role":"assistant","content":"{\"value\":\"openai structured\"}"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":2}}`)
 			return
 		}
+		if strings.Contains(string(body), "vision conformance") {
+			assertOpenAIVisionRequest(t, body)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `{"id":"chatcmpl-vision","object":"chat.completion","model":"gpt-4o","choices":[{"message":{"role":"assistant","content":"openai vision"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":2}}`)
+			return
+		}
 		if request.Stream {
 			if len(request.Tools) != 0 && string(request.Tools) != "null" {
 				t.Fatalf("stream request unexpectedly included tools: %s", request.Tools)
@@ -532,6 +548,12 @@ data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text
 			_, _ = fmt.Fprint(w, `{"id":"msg-structured","role":"assistant","model":"claude-sonnet-4-6","content":[{"type":"tool_use","id":"call_structured","name":"final_result","input":{"value":"anthropic structured"}}],"stop_reason":"tool_use","usage":{"input_tokens":3,"output_tokens":2}}`)
 			return
 		}
+		if strings.Contains(string(body), "vision conformance") {
+			assertAnthropicVisionRequest(t, body)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `{"id":"msg-vision","role":"assistant","model":"claude-sonnet-4-6","content":[{"type":"text","text":"anthropic vision"}],"stop_reason":"end_turn","usage":{"input_tokens":3,"output_tokens":2}}`)
+			return
+		}
 		if strings.Contains(string(body), "reasoning conformance") {
 			if !request.Stream {
 				t.Fatal("Anthropic reasoning request was not streaming")
@@ -640,6 +662,70 @@ func assertAnthropicStructuredOutputTool(t *testing.T, raw json.RawMessage) {
 		}
 	}
 	t.Fatalf("Anthropic structured-output request omitted %q tool: %s", core.DefaultOutputToolName, raw)
+}
+
+func assertOpenAIVisionRequest(t *testing.T, body []byte) {
+	t.Helper()
+	var request struct {
+		Messages []struct {
+			Role    string          `json:"role"`
+			Content json.RawMessage `json:"content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(body, &request); err != nil {
+		t.Fatalf("decode OpenAI vision request: %v", err)
+	}
+	if len(request.Messages) != 1 || request.Messages[0].Role != "user" {
+		t.Fatalf("OpenAI vision messages = %#v, want one user message", request.Messages)
+	}
+	var parts []struct {
+		Type     string `json:"type"`
+		Text     string `json:"text"`
+		ImageURL *struct {
+			URL    string `json:"url"`
+			Detail string `json:"detail"`
+		} `json:"image_url"`
+	}
+	if err := json.Unmarshal(request.Messages[0].Content, &parts); err != nil {
+		t.Fatalf("decode OpenAI vision content: %v", err)
+	}
+	if len(parts) != 2 || parts[0].Type != "text" || parts[0].Text != "vision conformance" {
+		t.Fatalf("OpenAI vision content = %s, want text then image", request.Messages[0].Content)
+	}
+	if parts[1].Type != "image_url" || parts[1].ImageURL == nil || parts[1].ImageURL.URL != "data:image/png;base64,AQID" || parts[1].ImageURL.Detail != "low" {
+		t.Fatalf("OpenAI vision image = %#v, want low-detail PNG data URI", parts[1])
+	}
+}
+
+func assertAnthropicVisionRequest(t *testing.T, body []byte) {
+	t.Helper()
+	var request struct {
+		Messages []struct {
+			Role    string `json:"role"`
+			Content []struct {
+				Type   string `json:"type"`
+				Text   string `json:"text"`
+				Source *struct {
+					Type      string `json:"type"`
+					MediaType string `json:"media_type"`
+					Data      string `json:"data"`
+				} `json:"source"`
+			} `json:"content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(body, &request); err != nil {
+		t.Fatalf("decode Anthropic vision request: %v", err)
+	}
+	if len(request.Messages) != 1 || request.Messages[0].Role != "user" {
+		t.Fatalf("Anthropic vision messages = %#v, want one user message", request.Messages)
+	}
+	parts := request.Messages[0].Content
+	if len(parts) != 2 || parts[0].Type != "text" || parts[0].Text != "vision conformance" {
+		t.Fatalf("Anthropic vision content = %#v, want text then image", parts)
+	}
+	if parts[1].Type != "image" || parts[1].Source == nil || parts[1].Source.Type != "base64" || parts[1].Source.MediaType != "image/png" || parts[1].Source.Data != "AQID" {
+		t.Fatalf("Anthropic vision image = %#v, want base64 PNG source", parts[1])
+	}
 }
 
 func assertStructuredOutputSchema(t *testing.T, raw json.RawMessage) {


### PR DESCRIPTION
## Summary
- add a deterministic vision claim to the provider conformance contract
- assert the native OpenAI image_url and Anthropic base64 image wire shapes through loopback fixtures
- mark native vision input proven while keeping the local OpenAI-compatible profile unsupported

## Validation
- `go test ./provider/conformance`
- `go test ./provider/...`
- `go test ./appserver/catalog`
- `go vet ./...`
- `go build ./...`
- `make test` (Monty excluded by repository target)
- `make lint`