### PR TITLE
fix(appserver): retain generic runtime settings on retry

### DIFF
--- a/appserver/runtime.go
+++ b/appserver/runtime.go
@@ -643,6 +643,9 @@ type runtimeTurnInput struct {
 	ProviderID         string         `json:"providerId,omitempty"`
 	Provider           string         `json:"provider,omitempty"`
 	Model              string         `json:"model,omitempty"`
+	MaxTokens          *int           `json:"maxTokens,omitempty"`
+	Temperature        *float64       `json:"temperature,omitempty"`
+	TopP               *float64       `json:"topP,omitempty"`
 	ReasoningEffort    string         `json:"reasoningEffort,omitempty"`
 	ReasoningSummary   string         `json:"reasoningSummary,omitempty"`
 	ThinkingBudget     *int           `json:"thinkingBudget,omitempty"`
@@ -664,6 +667,9 @@ func runtimeTurnInputJSON(
 		ProviderID:         selection.ProviderID,
 		Provider:           selection.Provider,
 		Model:              selection.Model,
+		MaxTokens:          cloneInt(settings.MaxTokens),
+		Temperature:        cloneFloat64(settings.Temperature),
+		TopP:               cloneFloat64(settings.TopP),
 		ReasoningEffort:    runtimeReasoningEffort(settings),
 		ReasoningSummary:   runtimeReasoningSummary(settings),
 		ThinkingBudget:     runtimeThinkingBudget(settings),

--- a/appserver/runtime_params.go
+++ b/appserver/runtime_params.go
@@ -141,6 +141,9 @@ func runtimeModelSettingsFromInput(input json.RawMessage) core.ModelSettings {
 		return core.ModelSettings{}
 	}
 	settings := core.ModelSettings{
+		MaxTokens:          cloneInt(stored.MaxTokens),
+		Temperature:        cloneFloat64(stored.Temperature),
+		TopP:               cloneFloat64(stored.TopP),
 		ThinkingBudget:     cloneInt(stored.ThinkingBudget),
 		AdaptiveThinking:   cloneBool(stored.AdaptiveThinking),
 		ReasoningSummary:   cloneString(stored.ReasoningSummary),
@@ -169,6 +172,14 @@ func cloneInt(value *int) *int {
 	return &cloned
 }
 
+func cloneFloat64(value *float64) *float64 {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}
+
 func cloneString(value string) *string {
 	if value == "" {
 		return nil
@@ -190,6 +201,15 @@ func runtimeModelSettingsWithThreadDefaults(
 }
 
 func mergeRuntimeModelSettings(primary, fallback core.ModelSettings) core.ModelSettings {
+	if primary.MaxTokens == nil {
+		primary.MaxTokens = cloneInt(fallback.MaxTokens)
+	}
+	if primary.Temperature == nil {
+		primary.Temperature = cloneFloat64(fallback.Temperature)
+	}
+	if primary.TopP == nil {
+		primary.TopP = cloneFloat64(fallback.TopP)
+	}
 	if primary.ThinkingBudget == nil {
 		primary.ThinkingBudget = cloneInt(fallback.ThinkingBudget)
 	}

--- a/appserver/runtime_test.go
+++ b/appserver/runtime_test.go
@@ -636,6 +636,71 @@ func TestServerRuntimeRetryRetainsThinkingSettings(t *testing.T) {
 	}
 }
 
+func TestServerRuntimeRetryRetainsGenericModelSettings(t *testing.T) {
+	ctx := context.Background()
+	st := newRuntimeTestStore(t)
+	model := core.NewTestModel(core.TextResponse("first"), core.TextResponse("retry"))
+	server := readyServer(
+		WithStore(st),
+		WithRuntimeService(NewRuntimeService(WithRuntimeModel(
+			model,
+			RuntimeModelInfo{ProviderID: "openai", Model: "gpt-4o"},
+		))),
+	)
+	const (
+		maxTokens   = 1234
+		temperature = 0.35
+		topP        = 0.8
+	)
+	start := server.HandleRequest(ctx, request("thread/start", map[string]any{
+		"workspace":   t.TempDir(),
+		"prompt":      "persist generic model settings",
+		"providerId":  "openai",
+		"model":       "gpt-4o",
+		"maxTokens":   maxTokens,
+		"temperature": temperature,
+		"topP":        topP,
+	}))
+	if start.Error != nil {
+		t.Fatalf("thread/start error: %v", start.Error)
+	}
+	var started protocol.ThreadRunStartResult
+	decodeResult(t, start, &started)
+	waitForNotificationSet(t, server, "turn/completed")
+
+	retry := server.HandleRequest(ctx, request("turn/retry", map[string]any{"turnId": started.Turn.ID}))
+	if retry.Error != nil {
+		t.Fatalf("turn/retry error: %v", retry.Error)
+	}
+	var retried protocol.TurnRunRetryResult
+	decodeResult(t, retry, &retried)
+	waitForNotificationSet(t, server, "turn/completed")
+
+	persisted, err := st.GetTurn(ctx, retried.Turn.ID)
+	if err != nil {
+		t.Fatalf("GetTurn retry: %v", err)
+	}
+	var input runtimeTurnInput
+	if err := json.Unmarshal(persisted.Input, &input); err != nil {
+		t.Fatalf("decode retry input: %v", err)
+	}
+	if !sameIntPointer(input.MaxTokens, intPointer(maxTokens)) ||
+		!sameFloat64Pointer(input.Temperature, float64Pointer(temperature)) ||
+		!sameFloat64Pointer(input.TopP, float64Pointer(topP)) {
+		t.Fatalf("retry input settings = %#v, want max=%d temperature=%g topP=%g", input, maxTokens, temperature, topP)
+	}
+	calls := model.Calls()
+	if len(calls) != 2 {
+		t.Fatalf("model calls = %d, want 2", len(calls))
+	}
+	if calls[1].Settings == nil ||
+		!sameIntPointer(calls[1].Settings.MaxTokens, intPointer(maxTokens)) ||
+		!sameFloat64Pointer(calls[1].Settings.Temperature, float64Pointer(temperature)) ||
+		!sameFloat64Pointer(calls[1].Settings.TopP, float64Pointer(topP)) {
+		t.Fatalf("retry model settings = %#v, want max=%d temperature=%g topP=%g", calls[1].Settings, maxTokens, temperature, topP)
+	}
+}
+
 func TestServerRuntimeReasoningSummaryFailsClosedAndSurvivesRetry(t *testing.T) {
 	ctx := context.Background()
 	st := newRuntimeTestStore(t)
@@ -731,6 +796,21 @@ func sameBoolPointer(got, want *bool) bool {
 		return got == want
 	}
 	return *got == *want
+}
+
+func sameFloat64Pointer(got, want *float64) bool {
+	if got == nil || want == nil {
+		return got == want
+	}
+	return *got == *want
+}
+
+func intPointer(value int) *int {
+	return &value
+}
+
+func float64Pointer(value float64) *float64 {
+	return &value
 }
 
 func TestServerRuntimeSelectionValidatorFailsClosedBeforeThreadCreation(t *testing.T) {


### PR DESCRIPTION
## Summary
- persist public max-token and sampling settings in durable runtime turn input
- reconstruct and merge those settings for inherited retries
- add a regression test that verifies durable input and retry model invocation state

## Validation
- `go test ./appserver ./appserver/catalog ./appserver/protocol`
- `go test -race ./appserver ./appserver/catalog ./appserver/protocol -count=10`
- `go test ./appserver -run "^TestServerRuntimeRetryRetainsGenericModelSettings$" -count=20`
- `go vet ./appserver/...`
- `make lint`
- `make test` (Monty excluded)
- pre-push non-Monty lint/race/vet/tidy checks