### PR TITLE
fix(appserver): classify live runtime errors safely

### DIFF
--- a/appserver/runtime.go
+++ b/appserver/runtime.go
@@ -502,7 +502,12 @@ func (s *RuntimeService) run(ctx context.Context, st store.Store, notifier runti
 	})
 	defer unsubscribeDelta()
 	unsubscribeError := core.Subscribe(bus, func(event core.ErrorRaisedEvent) {
-		publishRuntimeError(notifier, turn, event.Error)
+		if event.Cause == nil {
+			// Preserve the redacted fallback for legacy string-only publishers.
+			publishRuntimeError(notifier, turn, event.Error)
+			return
+		}
+		publishPublicRuntimeError(notifier, turn, runtimePublicError(event.Cause))
 	})
 	defer unsubscribeError()
 	toolItems := newRuntimeToolItemTracker(st, notifier, turn, s.tools)
@@ -885,7 +890,14 @@ func publishRuntimeError(notifier runtimeNotifier, turn *store.Turn, text string
 	if notifier == nil || text == "" {
 		return
 	}
-	params := runtimeErrorNotificationParams{Error: runtimePublicErrorFailed, At: time.Now().UTC()}
+	publishPublicRuntimeError(notifier, turn, runtimePublicErrorFailed)
+}
+
+func publishPublicRuntimeError(notifier runtimeNotifier, turn *store.Turn, message string) {
+	if notifier == nil || message == "" {
+		return
+	}
+	params := runtimeErrorNotificationParams{Error: message, At: time.Now().UTC()}
 	if turn != nil {
 		params.ThreadID = turn.ThreadID
 		params.TurnID = turn.ID

--- a/appserver/runtime_error_notification_contract_test.go
+++ b/appserver/runtime_error_notification_contract_test.go
@@ -118,3 +118,12 @@ func TestPublishRuntimeErrorNoopGuards(t *testing.T) {
 		t.Fatalf("unexpected notification %q %#v", notifier.method, notifier.params)
 	}
 }
+
+func TestPublishPublicRuntimeErrorUsesProjectedMessage(t *testing.T) {
+	notifier := &runtimeErrorCaptureNotifier{}
+	publishPublicRuntimeError(notifier, &store.Turn{ID: "turn", ThreadID: "thread"}, runtimePublicErrorInterrupted)
+	params, ok := notifier.params.(runtimeErrorNotificationParams)
+	if notifier.method != "error" || !ok || params.Error != runtimePublicErrorInterrupted {
+		t.Fatalf("notification = %q %#v", notifier.method, notifier.params)
+	}
+}

--- a/appserver/runtime_test.go
+++ b/appserver/runtime_test.go
@@ -172,6 +172,59 @@ func TestServerRuntimeFailureRedactsPersistedAndNotifiedErrors(t *testing.T) {
 	t.Fatal("runtime error notification missing")
 }
 
+func TestServerRuntimeHTTPFailureClassifiesLiveNotificationWithoutProviderDetails(t *testing.T) {
+	const secret = "https://provider.invalid/v1?api_key=super-secret"
+	ctx := context.Background()
+	st := newRuntimeTestStore(t)
+	server := readyServer(
+		WithStore(st),
+		WithRuntimeService(NewRuntimeService(WithRuntimeModel(
+			runtimeFailingModel{err: &core.ModelHTTPError{
+				Message:    "Authorization: Bearer super-secret for " + secret,
+				StatusCode: 429,
+				Body:       "prompt=super-secret",
+			}},
+			RuntimeModelInfo{ProviderID: "test", Model: "failing"},
+		))),
+	)
+
+	response := server.HandleRequest(ctx, request("thread/start", map[string]any{
+		"prompt": "do not disclose this prompt",
+	}))
+	if response.Error != nil {
+		t.Fatalf("thread/start error: %v", response.Error)
+	}
+	var started protocol.ThreadRunStartResult
+	decodeResult(t, response, &started)
+	notifications := waitForNotificationSet(t, server, "error", "turn/completed")
+
+	persisted, err := st.GetTurn(ctx, started.Turn.ID)
+	if err != nil {
+		t.Fatalf("GetTurn: %v", err)
+	}
+	want := "Provider request failed (HTTP 429)."
+	if persisted.Status != store.TurnFailed || persisted.Error != want {
+		t.Fatalf("persisted turn = %#v, want safely classified failed turn", persisted)
+	}
+	for _, notification := range notifications {
+		if notification.Method != "error" {
+			continue
+		}
+		var params runtimeErrorNotificationParams
+		if err := json.Unmarshal(notification.Params, &params); err != nil {
+			t.Fatalf("decode error notification: %v", err)
+		}
+		if params.Error != want || params.ThreadID != started.Thread.ID || params.TurnID != started.Turn.ID {
+			t.Fatalf("error notification = %#v", params)
+		}
+		if strings.Contains(params.Error, "super-secret") || strings.Contains(params.Error, "provider.invalid") {
+			t.Fatalf("notification error exposed provider detail: %q", params.Error)
+		}
+		return
+	}
+	t.Fatal("runtime error notification missing")
+}
+
 func TestRuntimeStartPersistsExplicitReasoningEffort(t *testing.T) {
 	ctx := context.Background()
 	st := newRuntimeTestStore(t)

--- a/core/agent.go
+++ b/core/agent.go
@@ -393,6 +393,7 @@ func (a *Agent[T]) endRun(ctx context.Context, state *agentRunState, deps any, p
 				ParentRunID: state.parentRunID,
 				TurnNumber:  state.runStep,
 				Error:       runErr.Error(),
+				Cause:       runErr,
 				RaisedAt:    time.Now(),
 			})
 		}

--- a/core/runtime_events.go
+++ b/core/runtime_events.go
@@ -476,7 +476,11 @@ type ErrorRaisedEvent struct {
 	ToolName    string
 	ToolCallID  string
 	Error       string
-	RaisedAt    time.Time
+	// Cause retains the original error for in-process subscribers that need to
+	// classify it. It is unsafe for persistence, logging, or network transport;
+	// consumers must project it to a public-safe value before exposing it.
+	Cause    error
+	RaisedAt time.Time
 }
 
 func (e ErrorRaisedEvent) RuntimeEventType() string     { return RuntimeEventTypeErrorRaised }

--- a/core/runtime_events_test.go
+++ b/core/runtime_events_test.go
@@ -1,7 +1,9 @@
 package core
 
 import (
+	"context"
 	"errors"
+	"net/http"
 	"testing"
 	"time"
 )
@@ -13,6 +15,22 @@ func (testDeferredRunError) deferredRunError()    {}
 func (testDeferredRunError) Is(target error) bool { return target == errDeferredSentinel }
 
 var errDeferredSentinel = errors.New("deferred sentinel")
+
+type errorRaisedEventTestModel struct {
+	err error
+}
+
+func (m errorRaisedEventTestModel) Request(context.Context, []ModelMessage, *ModelSettings, *ModelRequestParameters) (*ModelResponse, error) {
+	return nil, m.err
+}
+
+func (m errorRaisedEventTestModel) RequestStream(context.Context, []ModelMessage, *ModelSettings, *ModelRequestParameters) (StreamedResponse, error) {
+	return nil, m.err
+}
+
+func (errorRaisedEventTestModel) ModelName() string {
+	return "error-raised-event-test"
+}
 
 func TestRuntimeEventsExposeCanonicalMetadata(t *testing.T) {
 	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
@@ -67,6 +85,35 @@ func TestRuntimeEventsExposeCanonicalMetadata(t *testing.T) {
 		if !event.RuntimeOccurredAt().Equal(now) && !event.RuntimeOccurredAt().Equal(now.Add(time.Second)) {
 			t.Fatalf("unexpected occurrence time %s for %#v", event.RuntimeOccurredAt(), event)
 		}
+	}
+}
+
+func TestAgentErrorRaisedEventRetainsOriginalCauseForInProcessSubscribers(t *testing.T) {
+	bus := NewEventBus()
+	defer bus.Close()
+
+	cause := &ModelHTTPError{
+		Message:    "Authorization: Bearer super-secret",
+		StatusCode: 429,
+		Body:       "prompt=super-secret",
+	}
+	var received ErrorRaisedEvent
+	Subscribe(bus, func(event ErrorRaisedEvent) {
+		received = event
+	})
+
+	agent := NewAgent[string](errorRaisedEventTestModel{err: cause}, WithEventBus[string](bus))
+	_, err := agent.Run(context.Background(), "fail")
+	if !errors.Is(err, cause) {
+		t.Fatalf("Run error = %v, want %v", err, cause)
+	}
+
+	var httpErr *ModelHTTPError
+	if !errors.As(received.Cause, &httpErr) || httpErr.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("Cause = %#v, want HTTP 429 error", received.Cause)
+	}
+	if received.Error != err.Error() {
+		t.Fatalf("Error = %q, want %q", received.Error, err.Error())
 	}
 }
 


### PR DESCRIPTION
## Summary
- retain the original runtime error only for in-process event subscribers
- project cancellation, timeout, and provider HTTP failures to stable safe live notifications
- preserve generic redaction for legacy string-only error events

## Validation
- go test ./core ./appserver -count=1
- go test ./appserver ./appserver/catalog ./appserver/protocol -count=3
- go test -race ./appserver ./appserver/catalog ./appserver/protocol -count=10
- go vet ./appserver/...
- make lint
- make test