### PR TITLE
test(provider): prove Vertex catalog capabilities

### DIFF
--- a/docs/PROVIDER_DRIVER_CONFORMANCE.md
+++ b/docs/PROVIDER_DRIVER_CONFORMANCE.md
@@ -36,6 +36,19 @@ provider default, `true` requests its configured native cache control, and
 cache entries, guarantee a cache hit, disable opaque provider-side automatic
 caching, or authorize a local response replay.
 
+## Vertex Catalog Profiles
+
+The hidden Vertex profiles remain catalog-visible through the app-server API,
+so their advertised capabilities require the same deterministic evidence as
+the visible providers. Their package-local fixtures use static test tokens and
+an in-process HTTP server; they do not create Google credentials or contact a
+remote endpoint.
+
+| Profile | Catalog-supported behavior | Evidence |
+| --- | --- | --- |
+| Vertex AI Gemini | Function tools, native structured output, inline image input, streaming, terminal usage, and configured cached-content attachment | `provider/vertexai` calls `provider/conformance.Verify`; the fixture asserts Gemini function declarations, `inlineData`, cached-content on normal and streaming requests, and normalized responses |
+| Vertex AI Anthropic | Function tools, schema-backed `final_result` output, base64 image input, streaming, terminal usage, prompt-cache activation, and reasoning visibility | `provider/vertexai_anthropic` calls `provider/conformance.Verify`; the fixture asserts Messages-tool/cache/image wire forms plus normalized `ThinkingPart` start, delta, and final retention |
+
 `Catalog-supported` means the catalog may expose the capability only for the
 listed provider/model profile. It does not make that behavior part of the common
 driver contract until a deterministic conformance scenario covers it.

--- a/provider/vertexai/conformance_test.go
+++ b/provider/vertexai/conformance_test.go
@@ -1,0 +1,185 @@
+package vertexai
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/fugue-labs/gollem/provider/conformance"
+)
+
+func TestCatalogCapabilityConformance(t *testing.T) {
+	fixture := &geminiConformanceFixture{t: t}
+	server := httptest.NewServer(http.HandlerFunc(fixture.serveHTTP))
+	defer server.Close()
+
+	model := New(
+		WithProject("conformance-project"),
+		WithLocation("us-central1"),
+		WithModel(Gemini25Flash),
+		WithCachedContent("projects/conformance/locations/us-central1/cachedContents/catalog-proof"),
+	)
+	model.tokenSource = &staticTokenSource{token: "conformance-token"}
+	model.httpClient = &http.Client{Transport: &rewriteTransport{
+		base:      server.Client().Transport,
+		targetURL: server.URL,
+	}}
+
+	err := conformance.Verify(t.Context(), conformance.Driver{
+		Name:                  "Vertex AI Gemini",
+		Model:                 model,
+		Claims:                conformance.Claims{ToolCalls: true, StructuredOutput: true, Vision: true, PromptCacheActivation: true, Streaming: true, Usage: true},
+		PromptCacheActivation: fixture.verify,
+		Expectations: conformance.Expectations{
+			ResponseText:          "vertex gemini response",
+			ToolName:              "conformance_echo",
+			ToolCallID:            "call_0",
+			ToolArgumentsJSON:     `{"value":"ok"}`,
+			StructuredOutputValue: "vertex gemini structured",
+			VisionText:            "vertex gemini vision",
+			StreamText:            "vertex gemini stream",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+type geminiConformanceFixture struct {
+	t *testing.T
+
+	mu                 sync.Mutex
+	cachedRequestCount int
+	toolRequestCount   int
+	visionRequestCount int
+}
+
+func (f *geminiConformanceFixture) serveHTTP(w http.ResponseWriter, r *http.Request) {
+	if got := r.Header.Get("Authorization"); got != "Bearer conformance-token" {
+		f.t.Errorf("Authorization = %q, want conformance bearer token", got)
+	}
+
+	var request map[string]any
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		f.t.Errorf("decode Gemini conformance request: %v", err)
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	if request["cachedContent"] == "projects/conformance/locations/us-central1/cachedContents/catalog-proof" {
+		f.mu.Lock()
+		f.cachedRequestCount++
+		f.mu.Unlock()
+	}
+
+	prompt := geminiConformancePrompt(request)
+	if strings.HasSuffix(r.URL.Path, ":streamGenerateContent") {
+		f.writeStream(w)
+		return
+	}
+
+	switch {
+	case strings.Contains(prompt, "structured output conformance"):
+		f.writeResponse(w, "{\"value\":\"vertex gemini structured\"}", nil)
+	case strings.Contains(prompt, "vision conformance"):
+		if !geminiConformanceHasInlineImage(request) {
+			f.t.Error("Gemini vision request omitted inlineData image input")
+		}
+		f.mu.Lock()
+		f.visionRequestCount++
+		f.mu.Unlock()
+		f.writeResponse(w, "vertex gemini vision", nil)
+	default:
+		if !geminiConformanceHasFunction(request, "conformance_echo") {
+			f.t.Error("Gemini tool request omitted conformance_echo function declaration")
+		}
+		f.mu.Lock()
+		f.toolRequestCount++
+		f.mu.Unlock()
+		f.writeResponse(w, "vertex gemini response", map[string]any{"name": "conformance_echo", "args": map[string]any{"value": "ok"}})
+	}
+}
+
+func (f *geminiConformanceFixture) writeResponse(w http.ResponseWriter, text string, functionCall map[string]any) {
+	parts := []any{map[string]any{"text": text}}
+	if functionCall != nil {
+		parts = append(parts, map[string]any{"functionCall": functionCall})
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"candidates": []any{map[string]any{
+			"content":      map[string]any{"role": "model", "parts": parts},
+			"finishReason": "STOP",
+		}},
+		"usageMetadata": map[string]any{"promptTokenCount": 3, "candidatesTokenCount": 2},
+	})
+}
+
+func (f *geminiConformanceFixture) writeStream(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	_, _ = fmt.Fprint(w, "data: {\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[{\"text\":\"vertex gemini stream\"}]},\"finishReason\":\"STOP\"}],\"usageMetadata\":{\"promptTokenCount\":3,\"candidatesTokenCount\":2}}\n\n")
+}
+
+func (f *geminiConformanceFixture) verify() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.cachedRequestCount < 2 {
+		return fmt.Errorf("cached content appeared on %d requests, want normal and streaming requests", f.cachedRequestCount)
+	}
+	if f.toolRequestCount == 0 {
+		return fmt.Errorf("fixture did not observe the declared function tool")
+	}
+	if f.visionRequestCount == 0 {
+		return fmt.Errorf("fixture did not observe the image request")
+	}
+	return nil
+}
+
+func geminiConformancePrompt(request map[string]any) string {
+	contents, _ := request["contents"].([]any)
+	var text strings.Builder
+	for _, rawContent := range contents {
+		content, _ := rawContent.(map[string]any)
+		parts, _ := content["parts"].([]any)
+		for _, rawPart := range parts {
+			part, _ := rawPart.(map[string]any)
+			if value, _ := part["text"].(string); value != "" {
+				text.WriteString(value)
+			}
+		}
+	}
+	return text.String()
+}
+
+func geminiConformanceHasFunction(request map[string]any, name string) bool {
+	tools, _ := request["tools"].([]any)
+	for _, rawTool := range tools {
+		tool, _ := rawTool.(map[string]any)
+		functions, _ := tool["functionDeclarations"].([]any)
+		for _, rawFunction := range functions {
+			function, _ := rawFunction.(map[string]any)
+			if function["name"] == name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func geminiConformanceHasInlineImage(request map[string]any) bool {
+	contents, _ := request["contents"].([]any)
+	for _, rawContent := range contents {
+		content, _ := rawContent.(map[string]any)
+		parts, _ := content["parts"].([]any)
+		for _, rawPart := range parts {
+			part, _ := rawPart.(map[string]any)
+			if _, ok := part["inlineData"].(map[string]any); ok {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/provider/vertexai_anthropic/conformance_test.go
+++ b/provider/vertexai_anthropic/conformance_test.go
@@ -1,0 +1,225 @@
+package vertexai_anthropic
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/fugue-labs/gollem/provider/conformance"
+)
+
+func TestCatalogCapabilityConformance(t *testing.T) {
+	fixture := &vertexAnthropicConformanceFixture{t: t}
+	server := httptest.NewServer(http.HandlerFunc(fixture.serveHTTP))
+	defer server.Close()
+
+	model := New(
+		WithProject("conformance-project"),
+		WithLocation("us-east5"),
+		WithModel(ClaudeSonnet46),
+		WithPromptCaching(true),
+	)
+	model.tokenSource = &staticTokenSource{token: "conformance-token"}
+	model.httpClient = &http.Client{Transport: &rewriteTransport{
+		base:      server.Client().Transport,
+		targetURL: server.URL,
+	}}
+
+	err := conformance.Verify(t.Context(), conformance.Driver{
+		Name:                  "Vertex AI Anthropic",
+		Model:                 model,
+		ReasoningModel:        model,
+		Claims:                conformance.Claims{ToolCalls: true, StructuredOutput: true, Vision: true, PromptCacheActivation: true, Streaming: true, Usage: true, ReasoningVisibility: true},
+		PromptCacheActivation: fixture.verify,
+		Expectations: conformance.Expectations{
+			ResponseText:          "vertex anthropic response",
+			ToolName:              "conformance_echo",
+			ToolCallID:            "call_vertex_anthropic",
+			ToolArgumentsJSON:     `{"value":"ok"}`,
+			StructuredOutputValue: "vertex anthropic structured",
+			VisionText:            "vertex anthropic vision",
+			StreamText:            "vertex anthropic stream",
+			ReasoningText:         "vertex anthropic reasoning",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+type vertexAnthropicConformanceFixture struct {
+	t *testing.T
+
+	mu                 sync.Mutex
+	cachedRequestCount int
+	toolRequestCount   int
+	visionRequestCount int
+}
+
+func (f *vertexAnthropicConformanceFixture) serveHTTP(w http.ResponseWriter, r *http.Request) {
+	if got := r.Header.Get("Authorization"); got != "Bearer conformance-token" {
+		f.t.Errorf("Authorization = %q, want conformance bearer token", got)
+	}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		f.t.Errorf("read Vertex Anthropic conformance request: %v", err)
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	var request map[string]any
+	if err := json.Unmarshal(body, &request); err != nil {
+		f.t.Errorf("decode Vertex Anthropic conformance request: %v", err)
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	if cacheControl, _ := request["cache_control"].(map[string]any); cacheControl["type"] == "ephemeral" {
+		f.mu.Lock()
+		f.cachedRequestCount++
+		f.mu.Unlock()
+	}
+
+	payload := string(body)
+	if strings.HasSuffix(r.URL.Path, ":streamRawPredict") {
+		if strings.Contains(payload, "reasoning conformance") {
+			f.writeReasoningStream(w)
+			return
+		}
+		f.writeStream(w)
+		return
+	}
+
+	switch {
+	case strings.Contains(payload, "structured output conformance"):
+		if !vertexAnthropicHasTool(request, "final_result") {
+			f.t.Error("Vertex Anthropic structured-output request omitted final_result tool")
+		}
+		f.writeResponse(w, []any{map[string]any{
+			"type": "tool_use", "id": "call_vertex_structured", "name": "final_result",
+			"input": map[string]any{"value": "vertex anthropic structured"},
+		}}, "tool_use")
+	case strings.Contains(payload, "vision conformance"):
+		if !vertexAnthropicHasImage(request) {
+			f.t.Error("Vertex Anthropic vision request omitted a base64 image block")
+		}
+		f.mu.Lock()
+		f.visionRequestCount++
+		f.mu.Unlock()
+		f.writeResponse(w, []any{map[string]any{"type": "text", "text": "vertex anthropic vision"}}, "end_turn")
+	default:
+		if !vertexAnthropicHasTool(request, "conformance_echo") {
+			f.t.Error("Vertex Anthropic tool request omitted conformance_echo")
+		}
+		f.mu.Lock()
+		f.toolRequestCount++
+		f.mu.Unlock()
+		f.writeResponse(w, []any{
+			map[string]any{"type": "text", "text": "vertex anthropic response"},
+			map[string]any{
+				"type": "tool_use", "id": "call_vertex_anthropic", "name": "conformance_echo",
+				"input": map[string]any{"value": "ok"},
+			},
+		}, "tool_use")
+	}
+}
+
+func (f *vertexAnthropicConformanceFixture) writeResponse(w http.ResponseWriter, content []any, stopReason string) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"content":     content,
+		"stop_reason": stopReason,
+		"usage":       map[string]any{"input_tokens": 3, "output_tokens": 2},
+	})
+}
+
+func (f *vertexAnthropicConformanceFixture) writeStream(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	_, _ = fmt.Fprint(w, `event: message_start
+data: {"type":"message_start","message":{"usage":{"input_tokens":3,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"vertex anthropic stream"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":2}}
+
+event: message_stop
+data: {"type":"message_stop"}
+
+`)
+}
+
+func (f *vertexAnthropicConformanceFixture) writeReasoningStream(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	_, _ = fmt.Fprint(w, `event: message_start
+data: {"type":"message_start","message":{"usage":{"input_tokens":3,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":"","signature":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"vertex anthropic reasoning"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":2}}
+
+event: message_stop
+data: {"type":"message_stop"}
+
+`)
+}
+
+func (f *vertexAnthropicConformanceFixture) verify() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.cachedRequestCount < 2 {
+		return fmt.Errorf("cache_control appeared on %d requests, want normal and streaming requests", f.cachedRequestCount)
+	}
+	if f.toolRequestCount == 0 {
+		return fmt.Errorf("fixture did not observe the declared function tool")
+	}
+	if f.visionRequestCount == 0 {
+		return fmt.Errorf("fixture did not observe the image request")
+	}
+	return nil
+}
+
+func vertexAnthropicHasTool(request map[string]any, name string) bool {
+	tools, _ := request["tools"].([]any)
+	for _, rawTool := range tools {
+		tool, _ := rawTool.(map[string]any)
+		if tool["name"] == name {
+			return true
+		}
+	}
+	return false
+}
+
+func vertexAnthropicHasImage(request map[string]any) bool {
+	messages, _ := request["messages"].([]any)
+	for _, rawMessage := range messages {
+		message, _ := rawMessage.(map[string]any)
+		blocks, _ := message["content"].([]any)
+		for _, rawBlock := range blocks {
+			block, _ := rawBlock.(map[string]any)
+			source, _ := block["source"].(map[string]any)
+			if block["type"] == "image" && source["type"] == "base64" {
+				return true
+			}
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- add deterministic, loopback-only conformance coverage for the Vertex Gemini catalog profile
- add equivalent coverage for Vertex Anthropic, including reasoning visibility
- document the Vertex profile evidence in the provider-driver conformance matrix

## Verification
- `go test ./provider/vertexai ./provider/vertexai_anthropic ./provider/conformance ./appserver/catalog`
- `go test -race ./provider/vertexai ./provider/vertexai_anthropic -count=10`
- `go vet ./provider/vertexai ./provider/vertexai_anthropic ./provider/conformance ./appserver/catalog`
- `make lint`
- `make test` (the repository command explicitly excludes `ext/monty`)
- pre-push lint, non-Monty race suite, vet, and module-tidiness checks

All provider tests use static tokens and loopback HTTP fixtures; no Google credentials or remote endpoints.