### PR TITLE
fix(appserver): emit exact runtime error notifications

### DIFF
--- a/appserver/protocol/methods_gen.go
+++ b/appserver/protocol/methods_gen.go
@@ -137,7 +137,7 @@ var methodRegistry = []MethodInfo{
 	{Method: "command/exec/outputDelta", Surface: SurfaceServerNotification, State: MethodImplemented, Source: "json schema:ServerNotification, protocol crate:common.rs:1639, typescript:ServerNotification.ts"},
 	{Method: "configWarning", Surface: SurfaceServerNotification, State: MethodBlocked, Source: "json schema:ServerNotification, protocol crate:common.rs:1675, typescript:ServerNotification.ts"},
 	{Method: "deprecationNotice", Surface: SurfaceServerNotification, State: MethodImplemented, Source: "json schema:ServerNotification, protocol crate:common.rs:1674, typescript:ServerNotification.ts"},
-	{Method: "error", Surface: SurfaceServerNotification, State: MethodBlocked, Source: "json schema:ServerNotification, protocol crate:common.rs:1609, typescript:ServerNotification.ts"},
+	{Method: "error", Surface: SurfaceServerNotification, State: MethodImplemented, Source: "json schema:ServerNotification, protocol crate:common.rs:1609, typescript:ServerNotification.ts"},
 	{Method: "externalAgentConfig/import/completed", Surface: SurfaceServerNotification, State: MethodDeferredStub, Source: "json schema:ServerNotification, protocol crate:common.rs:1660, typescript:ServerNotification.ts"},
 	{Method: "externalAgentConfig/import/progress", Surface: SurfaceServerNotification, State: MethodDeferredStub, Source: "json schema:ServerNotification, protocol crate:common.rs:1659, typescript:ServerNotification.ts"},
 	{Method: "fs/changed", Surface: SurfaceServerNotification, State: MethodImplemented, Source: "json schema:ServerNotification, protocol crate:common.rs:1661, typescript:ServerNotification.ts"},

--- a/appserver/protocol/methods_test.go
+++ b/appserver/protocol/methods_test.go
@@ -103,6 +103,7 @@ func TestMethodRegistryCountsAndKeyMethods(t *testing.T) {
 	assertMethod(t, "thread/goal/cleared", SurfaceServerNotification, MethodImplemented)
 	assertMethod(t, "thread/name/updated", SurfaceServerNotification, MethodImplemented)
 	assertMethod(t, "deprecationNotice", SurfaceServerNotification, MethodImplemented)
+	assertMethod(t, "error", SurfaceServerNotification, MethodImplemented)
 	assertMethod(t, "thread/tokenUsage/updated", SurfaceServerNotification, MethodImplemented)
 	assertMethod(t, "turn/started", SurfaceServerNotification, MethodImplemented)
 	assertMethod(t, "turn/completed", SurfaceServerNotification, MethodImplemented)

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -26518,7 +26518,7 @@
     {
       "method": "error",
       "surface": "server-notification",
-      "state": "blocked",
+      "state": "implemented",
       "source": "json schema:ServerNotification, protocol crate:common.rs:1609, typescript:ServerNotification.ts"
     },
     {

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -160,7 +160,7 @@ export const protocolMethods = [
   { "method": "command/exec/outputDelta", "surface": "server-notification", "state": "implemented", "source": "json schema:ServerNotification, protocol crate:common.rs:1639, typescript:ServerNotification.ts" },
   { "method": "configWarning", "surface": "server-notification", "state": "blocked", "source": "json schema:ServerNotification, protocol crate:common.rs:1675, typescript:ServerNotification.ts" },
   { "method": "deprecationNotice", "surface": "server-notification", "state": "implemented", "source": "json schema:ServerNotification, protocol crate:common.rs:1674, typescript:ServerNotification.ts" },
-  { "method": "error", "surface": "server-notification", "state": "blocked", "source": "json schema:ServerNotification, protocol crate:common.rs:1609, typescript:ServerNotification.ts" },
+  { "method": "error", "surface": "server-notification", "state": "implemented", "source": "json schema:ServerNotification, protocol crate:common.rs:1609, typescript:ServerNotification.ts" },
   { "method": "externalAgentConfig/import/completed", "surface": "server-notification", "state": "deferred-stub", "source": "json schema:ServerNotification, protocol crate:common.rs:1660, typescript:ServerNotification.ts" },
   { "method": "externalAgentConfig/import/progress", "surface": "server-notification", "state": "deferred-stub", "source": "json schema:ServerNotification, protocol crate:common.rs:1659, typescript:ServerNotification.ts" },
   { "method": "fs/changed", "surface": "server-notification", "state": "implemented", "source": "json schema:ServerNotification, protocol crate:common.rs:1661, typescript:ServerNotification.ts" },

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -157,11 +157,14 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 			}
 		}
 	}
-	for _, method := range []string{"warning", "guardianWarning", "error"} {
+	for _, method := range []string{"warning", "guardianWarning"} {
 		info, ok := LookupMethod(method)
 		if !ok || info.State != MethodBlocked {
 			t.Errorf("%s = %#v, %v; want blocked", method, info, ok)
 		}
+	}
+	if info, ok := LookupMethod("error"); !ok || info.State != MethodImplemented {
+		t.Fatalf("error method = %#v, found=%v; want implemented", info, ok)
 	}
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 673 {
 		t.Fatalf("definition count = %d, want 673", got)

--- a/appserver/runtime.go
+++ b/appserver/runtime.go
@@ -770,12 +770,7 @@ type runtimeItemNotificationParams = protocol.ItemLifecycleNotificationParams
 
 type runtimeDeltaNotificationParams = protocol.RuntimeDeltaNotification
 
-type runtimeErrorNotificationParams struct {
-	ThreadID string    `json:"threadId,omitempty"`
-	TurnID   string    `json:"turnId,omitempty"`
-	Error    string    `json:"error"`
-	At       time.Time `json:"at"`
-}
+type runtimeErrorNotificationParams = protocol.ErrorNotification
 
 type threadTokenUsageUpdatedNotificationParams = protocol.ThreadTokenUsageUpdatedNotification
 type threadTokenUsagePayload = protocol.ThreadTokenUsage
@@ -894,15 +889,19 @@ func publishRuntimeError(notifier runtimeNotifier, turn *store.Turn, text string
 }
 
 func publishPublicRuntimeError(notifier runtimeNotifier, turn *store.Turn, message string) {
-	if notifier == nil || message == "" {
+	if notifier == nil || turn == nil || turn.ThreadID == "" || turn.ID == "" || message == "" {
 		return
 	}
-	params := runtimeErrorNotificationParams{Error: message, At: time.Now().UTC()}
-	if turn != nil {
-		params.ThreadID = turn.ThreadID
-		params.TurnID = turn.ID
-	}
-	notifier.PublishNotification("error", params)
+	notifier.PublishNotification("error", runtimeErrorNotificationParams{
+		Error: protocol.TurnError{
+			Message:           message,
+			CodexErrorInfo:    nil,
+			AdditionalDetails: nil,
+		},
+		WillRetry: false,
+		ThreadID:  turn.ThreadID,
+		TurnID:    turn.ID,
+	})
 }
 
 func runtimeUsageMap(usage core.RunUsage) map[string]any {

--- a/appserver/runtime_error_notification_contract_test.go
+++ b/appserver/runtime_error_notification_contract_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"reflect"
-	"slices"
 	"strings"
 	"testing"
 
@@ -24,52 +22,35 @@ func (n *runtimeErrorCaptureNotifier) PublishNotification(method string, params 
 	n.params = params
 }
 
-func TestPublishRuntimeErrorRetainsLiveExtensionShape(t *testing.T) {
-	for _, tc := range []struct {
-		name     string
-		turn     *store.Turn
-		wantKeys []string
-	}{
-		{"thread turn", &store.Turn{ID: "turn", ThreadID: "thread"}, []string{"at", "error", "threadId", "turnId"}},
-		{"global", nil, []string{"at", "error"}},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			notifier := &runtimeErrorCaptureNotifier{}
-			publishRuntimeError(notifier, tc.turn, "boom")
-			if notifier.method != "error" {
-				t.Fatalf("method = %q", notifier.method)
-			}
-			params, ok := notifier.params.(runtimeErrorNotificationParams)
-			if !ok || params.Error != runtimePublicErrorFailed || params.At.IsZero() {
-				t.Fatalf("params = %#v (%T)", notifier.params, notifier.params)
-			}
-			if tc.turn != nil && (params.ThreadID != "thread" || params.TurnID != "turn") {
-				t.Fatalf("correlated ids = %q/%q", params.ThreadID, params.TurnID)
-			}
-			if tc.turn == nil && (params.ThreadID != "" || params.TurnID != "") {
-				t.Fatalf("global ids = %q/%q", params.ThreadID, params.TurnID)
-			}
-			encoded, err := json.Marshal(params)
-			if err != nil {
-				t.Fatal(err)
-			}
-			var payload map[string]json.RawMessage
-			if err := json.Unmarshal(encoded, &payload); err != nil {
-				t.Fatal(err)
-			}
-			keys := make([]string, 0, len(payload))
-			for key := range payload {
-				keys = append(keys, key)
-			}
-			slices.Sort(keys)
-			if !reflect.DeepEqual(keys, tc.wantKeys) {
-				t.Fatalf("keys = %v, want %v", keys, tc.wantKeys)
-			}
-			var exact protocol.ErrorNotification
-			if err := json.Unmarshal(encoded, &exact); err == nil {
-				t.Fatal("incompatible live extension decoded as exact public error")
-			}
-		})
+func TestPublishRuntimeErrorUsesExactPublicShape(t *testing.T) {
+	notifier := &runtimeErrorCaptureNotifier{}
+	publishRuntimeError(notifier, &store.Turn{ID: "turn", ThreadID: "thread"}, "boom")
+	if notifier.method != "error" {
+		t.Fatalf("method = %q", notifier.method)
+	}
+	params, ok := notifier.params.(protocol.ErrorNotification)
+	if !ok {
+		t.Fatalf("params = %#v (%T), want protocol.ErrorNotification", notifier.params, notifier.params)
+	}
+	if params.Error.Message != runtimePublicErrorFailed || params.Error.CodexErrorInfo != nil || params.Error.AdditionalDetails != nil {
+		t.Fatalf("error = %#v", params.Error)
+	}
+	if params.WillRetry || params.ThreadID != "thread" || params.TurnID != "turn" {
+		t.Fatalf("params = %#v", params)
+	}
+	encoded, err := json.Marshal(params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var exact protocol.ErrorNotification
+	if err := json.Unmarshal(encoded, &exact); err != nil {
+		t.Fatalf("exact public error notification rejected %s: %v", encoded, err)
+	}
+
+	notifier = &runtimeErrorCaptureNotifier{}
+	publishRuntimeError(notifier, nil, "boom")
+	if notifier.method != "" || notifier.params != nil {
+		t.Fatalf("uncorrelated error notification = %q %#v", notifier.method, notifier.params)
 	}
 }
 
@@ -123,7 +104,7 @@ func TestPublishPublicRuntimeErrorUsesProjectedMessage(t *testing.T) {
 	notifier := &runtimeErrorCaptureNotifier{}
 	publishPublicRuntimeError(notifier, &store.Turn{ID: "turn", ThreadID: "thread"}, runtimePublicErrorInterrupted)
 	params, ok := notifier.params.(runtimeErrorNotificationParams)
-	if notifier.method != "error" || !ok || params.Error != runtimePublicErrorInterrupted {
+	if notifier.method != "error" || !ok || params.Error.Message != runtimePublicErrorInterrupted {
 		t.Fatalf("notification = %q %#v", notifier.method, notifier.params)
 	}
 }

--- a/appserver/runtime_test.go
+++ b/appserver/runtime_test.go
@@ -161,11 +161,11 @@ func TestServerRuntimeFailureRedactsPersistedAndNotifiedErrors(t *testing.T) {
 		if err := json.Unmarshal(notification.Params, &params); err != nil {
 			t.Fatalf("decode error notification: %v", err)
 		}
-		if params.Error != runtimePublicErrorFailed || params.ThreadID != started.Thread.ID || params.TurnID != started.Turn.ID {
+		if params.Error.Message != runtimePublicErrorFailed || params.ThreadID != started.Thread.ID || params.TurnID != started.Turn.ID {
 			t.Fatalf("error notification = %#v", params)
 		}
-		if strings.Contains(params.Error, secret) {
-			t.Fatalf("notification error exposed %q: %q", secret, params.Error)
+		if strings.Contains(params.Error.Message, secret) {
+			t.Fatalf("notification error exposed %q: %q", secret, params.Error.Message)
 		}
 		return
 	}
@@ -214,11 +214,11 @@ func TestServerRuntimeHTTPFailureClassifiesLiveNotificationWithoutProviderDetail
 		if err := json.Unmarshal(notification.Params, &params); err != nil {
 			t.Fatalf("decode error notification: %v", err)
 		}
-		if params.Error != want || params.ThreadID != started.Thread.ID || params.TurnID != started.Turn.ID {
+		if params.Error.Message != want || params.ThreadID != started.Thread.ID || params.TurnID != started.Turn.ID {
 			t.Fatalf("error notification = %#v", params)
 		}
-		if strings.Contains(params.Error, "super-secret") || strings.Contains(params.Error, "provider.invalid") {
-			t.Fatalf("notification error exposed provider detail: %q", params.Error)
+		if strings.Contains(params.Error.Message, "super-secret") || strings.Contains(params.Error.Message, "provider.invalid") {
+			t.Fatalf("notification error exposed provider detail: %q", params.Error.Message)
 		}
 		return
 	}


### PR DESCRIPTION
## Summary
- emit the existing public `ErrorNotification` contract for correlated runtime failures
- preserve the redacted message boundary and omit uncorrelated global errors rather than inventing a turn identity
- mark the public `error` server notification as implemented in the generated method inventory

## Verification
- deliberate red: `TestPublishRuntimeErrorUsesExactPublicShape` failed against the legacy extension
- `make test` (full non-Monty race suite)
- `make lint`
- `go vet ./...`
- `go generate ./appserver/protocol`
- focused appserver/protocol repetitions (`-count=10`)