### PR TITLE
test: prove provider cache-read usage conformance

### DIFF
--- a/docs/PROVIDER_DRIVER_CONFORMANCE.md
+++ b/docs/PROVIDER_DRIVER_CONFORMANCE.md
@@ -18,6 +18,7 @@ of behavior and must not enable a control solely on provider identity.
 | Vision image input | Proven | Unsupported | Proven | `provider/conformance` sends a deterministic PNG data URI through `core.ImagePart`, asserts each provider's native image wire format, and verifies the normalized response |
 | Reasoning visibility | Proven where catalog-supported | Unsupported | Proven where catalog-supported | `provider/conformance` verifies native `ThinkingPart` start/delta events and final retention; local Chat Completions remains unsupported |
 | Prompt cache / Responses API | Catalog-supported where applicable | Unsupported | Catalog-supported where applicable | Provider-specific tests; no common conformance claim yet |
+| Cache-read token accounting | Proven | Unsupported | Proven | `provider/conformance` verifies provider-reported cache reads normalize to `core.Usage.CacheReadTokens`; this is accounting evidence, not a portable prompt-cache activation control |
 | Malformed JSON stream event normalization | Proven | Proven | Proven | `provider/conformance` plus provider parser tests; returns `StreamProtocolError` without raw event data |
 | Abrupt EOF partial-stream result | Proven | Proven | Proven | `provider/conformance` plus provider parser tests; preserves partial response and returns `StreamIncompleteError` |
 | Read-error peer-disconnect classification | Proven | Proven | Proven | `provider/conformance` plus provider parser tests; returns source-free `StreamTransportError`, while context cancellation remains intact |

--- a/provider/conformance/conformance.go
+++ b/provider/conformance/conformance.go
@@ -24,6 +24,7 @@ type Claims struct {
 	ToolCalls           bool
 	StructuredOutput    bool
 	Vision              bool
+	CacheReadUsage      bool
 	Streaming           bool
 	Usage               bool
 	Cancellation        bool
@@ -40,7 +41,8 @@ type Claims struct {
 // produces. ToolName, ToolCallID, and ToolArgumentsJSON are required when
 // Claims.ToolCalls is true. StructuredOutputValue is required when
 // Claims.StructuredOutput is true. VisionText is required when Claims.Vision
-// is true. StreamText is required when
+// is true. CacheReadTokens is required when Claims.CacheReadUsage is true.
+// StreamText is required when
 // Claims.Streaming is true.
 type Expectations struct {
 	ResponseText          string
@@ -49,6 +51,7 @@ type Expectations struct {
 	ToolArgumentsJSON     string
 	StructuredOutputValue string
 	VisionText            string
+	CacheReadTokens       int
 	StreamText            string
 	PartialText           string
 	DisconnectText        string
@@ -92,6 +95,9 @@ func Verify(ctx context.Context, driver Driver) error {
 	}
 	if driver.Claims.Vision && strings.TrimSpace(driver.Expectations.VisionText) == "" {
 		return fmt.Errorf("provider conformance: %s vision fixture must expect a response", driver.Name)
+	}
+	if driver.Claims.CacheReadUsage && driver.Expectations.CacheReadTokens <= 0 {
+		return fmt.Errorf("provider conformance: %s cache-read fixture must expect positive cache-read tokens", driver.Name)
 	}
 	if driver.Claims.Streaming && strings.TrimSpace(driver.Expectations.StreamText) == "" {
 		return fmt.Errorf("provider conformance: %s streaming fixture must expect stream text", driver.Name)
@@ -144,6 +150,11 @@ func Verify(ctx context.Context, driver Driver) error {
 	}
 	if err := verifyResponse(driver, response, false); err != nil {
 		return err
+	}
+	if driver.Claims.CacheReadUsage {
+		if err := verifyCacheReadUsage(driver, response); err != nil {
+			return err
+		}
 	}
 	if driver.Claims.StructuredOutput {
 		if err := verifyStructuredOutput(ctx, driver); err != nil {
@@ -262,6 +273,21 @@ func verifyVision(ctx context.Context, driver Driver) error {
 	}
 	if got := response.TextContent(); got != driver.Expectations.VisionText {
 		return fmt.Errorf("provider conformance: %s vision text = %q, want %q", driver.Name, got, driver.Expectations.VisionText)
+	}
+	return nil
+}
+
+// verifyCacheReadUsage protects the provider-neutral accounting surface used
+// by cost tracking and quota reporting. It deliberately does not claim that
+// prompt-cache activation is portable across provider request APIs.
+func verifyCacheReadUsage(driver Driver, response *core.ModelResponse) error {
+	if got := response.Usage.CacheReadTokens; got != driver.Expectations.CacheReadTokens {
+		return fmt.Errorf(
+			"provider conformance: %s cache-read tokens = %d, want %d",
+			driver.Name,
+			got,
+			driver.Expectations.CacheReadTokens,
+		)
 	}
 	return nil
 }

--- a/provider/conformance/conformance_test.go
+++ b/provider/conformance/conformance_test.go
@@ -40,7 +40,7 @@ func TestDeterministicProviderDriverConformance(t *testing.T) {
 					Name:                "native OpenAI",
 					Model:               openai.New(openai.WithAPIKey("test-openai-key"), openai.WithBaseURL(openAIServer.URL), openai.WithModel("gpt-4o")),
 					ReasoningModel:      openai.New(openai.WithAPIKey("test-openai-key"), openai.WithBaseURL(openAIServer.URL), openai.WithModel("gpt-5")),
-					Claims:              conformance.Claims{ToolCalls: true, StructuredOutput: true, Vision: true, Streaming: true, Usage: true, Cancellation: true, PartialStream: true, MalformedStream: true, DisconnectStream: true, Retryability: true, RequestTimeout: true, StreamTimeout: true, ReasoningVisibility: true},
+					Claims:              conformance.Claims{ToolCalls: true, StructuredOutput: true, Vision: true, CacheReadUsage: true, Streaming: true, Usage: true, Cancellation: true, PartialStream: true, MalformedStream: true, DisconnectStream: true, Retryability: true, RequestTimeout: true, StreamTimeout: true, ReasoningVisibility: true},
 					CancellationReady:   openAICancellationReady,
 					RequestTimeoutReady: openAITimeout.readyFor("gpt-4o"),
 					Expectations: conformance.Expectations{
@@ -50,6 +50,7 @@ func TestDeterministicProviderDriverConformance(t *testing.T) {
 						ToolArgumentsJSON:     `{"value":"ok"}`,
 						StructuredOutputValue: "openai structured",
 						VisionText:            "openai vision",
+						CacheReadTokens:       2,
 						StreamText:            "openai stream",
 						PartialText:           "openai partial",
 						DisconnectText:        "openai disconnect",
@@ -99,7 +100,7 @@ func TestDeterministicProviderDriverConformance(t *testing.T) {
 					Name:                "native Anthropic",
 					Model:               model,
 					ReasoningModel:      model,
-					Claims:              conformance.Claims{ToolCalls: true, StructuredOutput: true, Vision: true, Streaming: true, Usage: true, Cancellation: true, PartialStream: true, MalformedStream: true, DisconnectStream: true, Retryability: true, RequestTimeout: true, StreamTimeout: true, ReasoningVisibility: true},
+					Claims:              conformance.Claims{ToolCalls: true, StructuredOutput: true, Vision: true, CacheReadUsage: true, Streaming: true, Usage: true, Cancellation: true, PartialStream: true, MalformedStream: true, DisconnectStream: true, Retryability: true, RequestTimeout: true, StreamTimeout: true, ReasoningVisibility: true},
 					CancellationReady:   anthropicCancellationReady,
 					RequestTimeoutReady: anthropicTimeout.readyFor(anthropic.ClaudeSonnet46),
 					Expectations: conformance.Expectations{
@@ -109,6 +110,7 @@ func TestDeterministicProviderDriverConformance(t *testing.T) {
 						ToolArgumentsJSON:     `{"value":"ok"}`,
 						StructuredOutputValue: "anthropic structured",
 						VisionText:            "anthropic vision",
+						CacheReadTokens:       2,
 						StreamText:            "anthropic stream",
 						PartialText:           "anthropic partial",
 						DisconnectText:        "anthropic disconnect",
@@ -150,6 +152,14 @@ func TestVerifyRejectsUnprovenClaims(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("Verify accepted a vision claim without an expected response")
+	}
+	err = conformance.Verify(context.Background(), conformance.Driver{
+		Name:   "missing cache-read fixture",
+		Model:  openai.New(openai.WithAPIKey("test-key")),
+		Claims: conformance.Claims{CacheReadUsage: true},
+	})
+	if err == nil {
+		t.Fatal("Verify accepted a cache-read claim without expected tokens")
 	}
 	err = conformance.Verify(context.Background(), conformance.Driver{
 		Name:   "missing tool fixture",
@@ -433,7 +443,7 @@ data: [DONE]
 			t.Fatal("tool-capable request did not include tools")
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = fmt.Fprint(w, `{"id":"chatcmpl-conformance","object":"chat.completion","model":"gpt-4o","choices":[{"message":{"role":"assistant","content":"openai response","tool_calls":[{"id":"call_openai","type":"function","function":{"name":"conformance_echo","arguments":"{\"value\":\"ok\"}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":3,"completion_tokens":2}}`)
+		_, _ = fmt.Fprint(w, `{"id":"chatcmpl-conformance","object":"chat.completion","model":"gpt-4o","choices":[{"message":{"role":"assistant","content":"openai response","tool_calls":[{"id":"call_openai","type":"function","function":{"name":"conformance_echo","arguments":"{\"value\":\"ok\"}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":3,"completion_tokens":2,"prompt_tokens_details":{"cached_tokens":2}}}`)
 	})
 }
 
@@ -616,7 +626,7 @@ data: {"type":"message_stop"}
 			t.Fatal("tool-capable request did not include tools")
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = fmt.Fprint(w, `{"id":"msg-conformance","role":"assistant","model":"claude-sonnet-4-6","content":[{"type":"text","text":"anthropic response"},{"type":"tool_use","id":"call_anthropic","name":"conformance_echo","input":{"value":"ok"}}],"stop_reason":"tool_use","usage":{"input_tokens":3,"output_tokens":2}}`)
+		_, _ = fmt.Fprint(w, `{"id":"msg-conformance","role":"assistant","model":"claude-sonnet-4-6","content":[{"type":"text","text":"anthropic response"},{"type":"tool_use","id":"call_anthropic","name":"conformance_echo","input":{"value":"ok"}}],"stop_reason":"tool_use","usage":{"input_tokens":3,"output_tokens":2,"cache_read_input_tokens":2}}`)
 	})
 }
 


### PR DESCRIPTION
## Summary
- add a deterministic cache-read usage claim to provider conformance
- verify native OpenAI and Anthropic normalize provider cache-read fields into `core.Usage.CacheReadTokens`
- document this as accounting evidence while retaining prompt-cache activation as catalog-supported only

## Validation
- `go test ./provider/conformance`
- `go test ./provider/...`
- `go test ./appserver/catalog`
- `go vet ./...`
- `go build ./...`
- `make test` (Monty excluded by repository target)
- `make lint`