### PR TITLE
feat(runtime): expose prompt cache activation control

### DIFF
--- a/appserver/protocol/runtime_client_types.go
+++ b/appserver/protocol/runtime_client_types.go
@@ -176,18 +176,19 @@ type ModelCatalogListResponse struct {
 }
 
 type RuntimeModelParams struct {
-	ProviderID       string          `json:"providerId,omitempty"`
-	Provider         string          `json:"provider,omitempty"`
-	Model            string          `json:"model,omitempty"`
-	MaxTokens        *int            `json:"maxTokens,omitempty"`
-	Temperature      *float64        `json:"temperature,omitempty"`
-	TopP             *float64        `json:"topP,omitempty"`
-	ThinkingBudget   *int            `json:"thinkingBudget,omitempty"`
-	AdaptiveThinking *bool           `json:"adaptiveThinking,omitempty"`
-	ReasoningEffort  *string         `json:"reasoningEffort,omitempty"`
-	StopSequences    []string        `json:"stopSequences,omitempty"`
-	Settings         map[string]any  `json:"settings,omitempty"`
-	Input            json.RawMessage `json:"input,omitempty"`
+	ProviderID         string          `json:"providerId,omitempty"`
+	Provider           string          `json:"provider,omitempty"`
+	Model              string          `json:"model,omitempty"`
+	MaxTokens          *int            `json:"maxTokens,omitempty"`
+	Temperature        *float64        `json:"temperature,omitempty"`
+	TopP               *float64        `json:"topP,omitempty"`
+	ThinkingBudget     *int            `json:"thinkingBudget,omitempty"`
+	AdaptiveThinking   *bool           `json:"adaptiveThinking,omitempty"`
+	ReasoningEffort    *string         `json:"reasoningEffort,omitempty"`
+	PromptCacheEnabled *bool           `json:"promptCacheEnabled,omitempty"`
+	StopSequences      []string        `json:"stopSequences,omitempty"`
+	Settings           map[string]any  `json:"settings,omitempty"`
+	Input              json.RawMessage `json:"input,omitempty"`
 }
 
 type ThreadRunStartParams struct {

--- a/appserver/protocol/runtime_client_types_contract_test.go
+++ b/appserver/protocol/runtime_client_types_contract_test.go
@@ -3,6 +3,7 @@ package protocol
 import (
 	"reflect"
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -70,6 +71,21 @@ func TestRuntimeClientBindingsAreExact(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("runtime client bindings = %#v, want %#v", got, want)
+	}
+}
+
+func TestRuntimeModelParamsExposePromptCacheSetting(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	properties := defs["RuntimeModelParams"].(Schema)["properties"].(Schema)
+	if _, ok := properties["promptCacheEnabled"]; !ok {
+		t.Fatal("RuntimeModelParams schema omitted promptCacheEnabled")
+	}
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	if !strings.Contains(string(generated), `"promptCacheEnabled"?: boolean | null;`) {
+		t.Fatal("RuntimeModelParams TypeScript omitted nullable promptCacheEnabled")
 	}
 }
 

--- a/appserver/protocol/runtime_recovery_contract_test.go
+++ b/appserver/protocol/runtime_recovery_contract_test.go
@@ -25,6 +25,7 @@ func TestTurnRunRetryContractIsGeneratedAndBound(t *testing.T) {
 		"thinkingBudget",
 		"adaptiveThinking",
 		"reasoningEffort",
+		"promptCacheEnabled",
 		"stopSequences",
 		"settings",
 		"input",

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -17148,6 +17148,16 @@
         "model": {
           "type": "string"
         },
+        "promptCacheEnabled": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "provider": {
           "type": "string"
         },
@@ -22829,6 +22839,16 @@
         "prompt": {
           "type": "string"
         },
+        "promptCacheEnabled": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "provider": {
           "type": "string"
         },
@@ -24498,6 +24518,16 @@
         "prompt": {
           "type": "string"
         },
+        "promptCacheEnabled": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "provider": {
           "type": "string"
         },
@@ -24648,6 +24678,16 @@
         },
         "prompt": {
           "type": "string"
+        },
+        "promptCacheEnabled": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "provider": {
           "type": "string"

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -3519,6 +3519,7 @@ export type RuntimeModelParams = {
   "input"?: unknown;
   "maxTokens"?: number | null;
   "model"?: string;
+  "promptCacheEnabled"?: boolean | null;
   "provider"?: string;
   "providerId"?: string;
   "reasoningEffort"?: string | null;
@@ -4304,6 +4305,7 @@ export type ThreadRunStartParams = {
   "metadata"?: Record<string, unknown> | null;
   "model"?: string;
   "prompt"?: string;
+  "promptCacheEnabled"?: boolean | null;
   "provider"?: string;
   "providerId"?: string;
   "reasoningEffort"?: string | null;
@@ -4664,6 +4666,7 @@ export type TurnRunRetryParams = {
   "metadata"?: Record<string, unknown> | null;
   "model"?: string;
   "prompt"?: string;
+  "promptCacheEnabled"?: boolean | null;
   "provider"?: string;
   "providerId"?: string;
   "reasoningEffort"?: string | null;
@@ -4691,6 +4694,7 @@ export type TurnRunStartParams = {
   "metadata"?: Record<string, unknown> | null;
   "model"?: string;
   "prompt"?: string;
+  "promptCacheEnabled"?: boolean | null;
   "provider"?: string;
   "providerId"?: string;
   "reasoningEffort"?: string | null;

--- a/appserver/runtime.go
+++ b/appserver/runtime.go
@@ -190,15 +190,7 @@ func (s *RuntimeService) Start(ctx context.Context, st store.Store, notifier run
 	}
 	s.mu.Unlock()
 	if len(req.Input) == 0 {
-		input, err := json.Marshal(runtimeTurnInput{
-			Prompt:          req.Prompt,
-			ProviderID:      req.Selection.ProviderID,
-			Provider:        req.Selection.Provider,
-			Model:           req.Selection.Model,
-			ReasoningEffort: runtimeReasoningEffort(req.ModelSettings),
-			Metadata:        cloneRuntimeMap(req.Metadata),
-			SubmittedAt:     time.Now().UTC(),
-		})
+		input, err := runtimeTurnInputJSON(req.Prompt, req.Selection, req.ModelSettings, req.Metadata)
 		if err != nil {
 			return nil, fmt.Errorf("marshal runtime input: %w", err)
 		}
@@ -291,6 +283,14 @@ func (s *RuntimeService) Retry(ctx context.Context, st store.Store, notifier run
 		return nil, ErrRuntimeShuttingDown
 	}
 	s.mu.Unlock()
+
+	if len(req.Input) == 0 {
+		input, err := runtimeTurnInputJSON(req.Prompt, req.Selection, req.ModelSettings, req.Metadata)
+		if err != nil {
+			return nil, err
+		}
+		req.Input = input
+	}
 
 	recoveryStore, ok := st.(store.RuntimeRecoveryStore)
 	if !ok {
@@ -639,13 +639,36 @@ func statusFromRuntimeError(err error) store.TurnStatus {
 }
 
 type runtimeTurnInput struct {
-	Prompt          string         `json:"prompt"`
-	ProviderID      string         `json:"providerId,omitempty"`
-	Provider        string         `json:"provider,omitempty"`
-	Model           string         `json:"model,omitempty"`
-	ReasoningEffort string         `json:"reasoningEffort,omitempty"`
-	Metadata        map[string]any `json:"metadata,omitempty"`
-	SubmittedAt     time.Time      `json:"submittedAt"`
+	Prompt             string         `json:"prompt"`
+	ProviderID         string         `json:"providerId,omitempty"`
+	Provider           string         `json:"provider,omitempty"`
+	Model              string         `json:"model,omitempty"`
+	ReasoningEffort    string         `json:"reasoningEffort,omitempty"`
+	PromptCacheEnabled *bool          `json:"promptCacheEnabled,omitempty"`
+	Metadata           map[string]any `json:"metadata,omitempty"`
+	SubmittedAt        time.Time      `json:"submittedAt"`
+}
+
+func runtimeTurnInputJSON(
+	prompt string,
+	selection RuntimeModelSelection,
+	settings core.ModelSettings,
+	metadata map[string]any,
+) (json.RawMessage, error) {
+	input, err := json.Marshal(runtimeTurnInput{
+		Prompt:             prompt,
+		ProviderID:         selection.ProviderID,
+		Provider:           selection.Provider,
+		Model:              selection.Model,
+		ReasoningEffort:    runtimeReasoningEffort(settings),
+		PromptCacheEnabled: runtimePromptCacheEnabled(settings),
+		Metadata:           cloneRuntimeMap(metadata),
+		SubmittedAt:        time.Now().UTC(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal runtime input: %w", err)
+	}
+	return input, nil
 }
 
 func runtimeReasoningEffort(settings core.ModelSettings) string {
@@ -653,6 +676,10 @@ func runtimeReasoningEffort(settings core.ModelSettings) string {
 		return ""
 	}
 	return strings.TrimSpace(*settings.ReasoningEffort)
+}
+
+func runtimePromptCacheEnabled(settings core.ModelSettings) *bool {
+	return cloneBool(settings.PromptCacheEnabled)
 }
 
 type runtimeResultPayload struct {
@@ -1001,5 +1028,6 @@ func hasRuntimeModelSettings(settings core.ModelSettings) bool {
 		settings.ThinkingBudget != nil ||
 		settings.AdaptiveThinking != nil ||
 		settings.ReasoningEffort != nil ||
+		settings.PromptCacheEnabled != nil ||
 		len(settings.StopSequences) > 0
 }

--- a/appserver/runtime_params.go
+++ b/appserver/runtime_params.go
@@ -117,13 +117,14 @@ func runtimeSelectionWithThreadDefaults(selection RuntimeModelSelection, setting
 
 func runtimeModelSettingsFromParams(params RuntimeModelParams) core.ModelSettings {
 	settings := core.ModelSettings{
-		MaxTokens:        params.MaxTokens,
-		Temperature:      params.Temperature,
-		TopP:             params.TopP,
-		ThinkingBudget:   params.ThinkingBudget,
-		AdaptiveThinking: params.AdaptiveThinking,
-		ReasoningEffort:  params.ReasoningEffort,
-		StopSequences:    append([]string(nil), params.StopSequences...),
+		MaxTokens:          params.MaxTokens,
+		Temperature:        params.Temperature,
+		TopP:               params.TopP,
+		ThinkingBudget:     params.ThinkingBudget,
+		AdaptiveThinking:   params.AdaptiveThinking,
+		ReasoningEffort:    params.ReasoningEffort,
+		PromptCacheEnabled: params.PromptCacheEnabled,
+		StopSequences:      append([]string(nil), params.StopSequences...),
 	}
 	if settings.ReasoningEffort == nil {
 		if effort := stringSetting(params.Settings, "reasoningEffort"); effort != "" {
@@ -138,11 +139,19 @@ func runtimeModelSettingsFromInput(input json.RawMessage) core.ModelSettings {
 	if len(input) == 0 || json.Unmarshal(input, &stored) != nil {
 		return core.ModelSettings{}
 	}
-	effort := strings.TrimSpace(stored.ReasoningEffort)
-	if effort == "" {
-		return core.ModelSettings{}
+	settings := core.ModelSettings{PromptCacheEnabled: cloneBool(stored.PromptCacheEnabled)}
+	if effort := strings.TrimSpace(stored.ReasoningEffort); effort != "" {
+		settings.ReasoningEffort = &effort
 	}
-	return core.ModelSettings{ReasoningEffort: &effort}
+	return settings
+}
+
+func cloneBool(value *bool) *bool {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
 }
 
 func runtimeModelSettingsWithThreadDefaults(
@@ -155,6 +164,16 @@ func runtimeModelSettingsWithThreadDefaults(
 		}
 	}
 	return settings
+}
+
+func mergeRuntimeModelSettings(primary, fallback core.ModelSettings) core.ModelSettings {
+	if primary.ReasoningEffort == nil {
+		primary.ReasoningEffort = fallback.ReasoningEffort
+	}
+	if primary.PromptCacheEnabled == nil {
+		primary.PromptCacheEnabled = cloneBool(fallback.PromptCacheEnabled)
+	}
+	return primary
 }
 
 func mergeRuntimeReasoningIntoSettings(
@@ -215,15 +234,4 @@ func stringSetting(settings map[string]any, key string) string {
 		return ""
 	}
 	return strings.TrimSpace(text)
-}
-
-func firstRaw(values ...json.RawMessage) json.RawMessage {
-	for _, value := range values {
-		if len(value) > 0 {
-			out := make([]byte, len(value))
-			copy(out, value)
-			return out
-		}
-	}
-	return nil
 }

--- a/appserver/runtime_test.go
+++ b/appserver/runtime_test.go
@@ -157,6 +157,42 @@ func TestRuntimeStartPersistsExplicitReasoningEffort(t *testing.T) {
 	}
 }
 
+func TestRuntimeStartPersistsExplicitPromptCacheSetting(t *testing.T) {
+	ctx := context.Background()
+	st := newRuntimeTestStore(t)
+	thread, err := st.CreateThread(ctx, store.CreateThreadRequest{Title: "Prompt cache receipt"})
+	if err != nil {
+		t.Fatalf("CreateThread: %v", err)
+	}
+	disabled := false
+	runtimeSvc := NewRuntimeService(WithRuntimeModel(
+		core.NewTestModel(core.TextResponse("done")),
+		RuntimeModelInfo{ProviderID: "openai", Model: "gpt-5"},
+	))
+
+	started, err := runtimeSvc.Start(ctx, st, nil, RuntimeStartRequest{
+		ThreadID: thread.ID,
+		Prompt:   "persist the prompt cache preference",
+		ModelSettings: core.ModelSettings{
+			PromptCacheEnabled: &disabled,
+		},
+	})
+	if err != nil {
+		t.Fatalf("RuntimeService.Start: %v", err)
+	}
+	var input runtimeTurnInput
+	if err := json.Unmarshal(started.Turn.Input, &input); err != nil {
+		t.Fatalf("decode turn input: %v", err)
+	}
+	if input.PromptCacheEnabled == nil || *input.PromptCacheEnabled {
+		t.Fatalf("turn prompt cache setting = %#v, want false", input.PromptCacheEnabled)
+	}
+	inherited := runtimeModelSettingsFromInput(started.Turn.Input)
+	if inherited.PromptCacheEnabled == nil || *inherited.PromptCacheEnabled {
+		t.Fatalf("inherited prompt cache setting = %#v, want false", inherited.PromptCacheEnabled)
+	}
+}
+
 func TestServerRuntimeReasoningEffortFailsClosedAgainstModelCatalog(t *testing.T) {
 	for _, tc := range []struct {
 		name       string
@@ -996,13 +1032,20 @@ func TestServerRuntimeThreadCompactBoundsResumeHistory(t *testing.T) {
 func TestServerRuntimeTurnRetryBranchesBeforeSourceTurn(t *testing.T) {
 	ctx := context.Background()
 	st := newRuntimeTestStore(t)
-	model := core.NewTestModel(core.TextResponse("first answer"), core.TextResponse("retry answer"))
+	model := core.NewTestModel(
+		core.TextResponse("first answer"),
+		core.TextResponse("retry answer"),
+		core.TextResponse("inherited retry answer"),
+	)
 	server := readyServer(
 		WithStore(st),
 		WithRuntimeService(NewRuntimeService(WithRuntimeModel(model, RuntimeModelInfo{ProviderID: "test", Model: "test-model"}))),
 	)
 
-	startResp := server.HandleRequest(ctx, request("thread/start", map[string]any{"prompt": "original prompt"}))
+	startResp := server.HandleRequest(ctx, request("thread/start", map[string]any{
+		"prompt":             "original prompt",
+		"promptCacheEnabled": false,
+	}))
 	if startResp.Error != nil {
 		t.Fatalf("thread/start error: %v", startResp.Error)
 	}
@@ -1012,11 +1055,27 @@ func TestServerRuntimeTurnRetryBranchesBeforeSourceTurn(t *testing.T) {
 	decodeResult(t, startResp, &started)
 	waitForNotificationSet(t, server, "turn/completed")
 
-	retryResp := server.HandleRequest(ctx, request("turn/retry", map[string]any{"turnId": started.Turn.ID}))
+	retryResp := server.HandleRequest(ctx, request("turn/retry", map[string]any{
+		"turnId":             started.Turn.ID,
+		"promptCacheEnabled": true,
+	}))
 	if retryResp.Error != nil {
 		t.Fatalf("turn/retry error: %v", retryResp.Error)
 	}
+	var retried protocol.TurnRunRetryResult
+	decodeResult(t, retryResp, &retried)
 	waitForNotificationSet(t, server, "turn/completed")
+	persisted, err := st.GetTurn(ctx, retried.Turn.ID)
+	if err != nil {
+		t.Fatalf("GetTurn retried: %v", err)
+	}
+	var persistedInput runtimeTurnInput
+	if err := json.Unmarshal(persisted.Input, &persistedInput); err != nil {
+		t.Fatalf("unmarshal retried input: %v", err)
+	}
+	if persistedInput.PromptCacheEnabled == nil || !*persistedInput.PromptCacheEnabled {
+		t.Fatalf("persisted retry prompt-cache setting = %#v, want explicit true override", persistedInput)
+	}
 
 	calls := model.Calls()
 	if len(calls) != 2 {
@@ -1025,7 +1084,26 @@ func TestServerRuntimeTurnRetryBranchesBeforeSourceTurn(t *testing.T) {
 	if len(calls[1].Messages) != 1 {
 		t.Fatalf("retry messages = %#v", calls[1].Messages)
 	}
+	if calls[1].Settings == nil || calls[1].Settings.PromptCacheEnabled == nil || !*calls[1].Settings.PromptCacheEnabled {
+		t.Fatalf("retry prompt-cache setting = %#v, want explicit true override", calls[1].Settings)
+	}
 	assertRuntimeUserPrompt(t, calls[1].Messages[0], "original prompt")
+
+	inheritedRetryResp := server.HandleRequest(ctx, request("turn/retry", map[string]any{
+		"turnId": retried.Turn.ID,
+	}))
+	if inheritedRetryResp.Error != nil {
+		t.Fatalf("inherited turn/retry error: %v", inheritedRetryResp.Error)
+	}
+	waitForNotificationSet(t, server, "turn/completed")
+
+	calls = model.Calls()
+	if len(calls) != 3 {
+		t.Fatalf("model calls after inherited retry = %d, want 3", len(calls))
+	}
+	if calls[2].Settings == nil || calls[2].Settings.PromptCacheEnabled == nil || !*calls[2].Settings.PromptCacheEnabled {
+		t.Fatalf("inherited retry prompt-cache setting = %#v, want persisted true", calls[2].Settings)
+	}
 }
 
 func TestServerRuntimeTurnRetryIsIdempotentAcrossDuplicateRequests(t *testing.T) {

--- a/appserver/server.go
+++ b/appserver/server.go
@@ -1620,9 +1620,7 @@ func (s *Server) handleTurnRetry(ctx context.Context, raw json.RawMessage) (any,
 	selection := runtimeSelectionFromParams(params.ProviderID, params.Provider, params.Model)
 	selection = mergeRuntimeSelection(selection, runtimeSelectionFromInput(source.Input))
 	modelSettings := runtimeModelSettingsFromParams(params.RuntimeModelParams)
-	if modelSettings.ReasoningEffort == nil {
-		modelSettings = runtimeModelSettingsFromInput(source.Input)
-	}
+	modelSettings = mergeRuntimeModelSettings(modelSettings, runtimeModelSettingsFromInput(source.Input))
 	if err := s.validateRuntimeSelection(selection, modelSettings); err != nil {
 		return nil, invalidParams(err.Error(), err)
 	}
@@ -1630,7 +1628,7 @@ func (s *Server) handleTurnRetry(ctx context.Context, raw json.RawMessage) (any,
 		SourceTurnID:   source.ID,
 		IdempotencyKey: idempotencyKey,
 		Prompt:         prompt,
-		Input:          firstRaw(params.Input, source.Input),
+		Input:          params.Input,
 		Metadata:       params.Metadata,
 		Selection:      selection,
 		ModelSettings:  modelSettings,

--- a/core/agent_runtime.go
+++ b/core/agent_runtime.go
@@ -134,6 +134,10 @@ func cloneModelSettings(settings *ModelSettings) *ModelSettings {
 	}
 	cloned := *settings
 	cloned.ToolChoice = cloneToolChoice(settings.ToolChoice)
+	if settings.PromptCacheEnabled != nil {
+		promptCacheEnabled := *settings.PromptCacheEnabled
+		cloned.PromptCacheEnabled = &promptCacheEnabled
+	}
 	return &cloned
 }
 

--- a/core/agent_runtime_test.go
+++ b/core/agent_runtime_test.go
@@ -47,6 +47,7 @@ func TestAgentRuntimeConfig_ClonesAndExports(t *testing.T) {
 	topP := 0.9
 	thinking := 256
 	effort := "high"
+	promptCacheEnabled := true
 	quota := &UsageQuota{
 		MaxRequests:    5,
 		MaxTotalTokens: 1000,
@@ -102,12 +103,13 @@ func TestAgentRuntimeConfig_ClonesAndExports(t *testing.T) {
 		return runtimeConfigOutput{Answer: "fixed"}, nil
 	})
 	agent.modelSettings = &ModelSettings{
-		MaxTokens:       &maxTokens,
-		Temperature:     &temperature,
-		TopP:            &topP,
-		ToolChoice:      ToolChoiceForce("direct_tool"),
-		ThinkingBudget:  &thinking,
-		ReasoningEffort: &effort,
+		MaxTokens:          &maxTokens,
+		Temperature:        &temperature,
+		TopP:               &topP,
+		ToolChoice:         ToolChoiceForce("direct_tool"),
+		ThinkingBudget:     &thinking,
+		ReasoningEffort:    &effort,
+		PromptCacheEnabled: &promptCacheEnabled,
 	}
 	agent.usageLimits = UsageLimits{
 		RequestLimit:   &reqLimit,
@@ -205,10 +207,10 @@ func TestAgentRuntimeConfig_ClonesAndExports(t *testing.T) {
 	if len(cfg.OutputValidators) != 1 || cfg.OutputValidators[0] == nil {
 		t.Fatalf("expected output validators, got %+v", cfg.OutputValidators)
 	}
-	if cfg.ModelSettings == nil || cfg.ModelSettings.ToolChoice == nil {
+	if cfg.ModelSettings == nil || cfg.ModelSettings.ToolChoice == nil || cfg.ModelSettings.PromptCacheEnabled == nil {
 		t.Fatalf("expected model settings clone, got %+v", cfg.ModelSettings)
 	}
-	if cfg.ModelSettings == agent.modelSettings || cfg.ModelSettings.ToolChoice == agent.modelSettings.ToolChoice {
+	if cfg.ModelSettings == agent.modelSettings || cfg.ModelSettings.ToolChoice == agent.modelSettings.ToolChoice || cfg.ModelSettings.PromptCacheEnabled == agent.modelSettings.PromptCacheEnabled {
 		t.Fatal("expected model settings and tool choice to be deep-cloned")
 	}
 	if cfg.UsageQuota == nil || cfg.UsageQuota == agent.usageQuota {

--- a/core/model.go
+++ b/core/model.go
@@ -42,6 +42,12 @@ type ModelSettings struct {
 	// Fable). Per-provider gating rejects values a given model doesn't accept
 	// (e.g., "xhigh" requires Opus 4.7+; "max" requires 4.6+).
 	ReasoningEffort *string `json:"reasoning_effort,omitempty"`
+	// PromptCacheEnabled controls Gollem's explicit prompt-cache request metadata.
+	// Nil preserves the provider default. False suppresses Gollem-managed cache
+	// keys, cache-control markers, and configured cache references; true asks a
+	// provider to emit its configured native cache control. It does not create a
+	// provider cache or override provider-side automatic caching.
+	PromptCacheEnabled *bool `json:"prompt_cache_enabled,omitempty"`
 	// StopSequences causes generation to halt when the model would emit any
 	// listed string. Supported by Anthropic (stop_sequences) and Gemini
 	// (stopSequences). Ignored by providers that don't support it (e.g.,

--- a/docs/PROVIDER_DRIVER_CONFORMANCE.md
+++ b/docs/PROVIDER_DRIVER_CONFORMANCE.md
@@ -17,8 +17,8 @@ of behavior and must not enable a control solely on provider identity.
 | Structured output | Proven native JSON-schema output | Unsupported | Proven schema-backed `final_result` tool output | `provider/conformance` runs native output mode through a typed agent and verifies the normalized result; fixtures assert OpenAI `response_format` and Anthropic's generated output tool schema |
 | Vision image input | Proven | Unsupported | Proven | `provider/conformance` sends a deterministic PNG data URI through `core.ImagePart`, asserts each provider's native image wire format, and verifies the normalized response |
 | Reasoning visibility | Proven where catalog-supported | Unsupported | Proven where catalog-supported | `provider/conformance` verifies native `ThinkingPart` start/delta events and final retention; local Chat Completions remains unsupported |
-| Prompt cache / Responses API | Catalog-supported where applicable | Unsupported | Catalog-supported where applicable | Provider-specific tests; no common conformance claim yet |
-| Cache-read token accounting | Proven | Unsupported | Proven | `provider/conformance` verifies provider-reported cache reads normalize to `core.Usage.CacheReadTokens`; this is accounting evidence, not a portable prompt-cache activation control |
+| Prompt-cache activation | Proven | Unsupported | Proven | `provider/conformance` sends `core.ModelSettings.PromptCacheEnabled=true` on normal and streaming requests and fixtures observe OpenAI cache metadata or Anthropic `cache_control` markers |
+| Cache-read token accounting | Proven | Unsupported | Proven | `provider/conformance` verifies provider-reported cache reads normalize to `core.Usage.CacheReadTokens`; accounting and activation remain distinct evidence |
 | Malformed JSON stream event normalization | Proven | Proven | Proven | `provider/conformance` plus provider parser tests; returns `StreamProtocolError` without raw event data |
 | Abrupt EOF partial-stream result | Proven | Proven | Proven | `provider/conformance` plus provider parser tests; preserves partial response and returns `StreamIncompleteError` |
 | Read-error peer-disconnect classification | Proven | Proven | Proven | `provider/conformance` plus provider parser tests; returns source-free `StreamTransportError`, while context cancellation remains intact |
@@ -27,6 +27,12 @@ of behavior and must not enable a control solely on provider identity.
 | Post-output retry / replay | Not yet proven | Not yet proven | Not yet proven | A stream may have produced caller-visible output; recovery must not replay it without an explicit safe-resume contract |
 | Endpoint health probe | Unsupported | Proven | Unsupported | `provider/health/probe` performs a loopback-only `GET /v1/models`; it returns only a typed status and never starts a model turn |
 | Capability mismatch | Catalog/daemon proven | Catalog/daemon proven | Catalog/daemon proven | `ValidateAgentRuntimeSelection` rejects unconfigured, unknown, cross-provider, and non-streaming/non-tool-capable selections before the daemon persists a thread or turn; Slang continues to render the same condition as unavailable |
+
+`core.ModelSettings.PromptCacheEnabled` is optional: `nil` preserves the
+provider default, `true` requests its configured native cache control, and
+`false` suppresses Gollem-managed explicit cache metadata. It does not create
+cache entries, guarantee a cache hit, disable opaque provider-side automatic
+caching, or authorize a local response replay.
 
 `Catalog-supported` means the catalog may expose the capability only for the
 listed provider/model profile. It does not make that behavior part of the common

--- a/provider/anthropic/anthropic.go
+++ b/provider/anthropic/anthropic.go
@@ -247,7 +247,7 @@ func (p *Provider) ModelName() string {
 func (p *Provider) Request(ctx context.Context, messages []core.ModelMessage, settings *core.ModelSettings, params *core.ModelRequestParameters) (*core.ModelResponse, error) {
 	ri := newRequestInstrumentation(p.requestObserver, p.model)
 	defer ri.finish()
-	req, err := buildRequest(messages, settings, params, p.model, p.maxTokens, false, !p.disablePromptCache, p.disableToolSearch)
+	req, err := buildRequest(messages, settings, params, p.model, p.maxTokens, false, p.promptCacheEnabled(settings), p.disableToolSearch)
 	if err != nil {
 		ri.recordError(err)
 		return nil, fmt.Errorf("anthropic: failed to build request: %w", err)
@@ -282,7 +282,7 @@ func (p *Provider) Request(ctx context.Context, messages []core.ModelMessage, se
 // RequestStream sends messages and returns a streaming response.
 func (p *Provider) RequestStream(ctx context.Context, messages []core.ModelMessage, settings *core.ModelSettings, params *core.ModelRequestParameters) (core.StreamedResponse, error) {
 	ri := newRequestInstrumentation(p.requestObserver, p.model)
-	req, err := buildRequest(messages, settings, params, p.model, p.maxTokens, true, !p.disablePromptCache, p.disableToolSearch)
+	req, err := buildRequest(messages, settings, params, p.model, p.maxTokens, true, p.promptCacheEnabled(settings), p.disableToolSearch)
 	if err != nil {
 		ri.recordError(err)
 		ri.finish()
@@ -305,6 +305,13 @@ func (p *Provider) RequestStream(ctx context.Context, messages []core.ModelMessa
 	}
 
 	return newStreamedResponse(resp.Body, p.model, ri), nil
+}
+
+func (p *Provider) promptCacheEnabled(settings *core.ModelSettings) bool {
+	if p.disablePromptCache {
+		return false
+	}
+	return settings == nil || settings.PromptCacheEnabled == nil || *settings.PromptCacheEnabled
 }
 
 // doRequest sends a single HTTP request and returns the response or a typed

--- a/provider/anthropic/anthropic_test.go
+++ b/provider/anthropic/anthropic_test.go
@@ -1689,6 +1689,28 @@ func TestAnthropicCacheControl_Disabled(t *testing.T) {
 	}
 }
 
+func TestPromptCacheEnabledSettingOverridesProviderDefault(t *testing.T) {
+	disabled := false
+	p := New()
+	if p.promptCacheEnabled(&core.ModelSettings{PromptCacheEnabled: &disabled}) {
+		t.Fatal("explicit prompt-cache disable should suppress Anthropic cache_control markers")
+	}
+	req, err := buildRequest([]core.ModelMessage{core.ModelRequest{Parts: []core.ModelRequestPart{
+		core.SystemPromptPart{Content: "stable context"},
+		core.UserPromptPart{Content: "hello"},
+	}}}, nil, nil, ClaudeSonnet46, 4096, false, p.promptCacheEnabled(&core.ModelSettings{PromptCacheEnabled: &disabled}), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(req.System) != 1 || req.System[0].CacheControl != nil {
+		t.Fatalf("disabled Anthropic cache markers = %#v, want no marker", req.System)
+	}
+	enabled := true
+	if !p.promptCacheEnabled(&core.ModelSettings{PromptCacheEnabled: &enabled}) {
+		t.Fatal("explicit prompt-cache enable should retain Anthropic cache_control markers")
+	}
+}
+
 func TestAnthropicCacheControl_UsageTracking(t *testing.T) {
 	usage := apiUsage{
 		InputTokens:              100,

--- a/provider/conformance/conformance.go
+++ b/provider/conformance/conformance.go
@@ -21,20 +21,21 @@ import (
 // A driver must not advertise one of these capabilities in Slang unless it has
 // a matching deterministic fixture and this verification passes.
 type Claims struct {
-	ToolCalls           bool
-	StructuredOutput    bool
-	Vision              bool
-	CacheReadUsage      bool
-	Streaming           bool
-	Usage               bool
-	Cancellation        bool
-	PartialStream       bool
-	MalformedStream     bool
-	DisconnectStream    bool
-	Retryability        bool
-	RequestTimeout      bool
-	StreamTimeout       bool
-	ReasoningVisibility bool
+	ToolCalls             bool
+	StructuredOutput      bool
+	Vision                bool
+	CacheReadUsage        bool
+	PromptCacheActivation bool
+	Streaming             bool
+	Usage                 bool
+	Cancellation          bool
+	PartialStream         bool
+	MalformedStream       bool
+	DisconnectStream      bool
+	Retryability          bool
+	RequestTimeout        bool
+	StreamTimeout         bool
+	ReasoningVisibility   bool
 }
 
 // Expectations declares the normalized outputs a deterministic fixture
@@ -63,13 +64,14 @@ type Expectations struct {
 // Driver binds a provider model to the common capability claims and expected
 // normalized results that its deterministic fixture produces.
 type Driver struct {
-	Name                string
-	Model               core.Model
-	Claims              Claims
-	Expectations        Expectations
-	CancellationReady   <-chan struct{}
-	RequestTimeoutReady <-chan struct{}
-	ReasoningModel      core.Model
+	Name                  string
+	Model                 core.Model
+	Claims                Claims
+	Expectations          Expectations
+	CancellationReady     <-chan struct{}
+	RequestTimeoutReady   <-chan struct{}
+	ReasoningModel        core.Model
+	PromptCacheActivation func() error
 }
 
 // Verify exercises the claimed common model surface through core.Model. It is
@@ -98,6 +100,9 @@ func Verify(ctx context.Context, driver Driver) error {
 	}
 	if driver.Claims.CacheReadUsage && driver.Expectations.CacheReadTokens <= 0 {
 		return fmt.Errorf("provider conformance: %s cache-read fixture must expect positive cache-read tokens", driver.Name)
+	}
+	if driver.Claims.PromptCacheActivation && driver.PromptCacheActivation == nil {
+		return fmt.Errorf("provider conformance: %s prompt-cache fixture must observe request activation", driver.Name)
 	}
 	if driver.Claims.Streaming && strings.TrimSpace(driver.Expectations.StreamText) == "" {
 		return fmt.Errorf("provider conformance: %s streaming fixture must expect stream text", driver.Name)
@@ -141,7 +146,9 @@ func Verify(ctx context.Context, driver Driver) error {
 			},
 		}}
 	}
-	response, err := driver.Model.Request(ctx, conformanceMessages(), nil, params)
+	promptCacheEnabled := true
+	promptCacheSettings := &core.ModelSettings{PromptCacheEnabled: &promptCacheEnabled}
+	response, err := driver.Model.Request(ctx, conformanceMessages(), promptCacheSettings, params)
 	if err != nil {
 		return fmt.Errorf("provider conformance: %s request: %w", driver.Name, err)
 	}
@@ -195,7 +202,7 @@ func Verify(ctx context.Context, driver Driver) error {
 	if !driver.Claims.Streaming {
 		return nil
 	}
-	stream, err := driver.Model.RequestStream(ctx, conformanceMessages(), nil, &core.ModelRequestParameters{AllowTextOutput: true})
+	stream, err := driver.Model.RequestStream(ctx, conformanceMessages(), promptCacheSettings, &core.ModelRequestParameters{AllowTextOutput: true})
 	if err != nil {
 		return fmt.Errorf("provider conformance: %s stream request: %w", driver.Name, err)
 	}
@@ -211,6 +218,11 @@ func Verify(ctx context.Context, driver Driver) error {
 	}
 	if err := verifyResponse(driver, stream.Response(), true); err != nil {
 		return err
+	}
+	if driver.Claims.PromptCacheActivation {
+		if err := driver.PromptCacheActivation(); err != nil {
+			return fmt.Errorf("provider conformance: %s prompt-cache activation: %w", driver.Name, err)
+		}
 	}
 	if driver.Claims.PartialStream {
 		if err := verifyPartialStream(ctx, driver); err != nil {
@@ -570,7 +582,10 @@ func verifyToolCall(driver Driver, parts []core.ModelResponsePart) error {
 
 func conformanceMessages() []core.ModelMessage {
 	return []core.ModelMessage{
-		core.ModelRequest{Parts: []core.ModelRequestPart{core.UserPromptPart{Content: "run conformance"}}},
+		core.ModelRequest{Parts: []core.ModelRequestPart{
+			core.SystemPromptPart{Content: "stable conformance context"},
+			core.UserPromptPart{Content: "run conformance"},
+		}},
 	}
 }
 

--- a/provider/conformance/conformance_test.go
+++ b/provider/conformance/conformance_test.go
@@ -18,15 +18,17 @@ import (
 )
 
 func TestDeterministicProviderDriverConformance(t *testing.T) {
+	openAIPromptCache := &promptCacheFixture{}
 	openAICancellationReady := make(chan struct{})
 	openAIRetry := newRetryFixture()
 	openAITimeout := newTimeoutFixture()
-	openAIServer := httptest.NewServer(openAIConformanceFixture(t, openAICancellationReady, openAIRetry, openAITimeout))
+	openAIServer := httptest.NewServer(openAIConformanceFixture(t, openAIPromptCache, openAICancellationReady, openAIRetry, openAITimeout))
 	defer openAIServer.Close()
+	anthropicPromptCache := &promptCacheFixture{}
 	anthropicCancellationReady := make(chan struct{})
 	anthropicRetry := newRetryFixture()
 	anthropicTimeout := newTimeoutFixture()
-	anthropicServer := httptest.NewServer(anthropicConformanceFixture(t, anthropicCancellationReady, anthropicRetry, anthropicTimeout))
+	anthropicServer := httptest.NewServer(anthropicConformanceFixture(t, anthropicPromptCache, anthropicCancellationReady, anthropicRetry, anthropicTimeout))
 	defer anthropicServer.Close()
 
 	cases := []struct {
@@ -37,12 +39,13 @@ func TestDeterministicProviderDriverConformance(t *testing.T) {
 			name: "native OpenAI",
 			model: func() (conformance.Driver, error) {
 				return conformance.Driver{
-					Name:                "native OpenAI",
-					Model:               openai.New(openai.WithAPIKey("test-openai-key"), openai.WithBaseURL(openAIServer.URL), openai.WithModel("gpt-4o")),
-					ReasoningModel:      openai.New(openai.WithAPIKey("test-openai-key"), openai.WithBaseURL(openAIServer.URL), openai.WithModel("gpt-5")),
-					Claims:              conformance.Claims{ToolCalls: true, StructuredOutput: true, Vision: true, CacheReadUsage: true, Streaming: true, Usage: true, Cancellation: true, PartialStream: true, MalformedStream: true, DisconnectStream: true, Retryability: true, RequestTimeout: true, StreamTimeout: true, ReasoningVisibility: true},
-					CancellationReady:   openAICancellationReady,
-					RequestTimeoutReady: openAITimeout.readyFor("gpt-4o"),
+					Name:                  "native OpenAI",
+					Model:                 openai.New(openai.WithAPIKey("test-openai-key"), openai.WithBaseURL(openAIServer.URL), openai.WithModel("gpt-4o"), openai.WithPromptCacheKey("conformance-cache"), openai.WithPromptCacheRetention("24h")),
+					ReasoningModel:        openai.New(openai.WithAPIKey("test-openai-key"), openai.WithBaseURL(openAIServer.URL), openai.WithModel("gpt-5")),
+					Claims:                conformance.Claims{ToolCalls: true, StructuredOutput: true, Vision: true, CacheReadUsage: true, PromptCacheActivation: true, Streaming: true, Usage: true, Cancellation: true, PartialStream: true, MalformedStream: true, DisconnectStream: true, Retryability: true, RequestTimeout: true, StreamTimeout: true, ReasoningVisibility: true},
+					PromptCacheActivation: openAIPromptCache.verify,
+					CancellationReady:     openAICancellationReady,
+					RequestTimeoutReady:   openAITimeout.readyFor("gpt-4o"),
 					Expectations: conformance.Expectations{
 						ResponseText:          "openai response",
 						ToolName:              "conformance_echo",
@@ -97,12 +100,13 @@ func TestDeterministicProviderDriverConformance(t *testing.T) {
 			model: func() (conformance.Driver, error) {
 				model := anthropic.New(anthropic.WithAPIKey("test-anthropic-key"), anthropic.WithBaseURL(anthropicServer.URL), anthropic.WithModel(anthropic.ClaudeSonnet46))
 				return conformance.Driver{
-					Name:                "native Anthropic",
-					Model:               model,
-					ReasoningModel:      model,
-					Claims:              conformance.Claims{ToolCalls: true, StructuredOutput: true, Vision: true, CacheReadUsage: true, Streaming: true, Usage: true, Cancellation: true, PartialStream: true, MalformedStream: true, DisconnectStream: true, Retryability: true, RequestTimeout: true, StreamTimeout: true, ReasoningVisibility: true},
-					CancellationReady:   anthropicCancellationReady,
-					RequestTimeoutReady: anthropicTimeout.readyFor(anthropic.ClaudeSonnet46),
+					Name:                  "native Anthropic",
+					Model:                 model,
+					ReasoningModel:        model,
+					Claims:                conformance.Claims{ToolCalls: true, StructuredOutput: true, Vision: true, CacheReadUsage: true, PromptCacheActivation: true, Streaming: true, Usage: true, Cancellation: true, PartialStream: true, MalformedStream: true, DisconnectStream: true, Retryability: true, RequestTimeout: true, StreamTimeout: true, ReasoningVisibility: true},
+					PromptCacheActivation: anthropicPromptCache.verify,
+					CancellationReady:     anthropicCancellationReady,
+					RequestTimeoutReady:   anthropicTimeout.readyFor(anthropic.ClaudeSonnet46),
 					Expectations: conformance.Expectations{
 						ResponseText:          "anthropic response",
 						ToolName:              "conformance_echo",
@@ -134,6 +138,31 @@ func TestDeterministicProviderDriverConformance(t *testing.T) {
 			}
 		})
 	}
+}
+
+type promptCacheFixture struct {
+	mu      sync.Mutex
+	request bool
+	stream  bool
+}
+
+func (f *promptCacheFixture) record(stream bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if stream {
+		f.stream = true
+		return
+	}
+	f.request = true
+}
+
+func (f *promptCacheFixture) verify() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if !f.request || !f.stream {
+		return fmt.Errorf("observed request=%t stream=%t, want both", f.request, f.stream)
+	}
+	return nil
 }
 
 func TestVerifyRejectsUnprovenClaims(t *testing.T) {
@@ -348,7 +377,7 @@ func TestVerifyRejectsStructuredOutputValueMismatch(t *testing.T) {
 	}
 }
 
-func openAIConformanceFixture(t *testing.T, cancellationReady chan<- struct{}, retry *retryFixture, timeout *timeoutFixture) http.Handler {
+func openAIConformanceFixture(t *testing.T, promptCache *promptCacheFixture, cancellationReady chan<- struct{}, retry *retryFixture, timeout *timeoutFixture) http.Handler {
 	t.Helper()
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/v1/responses" {
@@ -373,6 +402,10 @@ func openAIConformanceFixture(t *testing.T, cancellationReady chan<- struct{}, r
 		}
 		if err := json.Unmarshal(body, &request); err != nil {
 			t.Fatalf("decode OpenAI request: %v", err)
+		}
+		if request.Model == "gpt-4o" && strings.Contains(string(body), "run conformance") {
+			assertOpenAIPromptCache(t, body)
+			promptCache.record(request.Stream)
 		}
 		if strings.Contains(string(body), "cancel conformance") {
 			waitForCancellation(r, cancellationReady)
@@ -482,7 +515,7 @@ data: [DONE]
 `)
 }
 
-func anthropicConformanceFixture(t *testing.T, cancellationReady chan<- struct{}, retry *retryFixture, timeout *timeoutFixture) http.Handler {
+func anthropicConformanceFixture(t *testing.T, promptCache *promptCacheFixture, cancellationReady chan<- struct{}, retry *retryFixture, timeout *timeoutFixture) http.Handler {
 	t.Helper()
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/messages" {
@@ -502,6 +535,10 @@ func anthropicConformanceFixture(t *testing.T, cancellationReady chan<- struct{}
 		}
 		if err := json.Unmarshal(body, &request); err != nil {
 			t.Fatalf("decode Anthropic request: %v", err)
+		}
+		if strings.Contains(string(body), "run conformance") {
+			assertAnthropicPromptCache(t, body)
+			promptCache.record(request.Stream)
 		}
 		if strings.Contains(string(body), "cancel conformance") {
 			waitForCancellation(r, cancellationReady)
@@ -654,6 +691,37 @@ func assertOpenAIStructuredOutputFormat(t *testing.T, raw json.RawMessage) {
 		t.Fatalf("OpenAI json_schema = %#v, want strict %q schema", schema, core.DefaultOutputToolName)
 	}
 	assertStructuredOutputSchema(t, schema.Schema)
+}
+
+func assertOpenAIPromptCache(t *testing.T, body []byte) {
+	t.Helper()
+	var request map[string]any
+	if err := json.Unmarshal(body, &request); err != nil {
+		t.Fatalf("decode OpenAI prompt-cache request: %v", err)
+	}
+	if request["prompt_cache_key"] != "conformance-cache" {
+		t.Fatalf("OpenAI prompt_cache_key = %#v, want conformance-cache", request["prompt_cache_key"])
+	}
+	if request["prompt_cache_retention"] != "24h" {
+		t.Fatalf("OpenAI prompt_cache_retention = %#v, want 24h", request["prompt_cache_retention"])
+	}
+}
+
+func assertAnthropicPromptCache(t *testing.T, body []byte) {
+	t.Helper()
+	var request struct {
+		System []struct {
+			CacheControl *struct {
+				Type string `json:"type"`
+			} `json:"cache_control"`
+		} `json:"system"`
+	}
+	if err := json.Unmarshal(body, &request); err != nil {
+		t.Fatalf("decode Anthropic prompt-cache request: %v", err)
+	}
+	if len(request.System) == 0 || request.System[len(request.System)-1].CacheControl == nil || request.System[len(request.System)-1].CacheControl.Type != "ephemeral" {
+		t.Fatalf("Anthropic prompt-cache system blocks = %#v, want final ephemeral marker", request.System)
+	}
 }
 
 func assertAnthropicStructuredOutputTool(t *testing.T, raw json.RawMessage) {

--- a/provider/openai/openai.go
+++ b/provider/openai/openai.go
@@ -483,8 +483,7 @@ func (p *Provider) Request(ctx context.Context, messages []core.ModelMessage, se
 	if err != nil {
 		return nil, fmt.Errorf("openai: failed to build request: %w", err)
 	}
-	req.PromptCacheKey = p.promptCacheKey
-	req.PromptCacheRetention = p.promptCacheRetention
+	p.applyChatPromptCacheSettings(req, settings)
 	req.ServiceTier = p.serviceTier
 
 	body, err := json.Marshal(req)
@@ -494,7 +493,7 @@ func (p *Provider) Request(ctx context.Context, messages []core.ModelMessage, se
 	// Count the built API messages, not the input slice: one ModelMessage can
 	// expand into multiple API messages (multi-part system/user/tool content).
 	ri.setRequestShape(len(body), len(req.Messages))
-	ri.markCacheKey(p.promptCacheKey)
+	ri.markCacheKey(req.PromptCacheKey)
 
 	resp, err := p.doRequest(ctx, chatCompletionsEndpoint, body, ri)
 	if err != nil {
@@ -535,8 +534,7 @@ func (p *Provider) RequestStream(ctx context.Context, messages []core.ModelMessa
 		ri.finish()
 		return nil, fmt.Errorf("openai: failed to build request: %w", err)
 	}
-	req.PromptCacheKey = p.promptCacheKey
-	req.PromptCacheRetention = p.promptCacheRetention
+	p.applyChatPromptCacheSettings(req, settings)
 	req.ServiceTier = p.serviceTier
 
 	body, err := json.Marshal(req)
@@ -547,7 +545,7 @@ func (p *Provider) RequestStream(ctx context.Context, messages []core.ModelMessa
 	// Count the built API messages, not the input slice: one ModelMessage can
 	// expand into multiple API messages (multi-part system/user/tool content).
 	ri.setRequestShape(len(body), len(req.Messages))
-	ri.markCacheKey(p.promptCacheKey)
+	ri.markCacheKey(req.PromptCacheKey)
 
 	resp, err := p.doRequest(ctx, chatCompletionsEndpoint, body, ri) //nolint:bodyclose // Response body ownership transfers to streamedResponse.
 	if err != nil {
@@ -565,6 +563,18 @@ func (p *Provider) RequestStream(ctx context.Context, messages []core.ModelMessa
 	}
 
 	return newBoundStreamedResponse(resp.Body, p.model, p.resolveResponseModel, ri), nil
+}
+
+func (p *Provider) promptCacheEnabled(settings *core.ModelSettings) bool {
+	return settings == nil || settings.PromptCacheEnabled == nil || *settings.PromptCacheEnabled
+}
+
+func (p *Provider) applyChatPromptCacheSettings(req *apiRequest, settings *core.ModelSettings) {
+	if req == nil || !p.promptCacheEnabled(settings) {
+		return
+	}
+	req.PromptCacheKey = p.promptCacheKey
+	req.PromptCacheRetention = p.promptCacheRetention
 }
 
 // responsesEP returns the Responses API endpoint path. ChatGPT subscription

--- a/provider/openai/openai_test.go
+++ b/provider/openai/openai_test.go
@@ -2705,6 +2705,40 @@ func TestAutoPromptCacheRetentionExplicit(t *testing.T) {
 	}
 }
 
+func TestPromptCacheEnabledSettingSuppressesExplicitMetadata(t *testing.T) {
+	disabled := false
+	p := New(
+		WithAPIKey("test-key"),
+		WithPromptCacheKey("stable-key"),
+		WithPromptCacheRetention("24h"),
+	)
+	if p.promptCacheEnabled(&core.ModelSettings{PromptCacheEnabled: &disabled}) {
+		t.Fatal("explicit prompt-cache disable should suppress OpenAI cache metadata")
+	}
+}
+
+func TestPromptCacheDisabledOmitsChatAndResponsesMetadata(t *testing.T) {
+	disabled := false
+	settings := &core.ModelSettings{PromptCacheEnabled: &disabled}
+	p := New(
+		WithAPIKey("test-key"),
+		WithPromptCacheKey("stable-key"),
+		WithPromptCacheRetention("24h"),
+	)
+
+	chat := &apiRequest{}
+	p.applyChatPromptCacheSettings(chat, settings)
+	if chat.PromptCacheKey != "" || chat.PromptCacheRetention != "" {
+		t.Fatalf("chat cache metadata = %#v, want omitted", chat)
+	}
+
+	responses := &responsesRequest{Model: GPT56}
+	p.applyResponsesEndpointSettingsForSettings(responses, settings)
+	if responses.PromptCacheKey != "" || responses.PromptCacheRetention != "" || responses.PromptCacheOptions != nil {
+		t.Fatalf("responses cache metadata = %#v, want omitted", responses)
+	}
+}
+
 func TestChatGPTAuthMode_Headers(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Verify ChatGPT-Account-ID header is set.

--- a/provider/openai/responses.go
+++ b/provider/openai/responses.go
@@ -134,7 +134,14 @@ func (p *Provider) requestViaResponses(ctx context.Context, messages []core.Mode
 	if err != nil {
 		return nil, fmt.Errorf("openai: failed to build responses request: %w", err)
 	}
-	p.applyResponsesEndpointSettings(req)
+	p.applyResponsesEndpointSettingsForSettings(req, settings)
+	// The WebSocket create event carries prompt_cache_key for its active
+	// Responses session even when a proxy URL prevents endpoint classification.
+	// Keep that established transport behavior, but honor an explicit per-turn
+	// disable before the request reaches the socket.
+	if p.shouldUseResponsesWebSocket() && p.promptCacheEnabled(settings) && req.PromptCacheKey == "" {
+		req.PromptCacheKey = p.promptCacheKey
+	}
 	return p.requestViaResponsesWithReq(ctx, req, ri)
 }
 
@@ -142,18 +149,27 @@ func (p *Provider) requestViaResponses(ctx context.Context, messages []core.Mode
 // request (caching, service tier, reasoning, verbosity). Shared by both the
 // synchronous and streaming request paths.
 func (p *Provider) applyResponsesEndpointSettings(req *responsesRequest) {
+	p.applyResponsesEndpointSettingsForSettings(req, nil)
+}
+
+func (p *Provider) applyResponsesEndpointSettingsForSettings(req *responsesRequest, settings *core.ModelSettings) {
+	cacheEnabled := p.promptCacheEnabled(settings)
 	if p.isChatGPTEndpoint() {
 		// ChatGPT backend supports prefix-based caching via prompt_cache_key.
-		req.PromptCacheKey = p.promptCacheKey
+		if cacheEnabled {
+			req.PromptCacheKey = p.promptCacheKey
+		}
 		p.applyChatGPTRequirements(req)
 	} else if p.isOpenAIEndpoint() {
-		req.PromptCacheKey = p.promptCacheKey
-		if isGPT56Model(req.Model) {
+		if cacheEnabled {
+			req.PromptCacheKey = p.promptCacheKey
+		}
+		if cacheEnabled && isGPT56Model(req.Model) {
 			// GPT-5.6 replaces the legacy retention policy with a minimum
 			// cache lifetime. 30m is currently the only supported TTL.
 			req.PromptCacheRetention = ""
 			req.PromptCacheOptions = &promptCacheOptions{TTL: "30m"}
-		} else {
+		} else if cacheEnabled {
 			req.PromptCacheRetention = p.promptCacheRetention
 			req.PromptCacheOptions = nil
 		}
@@ -173,11 +189,13 @@ func (p *Provider) applyResponsesEndpointSettings(req *responsesRequest) {
 		//
 		// Exception: ChatGPT auth with a custom/proxy URL still gets caching
 		// since the backend supports it regardless of proxy routing.
-		if p.hasChatGPTAuth() {
+		if cacheEnabled && p.hasChatGPTAuth() {
 			req.PromptCacheKey = p.promptCacheKey
 		}
 		req.Reasoning = nil
-		req.PromptCacheRetention = p.promptCacheRetention
+		if cacheEnabled {
+			req.PromptCacheRetention = p.promptCacheRetention
+		}
 	}
 }
 
@@ -206,7 +224,7 @@ func (p *Provider) requestStreamViaResponses(ctx context.Context, messages []cor
 	streamTrue := true
 	req.Stream = &streamTrue
 
-	p.applyResponsesEndpointSettings(req)
+	p.applyResponsesEndpointSettingsForSettings(req, settings)
 
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -351,13 +369,8 @@ func extractTextContent(content any) string {
 }
 
 func (p *Provider) requestViaResponsesWithReq(ctx context.Context, req *responsesRequest, ri *requestInstrumentation) (*core.ModelResponse, error) {
-	// The cache key actually sent is whatever applyResponsesEndpointSettings
-	// copied onto req, falling back to the provider's configured key (the WS
-	// create event carries it regardless of endpoint classification).
+	// The trace reports only cache metadata actually placed on this request.
 	cacheKey := req.PromptCacheKey
-	if cacheKey == "" {
-		cacheKey = p.promptCacheKey
-	}
 	ri.markCacheKey(cacheKey)
 
 	// Finish the active trace on return. ri is reassigned below when the

--- a/provider/vertexai/vertexai.go
+++ b/provider/vertexai/vertexai.go
@@ -191,7 +191,7 @@ func (p *Provider) Request(ctx context.Context, messages []core.ModelMessage, se
 	if err != nil {
 		return nil, fmt.Errorf("vertexai: failed to build request: %w", err)
 	}
-	p.applyCacheSettings(req)
+	p.applyCacheSettings(req, settings)
 
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -231,7 +231,7 @@ func (p *Provider) RequestStream(ctx context.Context, messages []core.ModelMessa
 	if err != nil {
 		return nil, fmt.Errorf("vertexai: failed to build request: %w", err)
 	}
-	p.applyCacheSettings(req)
+	p.applyCacheSettings(req, settings)
 
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -271,8 +271,8 @@ func (p *Provider) setHeaders(ctx context.Context, req *http.Request) error {
 
 // applyCacheSettings attaches the cached content reference to the request
 // if configured on the provider.
-func (p *Provider) applyCacheSettings(req *geminiRequest) {
-	if p.cachedContent != "" {
+func (p *Provider) applyCacheSettings(req *geminiRequest, settings *core.ModelSettings) {
+	if p.cachedContent != "" && (settings == nil || settings.PromptCacheEnabled == nil || *settings.PromptCacheEnabled) {
 		req.CachedContent = p.cachedContent
 	}
 }

--- a/provider/vertexai_anthropic/vertexai_anthropic.go
+++ b/provider/vertexai_anthropic/vertexai_anthropic.go
@@ -291,7 +291,7 @@ func (p *Provider) Request(ctx context.Context, messages []core.ModelMessage, se
 	if err != nil {
 		return nil, fmt.Errorf("vertexai_anthropic: failed to build request: %w", err)
 	}
-	p.applyPromptCacheControl(req)
+	p.applyPromptCacheControl(req, settings)
 
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -331,7 +331,7 @@ func (p *Provider) RequestStream(ctx context.Context, messages []core.ModelMessa
 	if err != nil {
 		return nil, fmt.Errorf("vertexai_anthropic: failed to build request: %w", err)
 	}
-	p.applyPromptCacheControl(req)
+	p.applyPromptCacheControl(req, settings)
 
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -385,8 +385,8 @@ func envEnabled(name string) bool {
 	}
 }
 
-func (p *Provider) applyPromptCacheControl(req *apiRequest) {
-	if req == nil || !p.promptCachingEnabled {
+func (p *Provider) applyPromptCacheControl(req *apiRequest, settings *core.ModelSettings) {
+	if req == nil || !p.promptCachingEnabled || (settings != nil && settings.PromptCacheEnabled != nil && !*settings.PromptCacheEnabled) {
 		return
 	}
 	cc := &apiCacheControl{Type: "ephemeral"}


### PR DESCRIPTION
## Summary
- add an optional per-turn `promptCacheEnabled` runtime setting, persisted across retries and generated into the appserver protocol
- apply explicit activation or suppression consistently to native OpenAI, Anthropic, Vertex AI, and Vertex Anthropic controls
- prove native OpenAI and Anthropic activation on normal and streaming deterministic conformance requests; local OpenAI-compatible remains unsupported

## Validation
- `make test` (Monty excluded by repository configuration)
- `go vet ./...`
- `make lint`
- `go build ./cmd/gollem`
- `go test ./core ./appserver ./appserver/protocol ./provider/openai ./provider/anthropic ./provider/vertexai ./provider/vertexai_anthropic ./provider/conformance -count=1`
- `go test ./appserver/protocol -run 'TestSchemaJSONIsCurrent|TestTypeScriptBindingIsCurrent|TestRuntimeModelParamsExposePromptCacheSetting' -count=1`\n- `go mod tidy && git diff --exit-code -- go.mod go.sum`