### PR TITLE
fix(catalog): fail closed on reasoning efforts

### DIFF
--- a/appserver/catalog/catalog.go
+++ b/appserver/catalog/catalog.go
@@ -575,6 +575,14 @@ func tool(id, displayName, description, category string, methods []string, confi
 }
 
 func model(providerID, name, displayName, description string, hidden bool, modalities []string, personality bool, caps ModelCapabilities, efforts []string, defaultEffort string) Model {
+	var (
+		supportedEfforts []ReasoningEffortOption
+		defaultOption    *string
+	)
+	if caps.Reasoning {
+		supportedEfforts = effortOptions(efforts)
+		defaultOption = stringPointer(defaultEffort)
+	}
 	return Model{
 		ID:                        modelID(providerID, name),
 		ProviderID:                providerID,
@@ -582,14 +590,18 @@ func model(providerID, name, displayName, description string, hidden bool, modal
 		DisplayName:               displayName,
 		Description:               description,
 		Hidden:                    hidden,
-		SupportedReasoningEfforts: effortOptions(efforts),
-		DefaultReasoningEffort:    defaultEffort,
+		SupportedReasoningEfforts: supportedEfforts,
+		DefaultReasoningEffort:    defaultOption,
 		InputModalities:           append([]string(nil), modalities...),
 		SupportsPersonality:       personality,
 		AdditionalSpeedTiers:      []string{},
 		ServiceTiers:              []ModelServiceTier{},
 		Capabilities:              caps,
 	}
+}
+
+func stringPointer(value string) *string {
+	return &value
 }
 
 func capabilities(toolCalls, structured, vision, streaming, promptCache, reasoning, toolSearch bool) ModelCapabilities {

--- a/appserver/catalog/catalog_test.go
+++ b/appserver/catalog/catalog_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 
@@ -198,6 +199,36 @@ func TestReasoningSummaryCapabilityIsModelSpecific(t *testing.T) {
 	}
 }
 
+func TestReasoningEffortMetadataIsModelSpecific(t *testing.T) {
+	c := NewDefault(WithEnvLookup(mapEnv(nil)))
+	for _, provider := range c.providers {
+		for _, model := range provider.Models {
+			name := provider.ID + "/" + model.Model
+			if !model.Capabilities.Reasoning {
+				if len(model.SupportedReasoningEfforts) != 0 {
+					t.Errorf("%s exposes reasoning efforts without reasoning capability: %#v", name, model.SupportedReasoningEfforts)
+				}
+				if model.DefaultReasoningEffort != nil {
+					t.Errorf("%s exposes default reasoning effort without reasoning capability: %q", name, *model.DefaultReasoningEffort)
+				}
+				continue
+			}
+			if len(model.SupportedReasoningEfforts) == 0 {
+				t.Errorf("%s advertises reasoning without effort options", name)
+			}
+			if model.DefaultReasoningEffort == nil {
+				t.Errorf("%s advertises reasoning without a default effort", name)
+				continue
+			}
+			if !slices.ContainsFunc(model.SupportedReasoningEfforts, func(option ReasoningEffortOption) bool {
+				return option.ReasoningEffort == *model.DefaultReasoningEffort
+			}) {
+				t.Errorf("%s default reasoning effort %q is absent from %#v", name, *model.DefaultReasoningEffort, model.SupportedReasoningEfforts)
+			}
+		}
+	}
+}
+
 func TestValidateAgentRuntimeSelection(t *testing.T) {
 	c := NewDefault(WithEnvLookup(mapEnv(map[string]string{
 		"OPENAI_API_KEY": "configured",
@@ -289,8 +320,8 @@ func TestLocalOpenAICompatibleProviderUsesExplicitSafeConfiguration(t *testing.T
 	if len(models.Data) != 1 || models.Data[0].Model != model || !models.Data[0].Capabilities.ToolCalls || !models.Data[0].Capabilities.Streaming {
 		t.Fatalf("local provider models = %#v", models.Data)
 	}
-	if models.Data[0].DefaultReasoningEffort != "low" {
-		t.Fatalf("local provider default reasoning effort = %q, want low", models.Data[0].DefaultReasoningEffort)
+	if models.Data[0].DefaultReasoningEffort != nil || len(models.Data[0].SupportedReasoningEfforts) != 0 {
+		t.Fatalf("local provider reasoning metadata = default %#v, efforts %#v; want unavailable", models.Data[0].DefaultReasoningEffort, models.Data[0].SupportedReasoningEfforts)
 	}
 
 	encoded, err := json.Marshal(provider)

--- a/appserver/protocol/runtime_client_types.go
+++ b/appserver/protocol/runtime_client_types.go
@@ -91,7 +91,7 @@ type ModelCatalogEntry struct {
 	Description               string                              `json:"description"`
 	Hidden                    bool                                `json:"hidden"`
 	SupportedReasoningEfforts []ModelCatalogReasoningEffortOption `json:"supportedReasoningEfforts"`
-	DefaultReasoningEffort    string                              `json:"defaultReasoningEffort"`
+	DefaultReasoningEffort    *string                             `json:"defaultReasoningEffort"`
 	InputModalities           []string                            `json:"inputModalities"`
 	SupportsPersonality       bool                                `json:"supportsPersonality"`
 	AdditionalSpeedTiers      []string                            `json:"additionalSpeedTiers"`

--- a/appserver/protocol/runtime_client_types_contract_test.go
+++ b/appserver/protocol/runtime_client_types_contract_test.go
@@ -119,6 +119,21 @@ func TestModelCatalogCapabilitiesExposeThinkingModes(t *testing.T) {
 	}
 }
 
+func TestModelCatalogDefaultReasoningEffortIsNullable(t *testing.T) {
+	defs := JSONSchema()["$defs"].(Schema)
+	properties := defs["ModelCatalogEntry"].(Schema)["properties"].(Schema)
+	if got := properties["defaultReasoningEffort"]; !reflect.DeepEqual(got, nullableStringSchema()) {
+		t.Fatalf("ModelCatalogEntry.defaultReasoningEffort = %#v, want nullable string", got)
+	}
+	generated, err := MarshalTypeScript()
+	if err != nil {
+		t.Fatalf("MarshalTypeScript: %v", err)
+	}
+	if want := `"defaultReasoningEffort": string | null;`; !strings.Contains(string(generated), want) {
+		t.Errorf("ModelCatalogEntry TypeScript missing %q", want)
+	}
+}
+
 func TestRuntimeClientSchemasAreClosedAndCredentialFree(t *testing.T) {
 	defs := JSONSchema()["$defs"].(Schema)
 	names := []string{

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -13274,7 +13274,14 @@
           "$ref": "#/$defs/ModelCatalogCapabilities"
         },
         "defaultReasoningEffort": {
-          "type": "string"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "defaultServiceTier": {
           "anyOf": [

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -2780,7 +2780,7 @@ export type ModelCatalogEntry = {
   "additionalSpeedTiers": Array<string> | null;
   "availabilityNux": ModelCatalogAvailabilityNux | null;
   "capabilities": ModelCatalogCapabilities;
-  "defaultReasoningEffort": string;
+  "defaultReasoningEffort": string | null;
   "defaultServiceTier": string | null;
   "description": string;
   "displayName": string;


### PR DESCRIPTION
## Summary\n- represent a non-reasoning model default as explicit null in the live runtime catalog\n- omit effort options and defaults whenever the model does not advertise reasoning\n- enforce the invariant for every catalog profile and regenerate the protocol artifacts\n\n## Validation\n- go test ./appserver/catalog ./appserver/protocol\n- go test ./appserver ./appserver/catalog ./appserver/protocol\n- go test -race ./appserver ./appserver/catalog ./appserver/protocol -count=10\n- go vet ./appserver/... ./provider/anthropic ./provider/openai ./provider/vertexai ./provider/vertexai_anthropic\n- make lint\n- make test\n\nNo provider credentials or remote model calls.