### PR TITLE
fix(openai): bind Responses stream model before deltas

### DIFF
--- a/provider/openai/openai_test.go
+++ b/provider/openai/openai_test.go
@@ -3132,6 +3132,7 @@ func TestStrictModelBindingResponsesStreamBareTerminalPaths(t *testing.T) {
 				io.NopCloser(strings.NewReader(tt.sse)),
 				"gpt-5",
 				p.resolveResponseModel,
+				p.strictModelBinding,
 				nil,
 			)
 			defer stream.Close()

--- a/provider/openai/responses.go
+++ b/provider/openai/responses.go
@@ -253,7 +253,7 @@ func (p *Provider) requestStreamViaResponses(ctx context.Context, messages []cor
 		return &prebuiltResponsesStream{response: bound, instrumentation: ri}, nil
 	}
 
-	return newBoundResponsesStreamedResponse(resp.Body, p.model, p.resolveResponseModel, ri), nil
+	return newBoundResponsesStreamedResponse(resp.Body, p.model, p.resolveResponseModel, p.strictModelBinding, ri), nil
 }
 
 // applyChatGPTRequirements modifies a request for the ChatGPT backend:

--- a/provider/openai/responses_stream.go
+++ b/provider/openai/responses_stream.go
@@ -28,12 +28,14 @@ type responsesStreamEvent struct {
 // response.output_item.done, and terminal response events, yielding PartStartEvent
 // and PartDeltaEvent as they arrive.
 type responsesStreamedResponse struct {
-	scanner      *bufio.Scanner
-	body         io.ReadCloser
-	model        string
-	resolveModel func(string) (string, error)
-	modelSeen    bool
-	usage        core.Usage
+	scanner            *bufio.Scanner
+	body               io.ReadCloser
+	model              string
+	resolveModel       func(string) (string, error)
+	strictModelBinding bool
+	boundProviderModel string
+	modelSeen          bool
+	usage              core.Usage
 
 	stopReason core.FinishReason
 	done       bool
@@ -68,13 +70,14 @@ type responsesStreamedResponse struct {
 }
 
 func newResponsesStreamedResponse(body io.ReadCloser, model string) *responsesStreamedResponse {
-	return newBoundResponsesStreamedResponse(body, model, nil, nil)
+	return newBoundResponsesStreamedResponse(body, model, nil, false, nil)
 }
 
 func newBoundResponsesStreamedResponse(
 	body io.ReadCloser,
 	model string,
 	resolveModel func(string) (string, error),
+	strictModelBinding bool,
 	ri *requestInstrumentation,
 ) *responsesStreamedResponse {
 	scanner := bufio.NewScanner(body)
@@ -84,6 +87,7 @@ func newBoundResponsesStreamedResponse(
 		body:                 body,
 		model:                model,
 		resolveModel:         resolveModel,
+		strictModelBinding:   strictModelBinding,
 		stopReason:           core.FinishReasonStop,
 		instrumentation:      ri,
 		partsByIndex:         make(map[int]core.ModelResponsePart),
@@ -143,6 +147,12 @@ func (s *responsesStreamedResponse) Next() (core.ModelResponseStreamEvent, error
 			continue
 		}
 		s.instrumentation.recordFirstEvent()
+		if err := s.validateEventModelIdentity(&event); err != nil {
+			return s.failStream(err)
+		}
+		if s.strictModelBinding && responseEventCanEmitOutput(event.Type) && !s.modelSeen {
+			return s.failStream(&ModelIdentityError{Requested: s.model})
+		}
 
 		events := s.processEvent(&event)
 		if len(events) > 0 {
@@ -152,6 +162,35 @@ func (s *responsesStreamedResponse) Next() (core.ModelResponseStreamEvent, error
 			s.instrumentation.recordFirstToken()
 			return events[0], nil
 		}
+	}
+}
+
+func responseEventCanEmitOutput(eventType string) bool {
+	switch eventType {
+	case "response.output_text.delta",
+		"response.output_item.added",
+		"response.function_call_arguments.delta",
+		"response.reasoning_summary_text.delta",
+		"response.output_item.done":
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *responsesStreamedResponse) validateEventModelIdentity(event *responsesStreamEvent) error {
+	if !s.strictModelBinding {
+		return nil
+	}
+	switch event.Type {
+	case "response.created", "response.in_progress", "response.completed", "response.done", "response.incomplete":
+		var response responsesAPIResponse
+		if len(event.Response) == 0 || json.Unmarshal(event.Response, &response) != nil {
+			return s.bindResponseModel("")
+		}
+		return s.bindResponseModel(response.Model)
+	default:
+		return nil
 	}
 }
 
@@ -499,7 +538,11 @@ func (s *responsesStreamedResponse) handleCompleted(respJSON json.RawMessage) {
 }
 
 func (s *responsesStreamedResponse) bindResponseModel(actual string) error {
-	resolved := strings.TrimSpace(actual)
+	actual = strings.TrimSpace(actual)
+	if s.strictModelBinding && s.modelSeen && actual != s.boundProviderModel {
+		return &ModelIdentityError{Requested: s.boundProviderModel, Actual: actual}
+	}
+	resolved := actual
 	if s.resolveModel != nil {
 		var err error
 		resolved, err = s.resolveModel(actual)
@@ -510,7 +553,10 @@ func (s *responsesStreamedResponse) bindResponseModel(actual string) error {
 	if resolved != "" {
 		s.model = resolved
 	}
-	s.modelSeen = strings.TrimSpace(actual) != ""
+	if actual != "" {
+		s.modelSeen = true
+		s.boundProviderModel = actual
+	}
 	return nil
 }
 

--- a/provider/openai/responses_stream_test.go
+++ b/provider/openai/responses_stream_test.go
@@ -104,6 +104,177 @@ func assertResponsesStreamTextOnly(t *testing.T, s *responsesStreamedResponse) {
 	}
 }
 
+func TestStrictResponsesStreamRequiresIdentityBeforeEmittingDeltas(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		event string
+	}{
+		{
+			name:  "text",
+			event: `{"type":"response.output_text.delta","delta":"untrusted text"}`,
+		},
+		{
+			name:  "tool",
+			event: `{"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","name":"shell","call_id":"untrusted-call"}}`,
+		},
+		{
+			name:  "reasoning",
+			event: `{"type":"response.reasoning_summary_text.delta","output_index":0,"delta":"untrusted reasoning"}`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newStrictResponsesStream(t, `data: {"type":"response.created","response":{"id":"resp-1"}}
+
+data: `+tt.event+`
+
+data: {"type":"response.completed","response":{"id":"resp-1","model":"gpt-5","output":[]}}
+
+data: [DONE]
+`)
+			defer s.Close()
+
+			_, err := s.Next()
+			assertModelIdentityError(t, err)
+			if response := s.Response(); len(response.Parts) != 0 || response.TextContent() != "" {
+				t.Fatalf("unbound stream emitted response %#v", response)
+			}
+		})
+	}
+}
+
+func TestStrictResponsesStreamRejectsInitialAndLaterModelIdentityConflicts(t *testing.T) {
+	t.Run("initial mismatch", func(t *testing.T) {
+		s := newStrictResponsesStream(t, `data: {"type":"response.created","response":{"id":"resp-1","model":"gpt-5-mini"}}
+
+data: {"type":"response.output_text.delta","delta":"untrusted text"}
+
+data: [DONE]
+`)
+		defer s.Close()
+
+		_, err := s.Next()
+		assertModelIdentityError(t, err)
+		if response := s.Response(); len(response.Parts) != 0 || response.TextContent() != "" {
+			t.Fatalf("mismatched stream emitted response %#v", response)
+		}
+	})
+
+	t.Run("later compatible snapshot conflicts", func(t *testing.T) {
+		s := newStrictResponsesStream(t, `data: {"type":"response.created","response":{"id":"resp-1","model":"gpt-5-2026-08-15"}}
+
+data: {"type":"response.output_text.delta","delta":"trusted text"}
+
+data: {"type":"response.in_progress","response":{"id":"resp-1","model":"gpt-5-2026-08-16"}}
+
+data: {"type":"response.output_text.delta","delta":" untrusted text"}
+
+data: [DONE]
+`)
+		defer s.Close()
+
+		event, err := s.Next()
+		if err != nil {
+			t.Fatalf("trusted delta: %v", err)
+		}
+		if start, ok := event.(core.PartStartEvent); !ok || start.Part.(core.TextPart).Content != "trusted text" {
+			t.Fatalf("trusted delta = %#v", event)
+		}
+		_, err = s.Next()
+		assertModelIdentityError(t, err)
+		if got := s.Response().TextContent(); got != "trusted text" {
+			t.Fatalf("conflicting stream text = %q, want only trusted prefix", got)
+		}
+	})
+}
+
+func TestStrictResponsesStreamAcceptsConsistentInitialIdentity(t *testing.T) {
+	const actual = "gpt-5-2026-08-15"
+	s := newStrictResponsesStream(t, `data: {"type":"response.created","response":{"id":"resp-1","model":"`+actual+`"}}
+
+data: {"type":"response.in_progress","response":{"id":"resp-1","model":"`+actual+`"}}
+
+data: {"type":"response.output_text.delta","delta":"trusted text"}
+
+data: {"type":"response.completed","response":{"id":"resp-1","model":"`+actual+`","output":[]}}
+
+data: [DONE]
+`)
+	defer s.Close()
+
+	event, err := s.Next()
+	if err != nil {
+		t.Fatalf("Next(): %v", err)
+	}
+	if start, ok := event.(core.PartStartEvent); !ok || start.Part.(core.TextPart).Content != "trusted text" {
+		t.Fatalf("trusted delta = %#v", event)
+	}
+	if _, err := s.Next(); err != io.EOF {
+		t.Fatalf("completion error = %v, want EOF", err)
+	}
+	if got := s.Response().ModelName; got != actual {
+		t.Fatalf("response model = %q, want %q", got, actual)
+	}
+}
+
+func TestResponsesStreamNonStrictBindingRemainsPermissive(t *testing.T) {
+	provider := New(WithModel("gpt-5"))
+	s := newBoundResponsesStreamedResponse(
+		io.NopCloser(strings.NewReader(`data: {"type":"response.created","response":{"id":"resp-1","model":"gpt-5-2026-08-15"}}
+
+data: {"type":"response.output_text.delta","delta":"first"}
+
+data: {"type":"response.in_progress","response":{"id":"resp-1","model":"gpt-5-2026-08-16"}}
+
+data: {"type":"response.output_text.delta","delta":" second"}
+
+data: {"type":"response.completed","response":{"id":"resp-1","model":"gpt-5-2026-08-16","output":[]}}
+
+data: [DONE]
+`)),
+		"gpt-5",
+		provider.resolveResponseModel,
+		provider.strictModelBinding,
+		nil,
+	)
+	defer s.Close()
+
+	for {
+		_, err := s.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Next(): %v", err)
+		}
+	}
+	if got := s.Response().TextContent(); got != "first second" {
+		t.Fatalf("response text = %q", got)
+	}
+	if got := s.Response().ModelName; got != "gpt-5-2026-08-16" {
+		t.Fatalf("response model = %q, want final provider model", got)
+	}
+}
+
+func newStrictResponsesStream(t *testing.T, sse string) *responsesStreamedResponse {
+	t.Helper()
+	provider := New(WithModel("gpt-5"), WithStrictModelBinding())
+	return newBoundResponsesStreamedResponse(
+		io.NopCloser(strings.NewReader(sse)),
+		"gpt-5",
+		provider.resolveResponseModel,
+		provider.strictModelBinding,
+		nil,
+	)
+}
+
+func assertModelIdentityError(t *testing.T, err error) {
+	t.Helper()
+	var identityErr *ModelIdentityError
+	if !errors.As(err, &identityErr) {
+		t.Fatalf("error = %v, want ModelIdentityError", err)
+	}
+}
+
 func TestResponsesStreamedResponse_ToolCall(t *testing.T) {
 	sse := `data: {"type":"response.output_item.done","item":{"type":"function_call","name":"bash","call_id":"call_abc","arguments":"{\"cmd\":\"ls\"}"}}
 


### PR DESCRIPTION
Closes #239.

Strict Responses streams now establish model identity from `response.created` and subsequent full response events before exposing text, tool, or reasoning output. Conflicting later identities fail closed; non-strict streams preserve existing permissive behavior and final actual-model provenance.

Validation:
- `go test -race ./provider/openai -count=1`
- `go test ./provider/conformance -count=1`
- `make test` (Monty excluded by repository configuration)
- `go vet ./...`
- `make lint`
- `go build ./cmd/gollem`