### PR TITLE
feat(appserver): publish durable turn plan updates

### DIFF
--- a/appserver/protocol/account_credit_nudge_values_contract_test.go
+++ b/appserver/protocol/account_credit_nudge_values_contract_test.go
@@ -125,8 +125,8 @@ func TestAccountCreditNudgeValuesRemainStandaloneAndDeferred(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/account_envelope_contract_test.go
+++ b/appserver/protocol/account_envelope_contract_test.go
@@ -308,8 +308,8 @@ func TestAccountEnvelopeContractsRemainStandaloneAndDeferred(t *testing.T) {
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 675 {
 		t.Fatalf("definition count = %d, want 675", got)
 	}
-	if len(Methods()) != 229 || len(WireTypeBindings()) != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 229/85/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(Methods()) != 229 || len(WireTypeBindings()) != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 229/86/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/account_login_completed_notification_contract_test.go
+++ b/appserver/protocol/account_login_completed_notification_contract_test.go
@@ -94,8 +94,8 @@ func TestAccountLoginCompletedNotificationRemainsStandaloneAndDeferred(t *testin
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/account_rate_limits_contract_test.go
+++ b/appserver/protocol/account_rate_limits_contract_test.go
@@ -490,8 +490,8 @@ func TestAccountRateLimitContractsRemainStandaloneAndDeferred(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/account_token_usage_contract_test.go
+++ b/appserver/protocol/account_token_usage_contract_test.go
@@ -152,8 +152,8 @@ func TestAccountTokenUsageRecordsRemainStandaloneAndDeferred(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/additional_context_contract_test.go
+++ b/appserver/protocol/additional_context_contract_test.go
@@ -154,8 +154,8 @@ func TestAdditionalContextContractsRemainStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
+++ b/appserver/protocol/amazon_bedrock_credential_source_contract_test.go
@@ -60,8 +60,8 @@ func TestAmazonBedrockCredentialSourceRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_config_contract_test.go
+++ b/appserver/protocol/app_config_contract_test.go
@@ -115,8 +115,8 @@ func TestAppConfigRemainsStandaloneAndUnbound(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_info_contract_test.go
+++ b/appserver/protocol/app_info_contract_test.go
@@ -137,8 +137,8 @@ func TestAppInfoRemainsStandaloneAndDeferred(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_list_updated_notification_contract_test.go
+++ b/appserver/protocol/app_list_updated_notification_contract_test.go
@@ -111,8 +111,8 @@ func TestAppListUpdatedNotificationRemainsStandaloneAndDeferred(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_metadata_contract_test.go
+++ b/appserver/protocol/app_metadata_contract_test.go
@@ -113,8 +113,8 @@ func TestAppMetadataRemainsStandaloneAndDeferred(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_metadata_leaf_contract_test.go
+++ b/appserver/protocol/app_metadata_leaf_contract_test.go
@@ -163,8 +163,8 @@ func TestAppMetadataLeavesRemainStandaloneAndDeferred(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_summary_contract_test.go
+++ b/appserver/protocol/app_summary_contract_test.go
@@ -93,8 +93,8 @@ func TestAppSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_template_summary_contract_test.go
+++ b/appserver/protocol/app_template_summary_contract_test.go
@@ -113,8 +113,8 @@ func TestAppTemplateSummaryRemainsStandaloneAndUnbound(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_template_unavailable_reason_contract_test.go
+++ b/appserver/protocol/app_template_unavailable_reason_contract_test.go
@@ -77,8 +77,8 @@ func TestAppTemplateUnavailableReasonRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_tool_approval_contract_test.go
+++ b/appserver/protocol/app_tool_approval_contract_test.go
@@ -79,8 +79,8 @@ func TestAppToolApprovalRemainsStandaloneAndUnbound(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/app_tools_config_contract_test.go
+++ b/appserver/protocol/app_tools_config_contract_test.go
@@ -146,8 +146,8 @@ func TestAppToolConfigsRemainStandaloneAndUnbound(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/apply_patch_approval_params_contract_test.go
+++ b/appserver/protocol/apply_patch_approval_params_contract_test.go
@@ -145,8 +145,8 @@ func TestApplyPatchApprovalParamsRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/apps_config_contract_test.go
+++ b/appserver/protocol/apps_config_contract_test.go
@@ -191,8 +191,8 @@ func TestAppsConfigsRemainStandaloneAndUnbound(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/apps_list_contract_test.go
+++ b/appserver/protocol/apps_list_contract_test.go
@@ -174,8 +174,8 @@ func TestAppsListContractsRemainStandaloneAndDeferred(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/attestation_contract_test.go
+++ b/appserver/protocol/attestation_contract_test.go
@@ -140,8 +140,8 @@ func TestAttestationContractsRemainStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/auth_mode_contract_test.go
+++ b/appserver/protocol/auth_mode_contract_test.go
@@ -80,8 +80,8 @@ func TestAuthModeRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/auto_review_decision_source_contract_test.go
+++ b/appserver/protocol/auto_review_decision_source_contract_test.go
@@ -58,8 +58,8 @@ func TestAutoReviewDecisionSourceRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/bindings.go
+++ b/appserver/protocol/bindings.go
@@ -98,6 +98,7 @@ var wireTypeBindings = []WireTypeBinding{
 	{Method: "turn/completed", Surface: SurfaceServerNotification, Params: []string{"RuntimeTurnNotification"}},
 	{Method: "turn/diff/updated", Surface: SurfaceServerNotification, Params: []string{"TurnDiffUpdatedNotification"}},
 	{Method: "turn/interrupt", Surface: SurfaceClientRequest, Params: []string{"TurnRunInterruptParams"}, Result: []string{"TurnRunInterruptResult"}},
+	{Method: "turn/plan/updated", Surface: SurfaceServerNotification, Params: []string{"TurnPlanUpdatedNotification"}},
 	{Method: "turn/retry", Surface: SurfaceGollemExtension, Params: []string{"TurnRunRetryParams"}, Result: []string{"TurnRunRetryResult"}},
 	{Method: "turn/start", Surface: SurfaceClientRequest, Params: []string{"TurnRunStartParams"}, Result: []string{"TurnRunStartResult"}},
 	{Method: "turn/started", Surface: SurfaceServerNotification, Params: []string{"RuntimeTurnNotification"}},

--- a/appserver/protocol/cancel_login_account_contract_test.go
+++ b/appserver/protocol/cancel_login_account_contract_test.go
@@ -154,8 +154,8 @@ func TestCancelLoginAccountContractsRemainStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
+++ b/appserver/protocol/chatgpt_auth_tokens_refresh_contract_test.go
@@ -200,8 +200,8 @@ func TestChatgptAuthTokensRefreshRemainsStandaloneAndDeferred(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/collaboration_capability_contract_test.go
+++ b/appserver/protocol/collaboration_capability_contract_test.go
@@ -352,8 +352,8 @@ func TestCollaborationCapabilityContractsRemainStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/command_migration_contract_test.go
+++ b/appserver/protocol/command_migration_contract_test.go
@@ -108,8 +108,8 @@ func TestCommandMigrationRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/config_layer_metadata_contract_test.go
+++ b/appserver/protocol/config_layer_metadata_contract_test.go
@@ -223,8 +223,8 @@ func TestConfigLayerMetadataContractsRemainStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/config_layer_source_contract_test.go
+++ b/appserver/protocol/config_layer_source_contract_test.go
@@ -152,8 +152,8 @@ func TestConfigLayerSourceRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/config_prerequisites_contract_test.go
+++ b/appserver/protocol/config_prerequisites_contract_test.go
@@ -327,8 +327,8 @@ func TestConfigPrerequisitesRemainStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/config_read_params_contract_test.go
+++ b/appserver/protocol/config_read_params_contract_test.go
@@ -73,8 +73,8 @@ func TestConfigReadParamsRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/config_read_response_contract_test.go
+++ b/appserver/protocol/config_read_response_contract_test.go
@@ -206,8 +206,8 @@ func TestConfigReadResponseRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/config_requirements_contract_test.go
+++ b/appserver/protocol/config_requirements_contract_test.go
@@ -234,8 +234,8 @@ func TestConfigRequirementsContractsRemainStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/config_warning_notification_contract_test.go
+++ b/appserver/protocol/config_warning_notification_contract_test.go
@@ -172,8 +172,8 @@ func TestConfigWarningNotificationContractRemainsStandalone(t *testing.T) {
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 675 {
 		t.Fatalf("definition count = %d, want 675", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/config_write_contracts_contract_test.go
+++ b/appserver/protocol/config_write_contracts_contract_test.go
@@ -338,8 +338,8 @@ func TestConfigWriteContractsRemainStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/dynamic_tool_spec_contract_test.go
+++ b/appserver/protocol/dynamic_tool_spec_contract_test.go
@@ -324,8 +324,8 @@ func TestDynamicToolSpecContractsRemainStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/exec_command_approval_params_contract_test.go
+++ b/appserver/protocol/exec_command_approval_params_contract_test.go
@@ -143,8 +143,8 @@ func TestExecCommandApprovalParamsRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/experimental_feature_contract_test.go
+++ b/appserver/protocol/experimental_feature_contract_test.go
@@ -44,8 +44,8 @@ func TestExperimentalFeatureContractsRemainStandalone(t *testing.T) {
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 675 {
 		t.Fatalf("definition count = %d, want 675", got)
 	}
-	if len(Methods()) != 229 || len(WireTypeBindings()) != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("counts = %d/%d/%d, want 229/85/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(Methods()) != 229 || len(WireTypeBindings()) != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("counts = %d/%d/%d, want 229/86/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/external_agent_config_detect_contract_test.go
+++ b/appserver/protocol/external_agent_config_detect_contract_test.go
@@ -223,8 +223,8 @@ func TestExternalAgentConfigDetectRecordsRemainStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/external_agent_config_import_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_contract_test.go
@@ -209,8 +209,8 @@ func TestExternalAgentConfigImportRecordsRemainStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/external_agent_config_import_history_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_history_contract_test.go
@@ -266,8 +266,8 @@ func TestExternalAgentConfigImportHistoryTypesRemainStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/external_agent_config_import_item_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_item_result_contract_test.go
@@ -250,8 +250,8 @@ func TestExternalAgentConfigImportItemResultsRemainStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/external_agent_config_import_notification_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_notification_contract_test.go
@@ -168,8 +168,8 @@ func TestExternalAgentConfigImportNotificationsRemainStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/external_agent_config_import_type_result_contract_test.go
+++ b/appserver/protocol/external_agent_config_import_type_result_contract_test.go
@@ -181,8 +181,8 @@ func TestExternalAgentConfigImportTypeResultRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/external_agent_config_migration_item_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_contract_test.go
@@ -192,8 +192,8 @@ func TestExternalAgentConfigMigrationItemRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
+++ b/appserver/protocol/external_agent_config_migration_item_type_contract_test.go
@@ -90,8 +90,8 @@ func TestExternalAgentConfigMigrationItemTypeRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/file_change_contract_test.go
+++ b/appserver/protocol/file_change_contract_test.go
@@ -114,8 +114,8 @@ func TestFileChangeRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/file_change_output_delta_notification_contract_test.go
+++ b/appserver/protocol/file_change_output_delta_notification_contract_test.go
@@ -106,8 +106,8 @@ func TestFileChangeOutputDeltaNotificationRemainsDeprecatedAndStandalone(t *test
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/fuzzy_file_search_contract_test.go
+++ b/appserver/protocol/fuzzy_file_search_contract_test.go
@@ -387,8 +387,8 @@ func TestFuzzyFileSearchContractsRemainStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/guardian_approval_review_action_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_action_contract_test.go
@@ -232,8 +232,8 @@ func TestGuardianApprovalReviewActionRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_completed_notification_contract_test.go
@@ -170,8 +170,8 @@ func TestGuardianApprovalReviewCompletedNotificationRemainsStandalone(t *testing
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 	for _, method := range Methods() {
 		if (method.Method == "item/autoApprovalReview/started" ||

--- a/appserver/protocol/guardian_approval_review_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_contract_test.go
@@ -145,8 +145,8 @@ func TestGuardianApprovalReviewRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
+++ b/appserver/protocol/guardian_approval_review_started_notification_contract_test.go
@@ -181,8 +181,8 @@ func TestGuardianApprovalReviewStartedNotificationRemainsStandalone(t *testing.T
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 	for _, method := range Methods() {
 		if method.Method == "item/autoApprovalReview/started" && method.State != MethodBlocked {

--- a/appserver/protocol/guardian_enum_foundation_contract_test.go
+++ b/appserver/protocol/guardian_enum_foundation_contract_test.go
@@ -95,8 +95,8 @@ func TestGuardianEnumFoundationRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/hook_metadata_list_contract_test.go
+++ b/appserver/protocol/hook_metadata_list_contract_test.go
@@ -355,8 +355,8 @@ func TestHookMetadataListContractsStayStandalone(t *testing.T) {
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 675 {
 		t.Errorf("definition count = %d, want 675", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 {
-		t.Errorf("wire binding count = %d, want 85", got)
+	if got := len(WireTypeBindings()); got != 86 {
+		t.Errorf("wire binding count = %d, want 86", got)
 	}
 	if got := len(ItemPayloadBindings()); got != 5 {
 		t.Errorf("item binding count = %d, want 5", got)

--- a/appserver/protocol/hook_migration_contract_test.go
+++ b/appserver/protocol/hook_migration_contract_test.go
@@ -108,8 +108,8 @@ func TestHookMigrationRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/hook_run_notification_contract_test.go
+++ b/appserver/protocol/hook_run_notification_contract_test.go
@@ -300,7 +300,7 @@ func TestHookRunNotificationsRemainStandalone(t *testing.T) {
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 675 {
 		t.Fatalf("definition count = %d, want 675", got)
 	}
-	if len(Methods()) != 229 || len(WireTypeBindings()) != 85 || len(ItemPayloadBindings()) != 5 {
+	if len(Methods()) != 229 || len(WireTypeBindings()) != 86 || len(ItemPayloadBindings()) != 5 {
 		t.Fatalf("surface changed: %d methods, %d wire bindings, %d item bindings", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 }

--- a/appserver/protocol/hook_value_foundation_contract_test.go
+++ b/appserver/protocol/hook_value_foundation_contract_test.go
@@ -173,8 +173,8 @@ func TestHookValueFoundationRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/item_delta_notification_contract_test.go
+++ b/appserver/protocol/item_delta_notification_contract_test.go
@@ -226,8 +226,8 @@ func TestItemDeltaNotificationContractsRemainStandalone(t *testing.T) {
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 675 {
 		t.Fatalf("definition count = %d, want 675", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/item_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/item_lifecycle_notification_contract_test.go
@@ -162,8 +162,8 @@ func TestExactItemLifecycleNotificationBindingsPreserveCompatibility(t *testing.
 	if len(JSONSchema()["$defs"].(Schema)) != 675 {
 		t.Fatalf("definition count = %d, want 675", len(JSONSchema()["$defs"].(Schema)))
 	}
-	if len(WireTypeBindings()) != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(WireTypeBindings()) != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 
 	generated, err := MarshalTypeScript()

--- a/appserver/protocol/legacy_approval_response_contract_test.go
+++ b/appserver/protocol/legacy_approval_response_contract_test.go
@@ -104,8 +104,8 @@ func TestLegacyApprovalResponsesRemainStandaloneAndNominal(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/list_mcp_server_status_params_contract_test.go
+++ b/appserver/protocol/list_mcp_server_status_params_contract_test.go
@@ -133,8 +133,8 @@ func TestListMcpServerStatusParamsRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/login_account_contract_test.go
+++ b/appserver/protocol/login_account_contract_test.go
@@ -282,8 +282,8 @@ func TestLoginAccountContractsRemainStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/login_app_brand_contract_test.go
+++ b/appserver/protocol/login_app_brand_contract_test.go
@@ -63,8 +63,8 @@ func TestLoginAppBrandRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/logout_account_response_contract_test.go
+++ b/appserver/protocol/logout_account_response_contract_test.go
@@ -76,8 +76,8 @@ func TestLogoutAccountResponseRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/managed_hooks_requirements_contract_test.go
+++ b/appserver/protocol/managed_hooks_requirements_contract_test.go
@@ -233,8 +233,8 @@ func TestManagedHooksRequirementContractsRemainStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_auth_status_contract_test.go
+++ b/appserver/protocol/mcp_auth_status_contract_test.go
@@ -80,8 +80,8 @@ func TestMcpAuthStatusRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_resource_read_params_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_params_contract_test.go
@@ -120,8 +120,8 @@ func TestMcpResourceReadParamsRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_resource_read_response_contract_test.go
+++ b/appserver/protocol/mcp_resource_read_response_contract_test.go
@@ -136,8 +136,8 @@ func TestMcpResourceReadResponseRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_info_contract_test.go
+++ b/appserver/protocol/mcp_server_info_contract_test.go
@@ -154,8 +154,8 @@ func TestMcpServerInfoRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_migration_contract_test.go
+++ b/appserver/protocol/mcp_server_migration_contract_test.go
@@ -108,8 +108,8 @@ func TestMcpServerMigrationRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_oauth_login_contract_test.go
+++ b/appserver/protocol/mcp_server_oauth_login_contract_test.go
@@ -231,8 +231,8 @@ func TestMcpServerOauthLoginContractsRemainStandaloneAndBlocked(t *testing.T) {
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 675 {
 		t.Fatalf("definition count = %d, want 675", got)
 	}
-	if len(Methods()) != 229 || len(WireTypeBindings()) != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("counts = %d/%d/%d, want 229/85/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(Methods()) != 229 || len(WireTypeBindings()) != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("counts = %d/%d/%d, want 229/86/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_refresh_response_contract_test.go
+++ b/appserver/protocol/mcp_server_refresh_response_contract_test.go
@@ -76,8 +76,8 @@ func TestMcpServerRefreshResponseRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_startup_status_contract_test.go
+++ b/appserver/protocol/mcp_server_startup_status_contract_test.go
@@ -122,8 +122,8 @@ func TestMcpServerStartupStatusRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_status_contract_test.go
+++ b/appserver/protocol/mcp_server_status_contract_test.go
@@ -280,8 +280,8 @@ func TestMcpServerStatusContractsRemainStandalone(t *testing.T) {
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 675 {
 		t.Fatalf("definition count = %d, want 675", got)
 	}
-	if len(Methods()) != 229 || len(WireTypeBindings()) != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("counts = %d/%d/%d, want 229/85/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(Methods()) != 229 || len(WireTypeBindings()) != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("counts = %d/%d/%d, want 229/86/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_status_detail_contract_test.go
+++ b/appserver/protocol/mcp_server_status_detail_contract_test.go
@@ -75,8 +75,8 @@ func TestMcpServerStatusDetailRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
+++ b/appserver/protocol/mcp_server_status_updated_notification_contract_test.go
@@ -131,8 +131,8 @@ func TestMcpServerStatusUpdatedNotificationRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_tool_call_params_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_params_contract_test.go
@@ -146,8 +146,8 @@ func TestMcpServerToolCallParamsRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/mcp_server_tool_call_response_contract_test.go
+++ b/appserver/protocol/mcp_server_tool_call_response_contract_test.go
@@ -140,8 +140,8 @@ func TestMcpServerToolCallResponseRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/methods_gen.go
+++ b/appserver/protocol/methods_gen.go
@@ -194,7 +194,7 @@ var methodRegistry = []MethodInfo{
 	{Method: "turn/completed", Surface: SurfaceServerNotification, State: MethodImplemented, Source: "json schema:ServerNotification, protocol crate:common.rs:1625, typescript:ServerNotification.ts"},
 	{Method: "turn/diff/updated", Surface: SurfaceServerNotification, State: MethodImplemented, Source: "json schema:ServerNotification, protocol crate:common.rs:1627, typescript:ServerNotification.ts"},
 	{Method: "turn/moderationMetadata", Surface: SurfaceServerNotification, State: MethodBlocked, Source: "json schema:ServerNotification, protocol crate:common.rs:1670, typescript:ServerNotification.ts"},
-	{Method: "turn/plan/updated", Surface: SurfaceServerNotification, State: MethodBlocked, Source: "json schema:ServerNotification, protocol crate:common.rs:1628, typescript:ServerNotification.ts"},
+	{Method: "turn/plan/updated", Surface: SurfaceServerNotification, State: MethodImplemented, Source: "json schema:ServerNotification, protocol crate:common.rs:1628, typescript:ServerNotification.ts"},
 	{Method: "turn/started", Surface: SurfaceServerNotification, State: MethodImplemented, Source: "json schema:ServerNotification, protocol crate:common.rs:1623, typescript:ServerNotification.ts"},
 	{Method: "warning", Surface: SurfaceServerNotification, State: MethodBlocked, Source: "json schema:ServerNotification, protocol crate:common.rs:1672, typescript:ServerNotification.ts"},
 	{Method: "windows/worldWritableWarning", Surface: SurfaceServerNotification, State: MethodDeferredStub, Source: "json schema:ServerNotification, protocol crate:common.rs:1696, typescript:ServerNotification.ts"},

--- a/appserver/protocol/migration_details_contract_test.go
+++ b/appserver/protocol/migration_details_contract_test.go
@@ -174,8 +174,8 @@ func TestMigrationDetailsRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/model_catalog_leaf_contract_test.go
+++ b/appserver/protocol/model_catalog_leaf_contract_test.go
@@ -190,8 +190,8 @@ func TestModelCatalogLeafContractsRemainStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/model_contract_test.go
+++ b/appserver/protocol/model_contract_test.go
@@ -241,8 +241,8 @@ func TestModelNilReceiverAndStandaloneContract(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/model_list_contract_test.go
+++ b/appserver/protocol/model_list_contract_test.go
@@ -204,8 +204,8 @@ func TestModelListContractsRemainStandalone(t *testing.T) {
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 675 {
 		t.Fatalf("definition count = %d, want 675", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/model_provider_capabilities_contract_test.go
+++ b/appserver/protocol/model_provider_capabilities_contract_test.go
@@ -146,8 +146,8 @@ func TestModelProviderCapabilitiesContractsRemainStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/model_requirements_contract_test.go
+++ b/appserver/protocol/model_requirements_contract_test.go
@@ -165,8 +165,8 @@ func TestModelRequirementsContractsRemainStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/model_safety_notification_contract_test.go
+++ b/appserver/protocol/model_safety_notification_contract_test.go
@@ -251,8 +251,8 @@ func TestModelSafetyNotificationContractsRemainStandalone(t *testing.T) {
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 675 {
 		t.Fatalf("definition count = %d, want 675", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/network_approval_context_contract_test.go
+++ b/appserver/protocol/network_approval_context_contract_test.go
@@ -90,8 +90,8 @@ func TestNetworkApprovalContextRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/network_requirements_contract_test.go
+++ b/appserver/protocol/network_requirements_contract_test.go
@@ -169,8 +169,8 @@ func TestNetworkRequirementContractsRemainStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/operational_notification_leaves_contract_test.go
+++ b/appserver/protocol/operational_notification_leaves_contract_test.go
@@ -202,8 +202,8 @@ func TestOperationalNotificationLeavesFailClosedAndRemainStandalone(t *testing.T
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 675 {
 		t.Fatalf("definition count = %d, want 675", got)
 	}
-	if len(Methods()) != 229 || len(WireTypeBindings()) != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 229/85/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(Methods()) != 229 || len(WireTypeBindings()) != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 229/86/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/parsed_command_contract_test.go
+++ b/appserver/protocol/parsed_command_contract_test.go
@@ -126,8 +126,8 @@ func TestParsedCommandRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/permission_profile_list_contract_test.go
+++ b/appserver/protocol/permission_profile_list_contract_test.go
@@ -258,8 +258,8 @@ func TestPermissionProfileListContractsRemainStandalone(t *testing.T) {
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 675 {
 		t.Fatalf("definition count = %d, want 675", got)
 	}
-	if len(Methods()) != 229 || len(WireTypeBindings()) != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("counts = %d/%d/%d, want 229/85/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(Methods()) != 229 || len(WireTypeBindings()) != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("counts = %d/%d/%d, want 229/86/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/plugins_migration_contract_test.go
+++ b/appserver/protocol/plugins_migration_contract_test.go
@@ -133,8 +133,8 @@ func TestPluginsMigrationRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/process_contracts_contract_test.go
+++ b/appserver/protocol/process_contracts_contract_test.go
@@ -314,8 +314,8 @@ func TestProcessContractsRemainStandaloneFromLegacyRuntime(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/public_config_contract_test.go
+++ b/appserver/protocol/public_config_contract_test.go
@@ -264,8 +264,8 @@ func TestPublicConfigRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
+++ b/appserver/protocol/public_parent_lifecycle_notification_contract_test.go
@@ -200,8 +200,8 @@ func TestPublicParentLifecycleNotificationTypeScriptAndBindingsRemainStandalone(
 	if len(JSONSchema()["$defs"].(Schema)) != 675 {
 		t.Fatalf("definition count = %d, want 675", len(JSONSchema()["$defs"].(Schema)))
 	}
-	if len(WireTypeBindings()) != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(WireTypeBindings()) != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 	names := []string{
 		"ThreadStartedNotification", "ThreadStatusChangedNotification",

--- a/appserver/protocol/public_thread_contract_test.go
+++ b/appserver/protocol/public_thread_contract_test.go
@@ -207,8 +207,8 @@ func TestPublicThreadTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if len(JSONSchema()["$defs"].(Schema)) != 675 {
 		t.Fatalf("definition count = %d, want 675", len(JSONSchema()["$defs"].(Schema)))
 	}
-	if len(WireTypeBindings()) != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(WireTypeBindings()) != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 	for _, binding := range WireTypeBindings() {
 		if slices.Contains(binding.Params, "Thread") || slices.Contains(binding.Result, "Thread") {

--- a/appserver/protocol/public_thread_response_contract_test.go
+++ b/appserver/protocol/public_thread_response_contract_test.go
@@ -200,8 +200,8 @@ func TestPublicThreadResponsesRemainSeparateFromLiveResults(t *testing.T) {
 	if len(JSONSchema()["$defs"].(Schema)) != 675 {
 		t.Fatalf("definition count = %d, want 675", len(JSONSchema()["$defs"].(Schema)))
 	}
-	if len(bindings) != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", len(bindings), len(ItemPayloadBindings()))
+	if len(bindings) != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", len(bindings), len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/public_turn_contract_test.go
+++ b/appserver/protocol/public_turn_contract_test.go
@@ -149,8 +149,8 @@ func TestPublicTurnTypeScriptAndBindingsRemainStandalone(t *testing.T) {
 	if len(JSONSchema()["$defs"].(Schema)) != 675 {
 		t.Fatalf("definition count = %d, want 675", len(JSONSchema()["$defs"].(Schema)))
 	}
-	if len(WireTypeBindings()) != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(WireTypeBindings()) != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 	for _, binding := range WireTypeBindings() {
 		if slices.Contains(binding.Params, "Turn") || slices.Contains(binding.Result, "Turn") {

--- a/appserver/protocol/raw_response_item_completed_contract_test.go
+++ b/appserver/protocol/raw_response_item_completed_contract_test.go
@@ -97,8 +97,8 @@ func TestRawResponseItemCompletedNotificationRemainsStandalone(t *testing.T) {
 	if len(JSONSchema()["$defs"].(Schema)) != 675 {
 		t.Fatalf("definition count = %d, want 675", len(JSONSchema()["$defs"].(Schema)))
 	}
-	if len(WireTypeBindings()) != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(WireTypeBindings()) != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 
 	generated, err := MarshalTypeScript()

--- a/appserver/protocol/realtime_notification_contract_test.go
+++ b/appserver/protocol/realtime_notification_contract_test.go
@@ -227,8 +227,8 @@ func TestRealtimeNotificationsFailClosedAndRemainStandalone(t *testing.T) {
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 675 {
 		t.Fatalf("definition count = %d, want 675", got)
 	}
-	if len(Methods()) != 229 || len(WireTypeBindings()) != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 229/85/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(Methods()) != 229 || len(WireTypeBindings()) != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 229/86/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/resource_content_contract_test.go
+++ b/appserver/protocol/resource_content_contract_test.go
@@ -165,8 +165,8 @@ func TestResourceContentRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/review_decision_contract_test.go
+++ b/appserver/protocol/review_decision_contract_test.go
@@ -142,8 +142,8 @@ func TestReviewDecisionRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/schema.json
+++ b/appserver/protocol/schema.json
@@ -26913,7 +26913,7 @@
     {
       "method": "turn/plan/updated",
       "surface": "server-notification",
-      "state": "blocked",
+      "state": "implemented",
       "source": "json schema:ServerNotification, protocol crate:common.rs:1628, typescript:ServerNotification.ts"
     },
     {
@@ -27862,6 +27862,13 @@
       ],
       "result": [
         "TurnRunInterruptResult"
+      ]
+    },
+    {
+      "method": "turn/plan/updated",
+      "surface": "server-notification",
+      "params": [
+        "TurnPlanUpdatedNotification"
       ]
     },
     {

--- a/appserver/protocol/server_request_approval_params_contract_test.go
+++ b/appserver/protocol/server_request_approval_params_contract_test.go
@@ -169,8 +169,8 @@ func TestServerRequestApprovalParamsRemainStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/session_migration_contract_test.go
+++ b/appserver/protocol/session_migration_contract_test.go
@@ -134,8 +134,8 @@ func TestSessionMigrationRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/skill_migration_contract_test.go
+++ b/appserver/protocol/skill_migration_contract_test.go
@@ -108,8 +108,8 @@ func TestSkillMigrationRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/subagent_migration_contract_test.go
+++ b/appserver/protocol/subagent_migration_contract_test.go
@@ -108,8 +108,8 @@ func TestSubagentMigrationRemainsStandalone(t *testing.T) {
 	if got := len(Methods()); got != 229 {
 		t.Fatalf("methods = %d, want 229", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/thread_item_contract_test.go
+++ b/appserver/protocol/thread_item_contract_test.go
@@ -390,8 +390,8 @@ func TestThreadItemTypeScriptShapeAndBindingsRemainStandalone(t *testing.T) {
 	if len(JSONSchema()["$defs"].(Schema)) != 675 {
 		t.Fatalf("definition count = %d, want 675", len(JSONSchema()["$defs"].(Schema)))
 	}
-	if len(WireTypeBindings()) != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(WireTypeBindings()) != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 	for _, binding := range WireTypeBindings() {
 		if slices.Contains(binding.Params, "ThreadItem") || slices.Contains(binding.Result, "ThreadItem") {

--- a/appserver/protocol/thread_request_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_request_prerequisite_contract_test.go
@@ -97,8 +97,8 @@ func TestThreadRequestPrerequisitesRemainDistinctAndStandalone(t *testing.T) {
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 675 {
 		t.Fatalf("definition count = %d, want 675", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
+++ b/appserver/protocol/thread_response_policy_prerequisite_contract_test.go
@@ -265,8 +265,8 @@ func TestThreadResponsePolicyPrerequisitesRemainStandalone(t *testing.T) {
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 675 {
 		t.Fatalf("definition count = %d, want 675", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/thread_resume_pagination_contract_test.go
+++ b/appserver/protocol/thread_resume_pagination_contract_test.go
@@ -197,8 +197,8 @@ func TestThreadResumePaginationContractsRemainStandalone(t *testing.T) {
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 675 {
 		t.Fatalf("definition count = %d, want 675", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/thread_session_param_contract_test.go
+++ b/appserver/protocol/thread_session_param_contract_test.go
@@ -255,8 +255,8 @@ func TestThreadSessionParamsRemainStandalone(t *testing.T) {
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 675 {
 		t.Fatalf("definition count = %d, want 675", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/thread_session_response_contract_test.go
+++ b/appserver/protocol/thread_session_response_contract_test.go
@@ -157,8 +157,8 @@ func TestThreadSessionResponsesRemainStandalone(t *testing.T) {
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 675 {
 		t.Fatalf("definition count = %d, want 675", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/thread_turn_dependency_contract_test.go
+++ b/appserver/protocol/thread_turn_dependency_contract_test.go
@@ -314,8 +314,8 @@ func TestThreadTurnDependenciesRemainStandalone(t *testing.T) {
 	if len(JSONSchema()["$defs"].(Schema)) != 675 {
 		t.Fatalf("definition count = %d, want 675", len(JSONSchema()["$defs"].(Schema)))
 	}
-	if len(WireTypeBindings()) != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(WireTypeBindings()) != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 
 	generated, err := MarshalTypeScript()

--- a/appserver/protocol/thread_turn_leaf_contract_test.go
+++ b/appserver/protocol/thread_turn_leaf_contract_test.go
@@ -223,8 +223,8 @@ func TestThreadTurnLeafTypesRemainStandaloneAndDistinct(t *testing.T) {
 	if len(JSONSchema()["$defs"].(Schema)) != 675 {
 		t.Fatalf("definition count = %d, want 675", len(JSONSchema()["$defs"].(Schema)))
 	}
-	if len(WireTypeBindings()) != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(WireTypeBindings()) != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 
 	generated, err := MarshalTypeScript()

--- a/appserver/protocol/turn_interrupt_contract_test.go
+++ b/appserver/protocol/turn_interrupt_contract_test.go
@@ -122,8 +122,8 @@ func TestTurnInterruptContractsRemainStandalone(t *testing.T) {
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 675 {
 		t.Fatalf("definition count = %d, want 675", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/turn_plan_contract_test.go
+++ b/appserver/protocol/turn_plan_contract_test.go
@@ -199,21 +199,31 @@ func TestTurnPlanUpdatedNotificationRejectsMalformedForms(t *testing.T) {
 	}
 }
 
-func TestTurnPlanContractsRemainStandalone(t *testing.T) {
+func TestTurnPlanContractsAreBoundToLiveProducer(t *testing.T) {
+	var found bool
 	for _, binding := range WireTypeBindings() {
-		if binding.Method == "turn/plan/updated" {
-			t.Fatalf("turn/plan/updated unexpectedly bound: %#v", binding)
+		if binding.Method != "turn/plan/updated" {
+			continue
+		}
+		found = true
+		if binding.Surface != SurfaceServerNotification ||
+			!reflect.DeepEqual(binding.Params, []string{"TurnPlanUpdatedNotification"}) ||
+			len(binding.Result) != 0 {
+			t.Fatalf("turn/plan/updated binding = %#v", binding)
 		}
 	}
+	if !found {
+		t.Fatal("turn/plan/updated binding missing")
+	}
 	info, ok := LookupMethod("turn/plan/updated")
-	if !ok || info.State != MethodBlocked {
-		t.Fatalf("turn/plan/updated method = %#v, %v; want blocked", info, ok)
+	if !ok || info.Surface != SurfaceServerNotification || info.State != MethodImplemented {
+		t.Fatalf("turn/plan/updated method = %#v, %v; want implemented server notification", info, ok)
 	}
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 675 {
 		t.Fatalf("definition count = %d, want 675", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/turn_plan_types.go
+++ b/appserver/protocol/turn_plan_types.go
@@ -57,7 +57,6 @@ func (s *TurnPlanStep) UnmarshalJSON(data []byte) error {
 }
 
 // TurnPlanUpdatedNotification is the exact fixed public turn-plan snapshot.
-// It remains standalone until Gollem has an exact live producer.
 type TurnPlanUpdatedNotification struct {
 	ThreadID    string         `json:"threadId"`
 	TurnID      string         `json:"turnId"`

--- a/appserver/protocol/turn_start_contract_test.go
+++ b/appserver/protocol/turn_start_contract_test.go
@@ -244,8 +244,8 @@ func TestTurnStartContractsRemainStandalone(t *testing.T) {
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 675 {
 		t.Fatalf("definition count = %d, want 675", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/turn_steer_contract_test.go
+++ b/appserver/protocol/turn_steer_contract_test.go
@@ -167,8 +167,8 @@ func TestTurnSteerContractsAreBoundToLiveRuntime(t *testing.T) {
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 675 {
 		t.Fatalf("definition count = %d, want 675", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/typescript/gollem_appserver_protocol.ts
+++ b/appserver/protocol/typescript/gollem_appserver_protocol.ts
@@ -217,7 +217,7 @@ export const protocolMethods = [
   { "method": "turn/completed", "surface": "server-notification", "state": "implemented", "source": "json schema:ServerNotification, protocol crate:common.rs:1625, typescript:ServerNotification.ts" },
   { "method": "turn/diff/updated", "surface": "server-notification", "state": "implemented", "source": "json schema:ServerNotification, protocol crate:common.rs:1627, typescript:ServerNotification.ts" },
   { "method": "turn/moderationMetadata", "surface": "server-notification", "state": "blocked", "source": "json schema:ServerNotification, protocol crate:common.rs:1670, typescript:ServerNotification.ts" },
-  { "method": "turn/plan/updated", "surface": "server-notification", "state": "blocked", "source": "json schema:ServerNotification, protocol crate:common.rs:1628, typescript:ServerNotification.ts" },
+  { "method": "turn/plan/updated", "surface": "server-notification", "state": "implemented", "source": "json schema:ServerNotification, protocol crate:common.rs:1628, typescript:ServerNotification.ts" },
   { "method": "turn/started", "surface": "server-notification", "state": "implemented", "source": "json schema:ServerNotification, protocol crate:common.rs:1623, typescript:ServerNotification.ts" },
   { "method": "warning", "surface": "server-notification", "state": "blocked", "source": "json schema:ServerNotification, protocol crate:common.rs:1672, typescript:ServerNotification.ts" },
   { "method": "windows/worldWritableWarning", "surface": "server-notification", "state": "deferred-stub", "source": "json schema:ServerNotification, protocol crate:common.rs:1696, typescript:ServerNotification.ts" },
@@ -4965,6 +4965,7 @@ export const wireTypeBindings = [
   { "method": "turn/completed", "surface": "server-notification", "params": ["RuntimeTurnNotification"] },
   { "method": "turn/diff/updated", "surface": "server-notification", "params": ["TurnDiffUpdatedNotification"] },
   { "method": "turn/interrupt", "surface": "client-request", "params": ["TurnRunInterruptParams"], "result": ["TurnRunInterruptResult"] },
+  { "method": "turn/plan/updated", "surface": "server-notification", "params": ["TurnPlanUpdatedNotification"] },
   { "method": "turn/retry", "surface": "gollem-extension", "params": ["TurnRunRetryParams"], "result": ["TurnRunRetryResult"] },
   { "method": "turn/start", "surface": "client-request", "params": ["TurnRunStartParams"], "result": ["TurnRunStartResult"] },
   { "method": "turn/started", "surface": "server-notification", "params": ["RuntimeTurnNotification"] },
@@ -5053,6 +5054,7 @@ export interface MethodParamsByName {
   "turn/completed": RuntimeTurnNotification;
   "turn/diff/updated": TurnDiffUpdatedNotification;
   "turn/interrupt": TurnRunInterruptParams;
+  "turn/plan/updated": TurnPlanUpdatedNotification;
   "turn/retry": TurnRunRetryParams;
   "turn/start": TurnRunStartParams;
   "turn/started": RuntimeTurnNotification;

--- a/appserver/protocol/typescript/testdata/collaboration_capability_contract.ts
+++ b/appserver/protocol/typescript/testdata/collaboration_capability_contract.ts
@@ -74,7 +74,7 @@ type Contracts = [
   Expect<Equal<ExactMembers<MethodResultsByName[keyof MethodResultsByName], CollaborationCapabilityContracts>, never>>,
   Expect<Equal<ExactMembers<ItemPayloadByKind[keyof ItemPayloadByKind], CollaborationCapabilityContracts>, never>>,
   Expect<Equal<typeof protocolMethods["length"], 229>>,
-  Expect<Equal<typeof wireTypeBindings["length"], 85>>,
+  Expect<Equal<typeof wireTypeBindings["length"], 86>>,
   Expect<Equal<typeof itemPayloadBindings["length"], 5>>,
 ];
 

--- a/appserver/protocol/typescript/testdata/dynamic_tool_spec_contract.ts
+++ b/appserver/protocol/typescript/testdata/dynamic_tool_spec_contract.ts
@@ -58,7 +58,7 @@ type Contracts = [
   Expect<Equal<ExactMembers<MethodResultsByName[keyof MethodResultsByName], DynamicToolSpecContracts>, never>>,
   Expect<Equal<ExactMembers<ItemPayloadByKind[keyof ItemPayloadByKind], DynamicToolSpecContracts>, never>>,
   Expect<Equal<typeof protocolMethods["length"], 229>>,
-  Expect<Equal<typeof wireTypeBindings["length"], 85>>,
+  Expect<Equal<typeof wireTypeBindings["length"], 86>>,
   Expect<Equal<typeof itemPayloadBindings["length"], 5>>,
 ];
 

--- a/appserver/protocol/warning_error_notification_contract_test.go
+++ b/appserver/protocol/warning_error_notification_contract_test.go
@@ -169,8 +169,8 @@ func TestWarningErrorNotificationContractsRemainStandalone(t *testing.T) {
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 675 {
 		t.Fatalf("definition count = %d, want 675", got)
 	}
-	if got := len(WireTypeBindings()); got != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("bindings = %d methods/%d items, want 85/5", got, len(ItemPayloadBindings()))
+	if got := len(WireTypeBindings()); got != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("bindings = %d methods/%d items, want 86/5", got, len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/protocol/workspace_messages_contract_test.go
+++ b/appserver/protocol/workspace_messages_contract_test.go
@@ -212,8 +212,8 @@ func TestWorkspaceMessageContractsRemainStandaloneAndDeferred(t *testing.T) {
 	if got := len(JSONSchema()["$defs"].(Schema)); got != 675 {
 		t.Fatalf("definition count = %d, want 675", got)
 	}
-	if len(Methods()) != 229 || len(WireTypeBindings()) != 85 || len(ItemPayloadBindings()) != 5 {
-		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 229/85/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
+	if len(Methods()) != 229 || len(WireTypeBindings()) != 86 || len(ItemPayloadBindings()) != 5 {
+		t.Fatalf("counts = %d methods/%d method bindings/%d item bindings; want 229/86/5", len(Methods()), len(WireTypeBindings()), len(ItemPayloadBindings()))
 	}
 }
 

--- a/appserver/runtime.go
+++ b/appserver/runtime.go
@@ -478,6 +478,11 @@ func (s *RuntimeService) run(ctx context.Context, st store.Store, notifier runti
 	}()
 
 	ctx = withRuntimeTurnContext(ctx, turn.ThreadID, turn.ID)
+	ctx = withRuntimeToolDependencies(ctx, runtimeToolDependencies{
+		store:    st,
+		notifier: notifier,
+		turn:     turn,
+	})
 	model, info, err := s.modelFactory(ctx, req.Selection)
 	if err == nil && model == nil {
 		err = ErrRuntimeNotConfigured

--- a/appserver/runtime_plan_tools.go
+++ b/appserver/runtime_plan_tools.go
@@ -1,0 +1,293 @@
+package appserver
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/fugue-labs/gollem/appserver/protocol"
+	"github.com/fugue-labs/gollem/appserver/store"
+	"github.com/fugue-labs/gollem/core"
+)
+
+const (
+	runtimeUpdatePlanToolName      = "update_plan"
+	runtimePlanItemKind            = "plan"
+	runtimePlanUpdatedResult       = "Plan updated"
+	runtimePlanMaxSteps            = 64
+	runtimePlanMaxStepBytes        = 4 * 1024
+	runtimePlanMaxExplanationBytes = 8 * 1024
+	runtimePlanMaxArgsBytes        = 512 * 1024
+	runtimePlanMaxJSONDepth        = 8
+)
+
+type runtimeUpdatePlanStep struct {
+	Step   string `json:"step"`
+	Status string `json:"status" jsonschema:"enum=pending|inProgress|completed"`
+}
+
+type runtimeUpdatePlanParams struct {
+	Explanation *string                 `json:"explanation,omitempty"`
+	Plan        []runtimeUpdatePlanStep `json:"plan" jsonschema:"nonnullable=true"`
+}
+
+type runtimeToolDependencies struct {
+	store    store.Store
+	notifier runtimeNotifier
+	turn     *store.Turn
+}
+
+type runtimeToolDependenciesContextKey struct{}
+
+func withRuntimeToolDependencies(ctx context.Context, deps runtimeToolDependencies) context.Context {
+	return context.WithValue(ctx, runtimeToolDependenciesContextKey{}, deps)
+}
+
+func runtimeDependencies(ctx context.Context, rc *core.RunContext) (runtimeToolDependencies, bool) {
+	if ctx != nil {
+		if deps, ok := ctx.Value(runtimeToolDependenciesContextKey{}).(runtimeToolDependencies); ok {
+			return deps, runtimeDependenciesReady(deps)
+		}
+	}
+	if rc != nil {
+		if deps, ok := rc.Deps.(runtimeToolDependencies); ok {
+			return deps, runtimeDependenciesReady(deps)
+		}
+	}
+	return runtimeToolDependencies{}, false
+}
+
+func runtimeDependenciesReady(deps runtimeToolDependencies) bool {
+	return deps.store != nil && deps.notifier != nil && deps.turn != nil &&
+		deps.turn.ThreadID != "" && deps.turn.ID != ""
+}
+
+// PlanRuntimeTools exposes the exact main-owned plan snapshot producer.
+func PlanRuntimeTools() []core.Tool {
+	tool := core.FuncTool[runtimeUpdatePlanParams](
+		runtimeUpdatePlanToolName,
+		"Update the visible plan for the current turn. Provide the complete ordered plan on every call.",
+		func(ctx context.Context, rc *core.RunContext, params runtimeUpdatePlanParams) (string, error) {
+			return executeRuntimePlanUpdate(ctx, rc, params)
+		},
+		core.WithToolSequential(true),
+		core.WithToolStrict(true),
+	)
+	closeRuntimePlanToolSchema(tool.Definition.ParametersSchema)
+	generatedHandler := tool.Handler
+	tool.Handler = func(ctx context.Context, rc *core.RunContext, argsJSON string) (any, error) {
+		if _, err := decodeRuntimeUpdatePlanParams(argsJSON); err != nil {
+			return nil, err
+		}
+		return generatedHandler(ctx, rc, argsJSON)
+	}
+	return []core.Tool{tool}
+}
+
+func closeRuntimePlanToolSchema(schema core.Schema) {
+	schema["additionalProperties"] = false
+	properties, _ := schema["properties"].(core.Schema)
+	plan, _ := properties["plan"].(core.Schema)
+	items, _ := plan["items"].(core.Schema)
+	if items != nil {
+		items["additionalProperties"] = false
+	}
+}
+
+func decodeRuntimeUpdatePlanParams(argsJSON string) (runtimeUpdatePlanParams, error) {
+	if strings.TrimSpace(argsJSON) == "" {
+		return runtimeUpdatePlanParams{}, errors.New("update_plan requires a JSON object")
+	}
+	if len(argsJSON) > runtimePlanMaxArgsBytes {
+		return runtimeUpdatePlanParams{}, fmt.Errorf("update_plan arguments exceed %d bytes", runtimePlanMaxArgsBytes)
+	}
+	if err := rejectRuntimePlanDuplicateFields(argsJSON); err != nil {
+		return runtimeUpdatePlanParams{}, err
+	}
+	decoder := json.NewDecoder(bytes.NewBufferString(argsJSON))
+	decoder.DisallowUnknownFields()
+	var params runtimeUpdatePlanParams
+	if err := decoder.Decode(&params); err != nil {
+		return runtimeUpdatePlanParams{}, fmt.Errorf("decode update_plan arguments: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return runtimeUpdatePlanParams{}, errors.New("decode update_plan arguments: trailing JSON value")
+		}
+		return runtimeUpdatePlanParams{}, fmt.Errorf("decode update_plan arguments: %w", err)
+	}
+	if params.Plan == nil {
+		return runtimeUpdatePlanParams{}, errors.New("update_plan plan is required and cannot be null")
+	}
+	return params, nil
+}
+
+func rejectRuntimePlanDuplicateFields(argsJSON string) error {
+	decoder := json.NewDecoder(bytes.NewBufferString(argsJSON))
+	var walk func(int) error
+	walk = func(depth int) error {
+		if depth > runtimePlanMaxJSONDepth {
+			return fmt.Errorf("JSON nesting exceeds %d levels", runtimePlanMaxJSONDepth)
+		}
+		token, err := decoder.Token()
+		if err != nil {
+			return err
+		}
+		delim, ok := token.(json.Delim)
+		if !ok {
+			return nil
+		}
+		switch delim {
+		case '{':
+			seen := make(map[string]struct{})
+			for decoder.More() {
+				keyToken, err := decoder.Token()
+				if err != nil {
+					return err
+				}
+				key, ok := keyToken.(string)
+				if !ok {
+					return errors.New("object field name is not a string")
+				}
+				if _, exists := seen[key]; exists {
+					return fmt.Errorf("duplicate field %q", key)
+				}
+				seen[key] = struct{}{}
+				if err := walk(depth + 1); err != nil {
+					return err
+				}
+			}
+			_, err = decoder.Token()
+			return err
+		case '[':
+			for decoder.More() {
+				if err := walk(depth + 1); err != nil {
+					return err
+				}
+			}
+			_, err = decoder.Token()
+			return err
+		default:
+			return fmt.Errorf("unexpected JSON delimiter %q", delim)
+		}
+	}
+	if err := walk(0); err != nil {
+		return fmt.Errorf("decode update_plan arguments: %w", err)
+	}
+	if _, err := decoder.Token(); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errors.New("decode update_plan arguments: trailing JSON value")
+		}
+		return fmt.Errorf("decode update_plan arguments: %w", err)
+	}
+	return nil
+}
+
+func executeRuntimePlanUpdate(ctx context.Context, rc *core.RunContext, params runtimeUpdatePlanParams) (string, error) {
+	deps, ok := runtimeDependencies(ctx, rc)
+	if !ok {
+		return "", errors.New("update_plan requires an active runtime turn")
+	}
+	notification, err := normalizeRuntimePlanUpdate(deps.turn, params)
+	if err != nil {
+		return "", err
+	}
+	payload, err := json.Marshal(notification)
+	if err != nil {
+		return "", fmt.Errorf("encode update_plan snapshot: %w", err)
+	}
+	items, err := deps.store.ListItems(ctx, store.ItemFilter{
+		ThreadID: deps.turn.ThreadID,
+		TurnID:   deps.turn.ID,
+	})
+	if err != nil {
+		return "", fmt.Errorf("read durable update_plan snapshot: %w", err)
+	}
+	status := runtimePlanItemStatus(notification.Plan)
+	var existing *store.Item
+	for i := len(items) - 1; i >= 0; i-- {
+		if items[i] != nil && items[i].Kind == runtimePlanItemKind {
+			existing = items[i]
+			break
+		}
+	}
+	if existing == nil {
+		_, err = deps.store.AppendItem(ctx, store.AppendItemRequest{
+			ThreadID: deps.turn.ThreadID,
+			TurnID:   deps.turn.ID,
+			Kind:     runtimePlanItemKind,
+			Status:   status,
+			Payload:  payload,
+		})
+	} else {
+		_, err = deps.store.UpdateItem(ctx, store.UpdateItemRequest{
+			ID:      existing.ID,
+			Status:  status,
+			Payload: payload,
+		})
+	}
+	if err != nil {
+		return "", fmt.Errorf("persist update_plan snapshot: %w", err)
+	}
+	deps.notifier.PublishNotification("turn/plan/updated", notification)
+	return runtimePlanUpdatedResult, nil
+}
+
+func normalizeRuntimePlanUpdate(turn *store.Turn, params runtimeUpdatePlanParams) (protocol.TurnPlanUpdatedNotification, error) {
+	if turn == nil || turn.ThreadID == "" || turn.ID == "" {
+		return protocol.TurnPlanUpdatedNotification{}, errors.New("update_plan requires an active runtime turn")
+	}
+	if params.Plan == nil {
+		return protocol.TurnPlanUpdatedNotification{}, errors.New("update_plan plan is required and cannot be null")
+	}
+	if len(params.Plan) > runtimePlanMaxSteps {
+		return protocol.TurnPlanUpdatedNotification{}, fmt.Errorf("update_plan plan exceeds %d steps", runtimePlanMaxSteps)
+	}
+	plan := make([]protocol.TurnPlanStep, len(params.Plan))
+	for i, value := range params.Plan {
+		step := strings.TrimSpace(value.Step)
+		if step == "" {
+			return protocol.TurnPlanUpdatedNotification{}, fmt.Errorf("update_plan plan[%d].step is required", i)
+		}
+		if len(step) > runtimePlanMaxStepBytes {
+			return protocol.TurnPlanUpdatedNotification{}, fmt.Errorf("update_plan plan[%d].step exceeds %d bytes", i, runtimePlanMaxStepBytes)
+		}
+		status := protocol.TurnPlanStepStatus(value.Status)
+		switch status {
+		case protocol.TurnPlanStepStatusPending,
+			protocol.TurnPlanStepStatusInProgress,
+			protocol.TurnPlanStepStatusCompleted:
+		default:
+			return protocol.TurnPlanUpdatedNotification{}, fmt.Errorf("update_plan plan[%d].status is invalid", i)
+		}
+		plan[i] = protocol.TurnPlanStep{Step: step, Status: status}
+	}
+	var explanation *string
+	if params.Explanation != nil {
+		value := strings.TrimSpace(*params.Explanation)
+		if len(value) > runtimePlanMaxExplanationBytes {
+			return protocol.TurnPlanUpdatedNotification{}, fmt.Errorf("update_plan explanation exceeds %d bytes", runtimePlanMaxExplanationBytes)
+		}
+		explanation = &value
+	}
+	return protocol.TurnPlanUpdatedNotification{
+		ThreadID:    turn.ThreadID,
+		TurnID:      turn.ID,
+		Explanation: explanation,
+		Plan:        plan,
+	}, nil
+}
+
+func runtimePlanItemStatus(plan []protocol.TurnPlanStep) string {
+	for _, step := range plan {
+		if step.Status != protocol.TurnPlanStepStatusCompleted {
+			return protocol.ItemStatusInProgress
+		}
+	}
+	return protocol.ItemStatusCompleted
+}

--- a/appserver/runtime_plan_tools_test.go
+++ b/appserver/runtime_plan_tools_test.go
@@ -1,0 +1,303 @@
+package appserver
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/fugue-labs/gollem/appserver/protocol"
+	"github.com/fugue-labs/gollem/appserver/store"
+	"github.com/fugue-labs/gollem/core"
+)
+
+type runtimePlanCaptureNotifier struct {
+	mu     sync.Mutex
+	events []protocol.Notification
+}
+
+func (n *runtimePlanCaptureNotifier) PublishNotification(method string, params any) {
+	encoded, err := json.Marshal(params)
+	if err != nil {
+		panic(err)
+	}
+	n.mu.Lock()
+	n.events = append(n.events, protocol.Notification{Method: method, Params: encoded})
+	n.mu.Unlock()
+}
+
+func (n *runtimePlanCaptureNotifier) snapshot() []protocol.Notification {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return append([]protocol.Notification(nil), n.events...)
+}
+
+func TestPlanRuntimeToolsExposeExactSequentialUpdatePlan(t *testing.T) {
+	tools := PlanRuntimeTools()
+	if len(tools) != 1 {
+		t.Fatalf("plan runtime tools = %d, want 1", len(tools))
+	}
+	tool := tools[0]
+	if tool.Definition.Name != runtimeUpdatePlanToolName ||
+		tool.Definition.Namespace != "" ||
+		!tool.Definition.Sequential ||
+		tool.Definition.ConcurrencySafe ||
+		tool.Definition.Strict == nil || !*tool.Definition.Strict {
+		t.Fatalf("update_plan definition = %#v", tool.Definition)
+	}
+	schema := tool.Definition.ParametersSchema
+	if schema["type"] != "object" || schema["additionalProperties"] != false {
+		t.Fatalf("update_plan schema = %#v", schema)
+	}
+	properties, ok := schema["properties"].(core.Schema)
+	if !ok {
+		t.Fatalf("update_plan properties = %T", schema["properties"])
+	}
+	if _, ok := properties["explanation"]; !ok {
+		t.Fatal("update_plan schema missing explanation")
+	}
+	plan, ok := properties["plan"].(core.Schema)
+	if !ok || plan["type"] != "array" {
+		t.Fatalf("update_plan plan schema = %#v", properties["plan"])
+	}
+	items, ok := plan["items"].(core.Schema)
+	if !ok || items["type"] != "object" || items["additionalProperties"] != false {
+		t.Fatalf("update_plan step schema = %#v", plan["items"])
+	}
+	stepProperties, ok := items["properties"].(core.Schema)
+	status, statusOK := stepProperties["status"].(core.Schema)
+	if !ok || !statusOK || !reflect.DeepEqual(status["enum"], []any{"pending", "inProgress", "completed"}) {
+		t.Fatalf("update_plan status schema = %#v", stepProperties["status"])
+	}
+	if got := schema["required"]; !reflect.DeepEqual(got, []string{"plan"}) {
+		t.Fatalf("update_plan required = %#v, want plan", got)
+	}
+}
+
+func TestPlanRuntimeToolPersistsOnePlanSnapshotBeforePublishing(t *testing.T) {
+	ctx := context.Background()
+	st := newRuntimeTestStore(t)
+	thread, err := st.CreateThread(ctx, store.CreateThreadRequest{Title: "Plan updates"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	turn, err := st.CreateTurn(ctx, store.CreateTurnRequest{ThreadID: thread.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	notifier := &runtimePlanCaptureNotifier{}
+	tool := findRuntimeToolByName(t, PlanRuntimeTools(), runtimeUpdatePlanToolName)
+	runContext := &core.RunContext{
+		Deps:       runtimeToolDependencies{store: st, notifier: notifier, turn: turn},
+		ToolName:   runtimeUpdatePlanToolName,
+		ToolCallID: "plan-call-1",
+	}
+
+	result, err := tool.Handler(ctx, runContext, `{"explanation":"Inspect before editing","plan":[{"step":"Inspect","status":"inProgress"},{"step":"Implement","status":"pending"}]}`)
+	if err != nil {
+		t.Fatalf("first update_plan: %v", err)
+	}
+	if result != runtimePlanUpdatedResult {
+		t.Fatalf("first update_plan result = %#v", result)
+	}
+	firstItem, firstPlan := runtimeStoredPlan(t, st, thread.ID, turn.ID)
+	if firstItem.Status != protocol.ItemStatusInProgress || firstPlan.Explanation == nil || *firstPlan.Explanation != "Inspect before editing" {
+		t.Fatalf("first durable plan = item %#v payload %#v", firstItem, firstPlan)
+	}
+	firstEvents := notifier.snapshot()
+	if len(firstEvents) != 1 || firstEvents[0].Method != "turn/plan/updated" {
+		t.Fatalf("first plan notifications = %#v", firstEvents)
+	}
+	var firstNotification protocol.TurnPlanUpdatedNotification
+	if err := json.Unmarshal(firstEvents[0].Params, &firstNotification); err != nil {
+		t.Fatalf("decode first notification: %v", err)
+	}
+	if !reflect.DeepEqual(firstNotification, firstPlan) {
+		t.Fatalf("first notification = %#v, durable %#v", firstNotification, firstPlan)
+	}
+
+	runContext.ToolCallID = "plan-call-2"
+	result, err = tool.Handler(ctx, runContext, `{"plan":[{"step":"Inspect","status":"completed"},{"step":"Implement","status":"completed"}]}`)
+	if err != nil {
+		t.Fatalf("second update_plan: %v", err)
+	}
+	if result != runtimePlanUpdatedResult {
+		t.Fatalf("second update_plan result = %#v", result)
+	}
+	secondItem, secondPlan := runtimeStoredPlan(t, st, thread.ID, turn.ID)
+	if secondItem.ID != firstItem.ID || secondItem.Status != protocol.ItemStatusCompleted {
+		t.Fatalf("second durable plan item = %#v, first id %q", secondItem, firstItem.ID)
+	}
+	if secondPlan.Explanation != nil || len(secondPlan.Plan) != 2 || secondPlan.Plan[1].Status != protocol.TurnPlanStepStatusCompleted {
+		t.Fatalf("second durable plan payload = %#v", secondPlan)
+	}
+	events := notifier.snapshot()
+	if len(events) != 2 || events[1].Method != "turn/plan/updated" {
+		t.Fatalf("plan notifications = %#v", events)
+	}
+	var secondNotification protocol.TurnPlanUpdatedNotification
+	if err := json.Unmarshal(events[1].Params, &secondNotification); err != nil {
+		t.Fatalf("decode second notification: %v", err)
+	}
+	if !reflect.DeepEqual(secondNotification, secondPlan) {
+		t.Fatalf("second notification = %#v, durable %#v", secondNotification, secondPlan)
+	}
+}
+
+func TestPlanRuntimeToolRejectsMalformedOrUnownedUpdatesWithoutPersistence(t *testing.T) {
+	ctx := context.Background()
+	st := newRuntimeTestStore(t)
+	thread, err := st.CreateThread(ctx, store.CreateThreadRequest{Title: "Invalid plans"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	turn, err := st.CreateTurn(ctx, store.CreateTurnRequest{ThreadID: thread.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	notifier := &runtimePlanCaptureNotifier{}
+	tool := findRuntimeToolByName(t, PlanRuntimeTools(), runtimeUpdatePlanToolName)
+	runContext := &core.RunContext{Deps: runtimeToolDependencies{store: st, notifier: notifier, turn: turn}}
+
+	invalid := []string{
+		`null`,
+		`[]`,
+		`{}`,
+		`{"plan":null}`,
+		`{"plan":[{"step":"","status":"pending"}]}`,
+		`{"plan":[{"step":"Inspect","status":"blocked"}]}`,
+		`{"plan":[],"plan":[]}`,
+		`{"plan":[{"step":"Inspect","step":"Replace","status":"pending"}]}`,
+		`{"plan":[],"extra":true}`,
+		`{"plan":[]} {}`,
+	}
+	tooManySteps := make([]runtimeUpdatePlanStep, runtimePlanMaxSteps+1)
+	for i := range tooManySteps {
+		tooManySteps[i] = runtimeUpdatePlanStep{Step: "step", Status: "pending"}
+	}
+	tooManyJSON, err := json.Marshal(runtimeUpdatePlanParams{Plan: tooManySteps})
+	if err != nil {
+		t.Fatal(err)
+	}
+	invalid = append(
+		invalid,
+		string(tooManyJSON),
+		`{"plan":[{"step":"`+strings.Repeat("x", runtimePlanMaxStepBytes+1)+`","status":"pending"}]}`,
+		`{"explanation":"`+strings.Repeat("x", runtimePlanMaxExplanationBytes+1)+`","plan":[]}`,
+	)
+	for _, input := range invalid {
+		if _, err := tool.Handler(ctx, runContext, input); err == nil {
+			t.Errorf("update_plan(%s) succeeded", input)
+		}
+	}
+	if _, err := tool.Handler(ctx, &core.RunContext{}, `{"plan":[]}`); err == nil || !strings.Contains(err.Error(), "active runtime turn") {
+		t.Fatalf("unowned update_plan error = %v", err)
+	}
+	items, err := st.ListItems(ctx, store.ItemFilter{ThreadID: thread.ID, TurnID: turn.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 0 || len(notifier.snapshot()) != 0 {
+		t.Fatalf("invalid plans persisted items=%#v notifications=%#v", items, notifier.snapshot())
+	}
+}
+
+func TestPlanRuntimeToolDoesNotPublishWhenDurableWriteFails(t *testing.T) {
+	ctx := context.Background()
+	st := newRuntimeTestStore(t)
+	thread, err := st.CreateThread(ctx, store.CreateThreadRequest{Title: "Failed plan"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	turn, err := st.CreateTurn(ctx, store.CreateTurnRequest{ThreadID: thread.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatal(err)
+	}
+	notifier := &runtimePlanCaptureNotifier{}
+	tool := findRuntimeToolByName(t, PlanRuntimeTools(), runtimeUpdatePlanToolName)
+	_, err = tool.Handler(ctx, &core.RunContext{
+		Deps: runtimeToolDependencies{store: st, notifier: notifier, turn: turn},
+	}, `{"plan":[]}`)
+	if err == nil {
+		t.Fatal("update_plan succeeded against closed durable store")
+	}
+	if len(notifier.snapshot()) != 0 {
+		t.Fatalf("failed durable write published %#v", notifier.snapshot())
+	}
+}
+
+func TestServerRuntimeUpdatePlanIsDurableAndCorrelated(t *testing.T) {
+	ctx := context.Background()
+	st := newRuntimeTestStore(t)
+	model := core.NewTestModel(
+		core.ToolCallResponseWithID(runtimeUpdatePlanToolName, `{"explanation":"Work in order","plan":[{"step":"Inspect","status":"completed"},{"step":"Verify","status":"inProgress"}]}`, "call-plan"),
+		core.TextResponse("plan recorded"),
+	)
+	server := readyServer(
+		WithStore(st),
+		WithRuntimeService(NewRuntimeService(
+			WithRuntimeModel(model, RuntimeModelInfo{ProviderID: "test", Model: "test-model"}),
+			WithRuntimeTools(PlanRuntimeTools()...),
+		)),
+	)
+
+	response := server.HandleRequest(ctx, request("thread/start", map[string]any{"prompt": "make a plan"}))
+	if response.Error != nil {
+		t.Fatalf("thread/start error: %v", response.Error)
+	}
+	var started struct {
+		Thread *store.Thread `json:"thread"`
+		Turn   *store.Turn   `json:"turn"`
+	}
+	decodeResult(t, response, &started)
+	notifications := waitForNotificationSet(t, server, "turn/plan/updated", "turn/completed")
+	var got protocol.TurnPlanUpdatedNotification
+	for _, notification := range notifications {
+		if notification.Method != "turn/plan/updated" {
+			continue
+		}
+		if err := json.Unmarshal(notification.Params, &got); err != nil {
+			t.Fatalf("decode plan notification: %v", err)
+		}
+	}
+	if got.ThreadID != started.Thread.ID || got.TurnID != started.Turn.ID || got.Explanation == nil || *got.Explanation != "Work in order" || len(got.Plan) != 2 {
+		t.Fatalf("runtime plan notification = %#v", got)
+	}
+	_, durable := runtimeStoredPlan(t, st, started.Thread.ID, started.Turn.ID)
+	if !reflect.DeepEqual(durable, got) {
+		t.Fatalf("runtime durable plan = %#v, notification %#v", durable, got)
+	}
+	if calls := len(model.Calls()); calls != 2 {
+		t.Fatalf("model calls = %d, want tool call then final response", calls)
+	}
+}
+
+func runtimeStoredPlan(t *testing.T, st store.Store, threadID, turnID string) (*store.Item, protocol.TurnPlanUpdatedNotification) {
+	t.Helper()
+	items, err := st.ListItems(context.Background(), store.ItemFilter{ThreadID: threadID, TurnID: turnID})
+	if err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+	var found *store.Item
+	for _, item := range items {
+		if item != nil && item.Kind == runtimePlanItemKind {
+			if found != nil {
+				t.Fatalf("multiple durable plan items: %q and %q", found.ID, item.ID)
+			}
+			found = item
+		}
+	}
+	if found == nil {
+		t.Fatalf("durable plan item missing from %#v", items)
+	}
+	var plan protocol.TurnPlanUpdatedNotification
+	if err := json.Unmarshal(found.Payload, &plan); err != nil {
+		t.Fatalf("decode durable plan: %v", err)
+	}
+	return found, plan
+}

--- a/cmd/gollem/app_server.go
+++ b/cmd/gollem/app_server.go
@@ -333,6 +333,7 @@ func newCLIAppServerWithRuntimeFactoryAndSelectionValidation(
 	}
 	runtimeTools = append(runtimeTools, appserver.MCPRuntimeTools(mcpSvc, approvals)...)
 	runtimeTools = append(runtimeTools, appserver.InteractionRuntimeTools(interactionSvc)...)
+	runtimeTools = append(runtimeTools, appserver.PlanRuntimeTools()...)
 	cacheSvc := appcache.NewService()
 	runtimeSvc := appserver.NewRuntimeService(
 		appserver.WithRuntimeModelFactory(runtimeFactory),

--- a/cmd/gollem/app_server_test.go
+++ b/cmd/gollem/app_server_test.go
@@ -1205,6 +1205,7 @@ func TestCLIAppServerRuntimeUsesScopedProcessAndGitTools(t *testing.T) {
 func TestCLIAppServerRuntimeUsesMCPAndSharedInteractionTools(t *testing.T) {
 	model := core.NewTestModel(
 		core.ToolCallResponseWithID("mcp_list_servers", `{}`, "call-cli-mcp-list"),
+		core.ToolCallResponseWithID("update_plan", `{"explanation":"Use the available tools","plan":[{"step":"Inspect MCP","status":"completed"},{"step":"Ask the client","status":"inProgress"}]}`, "call-cli-plan"),
 		core.ToolCallResponseWithID("curr_time", `{}`, "call-cli-current-time"),
 		core.ToolCallResponseWithID("request_user_input", `{"prompt":"Choose","options":["one","two"]}`, "call-cli-input"),
 		core.TextResponse("interaction complete"),
@@ -1300,6 +1301,9 @@ func TestCLIAppServerRuntimeUsesMCPAndSharedInteractionTools(t *testing.T) {
 		t.Fatalf("thread/items/list error: %v", itemsResp.Error)
 	}
 	if !strings.Contains(string(itemsResp.Result), `"tool":"mcp_list_servers"`) ||
+		!strings.Contains(string(itemsResp.Result), `"tool":"update_plan"`) ||
+		!strings.Contains(string(itemsResp.Result), `"kind":"plan"`) ||
+		!strings.Contains(string(itemsResp.Result), `"step":"Ask the client","status":"inProgress"`) ||
 		!strings.Contains(string(itemsResp.Result), `"tool":"curr_time"`) ||
 		!strings.Contains(string(itemsResp.Result), `It is 2026-06-17 17:34:15 UTC.`) ||
 		!strings.Contains(string(itemsResp.Result), `"tool":"request_user_input"`) {


### PR DESCRIPTION
## Summary
- add a strict, bounded `update_plan` runtime tool with exact Codex plan statuses
- persist one current plan snapshot per turn before publishing `turn/plan/updated`
- bind the method in generated schema/TypeScript and exercise production CLI wiring

## Verification
- `go test` across all non-Monty packages
- `go test -race` across all non-Monty packages
- `go vet ./...`
- `golangci-lint run ./...`
- generation idempotence and `go mod tidy`

Monty tests remain skipped per project instruction.