### PR TITLE
fix(runtime): gate prompt cache settings by model

### DIFF
--- a/appserver/runtime_prompt_cache.go
+++ b/appserver/runtime_prompt_cache.go
@@ -1,0 +1,28 @@
+package appserver
+
+import (
+	"fmt"
+
+	"github.com/fugue-labs/gollem/appserver/catalog"
+	"github.com/fugue-labs/gollem/core"
+)
+
+// validateRuntimePromptCacheSelection prevents durable runtime settings from
+// claiming cache control for a model whose catalog profile cannot honor it.
+func validateRuntimePromptCacheSelection(
+	catalogService *catalog.Catalog,
+	selection RuntimeModelSelection,
+	settings core.ModelSettings,
+) error {
+	if settings.PromptCacheEnabled == nil {
+		return nil
+	}
+	selected, err := selectedRuntimeCatalogModel(catalogService, selection)
+	if err != nil {
+		return err
+	}
+	if !selected.Capabilities.PromptCache {
+		return fmt.Errorf("model %q does not advertise prompt caching", selected.ID)
+	}
+	return nil
+}

--- a/appserver/runtime_selection.go
+++ b/appserver/runtime_selection.go
@@ -14,5 +14,8 @@ func (s *Server) validateRuntimeSelection(selection RuntimeModelSelection, setti
 	if err := validateRuntimeReasoningSummarySelection(s.catalog, selection, settings); err != nil {
 		return err
 	}
+	if err := validateRuntimePromptCacheSelection(s.catalog, selection, settings); err != nil {
+		return err
+	}
 	return validateRuntimeThinkingSelection(s.catalog, selection, settings)
 }

--- a/appserver/runtime_test.go
+++ b/appserver/runtime_test.go
@@ -309,6 +309,93 @@ func TestServerRuntimeReasoningEffortFailsClosedAgainstModelCatalog(t *testing.T
 	}
 }
 
+func TestServerRuntimePromptCacheFailsClosedAgainstModelCatalog(t *testing.T) {
+	cacheEnabled := true
+	cacheDisabled := false
+	for _, tc := range []struct {
+		name       string
+		providerID string
+		model      string
+		cache      *bool
+		wantReason string
+	}{
+		{
+			name:       "local model does not advertise cache control",
+			providerID: "openai-compatible-local",
+			model:      "llama3",
+			cache:      &cacheEnabled,
+			wantReason: "does not advertise prompt caching",
+		},
+		{
+			name:       "local model rejects explicit disable too",
+			providerID: "openai-compatible-local",
+			model:      "llama3",
+			cache:      &cacheDisabled,
+			wantReason: "does not advertise prompt caching",
+		},
+		{
+			name:       "unknown model cannot persist cache control",
+			providerID: "openai",
+			model:      "future-model",
+			cache:      &cacheEnabled,
+			wantReason: "model capability is unavailable",
+		},
+		{
+			name:       "catalog-supported model",
+			providerID: "openai",
+			model:      "gpt-4o",
+			cache:      &cacheDisabled,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			st := newRuntimeTestStore(t)
+			server := readyServer(
+				WithStore(st),
+				WithRuntimeService(NewRuntimeService(WithRuntimeModel(
+					core.NewTestModel(core.TextResponse("done")),
+					RuntimeModelInfo{ProviderID: tc.providerID, Model: tc.model},
+				))),
+			)
+			response := server.HandleRequest(ctx, request("thread/start", map[string]any{
+				"workspace":          t.TempDir(),
+				"prompt":             "use prompt cache control",
+				"providerId":         tc.providerID,
+				"model":              tc.model,
+				"promptCacheEnabled": *tc.cache,
+			}))
+			if tc.wantReason != "" {
+				if response.Error == nil || response.Error.Code != protocol.CodeInvalidParams {
+					t.Fatalf("thread/start error = %#v, want invalid params", response.Error)
+				}
+				if !strings.Contains(response.Error.Message, tc.wantReason) {
+					t.Fatalf("thread/start error = %q, want %q", response.Error.Message, tc.wantReason)
+				}
+				threads, err := st.ListThreads(ctx, store.ThreadFilter{})
+				if err != nil {
+					t.Fatalf("ListThreads: %v", err)
+				}
+				if len(threads) != 0 {
+					t.Fatalf("invalid prompt-cache selection created %d threads", len(threads))
+				}
+				return
+			}
+			if response.Error != nil {
+				t.Fatalf("thread/start error: %v", response.Error)
+			}
+			var result protocol.ThreadRunStartResult
+			decodeResult(t, response, &result)
+			var input runtimeTurnInput
+			if err := json.Unmarshal(result.Turn.Input, &input); err != nil {
+				t.Fatalf("decode turn input: %v", err)
+			}
+			if input.PromptCacheEnabled == nil || *input.PromptCacheEnabled != *tc.cache {
+				t.Fatalf("turn prompt-cache setting = %#v, want %t", input.PromptCacheEnabled, *tc.cache)
+			}
+		})
+	}
+}
+
 func TestServerRuntimeThinkingModesFailClosedAgainstModelCatalog(t *testing.T) {
 	on := true
 	budget := 2048
@@ -1278,11 +1365,13 @@ func TestServerRuntimeTurnRetryBranchesBeforeSourceTurn(t *testing.T) {
 	)
 	server := readyServer(
 		WithStore(st),
-		WithRuntimeService(NewRuntimeService(WithRuntimeModel(model, RuntimeModelInfo{ProviderID: "test", Model: "test-model"}))),
+		WithRuntimeService(NewRuntimeService(WithRuntimeModel(model, RuntimeModelInfo{ProviderID: "openai", Model: "gpt-4o"}))),
 	)
 
 	startResp := server.HandleRequest(ctx, request("thread/start", map[string]any{
 		"prompt":             "original prompt",
+		"providerId":         "openai",
+		"model":              "gpt-4o",
 		"promptCacheEnabled": false,
 	}))
 	if startResp.Error != nil {


### PR DESCRIPTION
## Summary\n- reject explicit prompt-cache controls for models whose catalog capability is unavailable\n- retain valid cache preferences through the existing durable retry path\n- cover unsupported, unknown, and catalog-supported model selections\n\n## Validation\n- go test ./appserver ./appserver/catalog ./appserver/protocol\n- go test -race ./appserver ./appserver/catalog ./appserver/protocol -count=10\n- go vet ./appserver/...\n- make lint\n- make test\n\nThe provider behavior is covered by existing static-token loopback conformance fixtures; no real provider credentials or endpoints were used.