### PR TITLE
refactor(provider): share Vertex GCP auth plumbing

### DIFF
--- a/provider/internal/gcpauth/gcpauth.go
+++ b/provider/internal/gcpauth/gcpauth.go
@@ -1,0 +1,90 @@
+// Package gcpauth contains shared GCP authentication and HTTP-error plumbing
+// for Vertex providers. Provider packages retain their own request semantics
+// and prefix the returned errors with their public provider identity.
+package gcpauth
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+
+	"github.com/fugue-labs/gollem/provider/internal/vertexerror"
+)
+
+const cloudPlatformScope = "https://www.googleapis.com/auth/cloud-platform"
+
+// Credentials identifies the process-owner supplied credential material used
+// to acquire a GCP access token. An empty value uses application default
+// credentials.
+type Credentials struct {
+	File string
+	JSON []byte
+}
+
+// SourceCreationError distinguishes lazy credential construction from a token
+// refresh failure so callers can preserve their existing diagnostics.
+type SourceCreationError struct {
+	err error
+}
+
+func (e *SourceCreationError) Error() string { return e.err.Error() }
+
+func (e *SourceCreationError) Unwrap() error { return e.err }
+
+// AccessToken resolves and caches a token source supplied by the caller. The
+// caller owns synchronization around source when concurrent requests are
+// possible.
+func AccessToken(ctx context.Context, source *oauth2.TokenSource, credentials Credentials) (string, error) {
+	if *source == nil {
+		created, err := createTokenSource(ctx, credentials)
+		if err != nil {
+			return "", &SourceCreationError{err: err}
+		}
+		*source = created
+	}
+
+	token, err := (*source).Token()
+	if err != nil {
+		return "", err
+	}
+	return token.AccessToken, nil
+}
+
+func createTokenSource(ctx context.Context, credentials Credentials) (oauth2.TokenSource, error) {
+	if credentials.JSON != nil {
+		creds, err := google.CredentialsFromJSON(ctx, credentials.JSON, cloudPlatformScope) //nolint:staticcheck,nolintlint // credentials are explicitly configured by the process owner
+		if err != nil {
+			return nil, err
+		}
+		return creds.TokenSource, nil
+	}
+	if credentials.File != "" {
+		data, err := os.ReadFile(credentials.File)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read credentials file: %w", err)
+		}
+		creds, err := google.CredentialsFromJSON(ctx, data, cloudPlatformScope) //nolint:staticcheck,nolintlint // credentials are explicitly configured by the process owner
+		if err != nil {
+			return nil, err
+		}
+		return creds.TokenSource, nil
+	}
+	return google.DefaultTokenSource(ctx, cloudPlatformScope)
+}
+
+// SetJSONBearer applies the headers common to Vertex JSON API requests.
+func SetJSONBearer(req *http.Request, accessToken string) {
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+}
+
+// ParseHTTPError closes a non-successful Vertex response and returns its
+// bounded, redacted provider error.
+func ParseHTTPError(provider, model string, resp *http.Response) error {
+	defer resp.Body.Close()
+	return vertexerror.NewHTTPError(provider, resp.StatusCode, resp.Body, resp.Header.Get("Retry-After"), model)
+}

--- a/provider/internal/gcpauth/gcpauth_test.go
+++ b/provider/internal/gcpauth/gcpauth_test.go
@@ -1,0 +1,61 @@
+package gcpauth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"golang.org/x/oauth2"
+)
+
+func TestAccessTokenUsesExistingSource(t *testing.T) {
+	var source oauth2.TokenSource = staticTokenSource("test-token")
+
+	token, err := AccessToken(context.Background(), &source, Credentials{})
+	if err != nil {
+		t.Fatalf("AccessToken() error = %v", err)
+	}
+	if token != "test-token" {
+		t.Errorf("AccessToken() = %q, want test-token", token)
+	}
+}
+
+func TestAccessTokenClassifiesSourceCreationFailure(t *testing.T) {
+	var source oauth2.TokenSource
+
+	_, err := AccessToken(context.Background(), &source, Credentials{
+		File: "/definitely/not/a/gcp-credential.json",
+	})
+	if err == nil {
+		t.Fatal("AccessToken() error = nil, want source creation error")
+	}
+	var creationError *SourceCreationError
+	if !errors.As(err, &creationError) {
+		t.Fatalf("AccessToken() error = %T %v, want SourceCreationError", err, err)
+	}
+	if !strings.Contains(err.Error(), "failed to read credentials file") {
+		t.Errorf("AccessToken() error = %q, want redacted file-read context", err)
+	}
+}
+
+func TestSetJSONBearer(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "https://example.invalid", nil)
+
+	SetJSONBearer(req, "test-token")
+
+	if got := req.Header.Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", got)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer test-token" {
+		t.Errorf("Authorization = %q, want bearer token", got)
+	}
+}
+
+type staticTokenSource string
+
+func (s staticTokenSource) Token() (*oauth2.Token, error) {
+	return &oauth2.Token{AccessToken: string(s)}, nil
+}

--- a/provider/vertexai/vertexai.go
+++ b/provider/vertexai/vertexai.go
@@ -7,16 +7,16 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
 	"sync"
 
 	"golang.org/x/oauth2"
-	"golang.org/x/oauth2/google"
 
 	"github.com/fugue-labs/gollem/core"
-	"github.com/fugue-labs/gollem/provider/internal/vertexerror"
+	"github.com/fugue-labs/gollem/provider/internal/gcpauth"
 )
 
 // Model constants for Gemini models.
@@ -31,7 +31,6 @@ const (
 const (
 	defaultLocation = "us-central1"
 	defaultModel    = Gemini25Flash
-	cloudScope      = "https://www.googleapis.com/auth/cloud-platform"
 )
 
 // Provider implements core.Model for Vertex AI Gemini API.
@@ -142,47 +141,18 @@ func (p *Provider) getToken(ctx context.Context) (string, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	if p.tokenSource == nil {
-		ts, err := p.createTokenSource(ctx)
-		if err != nil {
+	token, err := gcpauth.AccessToken(ctx, &p.tokenSource, gcpauth.Credentials{
+		File: p.credentialsFile,
+		JSON: p.credentialsJSON,
+	})
+	if err != nil {
+		var sourceCreationError *gcpauth.SourceCreationError
+		if errors.As(err, &sourceCreationError) {
 			return "", fmt.Errorf("vertexai: failed to create token source: %w", err)
 		}
-		p.tokenSource = ts
-	}
-
-	token, err := p.tokenSource.Token()
-	if err != nil {
 		return "", fmt.Errorf("vertexai: failed to get token: %w", err)
 	}
-	return token.AccessToken, nil
-}
-
-// createTokenSource creates an OAuth2 token source based on configuration.
-func (p *Provider) createTokenSource(ctx context.Context) (oauth2.TokenSource, error) {
-	if p.credentialsJSON != nil {
-		creds, err := google.CredentialsFromJSON(ctx, p.credentialsJSON, cloudScope) //nolint:staticcheck,nolintlint // credentials are explicitly configured by the process owner
-		if err != nil {
-			return nil, err
-		}
-		return creds.TokenSource, nil
-	}
-	if p.credentialsFile != "" {
-		data, err := os.ReadFile(p.credentialsFile)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read credentials file: %w", err)
-		}
-		creds, err := google.CredentialsFromJSON(ctx, data, cloudScope) //nolint:staticcheck,nolintlint // credentials are explicitly configured by the process owner
-		if err != nil {
-			return nil, err
-		}
-		return creds.TokenSource, nil
-	}
-	// Fall back to Application Default Credentials.
-	ts, err := google.DefaultTokenSource(ctx, cloudScope)
-	if err != nil {
-		return nil, err
-	}
-	return ts, nil
+	return token, nil
 }
 
 // Request sends messages to Vertex AI Gemini and returns a complete response.
@@ -247,7 +217,9 @@ func (p *Provider) RequestStream(ctx context.Context, messages []core.ModelMessa
 		return nil, err
 	}
 
-	resp, err := p.httpClient.Do(httpReq)
+	// The error helper closes non-successful bodies; successful streams transfer
+	// ownership to newStreamedResponse.
+	resp, err := p.httpClient.Do(httpReq) //nolint:bodyclose // ownership is split by the status branch below
 	if err != nil {
 		return nil, fmt.Errorf("vertexai: HTTP request failed: %w", err)
 	}
@@ -260,12 +232,11 @@ func (p *Provider) RequestStream(ctx context.Context, messages []core.ModelMessa
 }
 
 func (p *Provider) setHeaders(ctx context.Context, req *http.Request) error {
-	req.Header.Set("Content-Type", "application/json")
 	token, err := p.getToken(ctx)
 	if err != nil {
 		return err
 	}
-	req.Header.Set("Authorization", "Bearer "+token)
+	gcpauth.SetJSONBearer(req, token)
 	return nil
 }
 
@@ -279,8 +250,7 @@ func (p *Provider) applyCacheSettings(req *geminiRequest, settings *core.ModelSe
 
 // parseHTTPError constructs a bounded, redacted ModelHTTPError from a non-200 response.
 func (p *Provider) parseHTTPError(resp *http.Response) error {
-	defer resp.Body.Close()
-	return vertexerror.NewHTTPError("vertexai", resp.StatusCode, resp.Body, resp.Header.Get("Retry-After"), p.model)
+	return gcpauth.ParseHTTPError("vertexai", p.model, resp)
 }
 
 // Verify Provider implements core.Model.

--- a/provider/vertexai/vertexai_test.go
+++ b/provider/vertexai/vertexai_test.go
@@ -1970,3 +1970,15 @@ func TestMapUsageWithoutCachedContentTokens(t *testing.T) {
 		t.Errorf("expected CacheReadTokens 0 when not set, got %d", usage.CacheReadTokens)
 	}
 }
+
+func TestGetTokenSourceCreationErrorKeepsVertexPrefix(t *testing.T) {
+	p := New(WithCredentialsFile("/definitely/not/a/gcp-credential.json"))
+
+	_, err := p.getToken(context.Background())
+	if err == nil {
+		t.Fatal("getToken() error = nil, want source creation error")
+	}
+	if !strings.Contains(err.Error(), "vertexai: failed to create token source") {
+		t.Errorf("getToken() error = %q, want vertexai source-creation prefix", err)
+	}
+}

--- a/provider/vertexai_anthropic/vertexai_anthropic.go
+++ b/provider/vertexai_anthropic/vertexai_anthropic.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -14,10 +15,9 @@ import (
 	"sync"
 
 	"golang.org/x/oauth2"
-	"golang.org/x/oauth2/google"
 
 	"github.com/fugue-labs/gollem/core"
-	"github.com/fugue-labs/gollem/provider/internal/vertexerror"
+	"github.com/fugue-labs/gollem/provider/internal/gcpauth"
 )
 
 // Model constants for Claude models via Vertex AI.
@@ -38,7 +38,6 @@ const (
 	defaultModel     = ClaudeSonnet46
 	defaultMaxTokens = 4096
 	anthropicVersion = "vertex-2023-10-16"
-	cloudScope       = "https://www.googleapis.com/auth/cloud-platform"
 )
 
 // isOpus47 reports whether the model string identifies Opus 4.7 or Mythos.
@@ -243,46 +242,18 @@ func (p *Provider) getToken(ctx context.Context) (string, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	if p.tokenSource == nil {
-		ts, err := p.createTokenSource(ctx)
-		if err != nil {
+	token, err := gcpauth.AccessToken(ctx, &p.tokenSource, gcpauth.Credentials{
+		File: p.credentialsFile,
+		JSON: p.credentialsJSON,
+	})
+	if err != nil {
+		var sourceCreationError *gcpauth.SourceCreationError
+		if errors.As(err, &sourceCreationError) {
 			return "", fmt.Errorf("vertexai_anthropic: failed to create token source: %w", err)
 		}
-		p.tokenSource = ts
-	}
-
-	token, err := p.tokenSource.Token()
-	if err != nil {
 		return "", fmt.Errorf("vertexai_anthropic: failed to get token: %w", err)
 	}
-	return token.AccessToken, nil
-}
-
-// createTokenSource creates an OAuth2 token source based on configuration.
-func (p *Provider) createTokenSource(ctx context.Context) (oauth2.TokenSource, error) {
-	if p.credentialsJSON != nil {
-		creds, err := google.CredentialsFromJSON(ctx, p.credentialsJSON, cloudScope) //nolint:staticcheck,nolintlint // credentials are explicitly configured by the process owner
-		if err != nil {
-			return nil, err
-		}
-		return creds.TokenSource, nil
-	}
-	if p.credentialsFile != "" {
-		data, err := os.ReadFile(p.credentialsFile)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read credentials file: %w", err)
-		}
-		creds, err := google.CredentialsFromJSON(ctx, data, cloudScope) //nolint:staticcheck,nolintlint // credentials are explicitly configured by the process owner
-		if err != nil {
-			return nil, err
-		}
-		return creds.TokenSource, nil
-	}
-	ts, err := google.DefaultTokenSource(ctx, cloudScope)
-	if err != nil {
-		return nil, err
-	}
-	return ts, nil
+	return token, nil
 }
 
 // Request sends messages to Claude via Vertex AI and returns a complete response.
@@ -347,7 +318,9 @@ func (p *Provider) RequestStream(ctx context.Context, messages []core.ModelMessa
 		return nil, err
 	}
 
-	resp, err := p.httpClient.Do(httpReq)
+	// The error helper closes non-successful bodies; successful streams transfer
+	// ownership to newStreamedResponse.
+	resp, err := p.httpClient.Do(httpReq) //nolint:bodyclose // ownership is split by the status branch below
 	if err != nil {
 		return nil, fmt.Errorf("vertexai_anthropic: HTTP request failed: %w", err)
 	}
@@ -360,19 +333,17 @@ func (p *Provider) RequestStream(ctx context.Context, messages []core.ModelMessa
 }
 
 func (p *Provider) setHeaders(ctx context.Context, req *http.Request) error {
-	req.Header.Set("Content-Type", "application/json")
 	token, err := p.getToken(ctx)
 	if err != nil {
 		return err
 	}
-	req.Header.Set("Authorization", "Bearer "+token)
+	gcpauth.SetJSONBearer(req, token)
 	return nil
 }
 
 // parseHTTPError constructs a bounded, redacted ModelHTTPError from a non-200 response.
 func (p *Provider) parseHTTPError(resp *http.Response) error {
-	defer resp.Body.Close()
-	return vertexerror.NewHTTPError("vertexai_anthropic", resp.StatusCode, resp.Body, resp.Header.Get("Retry-After"), p.model)
+	return gcpauth.ParseHTTPError("vertexai_anthropic", p.model, resp)
 }
 
 func envEnabled(name string) bool {

--- a/provider/vertexai_anthropic/vertexai_anthropic_test.go
+++ b/provider/vertexai_anthropic/vertexai_anthropic_test.go
@@ -2004,6 +2004,18 @@ func TestParseHTTPErrorRetryAfter(t *testing.T) {
 	}
 }
 
+func TestGetTokenSourceCreationErrorKeepsVertexAnthropicPrefix(t *testing.T) {
+	p := New(WithCredentialsFile("/definitely/not/a/gcp-credential.json"))
+
+	_, err := p.getToken(context.Background())
+	if err == nil {
+		t.Fatal("getToken() error = nil, want source creation error")
+	}
+	if !strings.Contains(err.Error(), "vertexai_anthropic: failed to create token source") {
+		t.Errorf("getToken() error = %q, want vertexai_anthropic source-creation prefix", err)
+	}
+}
+
 // --- Test helpers ---
 
 type staticTokenSource struct {


### PR DESCRIPTION
## Summary
- centralize lazy GCP credential resolution, JSON bearer headers, and bounded Vertex HTTP errors
- preserve provider-local locking, diagnostics, request construction, and stream ownership
- add shared and provider-specific regression coverage

## Validation
- `go test -race ./provider/internal/gcpauth ./provider/vertexai ./provider/vertexai_anthropic`
- `make test` (non-Monty race suite)
- `make vet`
- `go build ./...`
- `make lint`