### PR TITLE
test(vertex): prove catalog model profiles

### DIFF
--- a/docs/PROVIDER_DRIVER_CONFORMANCE.md
+++ b/docs/PROVIDER_DRIVER_CONFORMANCE.md
@@ -47,8 +47,8 @@ remote endpoint.
 
 | Profile | Catalog-supported behavior | Evidence |
 | --- | --- | --- |
-| Vertex AI Gemini | Function tools, native structured output, inline image input, streaming, terminal usage, and configured cached-content attachment | `provider/vertexai` calls `provider/conformance.Verify`; the fixture asserts Gemini function declarations, `inlineData`, cached-content on normal and streaming requests, and normalized responses |
-| Vertex AI Anthropic | Function tools, schema-backed `final_result` output, base64 image input, streaming, terminal usage, prompt-cache activation, and reasoning visibility | `provider/vertexai_anthropic` calls `provider/conformance.Verify`; the fixture asserts Messages-tool/cache/image wire forms plus normalized `ThinkingPart` start, delta, and final retention |
+| Vertex AI Gemini | Function tools, native structured output, inline image input, streaming, terminal usage, and configured cached-content attachment | `provider/vertexai` runs every catalog-listed Gemini profile through `provider/conformance.Verify`; the fixture asserts each exact model route, Gemini function declarations, `inlineData`, cached-content on normal and streaming requests, and normalized responses |
+| Vertex AI Anthropic | Function tools, schema-backed `final_result` output, base64 image input, streaming, terminal usage, prompt-cache activation, and model-specific reasoning visibility | `provider/vertexai_anthropic` runs every catalog-listed Claude profile through `provider/conformance.Verify`; the fixture asserts each exact model route, Messages-tool/cache/image wire forms, and normalized output. Reasoning visibility runs only for the catalog-enabled Sonnet and Opus profiles; Haiku remains explicitly unclaimed. |
 
 `Catalog-supported` means the catalog may expose the capability only for the
 listed provider/model profile. It does not make that behavior part of the common

--- a/provider/vertexai/conformance_test.go
+++ b/provider/vertexai/conformance_test.go
@@ -13,44 +13,58 @@ import (
 )
 
 func TestCatalogCapabilityConformance(t *testing.T) {
-	fixture := &geminiConformanceFixture{t: t}
-	server := httptest.NewServer(http.HandlerFunc(fixture.serveHTTP))
-	defer server.Close()
+	// Keep this list in lockstep with the Vertex Gemini entries in the
+	// app-server catalog. The catalog exposes each profile as runnable, so the
+	// fixture must observe its exact model route rather than a representative.
+	for _, modelName := range []string{
+		Gemini25Flash,
+		Gemini25Pro,
+		Gemini31ProPreview,
+		Gemini3FlashPreview,
+		Gemini20Flash,
+	} {
+		t.Run(modelName, func(t *testing.T) {
+			fixture := &geminiConformanceFixture{t: t, model: modelName}
+			server := httptest.NewServer(http.HandlerFunc(fixture.serveHTTP))
+			defer server.Close()
 
-	model := New(
-		WithProject("conformance-project"),
-		WithLocation("us-central1"),
-		WithModel(Gemini25Flash),
-		WithCachedContent("projects/conformance/locations/us-central1/cachedContents/catalog-proof"),
-	)
-	model.tokenSource = &staticTokenSource{token: "conformance-token"}
-	model.httpClient = &http.Client{Transport: &rewriteTransport{
-		base:      server.Client().Transport,
-		targetURL: server.URL,
-	}}
+			model := New(
+				WithProject("conformance-project"),
+				WithLocation("us-central1"),
+				WithModel(modelName),
+				WithCachedContent("projects/conformance/locations/us-central1/cachedContents/catalog-proof"),
+			)
+			model.tokenSource = &staticTokenSource{token: "conformance-token"}
+			model.httpClient = &http.Client{Transport: &rewriteTransport{
+				base:      server.Client().Transport,
+				targetURL: server.URL,
+			}}
 
-	err := conformance.Verify(t.Context(), conformance.Driver{
-		Name:                  "Vertex AI Gemini",
-		Model:                 model,
-		Claims:                conformance.Claims{ToolCalls: true, StructuredOutput: true, Vision: true, PromptCacheActivation: true, Streaming: true, Usage: true},
-		PromptCacheActivation: fixture.verify,
-		Expectations: conformance.Expectations{
-			ResponseText:          "vertex gemini response",
-			ToolName:              "conformance_echo",
-			ToolCallID:            "call_0",
-			ToolArgumentsJSON:     `{"value":"ok"}`,
-			StructuredOutputValue: "vertex gemini structured",
-			VisionText:            "vertex gemini vision",
-			StreamText:            "vertex gemini stream",
-		},
-	})
-	if err != nil {
-		t.Fatal(err)
+			err := conformance.Verify(t.Context(), conformance.Driver{
+				Name:                  "Vertex AI Gemini " + modelName,
+				Model:                 model,
+				Claims:                conformance.Claims{ToolCalls: true, StructuredOutput: true, Vision: true, PromptCacheActivation: true, Streaming: true, Usage: true},
+				PromptCacheActivation: fixture.verify,
+				Expectations: conformance.Expectations{
+					ResponseText:          "vertex gemini response",
+					ToolName:              "conformance_echo",
+					ToolCallID:            "call_0",
+					ToolArgumentsJSON:     `{"value":"ok"}`,
+					StructuredOutputValue: "vertex gemini structured",
+					VisionText:            "vertex gemini vision",
+					StreamText:            "vertex gemini stream",
+				},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
 	}
 }
 
 type geminiConformanceFixture struct {
-	t *testing.T
+	t     *testing.T
+	model string
 
 	mu                 sync.Mutex
 	cachedRequestCount int
@@ -61,6 +75,9 @@ type geminiConformanceFixture struct {
 func (f *geminiConformanceFixture) serveHTTP(w http.ResponseWriter, r *http.Request) {
 	if got := r.Header.Get("Authorization"); got != "Bearer conformance-token" {
 		f.t.Errorf("Authorization = %q, want conformance bearer token", got)
+	}
+	if want := "/models/" + f.model + ":"; !strings.Contains(r.URL.Path, want) {
+		f.t.Errorf("Vertex Gemini request path = %q, want model route containing %q", r.URL.Path, want)
 	}
 
 	var request map[string]any

--- a/provider/vertexai_anthropic/conformance_test.go
+++ b/provider/vertexai_anthropic/conformance_test.go
@@ -14,46 +14,64 @@ import (
 )
 
 func TestCatalogCapabilityConformance(t *testing.T) {
-	fixture := &vertexAnthropicConformanceFixture{t: t}
-	server := httptest.NewServer(http.HandlerFunc(fixture.serveHTTP))
-	defer server.Close()
+	// Keep this list in lockstep with the Vertex Anthropic entries in the
+	// app-server catalog. Haiku deliberately omits reasoning visibility.
+	for _, tc := range []struct {
+		model     string
+		reasoning bool
+	}{
+		{ClaudeSonnet46, true},
+		{ClaudeOpus46, true},
+		{ClaudeOpus47, true},
+		{ClaudeHaiku45, false},
+	} {
+		t.Run(tc.model, func(t *testing.T) {
+			fixture := &vertexAnthropicConformanceFixture{t: t, model: tc.model}
+			server := httptest.NewServer(http.HandlerFunc(fixture.serveHTTP))
+			defer server.Close()
 
-	model := New(
-		WithProject("conformance-project"),
-		WithLocation("us-east5"),
-		WithModel(ClaudeSonnet46),
-		WithPromptCaching(true),
-	)
-	model.tokenSource = &staticTokenSource{token: "conformance-token"}
-	model.httpClient = &http.Client{Transport: &rewriteTransport{
-		base:      server.Client().Transport,
-		targetURL: server.URL,
-	}}
+			model := New(
+				WithProject("conformance-project"),
+				WithLocation("us-east5"),
+				WithModel(tc.model),
+				WithPromptCaching(true),
+			)
+			model.tokenSource = &staticTokenSource{token: "conformance-token"}
+			model.httpClient = &http.Client{Transport: &rewriteTransport{
+				base:      server.Client().Transport,
+				targetURL: server.URL,
+			}}
 
-	err := conformance.Verify(t.Context(), conformance.Driver{
-		Name:                  "Vertex AI Anthropic",
-		Model:                 model,
-		ReasoningModel:        model,
-		Claims:                conformance.Claims{ToolCalls: true, StructuredOutput: true, Vision: true, PromptCacheActivation: true, Streaming: true, Usage: true, ReasoningVisibility: true},
-		PromptCacheActivation: fixture.verify,
-		Expectations: conformance.Expectations{
-			ResponseText:          "vertex anthropic response",
-			ToolName:              "conformance_echo",
-			ToolCallID:            "call_vertex_anthropic",
-			ToolArgumentsJSON:     `{"value":"ok"}`,
-			StructuredOutputValue: "vertex anthropic structured",
-			VisionText:            "vertex anthropic vision",
-			StreamText:            "vertex anthropic stream",
-			ReasoningText:         "vertex anthropic reasoning",
-		},
-	})
-	if err != nil {
-		t.Fatal(err)
+			claims := conformance.Claims{ToolCalls: true, StructuredOutput: true, Vision: true, PromptCacheActivation: true, Streaming: true, Usage: true, ReasoningVisibility: tc.reasoning}
+			driver := conformance.Driver{
+				Name:                  "Vertex AI Anthropic " + tc.model,
+				Model:                 model,
+				Claims:                claims,
+				PromptCacheActivation: fixture.verify,
+				Expectations: conformance.Expectations{
+					ResponseText:          "vertex anthropic response",
+					ToolName:              "conformance_echo",
+					ToolCallID:            "call_vertex_anthropic",
+					ToolArgumentsJSON:     `{"value":"ok"}`,
+					StructuredOutputValue: "vertex anthropic structured",
+					VisionText:            "vertex anthropic vision",
+					StreamText:            "vertex anthropic stream",
+					ReasoningText:         "vertex anthropic reasoning",
+				},
+			}
+			if tc.reasoning {
+				driver.ReasoningModel = model
+			}
+			if err := conformance.Verify(t.Context(), driver); err != nil {
+				t.Fatal(err)
+			}
+		})
 	}
 }
 
 type vertexAnthropicConformanceFixture struct {
-	t *testing.T
+	t     *testing.T
+	model string
 
 	mu                 sync.Mutex
 	cachedRequestCount int
@@ -64,6 +82,9 @@ type vertexAnthropicConformanceFixture struct {
 func (f *vertexAnthropicConformanceFixture) serveHTTP(w http.ResponseWriter, r *http.Request) {
 	if got := r.Header.Get("Authorization"); got != "Bearer conformance-token" {
 		f.t.Errorf("Authorization = %q, want conformance bearer token", got)
+	}
+	if want := "/models/" + f.model + ":"; !strings.Contains(r.URL.Path, want) {
+		f.t.Errorf("Vertex Anthropic request path = %q, want model route containing %q", r.URL.Path, want)
 	}
 	body, err := io.ReadAll(r.Body)
 	if err != nil {


### PR DESCRIPTION
## Summary
- exercise every catalog-listed Vertex Gemini profile through deterministic conformance
- exercise every catalog-listed Vertex Anthropic profile with model-specific reasoning coverage
- assert the exact routed model ID and document the strengthened evidence

## Validation
- go test ./provider/vertexai ./provider/vertexai_anthropic -run "^TestCatalogCapabilityConformance$" -count=1
- go test ./provider/vertexai ./provider/vertexai_anthropic ./provider/conformance ./appserver/catalog
- go test -race ./provider/vertexai ./provider/vertexai_anthropic -count=10
- go vet ./provider/vertexai ./provider/vertexai_anthropic ./provider/conformance ./appserver/catalog
- make lint
- make test

Loopback fixtures only; no provider credentials or remote requests.