### PR TITLE
feat(catalog): gate runtime sampling by model

### DIFF
--- a/appserver/catalog/catalog.go
+++ b/appserver/catalog/catalog.go
@@ -240,6 +240,7 @@ func (c *Catalog) ProviderCapabilities(providerID string) (ProviderCapabilities,
 		aggregate.Vision = aggregate.Vision || provider.Capabilities.Vision
 		aggregate.Streaming = aggregate.Streaming || provider.Capabilities.Streaming
 		aggregate.PromptCache = aggregate.PromptCache || provider.Capabilities.PromptCache
+		aggregate.Sampling = aggregate.Sampling || provider.Capabilities.Sampling
 		aggregate.StopSequences = aggregate.StopSequences || provider.Capabilities.StopSequences
 		aggregate.ToolSearch = aggregate.ToolSearch || provider.Capabilities.ToolSearch
 		aggregate.Reasoning = aggregate.Reasoning || provider.Capabilities.Reasoning
@@ -377,13 +378,14 @@ func (c *Catalog) defaultProviders() []Provider {
 				Vision:             true,
 				Streaming:          true,
 				PromptCache:        true,
+				Sampling:           true,
 				Reasoning:          true,
 				ReasoningEfforts:   []string{"minimal", "low", "medium", "high"},
 				ReasoningSummaries: true,
 			},
 			Models: []Model{
-				model(ProviderOpenAI, openaiprovider.GPT4o, "GPT-4o", "General-purpose multimodal OpenAI model.", false, textAndImage(), false, capabilities(true, true, true, true, true, false, false), []string{"low", "medium", "high"}, "medium"),
-				model(ProviderOpenAI, openaiprovider.GPT4oMini, "GPT-4o mini", "Smaller OpenAI multimodal model for lower-latency turns.", false, textAndImage(), false, capabilities(true, true, true, true, true, false, false), []string{"low", "medium", "high"}, "medium"),
+				model(ProviderOpenAI, openaiprovider.GPT4o, "GPT-4o", "General-purpose multimodal OpenAI model.", false, textAndImage(), false, capabilities(true, true, true, true, true, false, false, true), []string{"low", "medium", "high"}, "medium"),
+				model(ProviderOpenAI, openaiprovider.GPT4oMini, "GPT-4o mini", "Smaller OpenAI multimodal model for lower-latency turns.", false, textAndImage(), false, capabilities(true, true, true, true, true, false, false, true), []string{"low", "medium", "high"}, "medium"),
 				model(ProviderOpenAI, openaiprovider.GPT5, "GPT-5", "OpenAI reasoning model with strong coding and tool-use support.", false, textAndImage(), false, reasoningSummaryCapabilities(capabilities(true, true, true, true, true, true, false), true), []string{"minimal", "low", "medium", "high"}, "medium"),
 				model(ProviderOpenAI, openaiprovider.GPT5Mini, "GPT-5 mini", "Lower-latency GPT-5 family model.", false, textAndImage(), false, reasoningSummaryCapabilities(capabilities(true, true, true, true, true, true, false), true), []string{"minimal", "low", "medium", "high"}, "medium"),
 				model(ProviderOpenAI, openaiprovider.GPT5Nano, "GPT-5 nano", "Small GPT-5 family model for fast utility work.", true, textAndImage(), false, reasoningSummaryCapabilities(capabilities(true, true, true, true, true, true, false), true), []string{"minimal", "low", "medium", "high"}, "low"),
@@ -437,6 +439,7 @@ func (c *Catalog) defaultProviders() []Provider {
 				Vision:           true,
 				Streaming:        true,
 				PromptCache:      true,
+				Sampling:         true,
 				StopSequences:    true,
 				ToolSearch:       true,
 				Reasoning:        true,
@@ -445,12 +448,12 @@ func (c *Catalog) defaultProviders() []Provider {
 				ManualThinking:   true,
 			},
 			Models: []Model{
-				model(ProviderAnthropic, anthropicprovider.ClaudeSonnet46, "Claude Sonnet 4.6", "Anthropic balanced coding and agentic workflow model.", false, textAndImage(), false, stopSequenceCapabilities(thinkingCapabilities(capabilities(true, true, true, true, true, true, true), true, true), true), []string{"low", "medium", "high", "max"}, "medium"),
-				model(ProviderAnthropic, anthropicprovider.ClaudeOpus46, "Claude Opus 4.6", "Anthropic high-capability reasoning model.", false, textAndImage(), false, stopSequenceCapabilities(thinkingCapabilities(capabilities(true, true, true, true, true, true, true), true, true), true), []string{"low", "medium", "high", "max"}, "medium"),
+				model(ProviderAnthropic, anthropicprovider.ClaudeSonnet46, "Claude Sonnet 4.6", "Anthropic balanced coding and agentic workflow model.", false, textAndImage(), false, stopSequenceCapabilities(thinkingCapabilities(capabilities(true, true, true, true, true, true, true, true), true, true), true), []string{"low", "medium", "high", "max"}, "medium"),
+				model(ProviderAnthropic, anthropicprovider.ClaudeOpus46, "Claude Opus 4.6", "Anthropic high-capability reasoning model.", false, textAndImage(), false, stopSequenceCapabilities(thinkingCapabilities(capabilities(true, true, true, true, true, true, true, true), true, true), true), []string{"low", "medium", "high", "max"}, "medium"),
 				model(ProviderAnthropic, anthropicprovider.ClaudeOpus47, "Claude Opus 4.7", "Anthropic flagship adaptive-thinking model.", false, textAndImage(), false, stopSequenceCapabilities(thinkingCapabilities(capabilities(true, true, true, true, true, true, true), true, false), true), []string{"low", "medium", "high", "xhigh", "max"}, "high"),
 				model(ProviderAnthropic, anthropicprovider.ClaudeOpus48, "Claude Opus 4.8", "Anthropic flagship adaptive-thinking model.", false, textAndImage(), false, stopSequenceCapabilities(thinkingCapabilities(capabilities(true, true, true, true, true, true, true), true, false), true), []string{"low", "medium", "high", "xhigh", "max"}, "high"),
 				model(ProviderAnthropic, anthropicprovider.ClaudeFable5, "Claude Fable 5", "Anthropic Fable tier model for high-end reasoning workflows.", true, textAndImage(), false, stopSequenceCapabilities(thinkingCapabilities(capabilities(true, true, true, true, true, true, false), true, false), true), []string{"low", "medium", "high", "xhigh", "max"}, "high"),
-				model(ProviderAnthropic, anthropicprovider.ClaudeHaiku45, "Claude Haiku 4.5", "Anthropic lower-latency utility model.", false, textAndImage(), false, stopSequenceCapabilities(capabilities(true, true, true, true, true, false, false), true), []string{"low", "medium", "high"}, "medium"),
+				model(ProviderAnthropic, anthropicprovider.ClaudeHaiku45, "Claude Haiku 4.5", "Anthropic lower-latency utility model.", false, textAndImage(), false, stopSequenceCapabilities(capabilities(true, true, true, true, true, false, false, true), true), []string{"low", "medium", "high"}, "medium"),
 			},
 		},
 		{
@@ -470,14 +473,15 @@ func (c *Catalog) defaultProviders() []Provider {
 				Vision:           true,
 				Streaming:        true,
 				PromptCache:      true,
+				Sampling:         true,
 				StopSequences:    true,
 			},
 			Models: []Model{
-				model(ProviderVertexAI, vertexprovider.Gemini25Flash, "Gemini 2.5 Flash", "Google Gemini fast multimodal model through Vertex AI.", true, textAndImage(), false, stopSequenceCapabilities(capabilities(true, true, true, true, true, false, false), true), nil, "medium"),
-				model(ProviderVertexAI, vertexprovider.Gemini25Pro, "Gemini 2.5 Pro", "Google Gemini Pro multimodal model through Vertex AI.", true, textAndImage(), false, stopSequenceCapabilities(capabilities(true, true, true, true, true, false, false), true), nil, "medium"),
-				model(ProviderVertexAI, vertexprovider.Gemini31ProPreview, "Gemini 3.1 Pro Preview", "Google Gemini preview model through Vertex AI.", true, textAndImage(), false, stopSequenceCapabilities(capabilities(true, true, true, true, true, false, false), true), nil, "medium"),
-				model(ProviderVertexAI, vertexprovider.Gemini3FlashPreview, "Gemini 3 Flash Preview", "Google Gemini preview flash model through Vertex AI.", true, textAndImage(), false, stopSequenceCapabilities(capabilities(true, true, true, true, true, false, false), true), nil, "medium"),
-				model(ProviderVertexAI, vertexprovider.Gemini20Flash, "Gemini 2.0 Flash", "Google Gemini 2.0 Flash model through Vertex AI.", true, textAndImage(), false, stopSequenceCapabilities(capabilities(true, true, true, true, true, false, false), true), nil, "medium"),
+				model(ProviderVertexAI, vertexprovider.Gemini25Flash, "Gemini 2.5 Flash", "Google Gemini fast multimodal model through Vertex AI.", true, textAndImage(), false, stopSequenceCapabilities(capabilities(true, true, true, true, true, false, false, true), true), nil, "medium"),
+				model(ProviderVertexAI, vertexprovider.Gemini25Pro, "Gemini 2.5 Pro", "Google Gemini Pro multimodal model through Vertex AI.", true, textAndImage(), false, stopSequenceCapabilities(capabilities(true, true, true, true, true, false, false, true), true), nil, "medium"),
+				model(ProviderVertexAI, vertexprovider.Gemini31ProPreview, "Gemini 3.1 Pro Preview", "Google Gemini preview model through Vertex AI.", true, textAndImage(), false, stopSequenceCapabilities(capabilities(true, true, true, true, true, false, false, true), true), nil, "medium"),
+				model(ProviderVertexAI, vertexprovider.Gemini3FlashPreview, "Gemini 3 Flash Preview", "Google Gemini preview flash model through Vertex AI.", true, textAndImage(), false, stopSequenceCapabilities(capabilities(true, true, true, true, true, false, false, true), true), nil, "medium"),
+				model(ProviderVertexAI, vertexprovider.Gemini20Flash, "Gemini 2.0 Flash", "Google Gemini 2.0 Flash model through Vertex AI.", true, textAndImage(), false, stopSequenceCapabilities(capabilities(true, true, true, true, true, false, false, true), true), nil, "medium"),
 			},
 		},
 		{
@@ -497,6 +501,7 @@ func (c *Catalog) defaultProviders() []Provider {
 				Vision:           true,
 				Streaming:        true,
 				PromptCache:      true,
+				Sampling:         true,
 				StopSequences:    true,
 				Reasoning:        true,
 				ReasoningEfforts: []string{"low", "medium", "high", "xhigh", "max"},
@@ -504,10 +509,10 @@ func (c *Catalog) defaultProviders() []Provider {
 				ManualThinking:   true,
 			},
 			Models: []Model{
-				model(ProviderVertexAIAnthropic, vertexanthropicprovider.ClaudeSonnet46, "Claude Sonnet 4.6 on Vertex AI", "Anthropic Sonnet through Vertex AI.", true, textAndImage(), false, stopSequenceCapabilities(thinkingCapabilities(capabilities(true, true, true, true, true, true, false), true, true), true), []string{"low", "medium", "high", "max"}, "medium"),
-				model(ProviderVertexAIAnthropic, vertexanthropicprovider.ClaudeOpus46, "Claude Opus 4.6 on Vertex AI", "Anthropic Opus through Vertex AI.", true, textAndImage(), false, stopSequenceCapabilities(thinkingCapabilities(capabilities(true, true, true, true, true, true, false), true, true), true), []string{"low", "medium", "high", "max"}, "medium"),
+				model(ProviderVertexAIAnthropic, vertexanthropicprovider.ClaudeSonnet46, "Claude Sonnet 4.6 on Vertex AI", "Anthropic Sonnet through Vertex AI.", true, textAndImage(), false, stopSequenceCapabilities(thinkingCapabilities(capabilities(true, true, true, true, true, true, false, true), true, true), true), []string{"low", "medium", "high", "max"}, "medium"),
+				model(ProviderVertexAIAnthropic, vertexanthropicprovider.ClaudeOpus46, "Claude Opus 4.6 on Vertex AI", "Anthropic Opus through Vertex AI.", true, textAndImage(), false, stopSequenceCapabilities(thinkingCapabilities(capabilities(true, true, true, true, true, true, false, true), true, true), true), []string{"low", "medium", "high", "max"}, "medium"),
 				model(ProviderVertexAIAnthropic, vertexanthropicprovider.ClaudeOpus47, "Claude Opus 4.7 on Vertex AI", "Anthropic Opus through Vertex AI.", true, textAndImage(), false, stopSequenceCapabilities(thinkingCapabilities(capabilities(true, true, true, true, true, true, false), true, false), true), []string{"low", "medium", "high", "xhigh", "max"}, "high"),
-				model(ProviderVertexAIAnthropic, vertexanthropicprovider.ClaudeHaiku45, "Claude Haiku 4.5 on Vertex AI", "Anthropic Haiku through Vertex AI.", true, textAndImage(), false, stopSequenceCapabilities(capabilities(true, true, true, true, true, false, false), true), []string{"low", "medium", "high"}, "medium"),
+				model(ProviderVertexAIAnthropic, vertexanthropicprovider.ClaudeHaiku45, "Claude Haiku 4.5 on Vertex AI", "Anthropic Haiku through Vertex AI.", true, textAndImage(), false, stopSequenceCapabilities(capabilities(true, true, true, true, true, false, false, true), true), []string{"low", "medium", "high"}, "medium"),
 			},
 		},
 	}
@@ -608,13 +613,14 @@ func stringPointer(value string) *string {
 	return &value
 }
 
-func capabilities(toolCalls, structured, vision, streaming, promptCache, reasoning, toolSearch bool) ModelCapabilities {
+func capabilities(toolCalls, structured, vision, streaming, promptCache, reasoning, toolSearch bool, sampling ...bool) ModelCapabilities {
 	return ModelCapabilities{
 		ToolCalls:        toolCalls,
 		StructuredOutput: structured,
 		Vision:           vision,
 		Streaming:        streaming,
 		PromptCache:      promptCache,
+		Sampling:         len(sampling) == 1 && sampling[0],
 		Reasoning:        reasoning,
 		ToolSearch:       toolSearch,
 	}

--- a/appserver/catalog/catalog_test.go
+++ b/appserver/catalog/catalog_test.go
@@ -90,7 +90,7 @@ func TestProviderCapabilities(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ProviderCapabilities(openai): %v", err)
 	}
-	if !caps.NamespaceTools || !caps.ToolCalls || !caps.StructuredOutput || !caps.Vision || !caps.Streaming {
+	if !caps.NamespaceTools || !caps.ToolCalls || !caps.StructuredOutput || !caps.Vision || !caps.Streaming || !caps.Sampling {
 		t.Fatalf("openai capabilities missing expected feature: %#v", caps)
 	}
 	if caps.Configured {
@@ -114,7 +114,7 @@ func TestProviderCapabilities(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ProviderCapabilities(aggregate): %v", err)
 	}
-	if !aggregate.NamespaceTools || !aggregate.ToolCalls || !aggregate.Reasoning {
+	if !aggregate.NamespaceTools || !aggregate.ToolCalls || !aggregate.Reasoning || !aggregate.Sampling {
 		t.Fatalf("aggregate capabilities missing expected feature: %#v", aggregate)
 	}
 
@@ -197,6 +197,52 @@ func TestStopSequenceCapabilitiesAreModelSpecific(t *testing.T) {
 		if provider.Capabilities.StopSequences != tc.want {
 			t.Errorf("provider %q stop sequence capability = %t, want %t", tc.provider, provider.Capabilities.StopSequences, tc.want)
 		}
+	}
+}
+
+func TestSamplingCapabilitiesAreModelSpecific(t *testing.T) {
+	c := NewDefault(WithEnvLookup(mapEnv(nil)))
+	for _, tc := range []struct {
+		provider string
+		model    string
+		want     bool
+	}{
+		{ProviderOpenAI, "gpt-4o", true},
+		{ProviderOpenAI, "gpt-4o-mini", true},
+		{ProviderOpenAI, "gpt-5", false},
+		{ProviderOpenAI, "gpt-5-mini", false},
+		{ProviderOpenAI, "gpt-5-nano", false},
+		{ProviderOpenAI, "gpt-5-codex", false},
+		{ProviderOpenAICompatibleLocal, "llama3", false},
+		{ProviderAnthropic, "claude-sonnet-4-6", true},
+		{ProviderAnthropic, "claude-opus-4-6", true},
+		{ProviderAnthropic, "claude-opus-4-7", false},
+		{ProviderAnthropic, "claude-opus-4-8", false},
+		{ProviderAnthropic, "claude-fable-5", false},
+		{ProviderAnthropic, "claude-haiku-4-5-20251001", true},
+		{ProviderVertexAI, vertexprovider.Gemini25Flash, true},
+		{ProviderVertexAI, vertexprovider.Gemini25Pro, true},
+		{ProviderVertexAI, vertexprovider.Gemini31ProPreview, true},
+		{ProviderVertexAI, vertexprovider.Gemini3FlashPreview, true},
+		{ProviderVertexAI, vertexprovider.Gemini20Flash, true},
+		{ProviderVertexAIAnthropic, "claude-sonnet-4-6", true},
+		{ProviderVertexAIAnthropic, "claude-opus-4-6", true},
+		{ProviderVertexAIAnthropic, "claude-opus-4-7", false},
+		{ProviderVertexAIAnthropic, "claude-haiku-4-5", true},
+	} {
+		t.Run(tc.provider+"/"+tc.model, func(t *testing.T) {
+			provider := findProvider(t, c.providers, tc.provider)
+			for _, model := range provider.Models {
+				if model.Model != tc.model {
+					continue
+				}
+				if model.Capabilities.Sampling != tc.want {
+					t.Fatalf("sampling capability = %t, want %t", model.Capabilities.Sampling, tc.want)
+				}
+				return
+			}
+			t.Fatalf("model %q missing from provider %#v", tc.model, provider.Models)
+		})
 	}
 }
 

--- a/appserver/protocol/runtime_client_types.go
+++ b/appserver/protocol/runtime_client_types.go
@@ -34,6 +34,7 @@ type ProviderCatalogCapabilities struct {
 	Vision                   bool     `json:"vision"`
 	Streaming                bool     `json:"streaming"`
 	PromptCache              bool     `json:"promptCache"`
+	Sampling                 bool     `json:"sampling"`
 	StopSequences            bool     `json:"stopSequences"`
 	ToolSearch               bool     `json:"toolSearch"`
 	Reasoning                bool     `json:"reasoning"`
@@ -50,6 +51,7 @@ type ModelCatalogCapabilities struct {
 	Vision             bool `json:"vision"`
 	Streaming          bool `json:"streaming"`
 	PromptCache        bool `json:"promptCache"`
+	Sampling           bool `json:"sampling"`
 	StopSequences      bool `json:"stopSequences"`
 	ToolSearch         bool `json:"toolSearch"`
 	Reasoning          bool `json:"reasoning"`

--- a/appserver/protocol/runtime_client_types_contract_test.go
+++ b/appserver/protocol/runtime_client_types_contract_test.go
@@ -99,14 +99,16 @@ func TestRuntimeModelParamsExposePromptCacheAndReasoningSummarySettings(t *testi
 func TestModelCatalogCapabilitiesExposeRuntimeControls(t *testing.T) {
 	defs := JSONSchema()["$defs"].(Schema)
 	properties := defs["ModelCatalogCapabilities"].(Schema)["properties"].(Schema)
-	for _, name := range []string{"adaptiveThinking", "manualThinking", "reasoningSummaries", "stopSequences"} {
+	for _, name := range []string{"adaptiveThinking", "manualThinking", "reasoningSummaries", "sampling", "stopSequences"} {
 		if _, ok := properties[name]; !ok {
 			t.Fatalf("ModelCatalogCapabilities schema omitted %s", name)
 		}
 	}
 	providerProperties := defs["ProviderCatalogCapabilities"].(Schema)["properties"].(Schema)
-	if _, ok := providerProperties["stopSequences"]; !ok {
-		t.Fatal("ProviderCatalogCapabilities schema omitted stopSequences")
+	for _, name := range []string{"sampling", "stopSequences"} {
+		if _, ok := providerProperties[name]; !ok {
+			t.Fatalf("ProviderCatalogCapabilities schema omitted %s", name)
+		}
 	}
 	generated, err := MarshalTypeScript()
 	if err != nil {
@@ -116,6 +118,7 @@ func TestModelCatalogCapabilitiesExposeRuntimeControls(t *testing.T) {
 		`"adaptiveThinking": boolean;`,
 		`"manualThinking": boolean;`,
 		`"reasoningSummaries": boolean;`,
+		`"sampling": boolean;`,
 		`"stopSequences": boolean;`,
 	} {
 		if !strings.Contains(string(generated), want) {

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -13214,6 +13214,9 @@
         "reasoningSummaries": {
           "type": "boolean"
         },
+        "sampling": {
+          "type": "boolean"
+        },
         "stopSequences": {
           "type": "boolean"
         },
@@ -13239,6 +13242,7 @@
         "vision",
         "streaming",
         "promptCache",
+        "sampling",
         "stopSequences",
         "toolSearch",
         "reasoning",
@@ -15272,6 +15276,9 @@
             }
           ]
         },
+        "sampling": {
+          "type": "boolean"
+        },
         "stopSequences": {
           "type": "boolean"
         },
@@ -15304,6 +15311,7 @@
         "vision",
         "streaming",
         "promptCache",
+        "sampling",
         "stopSequences",
         "toolSearch",
         "reasoning"

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -2769,6 +2769,7 @@ export type ModelCatalogCapabilities = {
   "promptCache": boolean;
   "reasoning": boolean;
   "reasoningSummaries": boolean;
+  "sampling": boolean;
   "stopSequences": boolean;
   "streaming": boolean;
   "structuredOutput": boolean;
@@ -3156,6 +3157,7 @@ export type ProviderCatalogCapabilities = {
   "reasoningEfforts"?: Array<string> | null;
   "reasoningSummaries"?: boolean;
   "requiresConfigurationEnv"?: Array<string> | null;
+  "sampling": boolean;
   "stopSequences": boolean;
   "streaming": boolean;
   "structuredOutput": boolean;

--- a/appserver/runtime_sampling.go
+++ b/appserver/runtime_sampling.go
@@ -1,0 +1,34 @@
+package appserver
+
+import (
+	"fmt"
+
+	"github.com/fugue-labs/gollem/appserver/catalog"
+	"github.com/fugue-labs/gollem/core"
+)
+
+// validateRuntimeSamplingSelection prevents durable settings from recording
+// sampling controls a selected model would silently discard.
+func validateRuntimeSamplingSelection(
+	catalogService *catalog.Catalog,
+	selection RuntimeModelSelection,
+	settings core.ModelSettings,
+) error {
+	if settings.Temperature == nil && settings.TopP == nil {
+		return nil
+	}
+	selected, err := selectedRuntimeCatalogModel(catalogService, selection)
+	if err != nil {
+		return err
+	}
+	if !selected.Capabilities.Sampling {
+		return fmt.Errorf("model %q does not advertise sampling", selected.ID)
+	}
+	manualThinking := settings.ThinkingBudget != nil && *settings.ThinkingBudget > 0
+	adaptiveThinking := settings.AdaptiveThinking != nil && *settings.AdaptiveThinking
+	if (manualThinking || adaptiveThinking) &&
+		(selected.Capabilities.ManualThinking || selected.Capabilities.AdaptiveThinking) {
+		return fmt.Errorf("model %q does not advertise sampling with thinking", selected.ID)
+	}
+	return nil
+}

--- a/appserver/runtime_selection.go
+++ b/appserver/runtime_selection.go
@@ -17,6 +17,9 @@ func (s *Server) validateRuntimeSelection(selection RuntimeModelSelection, setti
 	if err := validateRuntimePromptCacheSelection(s.catalog, selection, settings); err != nil {
 		return err
 	}
+	if err := validateRuntimeSamplingSelection(s.catalog, selection, settings); err != nil {
+		return err
+	}
 	if err := validateRuntimeStopSequenceSelection(s.catalog, selection, settings); err != nil {
 		return err
 	}

--- a/appserver/runtime_test.go
+++ b/appserver/runtime_test.go
@@ -502,6 +502,96 @@ func TestServerRuntimePromptCacheFailsClosedAgainstModelCatalog(t *testing.T) {
 	}
 }
 
+func TestServerRuntimeSamplingFailsClosedAgainstModelCatalog(t *testing.T) {
+	temperature := 0.7
+	topP := 0.9
+	thinkingBudget := 1024
+	for _, tc := range []struct {
+		name           string
+		providerID     string
+		model          string
+		thinkingBudget *int
+		wantReason     string
+	}{
+		{
+			name:       "OpenAI Responses model does not advertise sampling",
+			providerID: "openai",
+			model:      "gpt-5",
+			wantReason: "does not advertise sampling",
+		},
+		{
+			name:       "Anthropic adaptive model does not advertise sampling",
+			providerID: "anthropic",
+			model:      "claude-opus-4-7",
+			wantReason: "does not advertise sampling",
+		},
+		{
+			name:           "Anthropic manual thinking cannot combine sampling",
+			providerID:     "anthropic",
+			model:          "claude-sonnet-4-6",
+			thinkingBudget: &thinkingBudget,
+			wantReason:     "does not advertise sampling with thinking",
+		},
+		{
+			name:       "catalog-supported chat completion model",
+			providerID: "openai",
+			model:      "gpt-4o",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			st := newRuntimeTestStore(t)
+			server := readyServer(
+				WithStore(st),
+				WithRuntimeService(NewRuntimeService(WithRuntimeModel(
+					core.NewTestModel(core.TextResponse("done")),
+					RuntimeModelInfo{ProviderID: tc.providerID, Model: tc.model},
+				))),
+			)
+			params := map[string]any{
+				"workspace":   t.TempDir(),
+				"prompt":      "apply deterministic sampling",
+				"providerId":  tc.providerID,
+				"model":       tc.model,
+				"temperature": temperature,
+				"topP":        topP,
+			}
+			if tc.thinkingBudget != nil {
+				params["thinkingBudget"] = *tc.thinkingBudget
+			}
+			response := server.HandleRequest(ctx, request("thread/start", params))
+			if tc.wantReason != "" {
+				if response.Error == nil || response.Error.Code != protocol.CodeInvalidParams {
+					t.Fatalf("thread/start error = %#v, want invalid params", response.Error)
+				}
+				if !strings.Contains(response.Error.Message, tc.wantReason) {
+					t.Fatalf("thread/start error = %q, want %q", response.Error.Message, tc.wantReason)
+				}
+				threads, err := st.ListThreads(ctx, store.ThreadFilter{})
+				if err != nil {
+					t.Fatalf("ListThreads: %v", err)
+				}
+				if len(threads) != 0 {
+					t.Fatalf("unsupported sampling created %d threads", len(threads))
+				}
+				return
+			}
+			if response.Error != nil {
+				t.Fatalf("thread/start error: %v", response.Error)
+			}
+			var result protocol.ThreadRunStartResult
+			decodeResult(t, response, &result)
+			var input runtimeTurnInput
+			if err := json.Unmarshal(result.Turn.Input, &input); err != nil {
+				t.Fatalf("decode turn input: %v", err)
+			}
+			if input.Temperature == nil || *input.Temperature != temperature || input.TopP == nil || *input.TopP != topP {
+				t.Fatalf("turn sampling = %#v, want temperature=%v topP=%v", input, temperature, topP)
+			}
+		})
+	}
+}
+
 func TestServerRuntimeStopSequencesFailClosedAndSurviveRetry(t *testing.T) {
 	ctx := context.Background()
 	st := newRuntimeTestStore(t)


### PR DESCRIPTION
## Summary
- publish exact model/provider sampling capability for shared `temperature` and `topP` controls
- reject sampling requests before durable thread state when a selected profile cannot honor them
- reject sampling combined with manual or adaptive thinking where the current providers discard it

## Verification
- deliberate red test: `go test ./appserver -run ^TestServerRuntimeSamplingFailsClosedAgainstModelCatalog$ -count=1` failed before implementation
- `make test` (full non-Monty race suite)
- `make lint`
- `go vet ./...`
- `go generate ./appserver/protocol`
- focused appserver/catalog/protocol repetitions (`-count=10`)