### PR TITLE
feat(appserver): persist owner-lost terminal records

### DIFF
--- a/appserver/protocol/operational_inspector_contract_test.go
+++ b/appserver/protocol/operational_inspector_contract_test.go
@@ -52,7 +52,7 @@ func TestOperationalInspectorBindingsAreExact(t *testing.T) {
 		}
 	}
 	assertSchemaEnum(t, defs, "BackgroundTerminalStatus", []any{
-		"running", "completed", "failed", "killed", "timed_out",
+		"running", "completed", "failed", "killed", "timed_out", "owner_lost",
 	})
 }
 

--- a/appserver/protocol/operational_inspector_types.go
+++ b/appserver/protocol/operational_inspector_types.go
@@ -19,6 +19,7 @@ const (
 	BackgroundTerminalStatusFailed    BackgroundTerminalStatus = "failed"
 	BackgroundTerminalStatusKilled    BackgroundTerminalStatus = "killed"
 	BackgroundTerminalStatusTimedOut  BackgroundTerminalStatus = "timed_out"
+	BackgroundTerminalStatusOwnerLost BackgroundTerminalStatus = "owner_lost"
 )
 
 // BackgroundTerminal is the bounded, redacted process record exposed to
@@ -32,10 +33,11 @@ type BackgroundTerminal struct {
 	Title             string                   `json:"title"`
 	Command           string                   `json:"command"`
 	WorkDir           string                   `json:"workDir"`
-	Status            BackgroundTerminalStatus `json:"status" jsonschema:"enum=running|completed|failed|killed|timed_out"`
+	Status            BackgroundTerminalStatus `json:"status" jsonschema:"enum=running|completed|failed|killed|timed_out|owner_lost"`
 	ExitCode          *int                     `json:"exitCode,omitempty"`
 	StartedAt         time.Time                `json:"startedAt"`
 	EndedAt           *time.Time               `json:"endedAt,omitempty"`
+	OwnerLostAt       *time.Time               `json:"ownerLostAt,omitempty"`
 	ArgumentCount     int                      `json:"argumentCount"`
 	CommandRedacted   bool                     `json:"commandRedacted"`
 	MetadataTruncated bool                     `json:"metadataTruncated"`
@@ -82,7 +84,8 @@ type BackgroundTerminalTerminateResponse struct {
 }
 
 // BackgroundTerminalReadParams identifies one terminal from the current
-// in-memory process inventory. The identity is intentionally not durable.
+// process inventory. An owner_lost terminal remains inspectable in the list
+// but cannot be read because the previous owner did not retain its output.
 type BackgroundTerminalReadParams struct {
 	ID string `json:"id"`
 }
@@ -109,8 +112,8 @@ type BackgroundTerminalWriteParams struct {
 }
 
 // BackgroundTerminalWriteResponse acknowledges one accepted input without
-// returning the input itself. The terminal remains in-memory-only and can
-// become unavailable after a Gollem restart.
+// returning the input itself. Owner-lost terminals are intentionally rejected
+// because Gollem never reattaches their prior process or PTY after restart.
 type BackgroundTerminalWriteResponse struct {
 	OK           bool               `json:"ok"`
 	Terminal     BackgroundTerminal `json:"terminal"`

--- a/appserver/protocol/schema.go
+++ b/appserver/protocol/schema.go
@@ -1390,6 +1390,7 @@ func wireSchemasForDefinitions(definitions []wireSchemaDefinition) Schema {
 		string(BackgroundTerminalStatusFailed),
 		string(BackgroundTerminalStatusKilled),
 		string(BackgroundTerminalStatusTimedOut),
+		string(BackgroundTerminalStatusOwnerLost),
 	)
 	for name, schema := range accountRateLimitSchemas() {
 		schemas[name] = schema

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -1517,6 +1517,17 @@
         "metadataTruncated": {
           "type": "boolean"
         },
+        "ownerLostAt": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "pid": {
           "type": "integer"
         },
@@ -1547,7 +1558,8 @@
             "completed",
             "failed",
             "killed",
-            "timed_out"
+            "timed_out",
+            "owner_lost"
           ]
         },
         "terminalId": {
@@ -1756,7 +1768,8 @@
         "completed",
         "failed",
         "killed",
-        "timed_out"
+        "timed_out",
+        "owner_lost"
       ],
       "type": "string"
     },

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -791,6 +791,7 @@ export type BackgroundTerminal = {
   "exitCode"?: number | null;
   "id": string;
   "metadataTruncated": boolean;
+  "ownerLostAt"?: string | null;
   "pid": number;
   "processId": string;
   "pty": boolean;
@@ -846,7 +847,7 @@ export type BackgroundTerminalResizeResponse = {
   "terminal": BackgroundTerminal;
 };
 
-export type BackgroundTerminalStatus = "running" | "completed" | "failed" | "killed" | "timed_out";
+export type BackgroundTerminalStatus = "running" | "completed" | "failed" | "killed" | "timed_out" | "owner_lost";
 
 export type BackgroundTerminalTerminateParams = {
   "backgroundTerminalId"?: string;

--- a/appserver/server.go
+++ b/appserver/server.go
@@ -53,23 +53,25 @@ type Server struct {
 
 	workspaceCoordinator *WorkspaceMutationCoordinator
 
-	store              store.Store
-	fs                 *toolfs.Service
-	process            *toolprocess.Service
-	git                *toolgit.Service
-	catalog            *catalog.Catalog
-	config             *appconfig.Service
-	cache              *appcache.Service
-	mcp                *appmcp.Service
-	skills             *appskills.Service
-	events             *EventQueue
-	requests           *RequestQueue
-	approvals          *ApprovalService
-	interact           *InteractionService
-	daemon             *DaemonService
-	runtime            *RuntimeService
-	memory             *MemoryService
-	selectionValidator RuntimeSelectionValidator
+	store                store.Store
+	terminalOwnership    store.TerminalOwnershipStore
+	terminalWorkspaceKey string
+	fs                   *toolfs.Service
+	process              *toolprocess.Service
+	git                  *toolgit.Service
+	catalog              *catalog.Catalog
+	config               *appconfig.Service
+	cache                *appcache.Service
+	mcp                  *appmcp.Service
+	skills               *appskills.Service
+	events               *EventQueue
+	requests             *RequestQueue
+	approvals            *ApprovalService
+	interact             *InteractionService
+	daemon               *DaemonService
+	runtime              *RuntimeService
+	memory               *MemoryService
+	selectionValidator   RuntimeSelectionValidator
 
 	requestSchedulerLimit int
 	threadIdleUnloadAfter time.Duration
@@ -264,6 +266,7 @@ func NewServer(opts ...Option) *Server {
 	if s.interact != nil {
 		s.interact.setRequestQueue(s.requests)
 	}
+	s.initializeTerminalOwnership()
 	return s
 }
 
@@ -1279,7 +1282,10 @@ func (s *Server) handleBackgroundTerminalsList(ctx context.Context, raw json.Raw
 	if err != nil {
 		return nil, mapError("thread/backgroundTerminals/list", err)
 	}
-	terminals := operationalBackgroundTerminals(processSvc.Root(), snapshots)
+	terminals, err := s.backgroundTerminalInventory(ctx, snapshots)
+	if err != nil {
+		return nil, mapError("thread/backgroundTerminals/list", err)
+	}
 	snapshotID := operationalSnapshotID("thread/backgroundTerminals/list", terminals)
 	start, end, nextCursor, rpcErr := operationalPageBounds(
 		params, "thread/backgroundTerminals/list", snapshotID, len(terminals),
@@ -1312,14 +1318,21 @@ func (s *Server) handleBackgroundTerminalRead(ctx context.Context, raw json.RawM
 	if strings.TrimSpace(params.ID) == "" {
 		return nil, invalidParams("id is required", nil)
 	}
-	snapshot, err := processSvc.Snapshot(ctx, params.ID)
+	processID, record, err := s.resolveBackgroundTerminalID(ctx, params.ID)
+	if err != nil {
+		return nil, mapError("thread/backgroundTerminals/read", err)
+	}
+	if record != nil && record.Status == store.TerminalOwnershipOwnerLost {
+		return nil, ownerLostTerminalUnavailable("thread/backgroundTerminals/read")
+	}
+	snapshot, err := processSvc.Snapshot(ctx, processID)
 	if err != nil {
 		return nil, mapError("thread/backgroundTerminals/read", err)
 	}
 	stdout, stdoutTruncated := operationalTerminalOutput(snapshot.Stdout, snapshot.StdoutTruncated)
 	stderr, stderrTruncated := operationalTerminalOutput(snapshot.Stderr, snapshot.StderrTruncated)
 	return protocol.BackgroundTerminalReadResponse{
-		Terminal:        operationalBackgroundTerminal(processSvc.Root(), snapshot),
+		Terminal:        operationalBackgroundTerminalWithOwnership(processSvc.Root(), snapshot, record),
 		StdoutBase64:    stdout,
 		StderrBase64:    stderr,
 		StdoutTruncated: stdoutTruncated,
@@ -1341,23 +1354,30 @@ func (s *Server) handleBackgroundTerminalTerminate(ctx context.Context, raw json
 	if id == "" {
 		return nil, invalidParams("id, terminalId, backgroundTerminalId, or processId is required", nil)
 	}
+	processID, record, err := s.resolveBackgroundTerminalID(ctx, id)
+	if err != nil {
+		return nil, mapError("thread/backgroundTerminals/terminate", err)
+	}
+	if record != nil && record.Status == store.TerminalOwnershipOwnerLost {
+		return nil, ownerLostTerminalUnavailable("thread/backgroundTerminals/terminate")
+	}
 	approvalCtx := withRuntimeApprovalItemID(
 		ctx,
-		operationalTerminalTerminateApprovalItemID(id),
+		operationalTerminalTerminateApprovalItemID(processID),
 	)
-	if err := processSvc.Terminate(approvalCtx, id); err != nil {
+	if err := processSvc.Terminate(approvalCtx, processID); err != nil {
 		return nil, mapError("thread/backgroundTerminals/terminate", err)
 	}
 	waitCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
-	snapshot, err := processSvc.Wait(waitCtx, id)
+	snapshot, err := processSvc.Wait(waitCtx, processID)
 	if err != nil {
 		return nil, mapError("thread/backgroundTerminals/terminate", err)
 	}
 	return protocol.BackgroundTerminalTerminateResponse{
 		OK:       true,
 		ID:       id,
-		Terminal: operationalBackgroundTerminal(processSvc.Root(), snapshot),
+		Terminal: operationalBackgroundTerminalWithOwnership(processSvc.Root(), snapshot, record),
 	}, nil
 }
 
@@ -1380,24 +1400,31 @@ func (s *Server) handleBackgroundTerminalWrite(ctx context.Context, raw json.Raw
 	if len(params.Input) > operationalTerminalWriteMaxBytes {
 		return nil, invalidParams(fmt.Sprintf("input exceeds %d bytes", operationalTerminalWriteMaxBytes), nil)
 	}
-	snapshot, err := processSvc.Snapshot(ctx, id)
+	processID, record, err := s.resolveBackgroundTerminalID(ctx, id)
+	if err != nil {
+		return nil, mapError("thread/backgroundTerminals/write", err)
+	}
+	if record != nil && record.Status == store.TerminalOwnershipOwnerLost {
+		return nil, ownerLostTerminalUnavailable("thread/backgroundTerminals/write")
+	}
+	snapshot, err := processSvc.Snapshot(ctx, processID)
 	if err != nil {
 		return nil, mapError("thread/backgroundTerminals/write", err)
 	}
 	if snapshot.Status != toolprocess.StatusRunning {
 		return nil, invalidParams("background terminal is not running", nil)
 	}
-	approvalCtx := withRuntimeApprovalItemID(ctx, operationalTerminalWriteApprovalItemID(id))
-	if err := processSvc.WriteStdin(approvalCtx, id, []byte(params.Input)); err != nil {
+	approvalCtx := withRuntimeApprovalItemID(ctx, operationalTerminalWriteApprovalItemID(processID))
+	if err := processSvc.WriteStdin(approvalCtx, processID, []byte(params.Input)); err != nil {
 		return nil, mapError("thread/backgroundTerminals/write", err)
 	}
-	snapshot, err = processSvc.Snapshot(ctx, id)
+	snapshot, err = processSvc.Snapshot(ctx, processID)
 	if err != nil {
 		return nil, mapError("thread/backgroundTerminals/write", err)
 	}
 	return protocol.BackgroundTerminalWriteResponse{
 		OK:           true,
-		Terminal:     operationalBackgroundTerminal(processSvc.Root(), snapshot),
+		Terminal:     operationalBackgroundTerminalWithOwnership(processSvc.Root(), snapshot, record),
 		WrittenBytes: len(params.Input),
 		ObservedAt:   operationalObservedAt(),
 	}, nil
@@ -1419,23 +1446,30 @@ func (s *Server) handleBackgroundTerminalResize(ctx context.Context, raw json.Ra
 	if params.Size.Rows == 0 || params.Size.Cols == 0 {
 		return nil, invalidParams("size rows and cols must be positive", nil)
 	}
-	snapshot, err := processSvc.Snapshot(ctx, id)
+	processID, record, err := s.resolveBackgroundTerminalID(ctx, id)
+	if err != nil {
+		return nil, mapError("thread/backgroundTerminals/resize", err)
+	}
+	if record != nil && record.Status == store.TerminalOwnershipOwnerLost {
+		return nil, ownerLostTerminalUnavailable("thread/backgroundTerminals/resize")
+	}
+	snapshot, err := processSvc.Snapshot(ctx, processID)
 	if err != nil {
 		return nil, mapError("thread/backgroundTerminals/resize", err)
 	}
 	if snapshot.Status != toolprocess.StatusRunning {
 		return nil, invalidParams("background terminal is not running", nil)
 	}
-	if err := processSvc.ResizePTY(ctx, id, int(params.Size.Cols), int(params.Size.Rows)); err != nil {
+	if err := processSvc.ResizePTY(ctx, processID, int(params.Size.Cols), int(params.Size.Rows)); err != nil {
 		return nil, mapError("thread/backgroundTerminals/resize", err)
 	}
-	snapshot, err = processSvc.Snapshot(ctx, id)
+	snapshot, err = processSvc.Snapshot(ctx, processID)
 	if err != nil {
 		return nil, mapError("thread/backgroundTerminals/resize", err)
 	}
 	return protocol.BackgroundTerminalResizeResponse{
 		OK:         true,
-		Terminal:   operationalBackgroundTerminal(processSvc.Root(), snapshot),
+		Terminal:   operationalBackgroundTerminalWithOwnership(processSvc.Root(), snapshot, record),
 		ObservedAt: operationalObservedAt(),
 	}, nil
 }
@@ -1451,6 +1485,11 @@ func (s *Server) handleBackgroundTerminalsClean(ctx context.Context, raw json.Ra
 	removed, err := processSvc.CleanCompleted(ctx)
 	if err != nil {
 		return nil, mapError("thread/backgroundTerminals/clean", err)
+	}
+	if s.terminalOwnership != nil {
+		if err := s.terminalOwnership.DeleteInactiveTerminalOwnership(ctx, s.terminalWorkspaceKey); err != nil {
+			return nil, mapError("thread/backgroundTerminals/clean", err)
+		}
 	}
 	terminals := operationalBackgroundTerminals(processSvc.Root(), removed)
 	removedCount := len(terminals)

--- a/appserver/store/sqlite.go
+++ b/appserver/store/sqlite.go
@@ -20,6 +20,7 @@ var _ Store = (*SQLiteStore)(nil)
 var _ RuntimeRecoveryStore = (*SQLiteStore)(nil)
 var _ ThreadForkRecoveryStore = (*SQLiteStore)(nil)
 var _ FileChangeRecoveryStore = (*SQLiteStore)(nil)
+var _ TerminalOwnershipStore = (*SQLiteStore)(nil)
 
 // SQLiteStore persists app-server state in SQLite.
 type SQLiteStore struct {
@@ -129,6 +130,16 @@ func (s *SQLiteStore) init() error {
 			payload BLOB NOT NULL
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_app_file_change_recovery_thread ON app_file_change_recovery(thread_id, turn_id, item_id)`,
+		`CREATE TABLE IF NOT EXISTS app_terminal_ownership (
+			id TEXT PRIMARY KEY,
+			workspace_key TEXT NOT NULL,
+			process_id TEXT NOT NULL,
+			status TEXT NOT NULL,
+			started_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL,
+			payload BLOB NOT NULL
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_app_terminal_ownership_workspace ON app_terminal_ownership(workspace_key, started_at DESC, id ASC)`,
 	}
 	for _, stmt := range schema {
 		if _, err := s.db.ExecContext(ctx, stmt); err != nil {
@@ -170,6 +181,141 @@ func normalizeContext(ctx context.Context) context.Context {
 		return context.Background()
 	}
 	return ctx
+}
+
+// SaveTerminalOwnership writes a redacted terminal lifecycle snapshot. Older
+// events cannot overwrite a newer terminal state, which keeps concurrent exit
+// and startup reconciliation from reviving an owner-lost record.
+func (s *SQLiteStore) SaveTerminalOwnership(ctx context.Context, record TerminalOwnershipRecord) (*TerminalOwnershipRecord, error) {
+	ctx = normalizeContext(ctx)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	record = cloneTerminalOwnershipRecord(record)
+	if err := normalizeTerminalOwnershipRecord(&record); err != nil {
+		return nil, err
+	}
+	if err := s.withTx(ctx, func(tx *sql.Tx) error {
+		existing, err := loadTerminalOwnershipTx(ctx, tx, record.ID)
+		if err == nil && !record.UpdatedAt.After(existing.UpdatedAt) {
+			record = *existing
+			return nil
+		}
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return err
+		}
+		return saveTerminalOwnershipTx(ctx, tx, &record)
+	}); err != nil {
+		return nil, err
+	}
+	return terminalOwnershipRecordPtr(record), nil
+}
+
+// ListTerminalOwnership returns terminal lifecycle records for one opaque
+// workspace identity. Results are newest-first to make live operational views
+// useful without exposing the workspace path used to scope the record.
+func (s *SQLiteStore) ListTerminalOwnership(ctx context.Context, workspaceKey string) ([]*TerminalOwnershipRecord, error) {
+	ctx = normalizeContext(ctx)
+	workspaceKey = strings.TrimSpace(workspaceKey)
+	if workspaceKey == "" {
+		return nil, errors.New("appserver/store: terminal ownership workspace key is required")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	db, err := s.dbLocked()
+	if err != nil {
+		return nil, err
+	}
+	rows, err := db.QueryContext(ctx, `SELECT process_id, payload FROM app_terminal_ownership WHERE workspace_key = ? ORDER BY started_at DESC, id ASC`, workspaceKey)
+	if err != nil {
+		return nil, fmt.Errorf("list terminal ownership: %w", err)
+	}
+	defer rows.Close()
+	var records []*TerminalOwnershipRecord
+	for rows.Next() {
+		record, err := scanTerminalOwnership(rows)
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, terminalOwnershipRecordPtr(*record))
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate terminal ownership: %w", err)
+	}
+	return records, nil
+}
+
+// RecoverTerminalOwnership terminalizes only records that were still running
+// and have no matching live process in the newly-created process service.
+// This is deliberately not a reconnect mechanism: the old process/output is
+// unavailable to the new execution owner.
+func (s *SQLiteStore) RecoverTerminalOwnership(ctx context.Context, req RecoverTerminalOwnershipRequest) ([]*TerminalOwnershipRecord, error) {
+	ctx = normalizeContext(ctx)
+	workspaceKey := strings.TrimSpace(req.WorkspaceKey)
+	if workspaceKey == "" {
+		return nil, errors.New("appserver/store: terminal ownership workspace key is required")
+	}
+	recoveredAt := req.RecoveredAt.UTC()
+	if recoveredAt.IsZero() {
+		recoveredAt = time.Now().UTC()
+	}
+	live := make(map[string]struct{}, len(req.LiveProcessIDs))
+	for _, id := range req.LiveProcessIDs {
+		if id = strings.TrimSpace(id); id != "" {
+			live[id] = struct{}{}
+		}
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var recovered []*TerminalOwnershipRecord
+	if err := s.withTx(ctx, func(tx *sql.Tx) error {
+		records, err := loadTerminalOwnershipForWorkspaceTx(ctx, tx, workspaceKey)
+		if err != nil {
+			return err
+		}
+		for _, record := range records {
+			if record.Status != TerminalOwnershipRunning {
+				continue
+			}
+			if _, ok := live[record.ProcessID]; ok {
+				continue
+			}
+			record.Status = TerminalOwnershipOwnerLost
+			record.OwnerLostAt = timePtr(recoveredAt)
+			record.EndedAt = timePtr(recoveredAt)
+			record.ExitCode = nil
+			record.UpdatedAt = recoveredAt
+			if err := saveTerminalOwnershipTx(ctx, tx, record); err != nil {
+				return err
+			}
+			recovered = append(recovered, terminalOwnershipRecordPtr(*record))
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return recovered, nil
+}
+
+// DeleteInactiveTerminalOwnership clears completed or owner-lost records from
+// a workspace after the operational terminal inventory is cleaned.
+func (s *SQLiteStore) DeleteInactiveTerminalOwnership(ctx context.Context, workspaceKey string) error {
+	ctx = normalizeContext(ctx)
+	workspaceKey = strings.TrimSpace(workspaceKey)
+	if workspaceKey == "" {
+		return errors.New("appserver/store: terminal ownership workspace key is required")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	db, err := s.dbLocked()
+	if err != nil {
+		return err
+	}
+	if _, err := db.ExecContext(ctx, `DELETE FROM app_terminal_ownership WHERE workspace_key = ? AND status <> ?`, workspaceKey, TerminalOwnershipRunning); err != nil {
+		return fmt.Errorf("delete inactive terminal ownership: %w", err)
+	}
+	return nil
 }
 
 // CreateThread implements Store.
@@ -1447,6 +1593,30 @@ func saveFileChangeRecoveryTx(ctx context.Context, tx *sql.Tx, recovery *FileCha
 	return nil
 }
 
+func saveTerminalOwnershipTx(ctx context.Context, tx *sql.Tx, record *TerminalOwnershipRecord) error {
+	payload, err := json.Marshal(record)
+	if err != nil {
+		return fmt.Errorf("marshal terminal ownership: %w", err)
+	}
+	_, err = tx.ExecContext(ctx, `
+		INSERT INTO app_terminal_ownership (
+			id, workspace_key, process_id, status, started_at, updated_at, payload
+		)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET
+			workspace_key = excluded.workspace_key,
+			process_id = excluded.process_id,
+			status = excluded.status,
+			started_at = excluded.started_at,
+			updated_at = excluded.updated_at,
+			payload = excluded.payload
+	`, record.ID, record.WorkspaceKey, record.ProcessID, string(record.Status), formatTime(record.StartedAt), formatTime(record.UpdatedAt), payload)
+	if err != nil {
+		return fmt.Errorf("save terminal ownership: %w", err)
+	}
+	return nil
+}
+
 func loadThread(ctx context.Context, db *sql.DB, id string) (*Thread, error) {
 	return scanThread(db.QueryRowContext(ctx, `SELECT payload FROM app_threads WHERE id = ?`, id))
 }
@@ -1469,6 +1639,30 @@ func loadFileChangeRecovery(ctx context.Context, db *sql.DB, itemID string) (*Fi
 
 func loadFileChangeRecoveryTx(ctx context.Context, tx *sql.Tx, itemID string) (*FileChangeRecovery, error) {
 	return scanFileChangeRecovery(tx.QueryRowContext(ctx, `SELECT payload FROM app_file_change_recovery WHERE item_id = ?`, itemID))
+}
+
+func loadTerminalOwnershipTx(ctx context.Context, tx *sql.Tx, id string) (*TerminalOwnershipRecord, error) {
+	return scanTerminalOwnership(tx.QueryRowContext(ctx, `SELECT process_id, payload FROM app_terminal_ownership WHERE id = ?`, id))
+}
+
+func loadTerminalOwnershipForWorkspaceTx(ctx context.Context, tx *sql.Tx, workspaceKey string) ([]*TerminalOwnershipRecord, error) {
+	rows, err := tx.QueryContext(ctx, `SELECT process_id, payload FROM app_terminal_ownership WHERE workspace_key = ? ORDER BY started_at DESC, id ASC`, workspaceKey)
+	if err != nil {
+		return nil, fmt.Errorf("load terminal ownership: %w", err)
+	}
+	defer rows.Close()
+	var records []*TerminalOwnershipRecord
+	for rows.Next() {
+		record, err := scanTerminalOwnership(rows)
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, record)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate terminal ownership: %w", err)
+	}
+	return records, nil
 }
 
 func loadTurnsForThreadTx(ctx context.Context, tx *sql.Tx, threadID string) ([]*Turn, error) {
@@ -1820,6 +2014,20 @@ func scanFileChangeRecovery(row interface{ Scan(dest ...any) error }) (*FileChan
 	return &recovery, nil
 }
 
+func scanTerminalOwnership(row interface{ Scan(dest ...any) error }) (*TerminalOwnershipRecord, error) {
+	var processID string
+	var payload []byte
+	if err := row.Scan(&processID, &payload); err != nil {
+		return nil, fmt.Errorf("scan terminal ownership: %w", err)
+	}
+	var record TerminalOwnershipRecord
+	if err := json.Unmarshal(payload, &record); err != nil {
+		return nil, fmt.Errorf("unmarshal terminal ownership: %w", err)
+	}
+	record.ProcessID = processID
+	return &record, nil
+}
+
 func copyThreadHistoryTx(ctx context.Context, tx *sql.Tx, sourceThreadID, forkThreadID string, now time.Time) error {
 	rows, err := tx.QueryContext(ctx, `SELECT payload FROM app_turns WHERE thread_id = ? ORDER BY created_at ASC, id ASC`, sourceThreadID)
 	if err != nil {
@@ -2076,6 +2284,64 @@ func cloneFileChangeRecovery(src *FileChangeRecovery) *FileChangeRecovery {
 	dst := *src
 	dst.BeforeContent = append([]byte(nil), src.BeforeContent...)
 	return &dst
+}
+
+func cloneTerminalOwnershipRecord(src TerminalOwnershipRecord) TerminalOwnershipRecord {
+	dst := src
+	if src.ExitCode != nil {
+		exitCode := *src.ExitCode
+		dst.ExitCode = &exitCode
+	}
+	if src.EndedAt != nil {
+		endedAt := *src.EndedAt
+		dst.EndedAt = &endedAt
+	}
+	if src.OwnerLostAt != nil {
+		ownerLostAt := *src.OwnerLostAt
+		dst.OwnerLostAt = &ownerLostAt
+	}
+	return dst
+}
+
+func terminalOwnershipRecordPtr(record TerminalOwnershipRecord) *TerminalOwnershipRecord {
+	copy := cloneTerminalOwnershipRecord(record)
+	return &copy
+}
+
+func normalizeTerminalOwnershipRecord(record *TerminalOwnershipRecord) error {
+	if record == nil || strings.TrimSpace(record.ID) == "" || strings.TrimSpace(record.WorkspaceKey) == "" || strings.TrimSpace(record.ProcessID) == "" {
+		return errors.New("appserver/store: incomplete terminal ownership record")
+	}
+	switch record.Status {
+	case TerminalOwnershipRunning, TerminalOwnershipCompleted, TerminalOwnershipFailed, TerminalOwnershipKilled, TerminalOwnershipTimedOut, TerminalOwnershipOwnerLost:
+	default:
+		return fmt.Errorf("appserver/store: unsupported terminal ownership status %q", record.Status)
+	}
+	record.StartedAt = record.StartedAt.UTC()
+	if record.StartedAt.IsZero() {
+		return errors.New("appserver/store: terminal ownership started at is required")
+	}
+	record.UpdatedAt = record.UpdatedAt.UTC()
+	if record.UpdatedAt.IsZero() {
+		record.UpdatedAt = time.Now().UTC()
+	}
+	if record.EndedAt != nil {
+		endedAt := record.EndedAt.UTC()
+		record.EndedAt = &endedAt
+	}
+	if record.OwnerLostAt != nil {
+		ownerLostAt := record.OwnerLostAt.UTC()
+		record.OwnerLostAt = &ownerLostAt
+	}
+	if record.Status == TerminalOwnershipOwnerLost && record.OwnerLostAt == nil {
+		return errors.New("appserver/store: owner-lost terminal ownership requires owner-lost time")
+	}
+	return nil
+}
+
+func timePtr(value time.Time) *time.Time {
+	copy := value
+	return &copy
 }
 
 func turnIDs(turns []*Turn) []string {

--- a/appserver/store/types.go
+++ b/appserver/store/types.go
@@ -317,3 +317,57 @@ type FileChangeRecoveryStore interface {
 	AbortFileChangeRevert(context.Context, AbortFileChangeRevertRequest) (*FileChangeRecovery, error)
 	CompleteFileChangeRevert(context.Context, CompleteFileChangeRevertRequest) (*CompleteFileChangeRevertResult, error)
 }
+
+// TerminalOwnershipStatus is the durable lifecycle state of a redacted
+// workspace terminal record. It intentionally models ownership rather than
+// attempting to reattach to a process that survived an app-server restart.
+type TerminalOwnershipStatus string
+
+const (
+	TerminalOwnershipRunning   TerminalOwnershipStatus = "running"
+	TerminalOwnershipCompleted TerminalOwnershipStatus = "completed"
+	TerminalOwnershipFailed    TerminalOwnershipStatus = "failed"
+	TerminalOwnershipKilled    TerminalOwnershipStatus = "killed"
+	TerminalOwnershipTimedOut  TerminalOwnershipStatus = "timed_out"
+	TerminalOwnershipOwnerLost TerminalOwnershipStatus = "owner_lost"
+)
+
+// TerminalOwnershipRecord contains only redacted terminal metadata. Process
+// arguments, environment, output, and raw errors are never stored. ProcessID
+// is a private service correlation key and is deliberately omitted from JSON.
+type TerminalOwnershipRecord struct {
+	ID                string                  `json:"id"`
+	WorkspaceKey      string                  `json:"workspaceKey"`
+	ProcessID         string                  `json:"-"`
+	Title             string                  `json:"title"`
+	Command           string                  `json:"command"`
+	WorkDir           string                  `json:"workDir"`
+	Status            TerminalOwnershipStatus `json:"status"`
+	ExitCode          *int                    `json:"exitCode,omitempty"`
+	StartedAt         time.Time               `json:"startedAt"`
+	EndedAt           *time.Time              `json:"endedAt,omitempty"`
+	OwnerLostAt       *time.Time              `json:"ownerLostAt,omitempty"`
+	ArgumentCount     int                     `json:"argumentCount"`
+	CommandRedacted   bool                    `json:"commandRedacted"`
+	MetadataTruncated bool                    `json:"metadataTruncated"`
+	PTY               bool                    `json:"pty"`
+	PTYRows           uint16                  `json:"ptyRows,omitempty"`
+	PTYCols           uint16                  `json:"ptyCols,omitempty"`
+	UpdatedAt         time.Time               `json:"updatedAt"`
+}
+
+type RecoverTerminalOwnershipRequest struct {
+	WorkspaceKey   string
+	LiveProcessIDs []string
+	RecoveredAt    time.Time
+}
+
+// TerminalOwnershipStore is the optional persistence capability required to
+// report a terminal whose execution owner did not survive a restart. It does
+// not persist output or provide a process-reconnect mechanism.
+type TerminalOwnershipStore interface {
+	SaveTerminalOwnership(context.Context, TerminalOwnershipRecord) (*TerminalOwnershipRecord, error)
+	ListTerminalOwnership(context.Context, string) ([]*TerminalOwnershipRecord, error)
+	RecoverTerminalOwnership(context.Context, RecoverTerminalOwnershipRequest) ([]*TerminalOwnershipRecord, error)
+	DeleteInactiveTerminalOwnership(context.Context, string) error
+}

--- a/appserver/terminal_ownership.go
+++ b/appserver/terminal_ownership.go
@@ -1,0 +1,231 @@
+package appserver
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/fugue-labs/gollem/appserver/protocol"
+	"github.com/fugue-labs/gollem/appserver/store"
+	toolprocess "github.com/fugue-labs/gollem/appserver/tools/process"
+)
+
+// initializeTerminalOwnership makes restart recovery opt-in for stores that
+// can durably retain redacted terminal lifecycle evidence. A new server never
+// adopts a previous process: any saved running record without a current
+// process-service counterpart becomes owner_lost.
+func (s *Server) initializeTerminalOwnership() {
+	if s == nil || s.process == nil || s.store == nil {
+		return
+	}
+	ledger, ok := s.store.(store.TerminalOwnershipStore)
+	if !ok {
+		return
+	}
+	s.terminalOwnership = ledger
+	s.terminalWorkspaceKey = terminalOwnershipWorkspaceKey(s.process.Root())
+	s.process.AddLifecycleSink(func(snapshot toolprocess.Snapshot) {
+		s.saveTerminalOwnership(snapshot)
+	})
+
+	ctx := context.Background()
+	snapshots, err := s.process.List(ctx)
+	if err != nil {
+		return
+	}
+	liveProcessIDs := make([]string, 0, len(snapshots))
+	for _, snapshot := range snapshots {
+		liveProcessIDs = append(liveProcessIDs, snapshot.ID)
+	}
+	if _, err := ledger.RecoverTerminalOwnership(ctx, store.RecoverTerminalOwnershipRequest{
+		WorkspaceKey:   s.terminalWorkspaceKey,
+		LiveProcessIDs: liveProcessIDs,
+		RecoveredAt:    time.Now().UTC(),
+	}); err != nil {
+		return
+	}
+	for _, snapshot := range snapshots {
+		s.saveTerminalOwnership(snapshot)
+	}
+}
+
+func (s *Server) saveTerminalOwnership(snapshot toolprocess.Snapshot) {
+	if s == nil || s.terminalOwnership == nil || s.process == nil {
+		return
+	}
+	record := terminalOwnershipRecord(s.process.Root(), s.terminalWorkspaceKey, snapshot)
+	_, _ = s.terminalOwnership.SaveTerminalOwnership(context.Background(), record)
+}
+
+func terminalOwnershipWorkspaceKey(root string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(root)))
+	return "workspace-" + hex.EncodeToString(sum[:])
+}
+
+func terminalOwnershipID(workspaceKey string, snapshot toolprocess.Snapshot) string {
+	value := strings.Join([]string{
+		workspaceKey,
+		snapshot.ID,
+		snapshot.StartedAt.UTC().Format(time.RFC3339Nano),
+	}, "\x00")
+	sum := sha256.Sum256([]byte(value))
+	return "terminal-" + hex.EncodeToString(sum[:])
+}
+
+func terminalOwnershipRecord(root, workspaceKey string, snapshot toolprocess.Snapshot) store.TerminalOwnershipRecord {
+	terminal := operationalBackgroundTerminal(root, &snapshot)
+	updatedAt := snapshot.StartedAt.UTC()
+	if !snapshot.EndedAt.IsZero() {
+		updatedAt = snapshot.EndedAt.UTC()
+	}
+	if updatedAt.IsZero() {
+		updatedAt = time.Now().UTC()
+	}
+	record := store.TerminalOwnershipRecord{
+		ID:                terminalOwnershipID(workspaceKey, snapshot),
+		WorkspaceKey:      workspaceKey,
+		ProcessID:         snapshot.ID,
+		Title:             terminal.Title,
+		Command:           terminal.Command,
+		WorkDir:           terminal.WorkDir,
+		Status:            store.TerminalOwnershipStatus(terminal.Status),
+		ExitCode:          terminal.ExitCode,
+		StartedAt:         terminal.StartedAt,
+		EndedAt:           terminal.EndedAt,
+		ArgumentCount:     terminal.ArgumentCount,
+		CommandRedacted:   terminal.CommandRedacted,
+		MetadataTruncated: terminal.MetadataTruncated,
+		PTY:               terminal.PTY,
+		UpdatedAt:         updatedAt,
+	}
+	if terminal.PTYSize != nil {
+		record.PTYRows = terminal.PTYSize.Rows
+		record.PTYCols = terminal.PTYSize.Cols
+	}
+	return record
+}
+
+func terminalOwnershipTerminal(record *store.TerminalOwnershipRecord) protocol.BackgroundTerminal {
+	if record == nil {
+		return protocol.BackgroundTerminal{}
+	}
+	terminal := protocol.BackgroundTerminal{
+		ID:                record.ID,
+		TerminalID:        record.ID,
+		ProcessID:         record.ID,
+		Title:             record.Title,
+		Command:           record.Command,
+		WorkDir:           record.WorkDir,
+		Status:            protocol.BackgroundTerminalStatus(record.Status),
+		ExitCode:          cloneTerminalExitCode(record.ExitCode),
+		StartedAt:         record.StartedAt,
+		EndedAt:           cloneTerminalTime(record.EndedAt),
+		OwnerLostAt:       cloneTerminalTime(record.OwnerLostAt),
+		ArgumentCount:     record.ArgumentCount,
+		CommandRedacted:   record.CommandRedacted,
+		MetadataTruncated: record.MetadataTruncated,
+		PTY:               record.PTY,
+	}
+	if record.PTY {
+		terminal.PTYSize = &protocol.ProcessTerminalSize{Rows: record.PTYRows, Cols: record.PTYCols}
+	}
+	return terminal
+}
+
+func cloneTerminalExitCode(value *int) *int {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	return &copy
+}
+
+func cloneTerminalTime(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	return &copy
+}
+
+func (s *Server) backgroundTerminalInventory(ctx context.Context, snapshots []toolprocess.Snapshot) ([]protocol.BackgroundTerminal, error) {
+	if s == nil || s.process == nil || s.terminalOwnership == nil {
+		root := ""
+		if s != nil && s.process != nil {
+			root = s.process.Root()
+		}
+		return operationalBackgroundTerminals(root, snapshots), nil
+	}
+	records, err := s.terminalOwnership.ListTerminalOwnership(ctx, s.terminalWorkspaceKey)
+	if err != nil {
+		return nil, err
+	}
+	recordByID := make(map[string]*store.TerminalOwnershipRecord, len(records))
+	for _, record := range records {
+		recordByID[record.ID] = record
+	}
+	seen := make(map[string]struct{}, len(snapshots))
+	terminals := make([]protocol.BackgroundTerminal, 0, len(records)+len(snapshots))
+	for _, snapshot := range snapshots {
+		ledgerID := terminalOwnershipID(s.terminalWorkspaceKey, snapshot)
+		seen[ledgerID] = struct{}{}
+		terminal := operationalBackgroundTerminal(s.process.Root(), &snapshot)
+		if _, ok := recordByID[ledgerID]; ok {
+			terminal.ID = ledgerID
+			terminal.TerminalID = ledgerID
+			terminal.ProcessID = ledgerID
+		}
+		terminals = append(terminals, terminal)
+	}
+	for _, record := range records {
+		if _, live := seen[record.ID]; live {
+			continue
+		}
+		terminals = append(terminals, terminalOwnershipTerminal(record))
+	}
+	sort.Slice(terminals, func(i, j int) bool {
+		if terminals[i].StartedAt.Equal(terminals[j].StartedAt) {
+			return terminals[i].ID < terminals[j].ID
+		}
+		return terminals[i].StartedAt.After(terminals[j].StartedAt)
+	})
+	return terminals, nil
+}
+
+func (s *Server) resolveBackgroundTerminalID(ctx context.Context, id string) (string, *store.TerminalOwnershipRecord, error) {
+	id = strings.TrimSpace(id)
+	if s == nil || s.terminalOwnership == nil || id == "" {
+		return id, nil, nil
+	}
+	records, err := s.terminalOwnership.ListTerminalOwnership(ctx, s.terminalWorkspaceKey)
+	if err != nil {
+		return "", nil, err
+	}
+	for _, record := range records {
+		if record.ID == id {
+			return record.ProcessID, record, nil
+		}
+	}
+	return id, nil, nil
+}
+
+func operationalBackgroundTerminalWithOwnership(root string, snapshot *toolprocess.Snapshot, record *store.TerminalOwnershipRecord) protocol.BackgroundTerminal {
+	terminal := operationalBackgroundTerminal(root, snapshot)
+	if record == nil {
+		return terminal
+	}
+	terminal.ID = record.ID
+	terminal.TerminalID = record.ID
+	terminal.ProcessID = record.ID
+	return terminal
+}
+
+func ownerLostTerminalUnavailable(method string) *protocol.Error {
+	return protocol.MethodUnavailableErrorWithReason(
+		method,
+		"background terminal is unavailable because its execution owner exited",
+	)
+}

--- a/appserver/terminal_ownership_test.go
+++ b/appserver/terminal_ownership_test.go
@@ -1,0 +1,143 @@
+package appserver
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/fugue-labs/gollem/appserver/protocol"
+	"github.com/fugue-labs/gollem/appserver/store"
+	toolprocess "github.com/fugue-labs/gollem/appserver/tools/process"
+)
+
+func TestBackgroundTerminalOwnerLostAfterProcessServiceRestart(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	dbPath := filepath.Join(t.TempDir(), "threads.db")
+	st, err := store.NewSQLiteStore(dbPath)
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	firstProcess, err := toolprocess.NewService(root)
+	if err != nil {
+		t.Fatalf("NewService first: %v", err)
+	}
+	_ = readyServer(WithStore(st), WithProcess(firstProcess))
+	first, err := firstProcess.Start(ctx, toolprocess.StartRequest{
+		ID:      "reused-process-id",
+		Command: "sh",
+		Args:    []string{"-c", "sleep 30 # super-secret-terminal-argument"},
+	})
+	if err != nil {
+		t.Fatalf("Start first: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = firstProcess.Kill(context.Background(), first.ID)
+		_, _ = firstProcess.Wait(context.Background(), first.ID)
+	})
+	if err := st.Close(); err != nil {
+		t.Fatalf("Close first store: %v", err)
+	}
+	st, err = store.NewSQLiteStore(dbPath)
+	if err != nil {
+		t.Fatalf("reopen store: %v", err)
+	}
+
+	restartedProcess, err := toolprocess.NewService(root)
+	if err != nil {
+		t.Fatalf("NewService restarted: %v", err)
+	}
+	restartedServer := readyServer(WithStore(st), WithProcess(restartedProcess))
+
+	listResponse := restartedServer.HandleRequest(ctx, request("thread/backgroundTerminals/list", nil))
+	if listResponse.Error != nil {
+		t.Fatalf("owner-lost list error: %v", listResponse.Error)
+	}
+	if strings.Contains(string(listResponse.Result), "super-secret-terminal-argument") {
+		t.Fatalf("owner-lost list leaked process arguments: %s", listResponse.Result)
+	}
+	var list protocol.BackgroundTerminalListResponse
+	decodeResult(t, listResponse, &list)
+	if len(list.Terminals) != 1 {
+		t.Fatalf("owner-lost terminals = %#v", list.Terminals)
+	}
+	lost := list.Terminals[0]
+	if lost.Status != protocol.BackgroundTerminalStatusOwnerLost || lost.OwnerLostAt == nil ||
+		lost.PID != 0 || lost.ID == first.ID || lost.ProcessID != lost.ID {
+		t.Fatalf("owner-lost terminal = %#v", lost)
+	}
+
+	for method, params := range map[string]any{
+		"thread/backgroundTerminals/read":      map[string]any{"id": lost.ID},
+		"thread/backgroundTerminals/write":     map[string]any{"id": lost.ID, "input": "echo should-not-run\n"},
+		"thread/backgroundTerminals/resize":    map[string]any{"id": lost.ID, "size": map[string]any{"rows": 24, "cols": 80}},
+		"thread/backgroundTerminals/terminate": map[string]any{"id": lost.ID},
+	} {
+		response := restartedServer.HandleRequest(ctx, request(method, params))
+		if response.Error == nil || response.Error.Code != protocol.CodeMethodUnavailable ||
+			!strings.Contains(string(response.Error.Data), "owner exited") {
+			t.Fatalf("%s owner-lost response = %#v", method, response)
+		}
+	}
+
+	// A new service may reuse the old process ID. Its durable terminal identity
+	// must still be distinct so controls cannot target the owner-lost record.
+	current, err := restartedProcess.Start(ctx, toolprocess.StartRequest{
+		ID:      first.ID,
+		Command: "sh",
+		Args:    []string{"-c", "sleep 30"},
+	})
+	if err != nil {
+		t.Fatalf("Start current: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = restartedProcess.Kill(context.Background(), current.ID)
+		_, _ = restartedProcess.Wait(context.Background(), current.ID)
+	})
+
+	listResponse = restartedServer.HandleRequest(ctx, request("thread/backgroundTerminals/list", nil))
+	if listResponse.Error != nil {
+		t.Fatalf("mixed terminal list error: %v", listResponse.Error)
+	}
+	decodeResult(t, listResponse, &list)
+	if len(list.Terminals) != 2 {
+		t.Fatalf("mixed terminals = %#v", list.Terminals)
+	}
+	var currentTerminal protocol.BackgroundTerminal
+	for _, terminal := range list.Terminals {
+		if terminal.Status == protocol.BackgroundTerminalStatusRunning {
+			currentTerminal = terminal
+		}
+	}
+	if currentTerminal.ID == "" || currentTerminal.ID == lost.ID || currentTerminal.PID == 0 {
+		t.Fatalf("current terminal identity = %#v", currentTerminal)
+	}
+	terminateResponse := restartedServer.HandleRequest(ctx, request("thread/backgroundTerminals/terminate", map[string]any{"id": currentTerminal.ID}))
+	if terminateResponse.Error != nil {
+		t.Fatalf("terminate current terminal: %v", terminateResponse.Error)
+	}
+
+	cleanResponse := restartedServer.HandleRequest(ctx, request("thread/backgroundTerminals/clean", nil))
+	if cleanResponse.Error != nil {
+		t.Fatalf("clean terminal ledger: %v", cleanResponse.Error)
+	}
+	deadline := time.Now().Add(time.Second)
+	for {
+		response := restartedServer.HandleRequest(ctx, request("thread/backgroundTerminals/list", nil))
+		if response.Error != nil {
+			t.Fatalf("list after clean: %v", response.Error)
+		}
+		decodeResult(t, response, &list)
+		if len(list.Terminals) == 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("terminal ledger remained after clean: %#v", list.Terminals)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/appserver/tools/process/service.go
+++ b/appserver/tools/process/service.go
@@ -107,6 +107,11 @@ type AuditSink func(AuditEvent)
 type OutputSink func(OutputEvent)
 type ExitSink func(ExitEvent)
 
+// LifecycleSink receives the bounded process snapshot immediately after a
+// successful start and after terminal completion. Sinks must not retain raw
+// output unless their caller has an explicit retention policy.
+type LifecycleSink func(Snapshot)
+
 type Option func(*Service)
 
 func WithApproval(fn ApprovalFunc) Option {
@@ -160,6 +165,8 @@ type Service struct {
 	audit              AuditSink
 	output             OutputSink
 	exit               ExitSink
+	lifecycle          map[uint64]LifecycleSink
+	lifecycleCounter   uint64
 }
 
 type StartRequest struct {
@@ -256,6 +263,7 @@ func NewService(root string, opts ...Option) (*Service, error) {
 	s := &Service{
 		fs:                 fsSvc,
 		processes:          make(map[string]*managedProcess),
+		lifecycle:          make(map[uint64]LifecycleSink),
 		maxProcesses:       defaultMaxProcesses,
 		defaultOutputBytes: defaultOutputBytes,
 	}
@@ -263,6 +271,24 @@ func NewService(root string, opts ...Option) (*Service, error) {
 		opt(s)
 	}
 	return s, nil
+}
+
+// AddLifecycleSink observes future process starts and exits. The returned
+// function is idempotent and stops future callbacks for this observer.
+func (s *Service) AddLifecycleSink(sink LifecycleSink) func() {
+	if s == nil || sink == nil {
+		return func() {}
+	}
+	s.mu.Lock()
+	s.lifecycleCounter++
+	id := s.lifecycleCounter
+	s.lifecycle[id] = sink
+	s.mu.Unlock()
+	return func() {
+		s.mu.Lock()
+		delete(s.lifecycle, id)
+		s.mu.Unlock()
+	}
 }
 
 func (s *Service) Root() string {
@@ -389,6 +415,7 @@ func (s *Service) Start(ctx context.Context, req StartRequest) (*Snapshot, error
 	proc.setPID(cmd.Process.Pid)
 	s.processes[proc.id] = proc
 	s.mu.Unlock()
+	s.emitLifecycle(proc)
 
 	if proc.isPTY() {
 		go func(terminal *os.File, writer io.Writer, done chan struct{}) {
@@ -402,6 +429,7 @@ func (s *Service) Start(ctx context.Context, req StartRequest) (*Snapshot, error
 		proc.closePTY()
 		proc.finish(waitErr)
 		s.emitExit(proc)
+		s.emitLifecycle(proc)
 		close(proc.done)
 	}()
 	if req.Timeout > 0 {
@@ -744,6 +772,25 @@ func (s *Service) emitExit(proc *managedProcess) {
 	}
 	if proc.exit != nil {
 		proc.exit(event)
+	}
+}
+
+func (s *Service) emitLifecycle(proc *managedProcess) {
+	if s == nil || proc == nil {
+		return
+	}
+	s.mu.Lock()
+	sinks := make([]LifecycleSink, 0, len(s.lifecycle))
+	for _, sink := range s.lifecycle {
+		sinks = append(sinks, sink)
+	}
+	s.mu.Unlock()
+	if len(sinks) == 0 {
+		return
+	}
+	snapshot := proc.snapshot()
+	for _, sink := range sinks {
+		sink(snapshot)
 	}
 }
 


### PR DESCRIPTION
## Summary
- persist redacted terminal lifecycle records in SQLite using opaque per-launch terminal identities
- mark prior running records `owner_lost` on app-server restart without reattaching processes or retaining output
- expose the exact protocol status/timestamp and reject read, write, resize, and terminate for owner-lost terminals

## Verification
- `go test -race -count=20 ./appserver -run "^TestBackgroundTerminalOwnerLostAfterProcessServiceRestart$"`
- `go test ./appserver/store ./appserver/protocol ./appserver`
- `go vet ./...`
- `go build ./...`
- `make lint`
- `make test` (Monty excluded by repository target)