### PR TITLE
fix(runtime): validate model thinking settings

### DIFF
--- a/appserver/catalog/catalog.go
+++ b/appserver/catalog/catalog.go
@@ -444,11 +444,11 @@ func (c *Catalog) defaultProviders() []Provider {
 				ManualThinking:     true,
 			},
 			Models: []Model{
-				model(ProviderAnthropic, anthropicprovider.ClaudeSonnet46, "Claude Sonnet 4.6", "Anthropic balanced coding and agentic workflow model.", false, textAndImage(), false, capabilities(true, true, true, true, true, true, true), []string{"low", "medium", "high", "max"}, "medium"),
-				model(ProviderAnthropic, anthropicprovider.ClaudeOpus46, "Claude Opus 4.6", "Anthropic high-capability reasoning model.", false, textAndImage(), false, capabilities(true, true, true, true, true, true, true), []string{"low", "medium", "high", "max"}, "medium"),
-				model(ProviderAnthropic, anthropicprovider.ClaudeOpus47, "Claude Opus 4.7", "Anthropic flagship adaptive-thinking model.", false, textAndImage(), false, capabilities(true, true, true, true, true, true, true), []string{"low", "medium", "high", "xhigh", "max"}, "high"),
-				model(ProviderAnthropic, anthropicprovider.ClaudeOpus48, "Claude Opus 4.8", "Anthropic flagship adaptive-thinking model.", false, textAndImage(), false, capabilities(true, true, true, true, true, true, true), []string{"low", "medium", "high", "xhigh", "max"}, "high"),
-				model(ProviderAnthropic, anthropicprovider.ClaudeFable5, "Claude Fable 5", "Anthropic Fable tier model for high-end reasoning workflows.", true, textAndImage(), false, capabilities(true, true, true, true, true, true, true), []string{"low", "medium", "high", "xhigh", "max"}, "high"),
+				model(ProviderAnthropic, anthropicprovider.ClaudeSonnet46, "Claude Sonnet 4.6", "Anthropic balanced coding and agentic workflow model.", false, textAndImage(), false, thinkingCapabilities(capabilities(true, true, true, true, true, true, true), true, true), []string{"low", "medium", "high", "max"}, "medium"),
+				model(ProviderAnthropic, anthropicprovider.ClaudeOpus46, "Claude Opus 4.6", "Anthropic high-capability reasoning model.", false, textAndImage(), false, thinkingCapabilities(capabilities(true, true, true, true, true, true, true), true, true), []string{"low", "medium", "high", "max"}, "medium"),
+				model(ProviderAnthropic, anthropicprovider.ClaudeOpus47, "Claude Opus 4.7", "Anthropic flagship adaptive-thinking model.", false, textAndImage(), false, thinkingCapabilities(capabilities(true, true, true, true, true, true, true), true, false), []string{"low", "medium", "high", "xhigh", "max"}, "high"),
+				model(ProviderAnthropic, anthropicprovider.ClaudeOpus48, "Claude Opus 4.8", "Anthropic flagship adaptive-thinking model.", false, textAndImage(), false, thinkingCapabilities(capabilities(true, true, true, true, true, true, true), true, false), []string{"low", "medium", "high", "xhigh", "max"}, "high"),
+				model(ProviderAnthropic, anthropicprovider.ClaudeFable5, "Claude Fable 5", "Anthropic Fable tier model for high-end reasoning workflows.", true, textAndImage(), false, thinkingCapabilities(capabilities(true, true, true, true, true, true, true), true, false), []string{"low", "medium", "high", "xhigh", "max"}, "high"),
 				model(ProviderAnthropic, anthropicprovider.ClaudeHaiku45, "Claude Haiku 4.5", "Anthropic lower-latency utility model.", false, textAndImage(), false, capabilities(true, true, true, true, true, false, false), []string{"low", "medium", "high"}, "medium"),
 			},
 		},
@@ -502,9 +502,9 @@ func (c *Catalog) defaultProviders() []Provider {
 				ManualThinking:     true,
 			},
 			Models: []Model{
-				model(ProviderVertexAIAnthropic, vertexanthropicprovider.ClaudeSonnet46, "Claude Sonnet 4.6 on Vertex AI", "Anthropic Sonnet through Vertex AI.", true, textAndImage(), false, capabilities(true, true, true, true, true, true, false), []string{"low", "medium", "high", "max"}, "medium"),
-				model(ProviderVertexAIAnthropic, vertexanthropicprovider.ClaudeOpus46, "Claude Opus 4.6 on Vertex AI", "Anthropic Opus through Vertex AI.", true, textAndImage(), false, capabilities(true, true, true, true, true, true, false), []string{"low", "medium", "high", "max"}, "medium"),
-				model(ProviderVertexAIAnthropic, vertexanthropicprovider.ClaudeOpus47, "Claude Opus 4.7 on Vertex AI", "Anthropic Opus through Vertex AI.", true, textAndImage(), false, capabilities(true, true, true, true, true, true, false), []string{"low", "medium", "high", "xhigh", "max"}, "high"),
+				model(ProviderVertexAIAnthropic, vertexanthropicprovider.ClaudeSonnet46, "Claude Sonnet 4.6 on Vertex AI", "Anthropic Sonnet through Vertex AI.", true, textAndImage(), false, thinkingCapabilities(capabilities(true, true, true, true, true, true, false), true, true), []string{"low", "medium", "high", "max"}, "medium"),
+				model(ProviderVertexAIAnthropic, vertexanthropicprovider.ClaudeOpus46, "Claude Opus 4.6 on Vertex AI", "Anthropic Opus through Vertex AI.", true, textAndImage(), false, thinkingCapabilities(capabilities(true, true, true, true, true, true, false), true, true), []string{"low", "medium", "high", "max"}, "medium"),
+				model(ProviderVertexAIAnthropic, vertexanthropicprovider.ClaudeOpus47, "Claude Opus 4.7 on Vertex AI", "Anthropic Opus through Vertex AI.", true, textAndImage(), false, thinkingCapabilities(capabilities(true, true, true, true, true, true, false), true, false), []string{"low", "medium", "high", "xhigh", "max"}, "high"),
 				model(ProviderVertexAIAnthropic, vertexanthropicprovider.ClaudeHaiku45, "Claude Haiku 4.5 on Vertex AI", "Anthropic Haiku through Vertex AI.", true, textAndImage(), false, capabilities(true, true, true, true, true, false, false), []string{"low", "medium", "high"}, "medium"),
 			},
 		},
@@ -604,6 +604,12 @@ func capabilities(toolCalls, structured, vision, streaming, promptCache, reasoni
 		Reasoning:        reasoning,
 		ToolSearch:       toolSearch,
 	}
+}
+
+func thinkingCapabilities(caps ModelCapabilities, adaptive, manual bool) ModelCapabilities {
+	caps.AdaptiveThinking = adaptive
+	caps.ManualThinking = manual
+	return caps
 }
 
 func effortOptions(efforts []string) []ReasoningEffortOption {

--- a/appserver/catalog/catalog_test.go
+++ b/appserver/catalog/catalog_test.go
@@ -122,6 +122,37 @@ func TestProviderCapabilities(t *testing.T) {
 	}
 }
 
+func TestThinkingCapabilitiesAreModelSpecific(t *testing.T) {
+	c := NewDefault(WithEnvLookup(mapEnv(nil)))
+	cases := []struct {
+		provider string
+		model    string
+		adaptive bool
+		manual   bool
+	}{
+		{ProviderAnthropic, "claude-sonnet-4-6", true, true},
+		{ProviderAnthropic, "claude-opus-4-7", true, false},
+		{ProviderAnthropic, "claude-haiku-4-5-20251001", false, false},
+		{ProviderVertexAIAnthropic, "claude-sonnet-4-6", true, true},
+		{ProviderVertexAIAnthropic, "claude-opus-4-7", true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.provider+"/"+tc.model, func(t *testing.T) {
+			provider := findProvider(t, c.providers, tc.provider)
+			for _, model := range provider.Models {
+				if model.Model != tc.model {
+					continue
+				}
+				if model.Capabilities.AdaptiveThinking != tc.adaptive || model.Capabilities.ManualThinking != tc.manual {
+					t.Fatalf("thinking capabilities = %#v, want adaptive=%t manual=%t", model.Capabilities, tc.adaptive, tc.manual)
+				}
+				return
+			}
+			t.Fatalf("model %q missing from provider %#v", tc.model, provider.Models)
+		})
+	}
+}
+
 func TestValidateAgentRuntimeSelection(t *testing.T) {
 	c := NewDefault(WithEnvLookup(mapEnv(map[string]string{
 		"OPENAI_API_KEY": "configured",

--- a/appserver/protocol/runtime_client_types.go
+++ b/appserver/protocol/runtime_client_types.go
@@ -51,6 +51,8 @@ type ModelCatalogCapabilities struct {
 	PromptCache      bool `json:"promptCache"`
 	ToolSearch       bool `json:"toolSearch"`
 	Reasoning        bool `json:"reasoning"`
+	AdaptiveThinking bool `json:"adaptiveThinking"`
+	ManualThinking   bool `json:"manualThinking"`
 }
 
 type ModelCatalogReasoningEffortOption struct {

--- a/appserver/protocol/runtime_client_types_contract_test.go
+++ b/appserver/protocol/runtime_client_types_contract_test.go
@@ -89,6 +89,28 @@ func TestRuntimeModelParamsExposePromptCacheSetting(t *testing.T) {
 	}
 }
 
+func TestModelCatalogCapabilitiesExposeThinkingModes(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	properties := defs["ModelCatalogCapabilities"].(Schema)["properties"].(Schema)
+	for _, name := range []string{"adaptiveThinking", "manualThinking"} {
+		if _, ok := properties[name]; !ok {
+			t.Fatalf("ModelCatalogCapabilities schema omitted %s", name)
+		}
+	}
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	for _, want := range []string{
+		`"adaptiveThinking": boolean;`,
+		`"manualThinking": boolean;`,
+	} {
+		if !strings.Contains(string(generated), want) {
+			t.Errorf("ModelCatalogCapabilities TypeScript missing %q", want)
+		}
+	}
+}
+
 func TestRuntimeClientSchemasAreClosedAndCredentialFree(t *testing.T) {
 	defs := JSONSchema()["$defs"].(Schema)
 	names := []string{

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -13199,6 +13199,12 @@
     "ModelCatalogCapabilities": {
       "additionalProperties": false,
       "properties": {
+        "adaptiveThinking": {
+          "type": "boolean"
+        },
+        "manualThinking": {
+          "type": "boolean"
+        },
         "promptCache": {
           "type": "boolean"
         },
@@ -13228,7 +13234,9 @@
         "streaming",
         "promptCache",
         "toolSearch",
-        "reasoning"
+        "reasoning",
+        "adaptiveThinking",
+        "manualThinking"
       ],
       "type": "object"
     },

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -2764,6 +2764,8 @@ export type ModelCatalogAvailabilityNux = {
 };
 
 export type ModelCatalogCapabilities = {
+  "adaptiveThinking": boolean;
+  "manualThinking": boolean;
   "promptCache": boolean;
   "reasoning": boolean;
   "streaming": boolean;

--- a/appserver/runtime.go
+++ b/appserver/runtime.go
@@ -644,6 +644,8 @@ type runtimeTurnInput struct {
 	Provider           string         `json:"provider,omitempty"`
 	Model              string         `json:"model,omitempty"`
 	ReasoningEffort    string         `json:"reasoningEffort,omitempty"`
+	ThinkingBudget     *int           `json:"thinkingBudget,omitempty"`
+	AdaptiveThinking   *bool          `json:"adaptiveThinking,omitempty"`
 	PromptCacheEnabled *bool          `json:"promptCacheEnabled,omitempty"`
 	Metadata           map[string]any `json:"metadata,omitempty"`
 	SubmittedAt        time.Time      `json:"submittedAt"`
@@ -661,6 +663,8 @@ func runtimeTurnInputJSON(
 		Provider:           selection.Provider,
 		Model:              selection.Model,
 		ReasoningEffort:    runtimeReasoningEffort(settings),
+		ThinkingBudget:     runtimeThinkingBudget(settings),
+		AdaptiveThinking:   cloneBool(settings.AdaptiveThinking),
 		PromptCacheEnabled: runtimePromptCacheEnabled(settings),
 		Metadata:           cloneRuntimeMap(metadata),
 		SubmittedAt:        time.Now().UTC(),
@@ -680,6 +684,10 @@ func runtimeReasoningEffort(settings core.ModelSettings) string {
 
 func runtimePromptCacheEnabled(settings core.ModelSettings) *bool {
 	return cloneBool(settings.PromptCacheEnabled)
+}
+
+func runtimeThinkingBudget(settings core.ModelSettings) *int {
+	return cloneInt(settings.ThinkingBudget)
 }
 
 type runtimeResultPayload struct {

--- a/appserver/runtime_params.go
+++ b/appserver/runtime_params.go
@@ -139,7 +139,11 @@ func runtimeModelSettingsFromInput(input json.RawMessage) core.ModelSettings {
 	if len(input) == 0 || json.Unmarshal(input, &stored) != nil {
 		return core.ModelSettings{}
 	}
-	settings := core.ModelSettings{PromptCacheEnabled: cloneBool(stored.PromptCacheEnabled)}
+	settings := core.ModelSettings{
+		ThinkingBudget:     cloneInt(stored.ThinkingBudget),
+		AdaptiveThinking:   cloneBool(stored.AdaptiveThinking),
+		PromptCacheEnabled: cloneBool(stored.PromptCacheEnabled),
+	}
 	if effort := strings.TrimSpace(stored.ReasoningEffort); effort != "" {
 		settings.ReasoningEffort = &effort
 	}
@@ -147,6 +151,14 @@ func runtimeModelSettingsFromInput(input json.RawMessage) core.ModelSettings {
 }
 
 func cloneBool(value *bool) *bool {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}
+
+func cloneInt(value *int) *int {
 	if value == nil {
 		return nil
 	}
@@ -167,6 +179,12 @@ func runtimeModelSettingsWithThreadDefaults(
 }
 
 func mergeRuntimeModelSettings(primary, fallback core.ModelSettings) core.ModelSettings {
+	if primary.ThinkingBudget == nil {
+		primary.ThinkingBudget = cloneInt(fallback.ThinkingBudget)
+	}
+	if primary.AdaptiveThinking == nil {
+		primary.AdaptiveThinking = cloneBool(fallback.AdaptiveThinking)
+	}
 	if primary.ReasoningEffort == nil {
 		primary.ReasoningEffort = fallback.ReasoningEffort
 	}

--- a/appserver/runtime_reasoning.go
+++ b/appserver/runtime_reasoning.go
@@ -21,10 +21,55 @@ func validateRuntimeReasoningSelection(
 	if effort == "" {
 		return errors.New("reasoning effort must not be empty")
 	}
+	selected, err := selectedRuntimeCatalogModel(catalogService, selection)
+	if err != nil {
+		return err
+	}
+	if !selected.Capabilities.Reasoning {
+		return fmt.Errorf("model %q does not advertise reasoning", selected.ID)
+	}
+	for _, option := range selected.SupportedReasoningEfforts {
+		if strings.TrimSpace(option.ReasoningEffort) == effort {
+			return nil
+		}
+	}
+	return fmt.Errorf(
+		"model %q does not advertise reasoning effort %q",
+		selected.ID,
+		effort,
+	)
+}
+
+func validateRuntimeThinkingSelection(
+	catalogService *catalog.Catalog,
+	selection RuntimeModelSelection,
+	settings core.ModelSettings,
+) error {
+	adaptive := settings.AdaptiveThinking != nil && *settings.AdaptiveThinking
+	if settings.ThinkingBudget == nil && !adaptive {
+		return nil
+	}
+	if settings.ThinkingBudget != nil && adaptive {
+		return errors.New("thinking budget and adaptive thinking are mutually exclusive")
+	}
+	selected, err := selectedRuntimeCatalogModel(catalogService, selection)
+	if err != nil {
+		return err
+	}
+	if settings.ThinkingBudget != nil && !selected.Capabilities.ManualThinking {
+		return fmt.Errorf("model %q does not advertise manual thinking", selected.ID)
+	}
+	if adaptive && !selected.Capabilities.AdaptiveThinking {
+		return fmt.Errorf("model %q does not advertise adaptive thinking", selected.ID)
+	}
+	return nil
+}
+
+func selectedRuntimeCatalogModel(catalogService *catalog.Catalog, selection RuntimeModelSelection) (*catalog.Model, error) {
 	providerID := strings.TrimSpace(firstNonEmpty(selection.ProviderID, selection.Provider))
 	modelName := strings.TrimSpace(selection.Model)
 	if providerID == "" {
-		return fmt.Errorf("provider capability is unavailable for reasoning effort %q", effort)
+		return nil, errors.New("provider capability is unavailable")
 	}
 	includeHidden := true
 	response, err := catalogService.ListModels(catalog.ModelListParams{
@@ -32,7 +77,7 @@ func validateRuntimeReasoningSelection(
 		IncludeHidden: &includeHidden,
 	})
 	if err != nil {
-		return fmt.Errorf("read model capability: %w", err)
+		return nil, fmt.Errorf("read model capability: %w", err)
 	}
 	var selected *catalog.Model
 	for index := range response.Data {
@@ -50,19 +95,7 @@ func validateRuntimeReasoningSelection(
 		}
 	}
 	if selected == nil {
-		return fmt.Errorf("model capability is unavailable for %q", modelName)
+		return nil, fmt.Errorf("model capability is unavailable for %q", modelName)
 	}
-	if !selected.Capabilities.Reasoning {
-		return fmt.Errorf("model %q does not advertise reasoning", selected.ID)
-	}
-	for _, option := range selected.SupportedReasoningEfforts {
-		if strings.TrimSpace(option.ReasoningEffort) == effort {
-			return nil
-		}
-	}
-	return fmt.Errorf(
-		"model %q does not advertise reasoning effort %q",
-		selected.ID,
-		effort,
-	)
+	return selected, nil
 }

--- a/appserver/runtime_selection.go
+++ b/appserver/runtime_selection.go
@@ -8,5 +8,8 @@ func (s *Server) validateRuntimeSelection(selection RuntimeModelSelection, setti
 			return err
 		}
 	}
-	return validateRuntimeReasoningSelection(s.catalog, selection, settings)
+	if err := validateRuntimeReasoningSelection(s.catalog, selection, settings); err != nil {
+		return err
+	}
+	return validateRuntimeThinkingSelection(s.catalog, selection, settings)
 }

--- a/appserver/runtime_test.go
+++ b/appserver/runtime_test.go
@@ -309,6 +309,162 @@ func TestServerRuntimeReasoningEffortFailsClosedAgainstModelCatalog(t *testing.T
 	}
 }
 
+func TestServerRuntimeThinkingModesFailClosedAgainstModelCatalog(t *testing.T) {
+	on := true
+	budget := 2048
+	for _, tc := range []struct {
+		name       string
+		model      string
+		budget     *int
+		adaptive   *bool
+		wantReason string
+	}{
+		{
+			name:       "manual thinking unavailable on opus 4.7",
+			model:      "claude-opus-4-7",
+			budget:     &budget,
+			wantReason: "does not advertise manual thinking",
+		},
+		{
+			name:       "adaptive thinking unavailable on haiku",
+			model:      "claude-haiku-4-5-20251001",
+			adaptive:   &on,
+			wantReason: "does not advertise adaptive thinking",
+		},
+		{
+			name:       "manual and adaptive thinking conflict",
+			model:      "claude-sonnet-4-6",
+			budget:     &budget,
+			adaptive:   &on,
+			wantReason: "mutually exclusive",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			st := newRuntimeTestStore(t)
+			server := readyServer(
+				WithStore(st),
+				WithRuntimeService(NewRuntimeService(WithRuntimeModel(
+					core.NewTestModel(core.TextResponse("must not run")),
+					RuntimeModelInfo{ProviderID: "anthropic", Model: tc.model},
+				))),
+			)
+			params := map[string]any{
+				"workspace":  t.TempDir(),
+				"prompt":     "validate the selected thinking mode",
+				"providerId": "anthropic",
+				"model":      tc.model,
+			}
+			if tc.budget != nil {
+				params["thinkingBudget"] = *tc.budget
+			}
+			if tc.adaptive != nil {
+				params["adaptiveThinking"] = *tc.adaptive
+			}
+			response := server.HandleRequest(ctx, request("thread/start", params))
+			if response.Error == nil || response.Error.Code != protocol.CodeInvalidParams {
+				t.Fatalf("thread/start error = %#v, want invalid params", response.Error)
+			}
+			if !strings.Contains(response.Error.Message, tc.wantReason) {
+				t.Fatalf("thread/start error = %q, want %q", response.Error.Message, tc.wantReason)
+			}
+			threads, err := st.ListThreads(ctx, store.ThreadFilter{})
+			if err != nil {
+				t.Fatalf("ListThreads: %v", err)
+			}
+			if len(threads) != 0 {
+				t.Fatalf("invalid thinking mode created %d threads", len(threads))
+			}
+		})
+	}
+}
+
+func TestServerRuntimeRetryRetainsThinkingSettings(t *testing.T) {
+	on := true
+	budget := 2048
+	for _, tc := range []struct {
+		name     string
+		budget   *int
+		adaptive *bool
+	}{
+		{name: "manual", budget: &budget},
+		{name: "adaptive", adaptive: &on},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			st := newRuntimeTestStore(t)
+			model := core.NewTestModel(core.TextResponse("first"), core.TextResponse("retry"))
+			server := readyServer(
+				WithStore(st),
+				WithRuntimeService(NewRuntimeService(WithRuntimeModel(
+					model,
+					RuntimeModelInfo{ProviderID: "anthropic", Model: "claude-sonnet-4-6"},
+				))),
+			)
+			params := map[string]any{
+				"workspace":  t.TempDir(),
+				"prompt":     "persist the thinking selection",
+				"providerId": "anthropic",
+				"model":      "claude-sonnet-4-6",
+			}
+			if tc.budget != nil {
+				params["thinkingBudget"] = *tc.budget
+			}
+			if tc.adaptive != nil {
+				params["adaptiveThinking"] = *tc.adaptive
+			}
+			start := server.HandleRequest(ctx, request("thread/start", params))
+			if start.Error != nil {
+				t.Fatalf("thread/start error: %v", start.Error)
+			}
+			var started protocol.ThreadRunStartResult
+			decodeResult(t, start, &started)
+			waitForNotificationSet(t, server, "turn/completed")
+
+			retry := server.HandleRequest(ctx, request("turn/retry", map[string]any{"turnId": started.Turn.ID}))
+			if retry.Error != nil {
+				t.Fatalf("turn/retry error: %v", retry.Error)
+			}
+			var retried protocol.TurnRunRetryResult
+			decodeResult(t, retry, &retried)
+			waitForNotificationSet(t, server, "turn/completed")
+
+			persisted, err := st.GetTurn(ctx, retried.Turn.ID)
+			if err != nil {
+				t.Fatalf("GetTurn retry: %v", err)
+			}
+			var input runtimeTurnInput
+			if err := json.Unmarshal(persisted.Input, &input); err != nil {
+				t.Fatalf("decode retry input: %v", err)
+			}
+			if !sameIntPointer(input.ThinkingBudget, tc.budget) || !sameBoolPointer(input.AdaptiveThinking, tc.adaptive) {
+				t.Fatalf("retry input thinking settings = %#v, want budget=%#v adaptive=%#v", input, tc.budget, tc.adaptive)
+			}
+			calls := model.Calls()
+			if len(calls) != 2 {
+				t.Fatalf("model calls = %d, want 2", len(calls))
+			}
+			if calls[1].Settings == nil || !sameIntPointer(calls[1].Settings.ThinkingBudget, tc.budget) || !sameBoolPointer(calls[1].Settings.AdaptiveThinking, tc.adaptive) {
+				t.Fatalf("retry model settings = %#v, want budget=%#v adaptive=%#v", calls[1].Settings, tc.budget, tc.adaptive)
+			}
+		})
+	}
+}
+
+func sameIntPointer(got, want *int) bool {
+	if got == nil || want == nil {
+		return got == want
+	}
+	return *got == *want
+}
+
+func sameBoolPointer(got, want *bool) bool {
+	if got == nil || want == nil {
+		return got == want
+	}
+	return *got == *want
+}
+
 func TestServerRuntimeSelectionValidatorFailsClosedBeforeThreadCreation(t *testing.T) {
 	ctx := context.Background()
 	st := newRuntimeTestStore(t)

--- a/docs/PROVIDER_DRIVER_CONFORMANCE.md
+++ b/docs/PROVIDER_DRIVER_CONFORMANCE.md
@@ -28,7 +28,7 @@ of behavior and must not enable a control solely on provider identity.
 | Request deadline propagation | Proven | Proven | Proven | `provider/conformance` confirms initial-request and post-header streaming cancellation with `context.DeadlineExceeded` normalization |
 | Post-output retry / replay | Not yet proven | Not yet proven | Not yet proven | A stream may have produced caller-visible output; recovery must not replay it without an explicit safe-resume contract |
 | Endpoint health probe | Unsupported | Proven | Unsupported | `provider/health/probe` performs a loopback-only `GET /v1/models`; it returns only a typed status and never starts a model turn |
-| Capability mismatch | Catalog/daemon proven | Catalog/daemon proven | Catalog/daemon proven | `ValidateAgentRuntimeSelection` rejects unconfigured, unknown, cross-provider, and non-streaming/non-tool-capable selections before the daemon persists a thread or turn; Slang continues to render the same condition as unavailable |
+| Capability mismatch | Catalog/daemon proven | Catalog/daemon proven | Catalog/daemon proven | `ValidateAgentRuntimeSelection` rejects unconfigured, unknown, cross-provider, and non-streaming/non-tool-capable selections before the daemon persists a thread or turn; model-specific manual/adaptive thinking selection is likewise rejected before persistence, and Slang continues to render the same condition as unavailable |
 
 `core.ModelSettings.PromptCacheEnabled` is optional: `nil` preserves the
 provider default, `true` requests its configured native cache control, and


### PR DESCRIPTION
## Summary
- expose adaptive and manual thinking support on each catalog model
- reject incompatible thinking modes before a thread or turn is persisted
- preserve thinking budget and adaptive-thinking selection through retry
- regenerate the schema and TypeScript protocol binding

## Verification
- go test -race ./appserver ./appserver/catalog ./appserver/protocol -count=10
- go test ./provider/anthropic ./provider/vertexai_anthropic
- go test -race ./ext/codetool -run "^TestStartServerReapsProcessOnInitializeFailure$" -count=20
- make lint
- go vet ./appserver/... ./provider/anthropic ./provider/vertexai_anthropic
- make test (Monty excluded by repository configuration; passed on retry after one unrelated LSP fixture timing failure)
- pre-push: lint, non-Monty race suite, vet, tidy check