### PR TITLE
feat(runtime): add model-bound reasoning summaries

### DIFF
--- a/appserver/catalog/catalog.go
+++ b/appserver/catalog/catalog.go
@@ -383,10 +383,10 @@ func (c *Catalog) defaultProviders() []Provider {
 			Models: []Model{
 				model(ProviderOpenAI, openaiprovider.GPT4o, "GPT-4o", "General-purpose multimodal OpenAI model.", false, textAndImage(), false, capabilities(true, true, true, true, true, false, false), []string{"low", "medium", "high"}, "medium"),
 				model(ProviderOpenAI, openaiprovider.GPT4oMini, "GPT-4o mini", "Smaller OpenAI multimodal model for lower-latency turns.", false, textAndImage(), false, capabilities(true, true, true, true, true, false, false), []string{"low", "medium", "high"}, "medium"),
-				model(ProviderOpenAI, openaiprovider.GPT5, "GPT-5", "OpenAI reasoning model with strong coding and tool-use support.", false, textAndImage(), false, capabilities(true, true, true, true, true, true, false), []string{"minimal", "low", "medium", "high"}, "medium"),
-				model(ProviderOpenAI, openaiprovider.GPT5Mini, "GPT-5 mini", "Lower-latency GPT-5 family model.", false, textAndImage(), false, capabilities(true, true, true, true, true, true, false), []string{"minimal", "low", "medium", "high"}, "medium"),
-				model(ProviderOpenAI, openaiprovider.GPT5Nano, "GPT-5 nano", "Small GPT-5 family model for fast utility work.", true, textAndImage(), false, capabilities(true, true, true, true, true, true, false), []string{"minimal", "low", "medium", "high"}, "low"),
-				model(ProviderOpenAI, openaiprovider.GPT5Codex, "GPT-5 Codex", "OpenAI coding-specialized model exposed through Gollem's neutral model controls.", false, textAndImage(), false, capabilities(true, true, true, true, true, true, false), []string{"minimal", "low", "medium", "high"}, "medium"),
+				model(ProviderOpenAI, openaiprovider.GPT5, "GPT-5", "OpenAI reasoning model with strong coding and tool-use support.", false, textAndImage(), false, reasoningSummaryCapabilities(capabilities(true, true, true, true, true, true, false), true), []string{"minimal", "low", "medium", "high"}, "medium"),
+				model(ProviderOpenAI, openaiprovider.GPT5Mini, "GPT-5 mini", "Lower-latency GPT-5 family model.", false, textAndImage(), false, reasoningSummaryCapabilities(capabilities(true, true, true, true, true, true, false), true), []string{"minimal", "low", "medium", "high"}, "medium"),
+				model(ProviderOpenAI, openaiprovider.GPT5Nano, "GPT-5 nano", "Small GPT-5 family model for fast utility work.", true, textAndImage(), false, reasoningSummaryCapabilities(capabilities(true, true, true, true, true, true, false), true), []string{"minimal", "low", "medium", "high"}, "low"),
+				model(ProviderOpenAI, openaiprovider.GPT5Codex, "GPT-5 Codex", "OpenAI coding-specialized model exposed through Gollem's neutral model controls.", false, textAndImage(), false, reasoningSummaryCapabilities(capabilities(true, true, true, true, true, true, false), true), []string{"minimal", "low", "medium", "high"}, "medium"),
 			},
 		},
 		{
@@ -431,17 +431,16 @@ func (c *Catalog) defaultProviders() []Provider {
 			RequiredEnvVars: []string{"ANTHROPIC_API_KEY"},
 			AuthModes:       []string{"api-key"},
 			Capabilities: ProviderCapabilities{
-				ToolCalls:          true,
-				StructuredOutput:   true,
-				Vision:             true,
-				Streaming:          true,
-				PromptCache:        true,
-				ToolSearch:         true,
-				Reasoning:          true,
-				ReasoningEfforts:   []string{"low", "medium", "high", "xhigh", "max"},
-				ReasoningSummaries: true,
-				AdaptiveThinking:   true,
-				ManualThinking:     true,
+				ToolCalls:        true,
+				StructuredOutput: true,
+				Vision:           true,
+				Streaming:        true,
+				PromptCache:      true,
+				ToolSearch:       true,
+				Reasoning:        true,
+				ReasoningEfforts: []string{"low", "medium", "high", "xhigh", "max"},
+				AdaptiveThinking: true,
+				ManualThinking:   true,
 			},
 			Models: []Model{
 				model(ProviderAnthropic, anthropicprovider.ClaudeSonnet46, "Claude Sonnet 4.6", "Anthropic balanced coding and agentic workflow model.", false, textAndImage(), false, thinkingCapabilities(capabilities(true, true, true, true, true, true, true), true, true), []string{"low", "medium", "high", "max"}, "medium"),
@@ -490,16 +489,15 @@ func (c *Catalog) defaultProviders() []Provider {
 			OptionalEnvVars: []string{"GOOGLE_APPLICATION_CREDENTIALS"},
 			AuthModes:       []string{"application-default-credentials", "service-account"},
 			Capabilities: ProviderCapabilities{
-				ToolCalls:          true,
-				StructuredOutput:   true,
-				Vision:             true,
-				Streaming:          true,
-				PromptCache:        true,
-				Reasoning:          true,
-				ReasoningEfforts:   []string{"low", "medium", "high", "xhigh", "max"},
-				ReasoningSummaries: true,
-				AdaptiveThinking:   true,
-				ManualThinking:     true,
+				ToolCalls:        true,
+				StructuredOutput: true,
+				Vision:           true,
+				Streaming:        true,
+				PromptCache:      true,
+				Reasoning:        true,
+				ReasoningEfforts: []string{"low", "medium", "high", "xhigh", "max"},
+				AdaptiveThinking: true,
+				ManualThinking:   true,
 			},
 			Models: []Model{
 				model(ProviderVertexAIAnthropic, vertexanthropicprovider.ClaudeSonnet46, "Claude Sonnet 4.6 on Vertex AI", "Anthropic Sonnet through Vertex AI.", true, textAndImage(), false, thinkingCapabilities(capabilities(true, true, true, true, true, true, false), true, true), []string{"low", "medium", "high", "max"}, "medium"),
@@ -609,6 +607,11 @@ func capabilities(toolCalls, structured, vision, streaming, promptCache, reasoni
 func thinkingCapabilities(caps ModelCapabilities, adaptive, manual bool) ModelCapabilities {
 	caps.AdaptiveThinking = adaptive
 	caps.ManualThinking = manual
+	return caps
+}
+
+func reasoningSummaryCapabilities(caps ModelCapabilities, summaries bool) ModelCapabilities {
+	caps.ReasoningSummaries = summaries
 	return caps
 }
 

--- a/appserver/catalog/catalog_test.go
+++ b/appserver/catalog/catalog_test.go
@@ -153,6 +153,51 @@ func TestThinkingCapabilitiesAreModelSpecific(t *testing.T) {
 	}
 }
 
+func TestReasoningSummaryCapabilityIsModelSpecific(t *testing.T) {
+	c := NewDefault(WithEnvLookup(mapEnv(nil)))
+	cases := []struct {
+		provider string
+		model    string
+		want     bool
+	}{
+		{ProviderOpenAI, "gpt-4o", false},
+		{ProviderOpenAI, "gpt-5", true},
+		{ProviderOpenAI, "gpt-5-mini", true},
+		{ProviderOpenAI, "gpt-5-codex", true},
+		{ProviderAnthropic, "claude-sonnet-4-6", false},
+		{ProviderVertexAIAnthropic, "claude-sonnet-4-6", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.provider+"/"+tc.model, func(t *testing.T) {
+			provider := findProvider(t, c.providers, tc.provider)
+			for _, model := range provider.Models {
+				if model.Model != tc.model {
+					continue
+				}
+				if model.Capabilities.ReasoningSummaries != tc.want {
+					t.Fatalf("reasoning summary capability = %t, want %t", model.Capabilities.ReasoningSummaries, tc.want)
+				}
+				return
+			}
+			t.Fatalf("model %q missing from provider %#v", tc.model, provider.Models)
+		})
+	}
+
+	for _, tc := range []struct {
+		provider string
+		want     bool
+	}{
+		{ProviderOpenAI, true},
+		{ProviderAnthropic, false},
+		{ProviderVertexAIAnthropic, false},
+	} {
+		provider := findProvider(t, c.providers, tc.provider)
+		if provider.Capabilities.ReasoningSummaries != tc.want {
+			t.Fatalf("provider %q reasoning summaries = %t, want %t", tc.provider, provider.Capabilities.ReasoningSummaries, tc.want)
+		}
+	}
+}
+
 func TestValidateAgentRuntimeSelection(t *testing.T) {
 	c := NewDefault(WithEnvLookup(mapEnv(map[string]string{
 		"OPENAI_API_KEY": "configured",

--- a/appserver/protocol/runtime_client_types.go
+++ b/appserver/protocol/runtime_client_types.go
@@ -44,15 +44,16 @@ type ProviderCatalogCapabilities struct {
 }
 
 type ModelCatalogCapabilities struct {
-	ToolCalls        bool `json:"toolCalls"`
-	StructuredOutput bool `json:"structuredOutput"`
-	Vision           bool `json:"vision"`
-	Streaming        bool `json:"streaming"`
-	PromptCache      bool `json:"promptCache"`
-	ToolSearch       bool `json:"toolSearch"`
-	Reasoning        bool `json:"reasoning"`
-	AdaptiveThinking bool `json:"adaptiveThinking"`
-	ManualThinking   bool `json:"manualThinking"`
+	ToolCalls          bool `json:"toolCalls"`
+	StructuredOutput   bool `json:"structuredOutput"`
+	Vision             bool `json:"vision"`
+	Streaming          bool `json:"streaming"`
+	PromptCache        bool `json:"promptCache"`
+	ToolSearch         bool `json:"toolSearch"`
+	Reasoning          bool `json:"reasoning"`
+	AdaptiveThinking   bool `json:"adaptiveThinking"`
+	ManualThinking     bool `json:"manualThinking"`
+	ReasoningSummaries bool `json:"reasoningSummaries"`
 }
 
 type ModelCatalogReasoningEffortOption struct {
@@ -187,6 +188,7 @@ type RuntimeModelParams struct {
 	ThinkingBudget     *int            `json:"thinkingBudget,omitempty"`
 	AdaptiveThinking   *bool           `json:"adaptiveThinking,omitempty"`
 	ReasoningEffort    *string         `json:"reasoningEffort,omitempty"`
+	ReasoningSummary   *string         `json:"reasoningSummary,omitempty"`
 	PromptCacheEnabled *bool           `json:"promptCacheEnabled,omitempty"`
 	StopSequences      []string        `json:"stopSequences,omitempty"`
 	Settings           map[string]any  `json:"settings,omitempty"`

--- a/appserver/protocol/runtime_client_types_contract_test.go
+++ b/appserver/protocol/runtime_client_types_contract_test.go
@@ -74,25 +74,32 @@ func TestRuntimeClientBindingsAreExact(t *testing.T) {
 	}
 }
 
-func TestRuntimeModelParamsExposePromptCacheSetting(t *testing.T) {
+func TestRuntimeModelParamsExposePromptCacheAndReasoningSummarySettings(t *testing.T) {
 	defs := JSONSchema()["$defs"].(Schema)
 	properties := defs["RuntimeModelParams"].(Schema)["properties"].(Schema)
-	if _, ok := properties["promptCacheEnabled"]; !ok {
-		t.Fatal("RuntimeModelParams schema omitted promptCacheEnabled")
+	for _, name := range []string{"promptCacheEnabled", "reasoningSummary"} {
+		if _, ok := properties[name]; !ok {
+			t.Fatalf("RuntimeModelParams schema omitted %s", name)
+		}
 	}
 	generated, err := MarshalTypeScript()
 	if err != nil {
 		t.Fatalf("MarshalTypeScript: %v", err)
 	}
-	if !strings.Contains(string(generated), `"promptCacheEnabled"?: boolean | null;`) {
-		t.Fatal("RuntimeModelParams TypeScript omitted nullable promptCacheEnabled")
+	for _, want := range []string{
+		`"promptCacheEnabled"?: boolean | null;`,
+		`"reasoningSummary"?: string | null;`,
+	} {
+		if !strings.Contains(string(generated), want) {
+			t.Errorf("RuntimeModelParams TypeScript omitted %q", want)
+		}
 	}
 }
 
 func TestModelCatalogCapabilitiesExposeThinkingModes(t *testing.T) {
 	defs := JSONSchema()["$defs"].(Schema)
 	properties := defs["ModelCatalogCapabilities"].(Schema)["properties"].(Schema)
-	for _, name := range []string{"adaptiveThinking", "manualThinking"} {
+	for _, name := range []string{"adaptiveThinking", "manualThinking", "reasoningSummaries"} {
 		if _, ok := properties[name]; !ok {
 			t.Fatalf("ModelCatalogCapabilities schema omitted %s", name)
 		}
@@ -104,6 +111,7 @@ func TestModelCatalogCapabilitiesExposeThinkingModes(t *testing.T) {
 	for _, want := range []string{
 		`"adaptiveThinking": boolean;`,
 		`"manualThinking": boolean;`,
+		`"reasoningSummaries": boolean;`,
 	} {
 		if !strings.Contains(string(generated), want) {
 			t.Errorf("ModelCatalogCapabilities TypeScript missing %q", want)

--- a/appserver/protocol/runtime_recovery_contract_test.go
+++ b/appserver/protocol/runtime_recovery_contract_test.go
@@ -25,6 +25,7 @@ func TestTurnRunRetryContractIsGeneratedAndBound(t *testing.T) {
 		"thinkingBudget",
 		"adaptiveThinking",
 		"reasoningEffort",
+		"reasoningSummary",
 		"promptCacheEnabled",
 		"stopSequences",
 		"settings",

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -13211,6 +13211,9 @@
         "reasoning": {
           "type": "boolean"
         },
+        "reasoningSummaries": {
+          "type": "boolean"
+        },
         "streaming": {
           "type": "boolean"
         },
@@ -13236,7 +13239,8 @@
         "toolSearch",
         "reasoning",
         "adaptiveThinking",
-        "manualThinking"
+        "manualThinking",
+        "reasoningSummaries"
       ],
       "type": "object"
     },
@@ -17186,6 +17190,16 @@
           "type": "string"
         },
         "reasoningEffort": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "reasoningSummary": {
           "anyOf": [
             {
               "type": "string"
@@ -22886,6 +22900,16 @@
             }
           ]
         },
+        "reasoningSummary": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "settings": {
           "anyOf": [
             {
@@ -24565,6 +24589,16 @@
             }
           ]
         },
+        "reasoningSummary": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "settings": {
           "anyOf": [
             {
@@ -24717,6 +24751,16 @@
           "type": "string"
         },
         "reasoningEffort": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "reasoningSummary": {
           "anyOf": [
             {
               "type": "string"

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -2768,6 +2768,7 @@ export type ModelCatalogCapabilities = {
   "manualThinking": boolean;
   "promptCache": boolean;
   "reasoning": boolean;
+  "reasoningSummaries": boolean;
   "streaming": boolean;
   "structuredOutput": boolean;
   "toolCalls": boolean;
@@ -3526,6 +3527,7 @@ export type RuntimeModelParams = {
   "provider"?: string;
   "providerId"?: string;
   "reasoningEffort"?: string | null;
+  "reasoningSummary"?: string | null;
   "settings"?: Record<string, unknown> | null;
   "stopSequences"?: Array<string> | null;
   "temperature"?: number | null;
@@ -4312,6 +4314,7 @@ export type ThreadRunStartParams = {
   "provider"?: string;
   "providerId"?: string;
   "reasoningEffort"?: string | null;
+  "reasoningSummary"?: string | null;
   "settings"?: Record<string, unknown> | null;
   "stopSequences"?: Array<string> | null;
   "temperature"?: number | null;
@@ -4673,6 +4676,7 @@ export type TurnRunRetryParams = {
   "provider"?: string;
   "providerId"?: string;
   "reasoningEffort"?: string | null;
+  "reasoningSummary"?: string | null;
   "settings"?: Record<string, unknown> | null;
   "stopSequences"?: Array<string> | null;
   "temperature"?: number | null;
@@ -4701,6 +4705,7 @@ export type TurnRunStartParams = {
   "provider"?: string;
   "providerId"?: string;
   "reasoningEffort"?: string | null;
+  "reasoningSummary"?: string | null;
   "settings"?: Record<string, unknown> | null;
   "stopSequences"?: Array<string> | null;
   "temperature"?: number | null;

--- a/appserver/runtime.go
+++ b/appserver/runtime.go
@@ -644,6 +644,7 @@ type runtimeTurnInput struct {
 	Provider           string         `json:"provider,omitempty"`
 	Model              string         `json:"model,omitempty"`
 	ReasoningEffort    string         `json:"reasoningEffort,omitempty"`
+	ReasoningSummary   string         `json:"reasoningSummary,omitempty"`
 	ThinkingBudget     *int           `json:"thinkingBudget,omitempty"`
 	AdaptiveThinking   *bool          `json:"adaptiveThinking,omitempty"`
 	PromptCacheEnabled *bool          `json:"promptCacheEnabled,omitempty"`
@@ -663,6 +664,7 @@ func runtimeTurnInputJSON(
 		Provider:           selection.Provider,
 		Model:              selection.Model,
 		ReasoningEffort:    runtimeReasoningEffort(settings),
+		ReasoningSummary:   runtimeReasoningSummary(settings),
 		ThinkingBudget:     runtimeThinkingBudget(settings),
 		AdaptiveThinking:   cloneBool(settings.AdaptiveThinking),
 		PromptCacheEnabled: runtimePromptCacheEnabled(settings),
@@ -680,6 +682,13 @@ func runtimeReasoningEffort(settings core.ModelSettings) string {
 		return ""
 	}
 	return strings.TrimSpace(*settings.ReasoningEffort)
+}
+
+func runtimeReasoningSummary(settings core.ModelSettings) string {
+	if settings.ReasoningSummary == nil {
+		return ""
+	}
+	return strings.TrimSpace(*settings.ReasoningSummary)
 }
 
 func runtimePromptCacheEnabled(settings core.ModelSettings) *bool {
@@ -1036,6 +1045,7 @@ func hasRuntimeModelSettings(settings core.ModelSettings) bool {
 		settings.ThinkingBudget != nil ||
 		settings.AdaptiveThinking != nil ||
 		settings.ReasoningEffort != nil ||
+		settings.ReasoningSummary != nil ||
 		settings.PromptCacheEnabled != nil ||
 		len(settings.StopSequences) > 0
 }

--- a/appserver/runtime_params.go
+++ b/appserver/runtime_params.go
@@ -123,6 +123,7 @@ func runtimeModelSettingsFromParams(params RuntimeModelParams) core.ModelSetting
 		ThinkingBudget:     params.ThinkingBudget,
 		AdaptiveThinking:   params.AdaptiveThinking,
 		ReasoningEffort:    params.ReasoningEffort,
+		ReasoningSummary:   params.ReasoningSummary,
 		PromptCacheEnabled: params.PromptCacheEnabled,
 		StopSequences:      append([]string(nil), params.StopSequences...),
 	}
@@ -142,6 +143,7 @@ func runtimeModelSettingsFromInput(input json.RawMessage) core.ModelSettings {
 	settings := core.ModelSettings{
 		ThinkingBudget:     cloneInt(stored.ThinkingBudget),
 		AdaptiveThinking:   cloneBool(stored.AdaptiveThinking),
+		ReasoningSummary:   cloneString(stored.ReasoningSummary),
 		PromptCacheEnabled: cloneBool(stored.PromptCacheEnabled),
 	}
 	if effort := strings.TrimSpace(stored.ReasoningEffort); effort != "" {
@@ -166,6 +168,14 @@ func cloneInt(value *int) *int {
 	return &cloned
 }
 
+func cloneString(value string) *string {
+	if value == "" {
+		return nil
+	}
+	cloned := value
+	return &cloned
+}
+
 func runtimeModelSettingsWithThreadDefaults(
 	settings core.ModelSettings,
 	threadSettings map[string]any,
@@ -186,7 +196,10 @@ func mergeRuntimeModelSettings(primary, fallback core.ModelSettings) core.ModelS
 		primary.AdaptiveThinking = cloneBool(fallback.AdaptiveThinking)
 	}
 	if primary.ReasoningEffort == nil {
-		primary.ReasoningEffort = fallback.ReasoningEffort
+		primary.ReasoningEffort = cloneString(runtimeReasoningEffort(fallback))
+	}
+	if primary.ReasoningSummary == nil {
+		primary.ReasoningSummary = cloneString(runtimeReasoningSummary(fallback))
 	}
 	if primary.PromptCacheEnabled == nil {
 		primary.PromptCacheEnabled = cloneBool(fallback.PromptCacheEnabled)

--- a/appserver/runtime_reasoning.go
+++ b/appserver/runtime_reasoning.go
@@ -65,6 +65,30 @@ func validateRuntimeThinkingSelection(
 	return nil
 }
 
+func validateRuntimeReasoningSummarySelection(
+	catalogService *catalog.Catalog,
+	selection RuntimeModelSelection,
+	settings core.ModelSettings,
+) error {
+	if settings.ReasoningSummary == nil {
+		return nil
+	}
+	summary := strings.TrimSpace(*settings.ReasoningSummary)
+	switch summary {
+	case "auto", "concise", "detailed":
+	default:
+		return fmt.Errorf("reasoning summary %q is unavailable; choose auto, concise, or detailed", summary)
+	}
+	selected, err := selectedRuntimeCatalogModel(catalogService, selection)
+	if err != nil {
+		return err
+	}
+	if !selected.Capabilities.ReasoningSummaries {
+		return fmt.Errorf("model %q does not advertise reasoning summaries", selected.ID)
+	}
+	return nil
+}
+
 func selectedRuntimeCatalogModel(catalogService *catalog.Catalog, selection RuntimeModelSelection) (*catalog.Model, error) {
 	providerID := strings.TrimSpace(firstNonEmpty(selection.ProviderID, selection.Provider))
 	modelName := strings.TrimSpace(selection.Model)

--- a/appserver/runtime_selection.go
+++ b/appserver/runtime_selection.go
@@ -11,5 +11,8 @@ func (s *Server) validateRuntimeSelection(selection RuntimeModelSelection, setti
 	if err := validateRuntimeReasoningSelection(s.catalog, selection, settings); err != nil {
 		return err
 	}
+	if err := validateRuntimeReasoningSummarySelection(s.catalog, selection, settings); err != nil {
+		return err
+	}
 	return validateRuntimeThinkingSelection(s.catalog, selection, settings)
 }

--- a/appserver/runtime_test.go
+++ b/appserver/runtime_test.go
@@ -451,6 +451,89 @@ func TestServerRuntimeRetryRetainsThinkingSettings(t *testing.T) {
 	}
 }
 
+func TestServerRuntimeReasoningSummaryFailsClosedAndSurvivesRetry(t *testing.T) {
+	ctx := context.Background()
+	st := newRuntimeTestStore(t)
+	model := core.NewTestModel(core.TextResponse("first"), core.TextResponse("retry"))
+	server := readyServer(
+		WithStore(st),
+		WithRuntimeService(NewRuntimeService(WithRuntimeModel(
+			model,
+			RuntimeModelInfo{ProviderID: "openai", Model: "gpt-5"},
+		))),
+	)
+
+	unsupported := server.HandleRequest(ctx, request("thread/start", map[string]any{
+		"workspace":        t.TempDir(),
+		"prompt":           "reject unsupported summary selection",
+		"providerId":       "openai",
+		"model":            "gpt-4o",
+		"reasoningSummary": "concise",
+	}))
+	if unsupported.Error == nil || unsupported.Error.Code != protocol.CodeInvalidParams || !strings.Contains(unsupported.Error.Message, "does not advertise reasoning summaries") {
+		t.Fatalf("unsupported reasoning summary error = %#v", unsupported.Error)
+	}
+	threads, err := st.ListThreads(ctx, store.ThreadFilter{})
+	if err != nil {
+		t.Fatalf("ListThreads: %v", err)
+	}
+	if len(threads) != 0 {
+		t.Fatalf("unsupported reasoning summary created %d threads", len(threads))
+	}
+
+	invalid := server.HandleRequest(ctx, request("thread/start", map[string]any{
+		"workspace":        t.TempDir(),
+		"prompt":           "reject invalid summary mode",
+		"providerId":       "openai",
+		"model":            "gpt-5",
+		"reasoningSummary": "full",
+	}))
+	if invalid.Error == nil || invalid.Error.Code != protocol.CodeInvalidParams || !strings.Contains(invalid.Error.Message, "reasoning summary") {
+		t.Fatalf("invalid reasoning summary error = %#v", invalid.Error)
+	}
+
+	start := server.HandleRequest(ctx, request("thread/start", map[string]any{
+		"workspace":        t.TempDir(),
+		"prompt":           "persist summary selection",
+		"providerId":       "openai",
+		"model":            "gpt-5",
+		"reasoningSummary": "concise",
+	}))
+	if start.Error != nil {
+		t.Fatalf("thread/start error: %v", start.Error)
+	}
+	var started protocol.ThreadRunStartResult
+	decodeResult(t, start, &started)
+	waitForNotificationSet(t, server, "turn/completed")
+
+	retry := server.HandleRequest(ctx, request("turn/retry", map[string]any{"turnId": started.Turn.ID}))
+	if retry.Error != nil {
+		t.Fatalf("turn/retry error: %v", retry.Error)
+	}
+	var retried protocol.TurnRunRetryResult
+	decodeResult(t, retry, &retried)
+	waitForNotificationSet(t, server, "turn/completed")
+
+	persisted, err := st.GetTurn(ctx, retried.Turn.ID)
+	if err != nil {
+		t.Fatalf("GetTurn retry: %v", err)
+	}
+	var input runtimeTurnInput
+	if err := json.Unmarshal(persisted.Input, &input); err != nil {
+		t.Fatalf("decode retry input: %v", err)
+	}
+	if input.ReasoningSummary != "concise" {
+		t.Fatalf("retry input reasoning summary = %q, want concise", input.ReasoningSummary)
+	}
+	calls := model.Calls()
+	if len(calls) != 2 {
+		t.Fatalf("model calls = %d, want 2", len(calls))
+	}
+	if calls[1].Settings == nil || calls[1].Settings.ReasoningSummary == nil || *calls[1].Settings.ReasoningSummary != "concise" {
+		t.Fatalf("retry model settings = %#v, want concise reasoning summary", calls[1].Settings)
+	}
+}
+
 func sameIntPointer(got, want *int) bool {
 	if got == nil || want == nil {
 		return got == want

--- a/core/model.go
+++ b/core/model.go
@@ -42,6 +42,11 @@ type ModelSettings struct {
 	// Fable). Per-provider gating rejects values a given model doesn't accept
 	// (e.g., "xhigh" requires Opus 4.7+; "max" requires 4.6+).
 	ReasoningEffort *string `json:"reasoning_effort,omitempty"`
+	// ReasoningSummary asks an adapter that supports user-visible reasoning
+	// summaries to request the selected bounded summary mode. Nil preserves the
+	// provider default. This is currently supported by OpenAI Responses
+	// reasoning models; catalog validation must reject it for other profiles.
+	ReasoningSummary *string `json:"reasoning_summary,omitempty"`
 	// PromptCacheEnabled controls Gollem's explicit prompt-cache request metadata.
 	// Nil preserves the provider default. False suppresses Gollem-managed cache
 	// keys, cache-control markers, and configured cache references; true asks a

--- a/docs/PROVIDER_DRIVER_CONFORMANCE.md
+++ b/docs/PROVIDER_DRIVER_CONFORMANCE.md
@@ -19,6 +19,7 @@ of behavior and must not enable a control solely on provider identity.
 | Namespace tool grouping | Proven for catalog-listed GPT-5 Responses models | Unsupported | Unsupported | `provider/conformance` groups a namespaced function through the OpenAI Responses API and verifies both the native `namespace` object and normalized tool-call namespace metadata |
 | Deferred tool search | Adapter proven for `gpt-5.4`, but not catalog-enabled | Unsupported | Proven for catalog-listed Sonnet and Opus models | `provider/conformance` sends a `DeferLoading` tool, verifies the normalized response, and fixtures assert OpenAI's `tool_search` or Anthropic's regex search primitive plus the deferred tool |
 | Reasoning visibility | Proven where catalog-supported | Unsupported | Proven where catalog-supported | `provider/conformance` verifies native `ThinkingPart` start/delta events and final retention; local Chat Completions remains unsupported |
+| Reasoning-summary selection | Proven for catalog-listed GPT-5 Responses models | Unsupported | Unsupported | `provider/openai` calls `provider/conformance.Verify` with `ReasoningSummary="concise"`, asserts `reasoning.summary` on the native request, and verifies the normalized `ThinkingPart` stream and final retention. Anthropic thinking visibility is distinct from OpenAI's selectable summary mode. |
 | Prompt-cache activation | Proven | Unsupported | Proven | `provider/conformance` sends `core.ModelSettings.PromptCacheEnabled=true` on normal and streaming requests and fixtures observe OpenAI cache metadata or Anthropic `cache_control` markers |
 | Cache-read token accounting | Proven | Unsupported | Proven | `provider/conformance` verifies provider-reported cache reads normalize to `core.Usage.CacheReadTokens`; accounting and activation remain distinct evidence |
 | Malformed JSON stream event normalization | Proven | Proven | Proven | `provider/conformance` plus provider parser tests; returns `StreamProtocolError` without raw event data |
@@ -52,6 +53,12 @@ remote endpoint.
 `Catalog-supported` means the catalog may expose the capability only for the
 listed provider/model profile. It does not make that behavior part of the common
 driver contract until a deterministic conformance scenario covers it.
+
+Reasoning summary is model-bound rather than inferred from provider-level
+thinking visibility. The current catalog exposes it only for OpenAI GPT-5
+Responses profiles. Anthropic and Vertex Anthropic retain their proven
+reasoning visibility but do not advertise a selectable summary request because
+their adapters do not receive one through the provider-neutral runtime.
 
 ## Custody And Local Endpoint Rules
 

--- a/provider/conformance/conformance.go
+++ b/provider/conformance/conformance.go
@@ -38,6 +38,7 @@ type Claims struct {
 	RequestTimeout        bool
 	StreamTimeout         bool
 	ReasoningVisibility   bool
+	ReasoningSummary      bool
 }
 
 // Expectations declares the normalized outputs a deterministic fixture
@@ -69,6 +70,7 @@ type Expectations struct {
 	RetryText             string
 	StreamTimeoutText     string
 	ReasoningText         string
+	ReasoningSummaryText  string
 }
 
 // Driver binds a provider model to the common capability claims and expected
@@ -81,6 +83,7 @@ type Driver struct {
 	CancellationReady        <-chan struct{}
 	RequestTimeoutReady      <-chan struct{}
 	ReasoningModel           core.Model
+	ReasoningSummaryModel    core.Model
 	ToolSearchModel          core.Model
 	NamespaceToolsModel      core.Model
 	PromptCacheActivation    func() error
@@ -172,6 +175,12 @@ func Verify(ctx context.Context, driver Driver) error {
 	if driver.Claims.ReasoningVisibility && strings.TrimSpace(driver.Expectations.ReasoningText) == "" {
 		return fmt.Errorf("provider conformance: %s reasoning fixture must expect reasoning text", driver.Name)
 	}
+	if driver.Claims.ReasoningSummary && driver.ReasoningSummaryModel == nil {
+		return fmt.Errorf("provider conformance: %s reasoning-summary-capable fixture must supply a reasoning summary model", driver.Name)
+	}
+	if driver.Claims.ReasoningSummary && strings.TrimSpace(driver.Expectations.ReasoningSummaryText) == "" {
+		return fmt.Errorf("provider conformance: %s reasoning-summary fixture must expect reasoning text", driver.Name)
+	}
 
 	params := &core.ModelRequestParameters{AllowTextOutput: true}
 	if driver.Claims.ToolCalls {
@@ -246,6 +255,11 @@ func Verify(ctx context.Context, driver Driver) error {
 	}
 	if driver.Claims.ReasoningVisibility {
 		if err := verifyReasoningVisibility(ctx, driver); err != nil {
+			return err
+		}
+	}
+	if driver.Claims.ReasoningSummary {
+		if err := verifyReasoningSummary(ctx, driver); err != nil {
 			return err
 		}
 	}
@@ -580,9 +594,33 @@ func verifyRetryability(ctx context.Context, driver Driver) error {
 }
 
 func verifyReasoningVisibility(ctx context.Context, driver Driver) error {
-	stream, err := driver.ReasoningModel.RequestStream(ctx, reasoningMessages(), nil, &core.ModelRequestParameters{AllowTextOutput: true})
+	return verifyReasoningStream(ctx, driver.Name, driver.ReasoningModel, nil, driver.Expectations.ReasoningText)
+}
+
+// verifyReasoningSummary proves the optional request selection independently
+// from generic thinking visibility. Fixtures must assert their native summary
+// selection field and return its normalized ThinkingPart stream.
+func verifyReasoningSummary(ctx context.Context, driver Driver) error {
+	summary := "concise"
+	return verifyReasoningStream(
+		ctx,
+		driver.Name,
+		driver.ReasoningSummaryModel,
+		&core.ModelSettings{ReasoningSummary: &summary},
+		driver.Expectations.ReasoningSummaryText,
+	)
+}
+
+func verifyReasoningStream(
+	ctx context.Context,
+	name string,
+	model core.Model,
+	settings *core.ModelSettings,
+	want string,
+) error {
+	stream, err := model.RequestStream(ctx, reasoningMessages(), settings, &core.ModelRequestParameters{AllowTextOutput: true})
 	if err != nil {
-		return fmt.Errorf("provider conformance: %s reasoning stream request: %w", driver.Name, err)
+		return fmt.Errorf("provider conformance: %s reasoning stream request: %w", name, err)
 	}
 	defer stream.Close()
 
@@ -596,7 +634,7 @@ func verifyReasoningVisibility(ctx context.Context, driver Driver) error {
 			break
 		}
 		if err != nil {
-			return fmt.Errorf("provider conformance: %s reasoning stream: %w", driver.Name, err)
+			return fmt.Errorf("provider conformance: %s reasoning stream: %w", name, err)
 		}
 		switch value := event.(type) {
 		case core.PartStartEvent:
@@ -611,17 +649,17 @@ func verifyReasoningVisibility(ctx context.Context, driver Driver) error {
 		}
 	}
 	if !started {
-		return fmt.Errorf("provider conformance: %s reasoning stream did not emit a ThinkingPart start", driver.Name)
+		return fmt.Errorf("provider conformance: %s reasoning stream did not emit a ThinkingPart start", name)
 	}
-	if got := deltas.String(); got != driver.Expectations.ReasoningText {
-		return fmt.Errorf("provider conformance: %s reasoning deltas = %q, want %q", driver.Name, got, driver.Expectations.ReasoningText)
+	if got := deltas.String(); got != want {
+		return fmt.Errorf("provider conformance: %s reasoning deltas = %q, want %q", name, got, want)
 	}
 	for _, part := range stream.Response().Parts {
-		if thinking, ok := part.(core.ThinkingPart); ok && thinking.Content == driver.Expectations.ReasoningText {
+		if thinking, ok := part.(core.ThinkingPart); ok && thinking.Content == want {
 			return nil
 		}
 	}
-	return fmt.Errorf("provider conformance: %s final response did not retain reasoning text", driver.Name)
+	return fmt.Errorf("provider conformance: %s final response did not retain reasoning text", name)
 }
 
 func verifyResponse(driver Driver, response *core.ModelResponse, streaming bool) error {

--- a/provider/openai/openai_test.go
+++ b/provider/openai/openai_test.go
@@ -2632,6 +2632,20 @@ func TestResponsesReasoningSummary(t *testing.T) {
 	}
 }
 
+func TestResponsesPerRequestReasoningSummaryOverridesProviderDefault(t *testing.T) {
+	defaultSummary := "detailed"
+	selectedSummary := "concise"
+	provider := New(WithModel(GPT5), WithReasoningSummary(defaultSummary))
+	req, err := buildResponsesRequest(nil, &core.ModelSettings{ReasoningSummary: &selectedSummary}, nil, GPT5, 4096, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	provider.applyResponsesEndpointSettingsForSettings(req, &core.ModelSettings{ReasoningSummary: &selectedSummary})
+	if req.Reasoning == nil || req.Reasoning.Summary != selectedSummary {
+		t.Fatalf("reasoning summary = %#v, want per-request %q", req.Reasoning, selectedSummary)
+	}
+}
+
 func TestResponsesTextVerbosity(t *testing.T) {
 	// Verify the text verbosity field is serialized correctly.
 	req := &responsesRequest{

--- a/provider/openai/reasoning_summary_conformance_test.go
+++ b/provider/openai/reasoning_summary_conformance_test.go
@@ -1,0 +1,107 @@
+package openai
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/fugue-labs/gollem/provider/conformance"
+)
+
+func TestCatalogReasoningSummaryConformance(t *testing.T) {
+	for _, modelName := range []string{GPT5, GPT5Mini, GPT5Nano, GPT5Codex} {
+		t.Run(modelName, func(t *testing.T) {
+			fixture := &reasoningSummaryConformanceFixture{t: t, model: modelName}
+			server := httptest.NewServer(http.HandlerFunc(fixture.serveHTTP))
+			defer server.Close()
+
+			model := New(
+				WithAPIKey("conformance-token"),
+				WithBaseURL(server.URL+"/openai.com"),
+				WithModel(modelName),
+			)
+			err := conformance.Verify(t.Context(), conformance.Driver{
+				Name:                  "OpenAI reasoning summary " + modelName,
+				Model:                 model,
+				ReasoningSummaryModel: model,
+				Claims:                conformance.Claims{ReasoningSummary: true},
+				Expectations: conformance.Expectations{
+					ResponseText:         "openai summary response",
+					ReasoningSummaryText: "openai selected summary",
+				},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !fixture.summaryRequest {
+				t.Fatal("reasoning summary fixture did not observe the selected summary request")
+			}
+		})
+	}
+}
+
+type reasoningSummaryConformanceFixture struct {
+	t              *testing.T
+	model          string
+	summaryRequest bool
+}
+
+func (f *reasoningSummaryConformanceFixture) serveHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/openai.com/v1/responses" {
+		f.t.Errorf("path = %q, want /openai.com/v1/responses", r.URL.Path)
+		http.NotFound(w, r)
+		return
+	}
+	if got := r.Header.Get("Authorization"); got != "Bearer conformance-token" {
+		f.t.Errorf("Authorization = %q, want static bearer token", got)
+	}
+	var req responsesRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		f.t.Errorf("decode request: %v", err)
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	if req.Model != f.model {
+		f.t.Errorf("model = %q, want %q", req.Model, f.model)
+	}
+	if req.Stream == nil || !*req.Stream {
+		f.writeResponse(w)
+		return
+	}
+	if req.Reasoning == nil || req.Reasoning.Summary != "concise" {
+		f.t.Errorf("reasoning summary = %#v, want concise", req.Reasoning)
+	}
+	f.summaryRequest = true
+	f.writeStream(w)
+}
+
+func (f *reasoningSummaryConformanceFixture) writeResponse(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(responsesAPIResponse{
+		ID:    "resp-summary-normal",
+		Model: f.model,
+		Output: []responsesOutputItem{{
+			Type:    "message",
+			Role:    "assistant",
+			Content: []responsesContentItem{{Type: "output_text", Text: "openai summary response"}},
+		}},
+		Usage: responsesUsage{InputTokens: 3, OutputTokens: 2},
+	})
+}
+
+func (f *reasoningSummaryConformanceFixture) writeStream(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	_, _ = fmt.Fprint(w, `data: {"type":"response.output_item.added","output_index":0,"item":{"type":"reasoning","summary":[]}}
+
+data: {"type":"response.reasoning_summary_text.delta","output_index":0,"delta":"openai selected summary"}
+
+data: {"type":"response.output_item.done","output_index":0,"item":{"type":"reasoning","summary":[{"type":"summary_text","text":"openai selected summary"}]}}
+
+data: {"type":"response.completed","response":{"id":"resp-summary-stream","model":"`+f.model+`","output":[{"type":"reasoning","summary":[{"type":"summary_text","text":"openai selected summary"}]}],"usage":{"input_tokens":3,"output_tokens":2}}}
+
+data: [DONE]
+
+`)
+}

--- a/provider/openai/responses.go
+++ b/provider/openai/responses.go
@@ -174,8 +174,15 @@ func (p *Provider) applyResponsesEndpointSettingsForSettings(req *responsesReque
 			req.PromptCacheOptions = nil
 		}
 		req.ServiceTier = p.serviceTier
-		if p.reasoningSummary != "" && req.Reasoning != nil {
-			req.Reasoning.Summary = p.reasoningSummary
+		summary := p.reasoningSummary
+		if settings != nil && settings.ReasoningSummary != nil {
+			summary = strings.TrimSpace(*settings.ReasoningSummary)
+		}
+		if summary != "" {
+			if req.Reasoning == nil {
+				req.Reasoning = &responsesReasoning{}
+			}
+			req.Reasoning.Summary = summary
 		}
 		if p.textVerbosity != "" {
 			if req.Text == nil {


### PR DESCRIPTION
## Summary
- add a nullable, durable `reasoningSummary` runtime setting with fail-closed model validation
- expose `reasoningSummaries` per model, limited to the catalog-listed OpenAI GPT-5 profiles
- route the selection into OpenAI Responses `reasoning.summary`, preserve it on retry, and remove unsupported Anthropic and Vertex Anthropic catalog claims
- prove each advertised GPT-5 profile through static-token loopback conformance and regenerate the shared protocol artifacts

## Verification
- `go test ./appserver ./appserver/catalog ./appserver/protocol ./provider/openai ./provider/conformance`
- `go test -race ./appserver ./appserver/catalog ./appserver/protocol ./provider/openai ./provider/conformance -count=10`
- `go vet ./appserver/... ./provider/openai ./provider/conformance`
- `make lint`
- `make test` (the repository command explicitly excludes `ext/monty`)
- pre-push lint, non-Monty race suite, vet, and module-tidiness checks

All provider coverage uses static credentials and loopback HTTP fixtures; no live OpenAI request or credential is used.