### PR TITLE
Redact failed runtime item diagnostics

### DIFF
--- a/appserver/runtime.go
+++ b/appserver/runtime.go
@@ -29,6 +29,8 @@ const (
 	runtimePublicErrorInterrupted = "Runtime execution was interrupted."
 	runtimePublicErrorTimedOut    = "Runtime execution timed out."
 	runtimePublicErrorProvider    = "Provider request failed."
+	runtimePublicToolFailure      = "Tool execution failed."
+	runtimePublicMCPToolFailure   = "MCP tool execution failed."
 )
 
 type RuntimeModelSelection struct {

--- a/appserver/runtime_interaction_tools_test.go
+++ b/appserver/runtime_interaction_tools_test.go
@@ -346,7 +346,7 @@ func TestServerRuntimeInterruptCancelsPendingInteraction(t *testing.T) {
 		t.Fatalf("ListItems: %v", err)
 	}
 	toolItem := findRuntimeToolItem(t, items, "request_user_input", "prompt", "Wait for input")
-	if toolItem.Status != runtimeToolStatusFailed || len(toolItem.Payload.ContentItems) != 1 || !strings.Contains(toolItem.Payload.ContentItems[0].Text, "canceled") {
+	if toolItem.Status != runtimeToolStatusFailed || len(toolItem.Payload.ContentItems) != 1 || toolItem.Payload.ContentItems[0].Text != runtimePublicToolFailure {
 		t.Fatalf("interrupted interaction item = %#v", toolItem)
 	}
 }

--- a/appserver/runtime_item_failure_redaction_test.go
+++ b/appserver/runtime_item_failure_redaction_test.go
@@ -1,0 +1,139 @@
+package appserver
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/fugue-labs/gollem/appserver/store"
+	"github.com/fugue-labs/gollem/core"
+)
+
+func TestServerRuntimeToolFailureRedactsPersistedAndNotifiedItem(t *testing.T) {
+	const secret = "https://tools.invalid/run?token=super-secret"
+	type args struct{}
+	tool := core.FuncTool[args]("secret_tool", "returns a secret-bearing error", func(context.Context, args) (string, error) {
+		return "", errors.New("tool request to " + secret + " failed")
+	})
+	st := newRuntimeTestStore(t)
+	server := readyServer(
+		WithStore(st),
+		WithRuntimeService(NewRuntimeService(
+			WithRuntimeModel(
+				core.NewTestModel(
+					core.ToolCallResponseWithID("secret_tool", `{}`, "call-secret"),
+					core.TextResponse("recovered"),
+				),
+				RuntimeModelInfo{ProviderID: "test", Model: "tool-failure"},
+			),
+			WithRuntimeTools(tool),
+		)),
+	)
+
+	response := server.HandleRequest(context.Background(), request("thread/start", map[string]any{"prompt": "run tool"}))
+	if response.Error != nil {
+		t.Fatalf("thread/start error: %v", response.Error)
+	}
+	var started struct {
+		Thread *store.Thread `json:"thread"`
+		Turn   *store.Turn   `json:"turn"`
+	}
+	decodeResult(t, response, &started)
+	notifications := waitForNotificationSet(t, server, "item/completed", "turn/completed")
+
+	items, err := st.ListItems(context.Background(), store.ItemFilter{ThreadID: started.Thread.ID, TurnID: started.Turn.ID})
+	if err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+	item, payload := runtimeFailedToolItem(t, items)
+	if item.Status != runtimeToolStatusFailed || payload.Status != runtimeToolStatusFailed || len(payload.ContentItems) != 1 || payload.ContentItems[0].Text != runtimePublicToolFailure {
+		t.Fatalf("persisted failed tool item = %#v, payload = %#v", item, payload)
+	}
+	if strings.Contains(payload.ContentItems[0].Text, "super-secret") || strings.Contains(payload.ContentItems[0].Text, "tools.invalid") {
+		t.Fatalf("persisted failed tool output leaked secret detail: %#v", payload.ContentItems)
+	}
+
+	for _, notification := range notifications {
+		if notification.Method != "item/completed" {
+			continue
+		}
+		var params runtimeToolItemCompletedNotificationParams
+		if err := json.Unmarshal(notification.Params, &params); err != nil {
+			t.Fatalf("decode tool completion notification: %v", err)
+		}
+		if params.Item.ID != item.ID {
+			continue
+		}
+		if len(params.Item.ContentItems) != 1 || params.Item.ContentItems[0].Text != runtimePublicToolFailure {
+			t.Fatalf("tool completion notification = %#v", params)
+		}
+		return
+	}
+	t.Fatal("failed tool completion notification missing")
+}
+
+func TestRuntimeMCPFailureRedactsPersistedAndNotifiedItem(t *testing.T) {
+	const secret = "Authorization: Bearer super-secret"
+	ctx := context.Background()
+	st := newRuntimeTestStore(t)
+	thread, err := st.CreateThread(ctx, store.CreateThreadRequest{Title: "MCP item redaction"})
+	if err != nil {
+		t.Fatalf("CreateThread: %v", err)
+	}
+	turn, err := st.CreateTurn(ctx, store.CreateTurnRequest{ThreadID: thread.ID})
+	if err != nil {
+		t.Fatalf("CreateTurn: %v", err)
+	}
+	notifier := &runtimeErrorCaptureNotifier{}
+	tracker := newRuntimeMCPItemTracker(st, notifier, turn, nil)
+	tracker.toolStarted(runtimeMCPToolStartedEvent{
+		RunID: "run", ToolCallID: "call", ToolName: "mcp_call_tool", Server: "repo", MCPTool: "status", StartedAt: time.Now().UTC(),
+	})
+	tracker.toolCompleted(runtimeMCPToolCompletedEvent{
+		RunID: "run", ToolCallID: "call", ToolName: "mcp_call_tool", Error: secret, CompletedAt: time.Now().UTC(),
+	})
+
+	items, err := st.ListItems(ctx, store.ItemFilter{ThreadID: thread.ID, TurnID: turn.ID})
+	if err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("items = %#v, want one MCP item", items)
+	}
+	var payload runtimeMCPToolCallPayload
+	if err := json.Unmarshal(items[0].Payload, &payload); err != nil {
+		t.Fatalf("decode MCP item: %v", err)
+	}
+	if items[0].Status != runtimeMCPStatusFailed || payload.Status != runtimeMCPStatusFailed || payload.Error == nil || payload.Error.Message != runtimePublicMCPToolFailure {
+		t.Fatalf("persisted MCP item = %#v, payload = %#v", items[0], payload)
+	}
+	if strings.Contains(payload.Error.Message, "super-secret") {
+		t.Fatalf("persisted MCP item leaked secret detail: %#v", payload.Error)
+	}
+
+	params, ok := notifier.params.(runtimeMCPItemCompletedNotificationParams)
+	if !ok || params.Item.Error == nil || params.Item.Error.Message != runtimePublicMCPToolFailure {
+		t.Fatalf("MCP completion notification = %#v (%T)", notifier.params, notifier.params)
+	}
+}
+
+func runtimeFailedToolItem(t *testing.T, items []*store.Item) (*store.Item, runtimeDynamicToolCallPayload) {
+	t.Helper()
+	for _, item := range items {
+		if item.Kind != runtimeDynamicToolCallItemKind {
+			continue
+		}
+		var payload runtimeDynamicToolCallPayload
+		if err := json.Unmarshal(item.Payload, &payload); err != nil {
+			t.Fatalf("decode dynamic tool item: %v", err)
+		}
+		if payload.Tool == "secret_tool" {
+			return item, payload
+		}
+	}
+	t.Fatal("failed dynamic tool item missing")
+	return nil, runtimeDynamicToolCallPayload{}
+}

--- a/appserver/runtime_mcp_items.go
+++ b/appserver/runtime_mcp_items.go
@@ -159,9 +159,8 @@ func (t *runtimeMCPItemTracker) toolCompleted(event runtimeMCPToolCompletedEvent
 	state.payload.DurationMS = runtimeInt64Pointer(duration)
 	state.payload.Status = runtimeMCPStatusCompleted
 	if event.Error != "" {
-		message, _ := boundedRuntimeMCPText(event.Error, runtimeMCPMetadataMaxBytes)
 		state.payload.Status = runtimeMCPStatusFailed
-		state.payload.Error = &runtimeMCPToolCallErrorPayload{Message: message}
+		state.payload.Error = &runtimeMCPToolCallErrorPayload{Message: runtimePublicMCPToolFailure}
 		state.payload.Result = nil
 	} else if event.Result != nil {
 		state.payload.Result = event.Result.ItemResult

--- a/appserver/runtime_mcp_tools_test.go
+++ b/appserver/runtime_mcp_tools_test.go
@@ -215,7 +215,7 @@ func TestServerRuntimeDeniedMCPCallPersistsFailedItemWithoutCallingSource(t *tes
 		t.Fatalf("ListItems: %v", err)
 	}
 	mcpItem := findRuntimeMCPItem(t, items, "repo", "mutate")
-	if mcpItem.Item.Status != runtimeMCPStatusFailed || mcpItem.Payload.Error == nil || !strings.Contains(mcpItem.Payload.Error.Message, "denied") {
+	if mcpItem.Item.Status != runtimeMCPStatusFailed || mcpItem.Payload.Error == nil || mcpItem.Payload.Error.Message != runtimePublicMCPToolFailure {
 		t.Fatalf("denied MCP item = %#v", mcpItem)
 	}
 	if source.callCount() != 0 {
@@ -274,7 +274,7 @@ func TestServerRuntimeInterruptCancelsPendingMCPApproval(t *testing.T) {
 		t.Fatalf("ListItems: %v", err)
 	}
 	mcpItem := findRuntimeMCPItem(t, items, "repo", "wait")
-	if mcpItem.Item.Status != runtimeMCPStatusFailed || mcpItem.Payload.Error == nil || !strings.Contains(mcpItem.Payload.Error.Message, "canceled") {
+	if mcpItem.Item.Status != runtimeMCPStatusFailed || mcpItem.Payload.Error == nil || mcpItem.Payload.Error.Message != runtimePublicMCPToolFailure {
 		t.Fatalf("interrupted MCP item = %#v", mcpItem)
 	}
 	requestID, _ := approvalRequest.ID.Value().(string)

--- a/appserver/runtime_test.go
+++ b/appserver/runtime_test.go
@@ -1365,7 +1365,7 @@ func TestServerRuntimePersistsFailedDynamicToolCall(t *testing.T) {
 	if failed.Status != "failed" || failed.Success == nil || *failed.Success {
 		t.Fatalf("failed tool item = %#v", failed)
 	}
-	if len(failed.ContentItems) != 1 || !strings.Contains(failed.ContentItems[0].Text, "boom") {
+	if len(failed.ContentItems) != 1 || failed.ContentItems[0].Text != runtimePublicToolFailure {
 		t.Fatalf("failed tool content = %#v", failed.ContentItems)
 	}
 

--- a/appserver/runtime_tool_items.go
+++ b/appserver/runtime_tool_items.go
@@ -154,6 +154,11 @@ func (t *runtimeToolItemTracker) complete(key, status, output string, success bo
 		return
 	}
 	delete(t.items, key)
+	if !success {
+		// Tool errors can contain provider, endpoint, credential, prompt, or tool details.
+		// Persisting a fixed failure label keeps the durable public timeline fail closed.
+		output = runtimePublicToolFailure
+	}
 	state.payload.Status = status
 	state.payload.ContentItems = []runtimeDynamicToolCallContentItem{{Type: "inputText", Text: boundedRuntimeToolOutput(output)}}
 	state.payload.Success = runtimeBoolPointer(success)


### PR DESCRIPTION
## Summary
- replace raw dynamic-tool and MCP failure details in durable items with stable public labels
- preserve successful tool output and all failure lifecycle, approval, and interruption states
- cover real runtime tool failures plus MCP item storage and lifecycle notification projection

## Validation
- go test ./appserver -count=1
- go test ./appserver -run 'Test(ServerRuntimeToolFailureRedactsPersistedAndNotifiedItem|RuntimeMCPFailureRedactsPersistedAndNotifiedItem|ServerRuntimeInterruptCancelsPendingInteraction|ServerRuntimeDeniedMCPCallPersistsFailedItemWithoutCallingSource|ServerRuntimeInterruptCancelsPendingMCPApproval|ServerRuntimePersistsFailedDynamicToolCall)' -count=30\n- go test ./appserver ./appserver/catalog ./appserver/protocol -count=3\n- go test -race ./appserver ./appserver/catalog ./appserver/protocol -count=10\n- go vet ./appserver/...\n- make lint\n- make test (explicitly excludes ext/monty)