### PR TITLE
Redact runtime failure details at the app-server boundary

### DIFF
--- a/appserver/runtime.go
+++ b/appserver/runtime.go
@@ -24,6 +24,13 @@ var (
 	ErrRuntimeRecoveryUnavailable = errors.New("appserver/runtime: store does not support restart recovery")
 )
 
+const (
+	runtimePublicErrorFailed      = "Runtime execution failed."
+	runtimePublicErrorInterrupted = "Runtime execution was interrupted."
+	runtimePublicErrorTimedOut    = "Runtime execution timed out."
+	runtimePublicErrorProvider    = "Provider request failed."
+)
+
 type RuntimeModelSelection struct {
 	ProviderID string `json:"providerId,omitempty"`
 	Provider   string `json:"provider,omitempty"`
@@ -608,10 +615,7 @@ func (s *RuntimeService) complete(st store.Store, notifier runtimeNotifier, turn
 	if payload, err := json.Marshal(resultPayload); err == nil {
 		rawResult = payload
 	}
-	errorText := ""
-	if runErr != nil {
-		errorText = runErr.Error()
-	}
+	errorText := runtimePublicError(runErr)
 	completed, err := st.CompleteTurn(context.Background(), store.CompleteTurnRequest{
 		ID:     turn.ID,
 		Status: status,
@@ -636,6 +640,29 @@ func statusFromRuntimeError(err error) store.TurnStatus {
 		return store.TurnInterrupted
 	}
 	return store.TurnFailed
+}
+
+// runtimePublicError deliberately projects only stable recovery information.
+// Runtime errors can contain provider payloads, endpoints, credentials, prompts,
+// or tool output and must not cross the durable or app-server notification boundary.
+func runtimePublicError(err error) string {
+	if err == nil {
+		return ""
+	}
+	if errors.Is(err, context.Canceled) {
+		return runtimePublicErrorInterrupted
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return runtimePublicErrorTimedOut
+	}
+	var httpErr *core.ModelHTTPError
+	if errors.As(err, &httpErr) && httpErr != nil {
+		if httpErr.StatusCode >= 100 && httpErr.StatusCode <= 599 {
+			return fmt.Sprintf("Provider request failed (HTTP %d).", httpErr.StatusCode)
+		}
+		return runtimePublicErrorProvider
+	}
+	return runtimePublicErrorFailed
 }
 
 type runtimeTurnInput struct {
@@ -856,7 +883,7 @@ func publishRuntimeError(notifier runtimeNotifier, turn *store.Turn, text string
 	if notifier == nil || text == "" {
 		return
 	}
-	params := runtimeErrorNotificationParams{Error: text, At: time.Now().UTC()}
+	params := runtimeErrorNotificationParams{Error: runtimePublicErrorFailed, At: time.Now().UTC()}
 	if turn != nil {
 		params.ThreadID = turn.ThreadID
 		params.TurnID = turn.ID

--- a/appserver/runtime_error_notification_contract_test.go
+++ b/appserver/runtime_error_notification_contract_test.go
@@ -1,13 +1,17 @@
 package appserver
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/fugue-labs/gollem/appserver/protocol"
 	"github.com/fugue-labs/gollem/appserver/store"
+	"github.com/fugue-labs/gollem/core"
 )
 
 type runtimeErrorCaptureNotifier struct {
@@ -36,7 +40,7 @@ func TestPublishRuntimeErrorRetainsLiveExtensionShape(t *testing.T) {
 				t.Fatalf("method = %q", notifier.method)
 			}
 			params, ok := notifier.params.(runtimeErrorNotificationParams)
-			if !ok || params.Error != "boom" || params.At.IsZero() {
+			if !ok || params.Error != runtimePublicErrorFailed || params.At.IsZero() {
 				t.Fatalf("params = %#v (%T)", notifier.params, notifier.params)
 			}
 			if tc.turn != nil && (params.ThreadID != "thread" || params.TurnID != "turn") {
@@ -64,6 +68,43 @@ func TestPublishRuntimeErrorRetainsLiveExtensionShape(t *testing.T) {
 			var exact protocol.ErrorNotification
 			if err := json.Unmarshal(encoded, &exact); err == nil {
 				t.Fatal("incompatible live extension decoded as exact public error")
+			}
+		})
+	}
+}
+
+func TestRuntimePublicErrorRedactsUntrustedDetails(t *testing.T) {
+	const secret = "https://provider.invalid/v1?api_key=super-secret"
+	for _, tc := range []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"generic", fmt.Errorf("request %s failed", secret), runtimePublicErrorFailed},
+		{"cancelled", fmt.Errorf("request %s: %w", secret, context.Canceled), runtimePublicErrorInterrupted},
+		{"timed out", fmt.Errorf("request %s: %w", secret, context.DeadlineExceeded), runtimePublicErrorTimedOut},
+		{
+			"provider HTTP status",
+			fmt.Errorf("request %s: %w", secret, &core.ModelHTTPError{
+				Message:    "Authorization: Bearer super-secret",
+				StatusCode: 429,
+				Body:       "prompt=super-secret",
+			}),
+			"Provider request failed (HTTP 429).",
+		},
+		{
+			"invalid provider status",
+			&core.ModelHTTPError{Message: secret, StatusCode: 0, Body: secret},
+			runtimePublicErrorProvider,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := runtimePublicError(tc.err)
+			if got != tc.want {
+				t.Fatalf("runtimePublicError(%v) = %q, want %q", tc.err, got, tc.want)
+			}
+			if got == "" || strings.Contains(got, "super-secret") || strings.Contains(got, "provider.invalid") {
+				t.Fatalf("runtimePublicError(%v) exposed untrusted detail: %q", tc.err, got)
 			}
 		})
 	}

--- a/appserver/runtime_test.go
+++ b/appserver/runtime_test.go
@@ -120,6 +120,58 @@ func TestRuntimeStartFailureTerminalizesCreatedTurn(t *testing.T) {
 	}
 }
 
+func TestServerRuntimeFailureRedactsPersistedAndNotifiedErrors(t *testing.T) {
+	const secret = "https://provider.invalid/v1?api_key=super-secret"
+	ctx := context.Background()
+	st := newRuntimeTestStore(t)
+	server := readyServer(
+		WithStore(st),
+		WithRuntimeService(NewRuntimeService(WithRuntimeModel(
+			runtimeFailingModel{err: errors.New("provider request to " + secret + " failed")},
+			RuntimeModelInfo{ProviderID: "test", Model: "failing"},
+		))),
+	)
+
+	response := server.HandleRequest(ctx, request("thread/start", map[string]any{
+		"prompt": "do not disclose this prompt",
+	}))
+	if response.Error != nil {
+		t.Fatalf("thread/start error: %v", response.Error)
+	}
+	var started protocol.ThreadRunStartResult
+	decodeResult(t, response, &started)
+	notifications := waitForNotificationSet(t, server, "error", "turn/completed")
+
+	persisted, err := st.GetTurn(ctx, started.Turn.ID)
+	if err != nil {
+		t.Fatalf("GetTurn: %v", err)
+	}
+	if persisted.Status != store.TurnFailed || persisted.Error != runtimePublicErrorFailed {
+		t.Fatalf("persisted turn = %#v, want redacted failed turn", persisted)
+	}
+	if strings.Contains(persisted.Error, secret) {
+		t.Fatalf("persisted error exposed %q: %q", secret, persisted.Error)
+	}
+
+	for _, notification := range notifications {
+		if notification.Method != "error" {
+			continue
+		}
+		var params runtimeErrorNotificationParams
+		if err := json.Unmarshal(notification.Params, &params); err != nil {
+			t.Fatalf("decode error notification: %v", err)
+		}
+		if params.Error != runtimePublicErrorFailed || params.ThreadID != started.Thread.ID || params.TurnID != started.Turn.ID {
+			t.Fatalf("error notification = %#v", params)
+		}
+		if strings.Contains(params.Error, secret) {
+			t.Fatalf("notification error exposed %q: %q", secret, params.Error)
+		}
+		return
+	}
+	t.Fatal("runtime error notification missing")
+}
+
 func TestRuntimeStartPersistsExplicitReasoningEffort(t *testing.T) {
 	ctx := context.Background()
 	st := newRuntimeTestStore(t)
@@ -1799,7 +1851,7 @@ func TestServerRuntimeTurnInterruptCancelsActiveRun(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetTurn: %v", err)
 	}
-	if turn.Status != store.TurnInterrupted {
+	if turn.Status != store.TurnInterrupted || turn.Error != runtimePublicErrorInterrupted {
 		t.Fatalf("turn status = %s, want interrupted; error=%q", turn.Status, turn.Error)
 	}
 }
@@ -1833,7 +1885,7 @@ func TestRuntimeShutdownCancelsActiveRunBeforeStoreClose(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetTurn: %v", err)
 	}
-	if turn.Status != store.TurnInterrupted {
+	if turn.Status != store.TurnInterrupted || turn.Error != runtimePublicErrorInterrupted {
 		t.Fatalf("turn status = %s, want interrupted; error=%q", turn.Status, turn.Error)
 	}
 	if err := st.Close(); err != nil {
@@ -2267,8 +2319,8 @@ func TestServerRuntimeTurnSteerFailsClosedWhenConsumptionBoundaryCannotPersist(t
 	if err != nil {
 		t.Fatalf("GetTurn: %v", err)
 	}
-	if turn.Status != store.TurnFailed || !strings.Contains(turn.Error, "item boundary unavailable") {
-		t.Fatalf("turn = %#v, want failed consumption acknowledgement", turn)
+	if turn.Status != store.TurnFailed || turn.Error != runtimePublicErrorFailed {
+		t.Fatalf("turn = %#v, want redacted failed consumption acknowledgement", turn)
 	}
 	items, err := base.ListItems(ctx, store.ItemFilter{
 		ThreadID: started.Turn.ThreadID,
@@ -2597,6 +2649,22 @@ func assertRuntimeAssistantText(t *testing.T, message core.ModelMessage, want st
 
 type blockingRuntimeModel struct {
 	started chan struct{}
+}
+
+type runtimeFailingModel struct {
+	err error
+}
+
+func (m runtimeFailingModel) Request(context.Context, []core.ModelMessage, *core.ModelSettings, *core.ModelRequestParameters) (*core.ModelResponse, error) {
+	return nil, m.err
+}
+
+func (m runtimeFailingModel) RequestStream(context.Context, []core.ModelMessage, *core.ModelSettings, *core.ModelRequestParameters) (core.StreamedResponse, error) {
+	return nil, m.err
+}
+
+func (runtimeFailingModel) ModelName() string {
+	return "failing"
 }
 
 func (m *blockingRuntimeModel) Request(ctx context.Context, _ []core.ModelMessage, _ *core.ModelSettings, _ *core.ModelRequestParameters) (*core.ModelResponse, error) {


### PR DESCRIPTION
## Summary
- persist stable, bounded recovery messages instead of raw runtime error text
- keep interruption, timeout, and valid provider HTTP status classifications actionable
- make live runtime error notifications fail closed and add regression coverage for secret-bearing failures

## Validation
- go test ./appserver -count=1
- go test ./appserver -run 'Test(ServerRuntimeFailureRedactsPersistedAndNotifiedErrors|ServerRuntimeTurnInterruptCancelsActiveRun|RuntimeShutdownCancelsActiveRunBeforeStoreClose|RuntimePublicErrorRedactsUntrustedDetails|PublishRuntimeError)' -count=30\n- go test ./appserver ./appserver/catalog ./appserver/protocol -count=3\n- go test -race ./appserver ./appserver/catalog ./appserver/protocol -count=10\n- go vet ./appserver/...\n- make lint\n- make test (explicitly excludes ext/monty)