### PR TITLE
test(appserver): wait for PTY output before kill

### DIFF
--- a/appserver/server_test.go
+++ b/appserver/server_test.go
@@ -2221,6 +2221,20 @@ func TestServerProcessPTYHandlers(t *testing.T) {
 	if writeResp.Error != nil {
 		t.Fatalf("process/writeStdin PTY error: %v", writeResp.Error)
 	}
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		snapshot, err := processSvc.Snapshot(ctx, started.Process.ID)
+		if err != nil {
+			t.Fatalf("snapshot after PTY write: %v", err)
+		}
+		if strings.Contains(string(snapshot.Stdout), "hello") {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("PTY process did not echo input before kill; stdout = %q", snapshot.Stdout)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 	if err := processSvc.Kill(ctx, started.Process.ID); err != nil {
 		t.Fatalf("Kill PTY process: %v", err)
 	}


### PR DESCRIPTION
## Summary
- wait for the asserted PTY echo before issuing the kill in the handler test
- retain resize, write, stdout, and kill coverage without racing the asynchronous reader

## Validation
- `go test -race -count=100 ./appserver -run "^TestServerProcessPTYHandlers$"`
- `go test -race ./appserver/tools/process -run TestServicePTY`
- `make test` (non-Monty race suite)
- `make lint`
- `make vet`
- `go build ./...`